### PR TITLE
Parse open files as standalone if not included in project.

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -72,8 +72,10 @@ describe('LanguageServer', () => {
 
         s.documents = {
             onDidChangeContent: () => null,
+            onDidClose: () => null,
             listen: () => null,
             get: () => { },
+            all: () => [],
             syncKind: TextDocumentSyncKind.Full
         };
     });

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -888,6 +888,21 @@ describe('Program', () => {
     });
 
     describe('getDiagnostics', () => {
+        it('includes diagnostics from files not included in any context', async () => {
+            let pathAbsolute = util.normalizeFilePath(`${rootDir}/components/a/b/c/main.brs`);
+            await program.addOrReplaceFile(pathAbsolute, `
+                sub A()
+                    "this string is not terminated
+                end sub
+            `);
+            //the file should be included in the program
+            expect(program.getFileByPathAbsolute(pathAbsolute)).to.exist;
+            let diagnostics = program.getDiagnostics();
+            expect(diagnostics.length).to.be.greaterThan(0);
+            let parseError = diagnostics.filter(x => x.message === 'Unterminated string at end of line')[0];
+            expect(parseError).to.exist;
+        });
+
         it('it excludes specified error codes', async () => {
             //declare file with two different syntax errors
             await program.addOrReplaceFile(n(`${rootDir}/source/main.brs`), `

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -324,21 +324,21 @@ export class Program {
 
     /**
      * Remove a set of files from the program
-     * @param filePaths
+     * @param absolutePaths
      */
-    public removeFiles(filePaths: string[]) {
-        for (let filePath of filePaths) {
-            this.removeFile(filePath);
+    public removeFiles(absolutePaths: string[]) {
+        for (let pathAbsolute of absolutePaths) {
+            this.removeFile(pathAbsolute);
         }
     }
 
     /**
      * Remove a file from the program
-     * @param filePath
+     * @param pathAbsolute
      */
-    public removeFile(filePath: string) {
-        filePath = util.normalizeFilePath(filePath);
-        let file = this.getFile(filePath);
+    public removeFile(pathAbsolute: string) {
+        pathAbsolute = util.normalizeFilePath(pathAbsolute);
+        let file = this.getFile(pathAbsolute);
 
         //notify every context of this file removal
         for (let contextName in this.contexts) {
@@ -353,7 +353,7 @@ export class Program {
             delete this.contexts[file.pkgPath];
         }
         //remove the file from the program
-        delete this.files[filePath];
+        delete this.files[pathAbsolute];
         this.emit('file-removed', file);
     }
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -8,7 +8,7 @@ import { Context } from './Context';
 import { diagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import { Diagnostic } from './interfaces';
+import { Diagnostic, File } from './interfaces';
 import { platformFile } from './platformCallables';
 import { util } from './util';
 import { XmlContext } from './XmlContext';
@@ -101,20 +101,54 @@ export class Program {
     private diagnostics = [] as Diagnostic[];
 
     /**
+     * Get a list of all files that are inlcuded in the project but are not referenced
+     * by any context in the program.
+     */
+    public getUnreferencedFiles() {
+        let result = [] as File[];
+        outer: for (let filePath in this.files) {
+            let file = this.files[filePath];
+            for (let key in this.contexts) {
+                let context = this.contexts[key];
+                //if any context has this file, then it is not unreferenced. skip to the next file
+                if (context.hasFile(filePath)) {
+                    continue outer;
+                }
+            }
+            //no contexts reference this file. add it to the list
+            result.push(file);
+        }
+        return result;
+    }
+
+    /**
      * Get the list of errors for the entire program. It's calculated on the fly
      * by walking through every file, so call this sparingly.
      */
     public getDiagnostics() {
-        let errorLists = [this.diagnostics];
+        let diagnostics = [...this.diagnostics];
+
+        //get the diagnostics from all contexts
         for (let contextName in this.contexts) {
             let context = this.contexts[contextName];
-            errorLists.push(context.getDiagnostics());
+            diagnostics = [
+                ...diagnostics,
+                ...context.getDiagnostics()
+            ];
         }
-        let allDiagnistics = Array.prototype.concat.apply([], errorLists) as Diagnostic[];
+
+        //get the diagnostics from all unreferenced files
+        let unreferencedFiles = this.getUnreferencedFiles();
+        for (let file of unreferencedFiles) {
+            diagnostics = [
+                ...diagnostics,
+                ...file.getDiagnostics()
+            ];
+        }
 
         let finalDiagnostics = [] as Diagnostic[];
 
-        for (let diagnostic of allDiagnistics) {
+        for (let diagnostic of diagnostics) {
             //skip duplicate diagnostics (by reference). This skips file parse diagnostics when multiple contexts include same file
             if (finalDiagnostics.indexOf(diagnostic) > -1) {
                 continue;

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -60,6 +60,28 @@ describe('ProgramBuilder', () => {
         });
     });
 
+    describe('run', () => {
+        it('uses default options when the config file fails to parse', async () => {
+            //supress the console log statements for the bsconfig parse errors
+            sinon.stub(console, 'log').returns(undefined);
+            //totally bogus config file
+            setVfsFile(n(`${rootDir}/bsconfig.json`), '{');
+            await builder.run({
+                project: n(`${rootDir}/bsconfig.json`),
+                username: 'john'
+            });
+            expect(builder.program.options.username).to.equal('rokudev');
+        });
+
+        it('throws an exception when run is called twice', async () => {
+            await builder.run({});
+            try {
+                await builder.run({});
+                expect(true).to.be.false('Should have thrown exception');
+            } catch (e) { }
+        });
+    });
+
     describe('handleFileChanges', () => {
         beforeEach(() => {
             setVfsFile(n(`${rootDir}/source/promise.brs`), 'sub promise()\nend sub');

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -74,7 +74,10 @@ export class ProgramBuilder {
             let err = e as Diagnostic;
             this.staticDiagnostics.push(err);
             await this.printDiagnostics();
-            throw new Error(diagnosticMessages.BsConfigJson_has_syntax_errors_1021().message);
+
+            //we added diagnostics, so hopefully that draws attention to the underlying issues.
+            //For now, just use a default options object so we have a functioning program
+            this.options = await util.normalizeConfig({});
         }
 
         this.program = new Program(this.options);

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -68,11 +68,17 @@ export class ProgramBuilder {
         if (this.isRunning) {
             throw new Error('Server is already running');
         }
+        this.isRunning = true;
         try {
             this.options = await util.normalizeAndResolveConfig(options);
         } catch (e) {
-            let err = e as Diagnostic;
-            this.staticDiagnostics.push(err);
+            if (e && e.file && e.message && e.code) {
+                let err = e as Diagnostic;
+                this.staticDiagnostics.push(err);
+            } else {
+                //if this is not a diagnostic, something else is wrong...
+                throw e;
+            }
             await this.printDiagnostics();
 
             //we added diagnostics, so hopefully that draws attention to the underlying issues.

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -113,12 +113,18 @@ describe('util', () => {
 
         it('finds config up the chain', async () => {
             let brsFilePath = addFile('src/app.brs');
-            let currentDirConfigPath = addFile('src/bsconfig.json');
-            let parentDirConfigPath = addFile('bsconfig.json');
+            let currentDirBsConfigPath = addFile('src/bsconfig.json');
+            let currentDirBrsConfigPath = addFile('src/brsconfig.json');
+            let parentDirBsConfigPath = addFile('bsconfig.json');
+            let parentDirBrsConfigPath = addFile('brsconfig.json');
 
-            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(currentDirConfigPath);
-            delete vfs[currentDirConfigPath];
-            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(parentDirConfigPath);
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(currentDirBsConfigPath);
+            delete vfs[currentDirBsConfigPath];
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(currentDirBrsConfigPath);
+            delete vfs[currentDirBrsConfigPath];
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(parentDirBsConfigPath);
+            delete vfs[parentDirBsConfigPath];
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(parentDirBrsConfigPath);
         });
     });
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -9,6 +9,11 @@ let cwd = process.cwd();
 let rootConfigPath = path.join(process.cwd(), 'bsconfig.json');
 let rootConfigDir = path.dirname(rootConfigPath);
 let vfs = {};
+function addFile(relativeFilePath: string, fileContents?: string) {
+    let absFilePath = n(`${cwd}/${relativeFilePath}`);
+    vfs[absFilePath] = fileContents || '';
+    return absFilePath;
+}
 //shorthand for normalizing a path
 let n = path.normalize;
 
@@ -73,13 +78,13 @@ describe('util', () => {
 
         it('uses cwd when not provided', async () => {
             //sanity check
-            let configFilePath = await util.getConfigFilePath();
-            expect(configFilePath).not.to.exist;
+            expect(await util.getConfigFilePath()).not.to.exist;
+
+            let actualConfigPath = addFile('testProjects/project2/bsconfig.json');
 
             let rootDir = path.join(cwd, 'testProjects', 'project2');
             process.chdir(rootDir);
-            configFilePath = await util.getConfigFilePath();
-            expect(configFilePath).to.equal(path.join(rootDir, 'bsconfig.json'));
+            expect(await util.getConfigFilePath()).to.equal(path.join(rootDir, 'bsconfig.json'));
         });
     });
 
@@ -96,6 +101,24 @@ describe('util', () => {
             expect(util.lowerDrivePath('C:/projects')).to.equal('c:/projects');
             //windows slashes
             expect(util.lowerDrivePath('C:\\projects')).to.equal(('c:\\projects'));
+        });
+    });
+
+    describe('findClosestConfigFile', () => {
+        beforeEach(() => {
+            sinon.stub(util, 'fileExists').callsFake(async (filePath) => {
+                return Object.keys(vfs).indexOf(filePath) > -1;
+            });
+        });
+
+        it('finds config up the chain', async () => {
+            let brsFilePath = addFile('src/app.brs');
+            let currentDirConfigPath = addFile('src/bsconfig.json');
+            let parentDirConfigPath = addFile('bsconfig.json');
+
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(currentDirConfigPath);
+            delete vfs[currentDirConfigPath];
+            expect(await util.findClosestConfigFile(brsFilePath)).to.equal(parentDirConfigPath);
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -689,9 +689,9 @@ export class Util {
 
             let bsPath = path.join(currentPath, 'bsconfig.json');
             let brsPath = path.join(currentPath, 'brsconfig.json');
-            if (await fsExtra.pathExists(bsPath)) {
+            if (await this.fileExists(bsPath)) {
                 return bsPath;
-            } else if (await fsExtra.pathExists(brsPath)) {
+            } else if (await this.fileExists(brsPath)) {
                 return brsPath;
             } else {
                 //walk upwards one directory

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,9 +45,7 @@ export class Util {
      * @param filePath
      */
     public fileExists(filePath: string) {
-        return new Promise((resolve, reject) => {
-            fsExtra.exists(filePath, resolve);
-        });
+        return fsExtra.pathExists(filePath);
     }
 
     /**
@@ -670,6 +668,37 @@ export class Util {
             tokens.push(currentToken);
         }
         return tokens;
+    }
+
+    /**
+     * Walks up the chain
+     * @param currentPath
+     */
+    public async findClosestConfigFile(currentPath: string) {
+        //make the path absolute
+        currentPath = path.resolve(
+            path.normalize(
+                currentPath
+            )
+        );
+
+        let previousPath: string;
+        //using ../ on the root of the drive results in the same file path, so that's how we know we reached the top
+        while (previousPath !== currentPath) {
+            previousPath = currentPath;
+
+            let bsPath = path.join(currentPath, 'bsconfig.json');
+            let brsPath = path.join(currentPath, 'brsconfig.json');
+            if (await fsExtra.pathExists(bsPath)) {
+                return bsPath;
+            } else if (await fsExtra.pathExists(brsPath)) {
+                return brsPath;
+            } else {
+                //walk upwards one directory
+                currentPath = path.resolve(path.join(currentPath, '../'));
+            }
+        }
+        //got to the root path, no config file exists
     }
 
     /**


### PR DESCRIPTION
This enhances the LanguageServer so that it supports basic file parsing and syntax checking regardless of whether you have a bsconfig.json file created or not. It will only parse "open" files, and once the files are closed their diagnostics are removed. 