### PR TITLE
Reorder lexer switch statement for perf boost.

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -119,12 +119,41 @@ export class Lexer {
      */
     private scanToken(): void {
         let c = this.advance();
+        if (isAlpha(c)) {
+            this.identifier();
+            return;
+        }
         switch (c.toLowerCase()) {
+            case '\r':
+            case '\n':
+                this.newline();
+                break;
+            case '.':
+                // this might be a float/double literal, because decimals without a leading 0
+                // are allowed
+                if (isDecimalDigit(this.peek())) {
+                    this.decimalNumber(true);
+                } else {
+                    this.addToken(TokenKind.Dot);
+                }
+                break;
             case '(':
                 this.addToken(TokenKind.LeftParen);
                 break;
             case ')':
                 this.addToken(TokenKind.RightParen);
+                break;
+            case '=':
+                this.addToken(TokenKind.Equal);
+                break;
+            case '"':
+                this.string();
+                break;
+            case `'`:
+                this.comment();
+                break;
+            case ',':
+                this.addToken(TokenKind.Comma);
                 break;
             case '{':
                 this.addToken(TokenKind.LeftCurlyBrace);
@@ -138,24 +167,12 @@ export class Lexer {
             case ']':
                 this.addToken(TokenKind.RightSquareBracket);
                 break;
-            case ',':
-                this.addToken(TokenKind.Comma);
-                break;
             case '@':
                 if (this.peek() === '.') {
                     this.advance();
                     this.addToken(TokenKind.Callfunc);
                 } else {
                     this.addToken(TokenKind.At);
-                }
-                break;
-            case '.':
-                // this might be a float/double literal, because decimals without a leading 0
-                // are allowed
-                if (isDecimalDigit(this.peek())) {
-                    this.decimalNumber(true);
-                } else {
-                    this.addToken(TokenKind.Dot);
                 }
                 break;
             case '+':
@@ -224,9 +241,6 @@ export class Lexer {
                         break;
                 }
                 break;
-            case '=':
-                this.addToken(TokenKind.Equal);
-                break;
             case ':':
                 this.addToken(TokenKind.Colon);
                 break;
@@ -286,19 +300,9 @@ export class Lexer {
                         break;
                 }
                 break;
-            case `'`:
-                this.comment();
-                break;
             case ' ':
             case '\t':
                 this.whitespace();
-                break;
-            case '\r':
-            case '\n':
-                this.newline();
-                break;
-            case '"':
-                this.string();
                 break;
             case '#':
                 this.preProcessedConditional();
@@ -309,8 +313,6 @@ export class Lexer {
                 } else if (c === '&' && this.peek().toLowerCase() === 'h') {
                     this.advance(); // move past 'h'
                     this.hexadecimalNumber();
-                } else if (isAlpha(c)) {
-                    this.identifier();
                 } else {
                     this.diagnostics.push({
                         ...DiagnosticMessages.unexpectedCharacter(c),


### PR DESCRIPTION
Certain tokens are used more than others in BrightScript. Since the lexer uses a switch statement on a per-char basis, it makes sense to optimize the lexer to look for the most common characters first. This PR optimizes the lexer based on the following test results. The test scanned every token across 20 different github projects to find the most commonly used tokens, and then sorted them by most-found to least-found. 
```
[ { kind: 'Identifier', count: 222360, percentage: 27.525 },
  { kind: 'Newline', count: 144800, percentage: 17.924 },
  { kind: 'Dot', count: 67827, percentage: 8.396 },
  { kind: 'RightParen', count: 48556, percentage: 6.011 },
  { kind: 'LeftParen', count: 48556, percentage: 6.011 },
  { kind: 'Equal', count: 41259, percentage: 5.107 },
  { kind: 'StringLiteral', count: 27127, percentage: 3.358 },
  { kind: 'Comment', count: 26715, percentage: 3.307 },
  { kind: 'Comma', count: 23926, percentage: 2.962 },
  { kind: 'IntegerLiteral', count: 18755, percentage: 2.322 },
  { kind: 'If', count: 10739, percentage: 1.329 },
  { kind: 'As', count: 8365, percentage: 1.035 },
  { kind: 'EndIf', count: 7887, percentage: 0.976 },
  { kind: 'Colon', count: 7319, percentage: 0.906 },
  { kind: 'Plus', count: 7184, percentage: 0.889 },
  { kind: 'Return', count: 6991, percentage: 0.865 },
  { kind: 'RightSquareBracket', count: 6577, percentage: 0.814 },
  { kind: 'LeftSquareBracket', count: 6577, percentage: 0.814 },
  { kind: 'Function', count: 5210, percentage: 0.645 },
  { kind: 'EndFunction', count: 5207, percentage: 0.645 },
  { kind: 'Invalid', count: 4977, percentage: 0.616 },
  { kind: 'Then', count: 4065, percentage: 0.503 },
  { kind: 'Print', count: 3665, percentage: 0.454 },
  { kind: 'True', count: 3312, percentage: 0.41 },
  { kind: 'Semicolon', count: 3155, percentage: 0.391 },
  { kind: 'Minus', count: 3025, percentage: 0.374 },
  { kind: 'False', count: 2843, percentage: 0.352 },
  { kind: 'LessGreater', count: 2765, percentage: 0.342 },
  { kind: 'Object', count: 2459, percentage: 0.304 },
  { kind: 'RightCurlyBrace', count: 2445, percentage: 0.303 },
  { kind: 'LeftCurlyBrace', count: 2445, percentage: 0.303 },
  { kind: 'ElseIf', count: 2392, percentage: 0.296 },
  { kind: 'Else', count: 2313, percentage: 0.286 },
  { kind: 'String', count: 2130, percentage: 0.264 },
  { kind: 'Sub', count: 1974, percentage: 0.244 },
  { kind: 'EndSub', count: 1974, percentage: 0.244 },
  { kind: 'And', count: 1827, percentage: 0.226 },
  { kind: 'Star', count: 1493, percentage: 0.185 },
  { kind: 'Or', count: 1183, percentage: 0.146 },
  { kind: 'Integer', count: 1181, percentage: 0.146 },
  { kind: 'Dynamic', count: 1125, percentage: 0.139 },
  { kind: 'Greater', count: 1058, percentage: 0.131 },
  { kind: 'ForEach', count: 947, percentage: 0.117 },
  { kind: 'Boolean', count: 909, percentage: 0.113 },
  { kind: 'EndFor', count: 865, percentage: 0.107 },
  { kind: 'Not', count: 836, percentage: 0.103 },
  { kind: 'While', count: 817, percentage: 0.101 },
  { kind: 'EndWhile', count: 817, percentage: 0.101 },
  { kind: 'Forwardslash', count: 795, percentage: 0.098 },
  { kind: 'Eof', count: 786, percentage: 0.097 },
  { kind: 'Less', count: 745, percentage: 0.092 },
  { kind: 'Next', count: 619, percentage: 0.077 },
  { kind: 'Void', count: 536, percentage: 0.066 },
  { kind: 'To', count: 468, percentage: 0.058 },
  { kind: 'For', count: 466, percentage: 0.058 },
  { kind: 'At', count: 359, percentage: 0.044 },
  { kind: 'GreaterEqual', count: 287, percentage: 0.036 },
  { kind: 'ExitWhile', count: 282, percentage: 0.035 },
  { kind: 'FloatLiteral', count: 265, percentage: 0.033 },
  { kind: 'Stop', count: 246, percentage: 0.03 },
  { kind: 'PlusEqual', count: 212, percentage: 0.026 },
  { kind: 'LessEqual', count: 211, percentage: 0.026 },
  { kind: 'PlusPlus', count: 124, percentage: 0.015 },
  { kind: 'Step', count: 82, percentage: 0.01 },
  { kind: 'MinusMinus', count: 60, percentage: 0.007 },
  { kind: 'Float', count: 58, percentage: 0.007 },
  { kind: 'MinusEqual', count: 56, percentage: 0.007 },
  { kind: 'Mod', count: 56, percentage: 0.007 },
  { kind: 'ExitFor', count: 47, percentage: 0.006 },
  { kind: 'Class', count: 36, percentage: 0.004 },
  { kind: 'Protected', count: 27, percentage: 0.003 },
  { kind: 'Goto', count: 22, percentage: 0.003 },
  { kind: 'Library', count: 16, percentage: 0.002 },
  { kind: 'New', count: 8, percentage: 0.001 },
  { kind: 'Dim', count: 6, percentage: 0.001 },
  { kind: 'DoubleLiteral', count: 6, percentage: 0.001 },
  { kind: 'Double', count: 5, percentage: 0.001 },
  { kind: 'LongInteger', count: 4, percentage: 0 },
  { kind: 'LeftShift', count: 4, percentage: 0 },
  { kind: 'ForwardslashEqual', count: 4, percentage: 0 },
  { kind: 'Backslash', count: 4, percentage: 0 },
  { kind: 'Caret', count: 2, percentage: 0 },
  { kind: 'StarEqual', count: 1, percentage: 0 },
  { kind: 'RightShift', count: 1, percentage: 0 } ]
```

Moving these tokens (identifier, newline, dot, rightparen, leftparen, equal, stringliteral, comment, comma) to the top of the switch improves from 40 ops/sec to 42 ops/sec. That's not huge, but probably still worth it.
However, what made the big difference was lifting the identifier check to the top. That (in addition to the prior fixes) improved from 40 ops/sec to 48 ops/sec!
Just to make those numbers look higher, I ran the same test on a 150 line file, and it increased from 1009 ops/sec to 1219 ops/sec!
So for larger files, it speeds the lexer by ~5%, but for smaller files it speeds up the lexer by ~20%.