### PR TITLE
Source literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ These are the options available in the `bsconfig.json` file.
         ```
  - **autoImportComponentScript**: `bool` - BrighterScript only: will automatically import a script at transpile-time for a component with the same name if it exists.
 
- - **sourceRoot*: `string` - Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.
+ - **sourceRoot*: `string` - Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files. This option also affects the `SOURCE_FILE_PATH` and `SOURCE_LOCATION` source literals.
 
 
 ## Ignore errors and warnings on a per-line basis

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -185,7 +185,7 @@
             ]
         },
         "sourceRoot": {
-            "description": "Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.",
+            "description": "Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files. This option also affects the `SOURCE_FILE_PATH` and `SOURCE_LOCATION` source literals.",
             "type": "string"
         }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,3 +7,4 @@ See the following pages for more information
  - [Imports](imports.md)
  - [Namespaces](namespaces.md)
  - [callfunc operator](callfunc-operator.md)
+ - [Source literals](source-literals.md)

--- a/docs/source-literals.md
+++ b/docs/source-literals.md
@@ -1,5 +1,5 @@
 # Source Literals
-BrightScript provides the `LINE_NUM` literal, which represents the runtime line number of the current line of code. In a similar fashion, BrighterScript provides several more source literals.
+BrightScript provides the `LINE_NUM` literal, which represents the runtime 1-based line number of the current line of code. In a similar fashion, BrighterScript provides several more source literals.
 
 These source literals are converted into inline variables at transpile-time, so keep in mind that any post-processing to the transpiled files could  cause these values to be incorrect.
 
@@ -13,23 +13,26 @@ print SOURCE_FILE_PATH
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+print "file:/c:\projects\roku\brighterscript\scripts\rootDir\source\main.bs"
 ```
 
 ## SOURCE_LINE_NUM
-The line number of the source file. 
+The 1-based line number of the source file. 
 
 ```BrighterScript
-print SOURCE_LINE_NUM
+'I am line 1
+print SOURCE_LINE_NUM 'I am line 2
 ```
 
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+'I am line 1
+print 2 'I am line 2
 ```
 
 ## FUNCTION_NAME
+### Basic
 The name of the current function
 ```BrighterScript
 function RunFromZombie()
@@ -40,9 +43,29 @@ end function
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+function RunFromZombie()
+    print "RunFromZombie"
+end function
 ```
 
+### Namespaced
+if the function is contained in a namespace, that name will be included in the function name
+```BrighterScript
+namespace Human.Versus.Zombie
+    function RunFromZombie()
+        print FUNCTION_NAME
+    end function
+end namespace
+```
+
+transpiles to: 
+
+```BrightScript
+function Human_Versus_Zombie_RunFromZombie()
+    print "Human_Versus_Zombie_RunFromZombie"
+end function
+```
+### Anonymous Functions
 For anonymous functions, FUNCTION_NAME will include the enclosing function name, followed by `anon` and the index of the function in its parent. If there are multiple nested anonymous functions, each level will have its own `anon[index]` in the name. Function indexes start at 0 within each enclosing function.
 
 ```BrighterScript
@@ -58,16 +81,66 @@ function main()
         useSword()
     end function
 end function
+namespace Human.Versus.Zombie
+    function Eat()
+        print SOURCE_FUNCTION_NAME
+        findFood = function()
+            print FUNCTION_NAME
+        end function
+    end function
+end namespace
 ```
 
 transpiles to: 
 
 ```BrightScript
-print FUNCTION_NAME
+function main()
+    zombieAttack = function()
+        print "main$anon0"
+    end function
+    humanAttack = function()
+        useSword = function()
+            print "main$anon1$anon0"
+        end function
+        useSword()
+    end function
+end function
+function Human_Versus_Zombie_Eat()
+    print "Human.Versus.Zombie.Eat"
+    findFood = function()
+        print "Human_Versus_Zombie_Eat$anon0"
+    end function
+end function
+```
+
+## SOURCE_FUNCTION_NAME
+This works the same as FUNCTION_NAME except that it will use a dot in namespace names instead of the transpiled underscores.
+
+
+```BrighterScript
+namespace Human.Versus.Zombie
+    function Eat()
+        print SOURCE_FUNCTION_NAME
+        findFood = function()
+            print SOURCE_FUNCTION_NAME
+        end function
+    end function
+end namespace
+```
+
+transpiles to: 
+
+```BrightScript
+function Human_Versus_Zombie_Eat()
+    print "Human.Versus.Zombie.Eat"
+    findFood = function()
+        print "Human.Versus.Zombie.Eat$anon0"
+    end function
+end function
 ```
 
 ## SOURCE_LOCATION
-A combination of SOURCE_FILE_PATH, FUNCTION_NAME, and SOURCE_LINE_NUM.
+A combination of SOURCE_FILE_PATH and SOURCE_LINE_NUM.
 
 ```BrighterScript
 function main()
@@ -78,7 +151,9 @@ end function
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+function main()
+    print "file:/c:\projects\roku\brighterscript\scripts\rootDir\source\main.bs:2"
+end function
 ```
 
 ## PKG_PATH
@@ -93,17 +168,19 @@ end function
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+function main()
+    print "pkg:/source/main.brs"
+end function
 ```
 
 ## PKG_LOCATION
-A combination of PKG_PATH, FUNCTION_NAME, and LINE_NUM. Keep in mind, LINE_NUM is a runtime variable provided by Roku. 
+A combination of PKG_PATH and LINE_NUM. Keep in mind, LINE_NUM is a runtime variable provided by Roku. 
 ```BrighterScript
-print SOURCE_FILE_PATH
+print PKG_LOCATION
 ```
 
 transpiles to: 
 
 ```BrightScript
-print SOURCE_FILE_PATH
+print "pkg:/source/main.brs:" + str(LINE_NUM)
 ```

--- a/docs/source-literals.md
+++ b/docs/source-literals.md
@@ -1,0 +1,109 @@
+# Source Literals
+BrightScript provides the `LINE_NUM` literal, which represents the runtime line number of the current line of code. In a similar fashion, BrighterScript provides several more source literals.
+
+These source literals are converted into inline variables at transpile-time, so keep in mind that any post-processing to the transpiled files could  cause these values to be incorrect.
+
+## SOURCE_FILE_PATH
+The absolute path to the source file, including a leading `file:/` scheme indicator. i.e. `"file:/C:/projects/RokuApp/source/main.bs"`.
+
+```BrighterScript
+print SOURCE_FILE_PATH
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```
+
+## SOURCE_LINE_NUM
+The line number of the source file. 
+
+```BrighterScript
+print SOURCE_LINE_NUM
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```
+
+## FUNCTION_NAME
+The name of the current function
+```BrighterScript
+function RunFromZombie()
+    print FUNCTION_NAME
+end function
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```
+
+For anonymous functions, FUNCTION_NAME will include the enclosing function name, followed by `anon` and the index of the function in its parent. If there are multiple nested anonymous functions, each level will have its own `anon[index]` in the name. Function indexes start at 0 within each enclosing function.
+
+```BrighterScript
+function main()
+    zombieAttack = function()
+        print FUNCTION_NAME
+    end function
+
+    humanAttack = function()
+        useSword = function()
+            print FUNCTION_NAME
+        end function
+        useSword()
+    end function
+end function
+```
+
+transpiles to: 
+
+```BrightScript
+print FUNCTION_NAME
+```
+
+## SOURCE_LOCATION
+A combination of SOURCE_FILE_PATH, FUNCTION_NAME, and SOURCE_LINE_NUM.
+
+```BrighterScript
+function main()
+    print SOURCE_LOCATION
+end function
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```
+
+## PKG_PATH
+The pkg path of the file.
+
+```BrighterScript
+function main()
+    print PKG_PATH
+end function
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```
+
+## PKG_LOCATION
+A combination of PKG_PATH, FUNCTION_NAME, and LINE_NUM. Keep in mind, LINE_NUM is a runtime variable provided by Roku. 
+```BrighterScript
+print SOURCE_FILE_PATH
+```
+
+transpiles to: 
+
+```BrightScript
+print SOURCE_FILE_PATH
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,6 +1796,11 @@
       "integrity": "sha512-r70c72ln2YHzQINNfxDp02hAhbGkt1HffZ+Du8oetWDLjDtFja/Lm10lUaSh9e+wD+7VDvPee0b0C9SAy8pWZg==",
       "dev": true
     },
+    "file-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
+      "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA=="
+    },
     "filing-cabinet": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "cross-platform-clear-console": "^2.3.0",
         "debounce-promise": "^3.1.0",
         "eventemitter3": "^4.0.0",
+        "file-url": "^3.0.0",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.6",
         "jsonc-parser": "^2.1.1",

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -121,7 +121,7 @@ export interface BsConfig {
      * Override the path to source files in source maps. Use this if you have a preprocess step and want
      * to ensure the source maps point to the original location.
      * This will only alter source maps for files within rootDir. Any files found outside of rootDir will not
-     * have their source maps changed.
+     * have their source maps changed. This option also affects the `SOURCE_FILE_PATH` and `SOURCE_LOCATION` source literals.
      */
     sourceRoot?: string;
 }

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -492,7 +492,7 @@ describe('BrsFile', () => {
                     print LINE_NUM
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expect(file.getDiagnostics()[0]?.message).not.to.exist;
         });
 
         it('supports many keywords as object property names', async () => {
@@ -2053,14 +2053,13 @@ export function getTestTranspile(scopeGetter: () => [Program, string]) {
         await program.validate();
         let diagnostics = file.getDiagnostics();
         if (diagnostics.length > 0 && failOnDiagnostic !== false) {
-
-            expect(
+            throw new Error(
                 diagnostics[0].range.start.line +
                 ':' +
                 diagnostics[0].range.start.character +
                 ' ' +
                 diagnostics[0]?.message
-            ).to.not.exist;
+            );
         }
         let transpiled = file.transpile();
 

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -819,4 +819,17 @@ describe('lexer', () => {
             ]);
         });
     });
+
+    it('identifies brighterscript source literals', () => {
+        let { tokens } = Lexer.scan('SOURCE_FILE_PATH SOURCE_LINE_NUM FUNCTION_NAME SOURCE_LOCATION PKG_PATH PKG_LOCATION');
+        expect(tokens.map(x => x.kind)).to.eql([
+            TokenKind.SourceFilePathLiteral,
+            TokenKind.SourceLineNumLiteral,
+            TokenKind.FunctionNameLiteral,
+            TokenKind.SourceLocationLiteral,
+            TokenKind.PkgPathLiteral,
+            TokenKind.PkgLocationLiteral,
+            TokenKind.Eof
+        ]);
+    });
 });

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -525,7 +525,7 @@ describe('lexer', () => {
                 TokenKind.Return,
                 TokenKind.True,
                 TokenKind.False,
-                TokenKind.Identifier,
+                TokenKind.LineNumLiteral,
                 TokenKind.Eof
             ]);
             expect(tokens.filter(w => !!w.literal).length).to.equal(0);
@@ -821,11 +821,13 @@ describe('lexer', () => {
     });
 
     it('identifies brighterscript source literals', () => {
-        let { tokens } = Lexer.scan('SOURCE_FILE_PATH SOURCE_LINE_NUM FUNCTION_NAME SOURCE_LOCATION PKG_PATH PKG_LOCATION');
+        let { tokens } = Lexer.scan('LINE_NUM SOURCE_FILE_PATH SOURCE_LINE_NUM FUNCTION_NAME SOURCE_FUNCTION_NAME SOURCE_LOCATION PKG_PATH PKG_LOCATION');
         expect(tokens.map(x => x.kind)).to.eql([
+            TokenKind.LineNumLiteral,
             TokenKind.SourceFilePathLiteral,
             TokenKind.SourceLineNumLiteral,
             TokenKind.FunctionNameLiteral,
+            TokenKind.SourceFunctionNameLiteral,
             TokenKind.SourceLocationLiteral,
             TokenKind.PkgPathLiteral,
             TokenKind.PkgLocationLiteral,

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -119,12 +119,41 @@ export class Lexer {
      */
     private scanToken(): void {
         let c = this.advance();
+        if (isAlpha(c)) {
+            this.identifier();
+            return;
+        }
         switch (c.toLowerCase()) {
+            case '\r':
+            case '\n':
+                this.newline();
+                break;
+            case '.':
+                // this might be a float/double literal, because decimals without a leading 0
+                // are allowed
+                if (isDecimalDigit(this.peek())) {
+                    this.decimalNumber(true);
+                } else {
+                    this.addToken(TokenKind.Dot);
+                }
+                break;
             case '(':
                 this.addToken(TokenKind.LeftParen);
                 break;
             case ')':
                 this.addToken(TokenKind.RightParen);
+                break;
+            case '=':
+                this.addToken(TokenKind.Equal);
+                break;
+            case '"':
+                this.string();
+                break;
+            case `'`:
+                this.comment();
+                break;
+            case ',':
+                this.addToken(TokenKind.Comma);
                 break;
             case '{':
                 this.addToken(TokenKind.LeftCurlyBrace);
@@ -138,24 +167,12 @@ export class Lexer {
             case ']':
                 this.addToken(TokenKind.RightSquareBracket);
                 break;
-            case ',':
-                this.addToken(TokenKind.Comma);
-                break;
             case '@':
                 if (this.peek() === '.') {
                     this.advance();
                     this.addToken(TokenKind.Callfunc);
                 } else {
                     this.addToken(TokenKind.At);
-                }
-                break;
-            case '.':
-                // this might be a float/double literal, because decimals without a leading 0
-                // are allowed
-                if (isDecimalDigit(this.peek())) {
-                    this.decimalNumber(true);
-                } else {
-                    this.addToken(TokenKind.Dot);
                 }
                 break;
             case '+':
@@ -224,9 +241,6 @@ export class Lexer {
                         break;
                 }
                 break;
-            case '=':
-                this.addToken(TokenKind.Equal);
-                break;
             case ':':
                 this.addToken(TokenKind.Colon);
                 break;
@@ -286,19 +300,9 @@ export class Lexer {
                         break;
                 }
                 break;
-            case `'`:
-                this.comment();
-                break;
             case ' ':
             case '\t':
                 this.whitespace();
-                break;
-            case '\r':
-            case '\n':
-                this.newline();
-                break;
-            case '"':
-                this.string();
                 break;
             case '#':
                 this.preProcessedConditional();
@@ -309,8 +313,6 @@ export class Lexer {
                 } else if (c === '&' && this.peek().toLowerCase() === 'h') {
                     this.advance(); // move past 'h'
                     this.hexadecimalNumber();
-                } else if (isAlpha(c)) {
-                    this.identifier();
                 } else {
                     this.diagnostics.push({
                         ...DiagnosticMessages.unexpectedCharacter(c),

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -143,9 +143,11 @@ export enum TokenKind {
     Import = 'Import',
 
     //brighterscript source literals
+    LineNumLiteral = 'LineNumLiteral',
     SourceFilePathLiteral = 'SourceFilePathLiteral',
     SourceLineNumLiteral = 'SourceLineNumLiteral',
     FunctionNameLiteral = 'FunctionNameLiteral',
+    SourceFunctionNameLiteral = 'SourceFunctionNameLiteral',
     SourceLocationLiteral = 'SourceLocationLiteral',
     PkgPathLiteral = 'PkgPathLiteral',
     PkgLocationLiteral = 'PkgLocationLiteral',
@@ -187,7 +189,6 @@ export const ReservedWords = new Set([
     'if',
     'invalid',
     'let',
-    'line_num',
     'next',
     'not',
     'objfun',
@@ -281,9 +282,11 @@ export const Keywords: { [key: string]: TokenKind } = {
     endnamespace: TokenKind.EndNamespace,
     'end namespace': TokenKind.EndNamespace,
     import: TokenKind.Import,
+    'line_num': TokenKind.LineNumLiteral,
     'source_file_path': TokenKind.SourceFilePathLiteral,
     'source_line_num': TokenKind.SourceLineNumLiteral,
     'function_name': TokenKind.FunctionNameLiteral,
+    'source_function_name': TokenKind.SourceFunctionNameLiteral,
     'source_location': TokenKind.SourceLocationLiteral,
     'pkg_path': TokenKind.PkgPathLiteral,
     'pkg_location': TokenKind.PkgLocationLiteral
@@ -394,9 +397,11 @@ export const AllowedProperties = [
     TokenKind.Namespace,
     TokenKind.EndNamespace,
     TokenKind.Import,
+    TokenKind.LineNumLiteral,
     TokenKind.SourceFilePathLiteral,
     TokenKind.SourceLineNumLiteral,
     TokenKind.FunctionNameLiteral,
+    TokenKind.SourceFunctionNameLiteral,
     TokenKind.SourceLocationLiteral,
     TokenKind.PkgPathLiteral,
     TokenKind.PkgLocationLiteral
@@ -429,6 +434,16 @@ export const AllowedLocalIdentifiers = [
     TokenKind.Namespace,
     TokenKind.EndNamespace,
     TokenKind.Import
+];
+
+export const BrighterScriptSourceLiterals = [
+    TokenKind.SourceFilePathLiteral,
+    TokenKind.SourceLineNumLiteral,
+    TokenKind.FunctionNameLiteral,
+    TokenKind.SourceFunctionNameLiteral,
+    TokenKind.SourceLocationLiteral,
+    TokenKind.PkgPathLiteral,
+    TokenKind.PkgLocationLiteral
 ];
 
 /**
@@ -477,11 +492,18 @@ export const DisallowedLocalIdentifiers = [
     TokenKind.To,
     TokenKind.True,
     TokenKind.Type,
-    TokenKind.While
+    TokenKind.While,
+    TokenKind.LineNumLiteral,
+    TokenKind.SourceFilePathLiteral,
+    TokenKind.SourceLineNumLiteral,
+    TokenKind.FunctionNameLiteral,
+    TokenKind.SourceFunctionNameLiteral,
+    TokenKind.SourceLocationLiteral,
+    TokenKind.PkgPathLiteral,
+    TokenKind.PkgLocationLiteral
 ];
 
 export const DisallowedLocalIdentifiersText = new Set([
     'run',
-    'line_num',
     ...DisallowedLocalIdentifiers.map(x => x.toLowerCase())
 ]);

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -142,6 +142,13 @@ export enum TokenKind {
     Override = 'Override',
     Import = 'Import',
 
+    //brighterscript source literals
+    SourceFilePath = 'SourceFilePath',
+    SourceLineNum = 'SourceLineNum',
+    FunctionName = 'FunctionName',
+    SourceLocation = 'SourceLocation',
+    PkgPath = 'PkgPath',
+    PkgLocation = 'PkgLocation',
 
     //comments
     Comment = 'Comment',

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -143,12 +143,12 @@ export enum TokenKind {
     Import = 'Import',
 
     //brighterscript source literals
-    SourceFilePath = 'SourceFilePath',
-    SourceLineNum = 'SourceLineNum',
-    FunctionName = 'FunctionName',
-    SourceLocation = 'SourceLocation',
-    PkgPath = 'PkgPath',
-    PkgLocation = 'PkgLocation',
+    SourceFilePathLiteral = 'SourceFilePathLiteral',
+    SourceLineNumLiteral = 'SourceLineNumLiteral',
+    FunctionNameLiteral = 'FunctionNameLiteral',
+    SourceLocationLiteral = 'SourceLocationLiteral',
+    PkgPathLiteral = 'PkgPathLiteral',
+    PkgLocationLiteral = 'PkgLocationLiteral',
 
     //comments
     Comment = 'Comment',
@@ -280,7 +280,13 @@ export const Keywords: { [key: string]: TokenKind } = {
     namespace: TokenKind.Namespace,
     endnamespace: TokenKind.EndNamespace,
     'end namespace': TokenKind.EndNamespace,
-    import: TokenKind.Import
+    import: TokenKind.Import,
+    'source_file_path': TokenKind.SourceFilePathLiteral,
+    'source_line_num': TokenKind.SourceLineNumLiteral,
+    'function_name': TokenKind.FunctionNameLiteral,
+    'source_location': TokenKind.SourceLocationLiteral,
+    'pkg_path': TokenKind.PkgPathLiteral,
+    'pkg_location': TokenKind.PkgLocationLiteral
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -387,7 +393,13 @@ export const AllowedProperties = [
     TokenKind.Override,
     TokenKind.Namespace,
     TokenKind.EndNamespace,
-    TokenKind.Import
+    TokenKind.Import,
+    TokenKind.SourceFilePathLiteral,
+    TokenKind.SourceLineNumLiteral,
+    TokenKind.FunctionNameLiteral,
+    TokenKind.SourceLocationLiteral,
+    TokenKind.PkgPathLiteral,
+    TokenKind.PkgLocationLiteral
 ];
 
 /** List of TokenKind that are allowed as local var identifiers. */

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -639,14 +639,14 @@ export class SourceLiteralExpression implements Expression {
                 text = `"file:/${state.file.pathAbsolute}:${this.token.range.start.line + 1}"`;
                 break;
             case TokenKind.PkgPathLiteral:
-                let pkgPath1 = `pkg:/${state.pkgPath}`
+                let pkgPath1 = `pkg:/${state.file.pkgPath}`
                     .replace(/\\/g, '/')
                     .replace(/\.bs$/i, '.brs');
 
                 text = `"${pkgPath1}"`;
                 break;
             case TokenKind.PkgLocationLiteral:
-                let pkgPath2 = `pkg:/${state.pkgPath}`
+                let pkgPath2 = `pkg:/${state.file.pkgPath}`
                     .replace(/\\/g, '/')
                     .replace(/\.bs$/i, '.brs');
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1,6 +1,6 @@
-import { Token, Identifier } from '../lexer';
+import { Token, Identifier, TokenKind } from '../lexer';
 import { BrsType, ValueKind, BrsString, FunctionParameter } from '../brsTypes';
-import { Block, CommentStatement } from './Statement';
+import { Block, CommentStatement, FunctionStatement } from './Statement';
 import { SourceNode } from 'source-map';
 
 import { Range } from 'vscode-languageserver';
@@ -100,6 +100,16 @@ export class FunctionExpression implements Expression {
      * declared in child functions
      */
     public callExpressions = [] as CallExpression[];
+
+    /**
+     * If this function is part of a FunctionStatement, this will be set. Otherwise this will be undefined
+     */
+    public functionStatement?: FunctionStatement;
+
+    /**
+     * A list of all child functions declared directly within this function
+     */
+    public childFunctionExpressions = [] as FunctionExpression[];
 
     /**
      * The range of the function, starting at the 'f' in function or 's' in sub (or the open paren if the keyword is missing),
@@ -558,6 +568,80 @@ export class VariableExpression implements Expression {
             );
         }
         return result;
+    }
+}
+
+export class SourceLiteralExpression implements Expression {
+    constructor(
+        readonly token: Token
+    ) {
+        this.range = token.range;
+    }
+
+    public readonly range: Range;
+
+    private getFunctionName(state: TranspileState, parseMode: ParseMode) {
+        let func = state.file.getFunctionScopeAtPosition(this.token.range.start).func;
+        let nameParts = [];
+        while (func.parentFunction) {
+            let index = func.parentFunction.childFunctionExpressions.indexOf(func);
+            nameParts.unshift(`anon${index}`);
+            func = func.parentFunction;
+        }
+        //get the index of this function in its parent
+        nameParts.unshift(
+            func.functionStatement.getName(parseMode)
+        );
+        return nameParts.join('$');
+    }
+
+    transpile(state: TranspileState) {
+        let text: string;
+        switch (this.token.kind) {
+            case TokenKind.SourceFilePathLiteral:
+                text = `"file:/${state.file.pathAbsolute}"`;
+                break;
+            case TokenKind.SourceLineNumLiteral:
+                text = `${this.token.range.start.line + 1}`;
+                break;
+            case TokenKind.FunctionNameLiteral:
+                text = `"${this.getFunctionName(state, ParseMode.BrightScript)}"`;
+                break;
+            case TokenKind.SourceFunctionNameLiteral:
+                text = `"${this.getFunctionName(state, ParseMode.BrighterScript)}"`;
+                break;
+            case TokenKind.SourceLocationLiteral:
+                text = `"file:/${state.file.pathAbsolute}:${this.token.range.start.line + 1}"`;
+                break;
+            case TokenKind.PkgPathLiteral:
+                let pkgPath1 = `pkg:/${state.pkgPath}`
+                    .replace(/\\/g, '/')
+                    .replace(/\.bs$/i, '.brs');
+
+                text = `"${pkgPath1}"`;
+                break;
+            case TokenKind.PkgLocationLiteral:
+                let pkgPath2 = `pkg:/${state.pkgPath}`
+                    .replace(/\\/g, '/')
+                    .replace(/\.bs$/i, '.brs');
+
+                text = `"${pkgPath2}:" + str(LINE_NUM)`;
+                break;
+            case TokenKind.LineNumLiteral:
+            default:
+                //use the original text (because it looks like a variable)
+                text = this.token.text;
+                break;
+
+        }
+        return [
+            new SourceNode(
+                this.range.start.line + 1,
+                this.range.start.character,
+                state.pathAbsolute,
+                text
+            )
+        ];
     }
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -2,11 +2,11 @@ import { Token, Identifier, TokenKind } from '../lexer';
 import { BrsType, ValueKind, BrsString, FunctionParameter } from '../brsTypes';
 import { Block, CommentStatement, FunctionStatement } from './Statement';
 import { SourceNode } from 'source-map';
-
 import { Range } from 'vscode-languageserver';
 import util from '../util';
 import { TranspileState } from './TranspileState';
 import { ParseMode } from './Parser';
+import * as fileUrl from 'file-url';
 
 /** A BrightScript expression */
 export interface Expression {
@@ -624,7 +624,7 @@ export class SourceLiteralExpression implements Expression {
         let text: string;
         switch (this.token.kind) {
             case TokenKind.SourceFilePathLiteral:
-                text = `"file:/${state.file.pathAbsolute}"`;
+                text = `"${fileUrl(state.pathAbsolute)}"`;
                 break;
             case TokenKind.SourceLineNumLiteral:
                 text = `${this.token.range.start.line + 1}`;
@@ -636,7 +636,7 @@ export class SourceLiteralExpression implements Expression {
                 text = `"${this.getFunctionName(state, ParseMode.BrighterScript)}"`;
                 break;
             case TokenKind.SourceLocationLiteral:
-                text = `"file:/${state.file.pathAbsolute}:${this.token.range.start.line + 1}"`;
+                text = `"${fileUrl(state.pathAbsolute)}:${this.token.range.start.line + 1}"`;
                 break;
             case TokenKind.PkgPathLiteral:
                 let pkgPath1 = `pkg:/${state.file.pkgPath}`

--- a/src/parser/tests/expression/SourceLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/SourceLiteralExpression.spec.ts
@@ -1,0 +1,178 @@
+import { getTestTranspile } from '../../../files/BrsFile.spec';
+import { Program } from '../../../Program';
+import { standardizePath as s } from '../../../util';
+
+describe('SourceLiteralExpression', () => {
+    let rootDir = process.cwd();
+    let program: Program;
+    let testTranspile = getTestTranspile(() => [program, rootDir]);
+
+    beforeEach(() => {
+        program = new Program({ rootDir: rootDir });
+    });
+    afterEach(() => {
+        program.dispose();
+    });
+
+    describe('transpile', () => {
+
+        it('allows bs source literals local vars in brs mode', async () => {
+            await testTranspile(`
+                sub main()
+                    source_file_path = true
+                    source_line_num = true
+                    function_name = true
+                    source_function_name = true
+                    source_location = true
+                    pkg_path = true
+                    pkg_location = true
+
+                    print line_num
+                    print source_file_path
+                    print source_line_num
+                    print function_name
+                    print source_function_name
+                    print source_location
+                    print pkg_path
+                    print pkg_location
+                end sub
+            `, undefined, 'none', 'main.brs');
+        });
+
+        it('computes SOURCE_FILE_PATH', async () => {
+            await testTranspile(`
+                sub main()
+                    print SOURCE_FILE_PATH
+                end sub
+            `, `
+                sub main()
+                    print "file:/${s`${rootDir}/source/main.bs`}"
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('computes SOURCE_LINE_NUM', async () => {
+            await testTranspile(`
+                sub main()
+                    print SOURCE_LINE_NUM
+                    print "hello world"
+                    print SOURCE_LINE_NUM
+                end sub
+            `, `
+                sub main()
+                    print 3
+                    print "hello world"
+                    print 5
+                end sub
+            `);
+        });
+
+        it('computes FUNCTION_NAME', async () => {
+            await testTranspile(`
+                sub main1()
+                    print FUNCTION_NAME
+                end sub
+                namespace Human.Versus.Zombie
+                    sub main2()
+                        print FUNCTION_NAME
+                    end sub
+                end namespace
+            `, `
+                sub main1()
+                    print "main1"
+                end sub
+                sub Human_Versus_Zombie_main2()
+                    print "Human_Versus_Zombie_main2"
+                end sub
+            `);
+        });
+
+        it('computes SOURCE_FUNCTION_NAME', async () => {
+            await testTranspile(`
+                sub main1()
+                    print SOURCE_FUNCTION_NAME
+                end sub
+                namespace Human.Versus.Zombie
+                    sub main2()
+                        print SOURCE_FUNCTION_NAME
+                    end sub
+                end namespace
+            `, `
+                sub main1()
+                    print "main1"
+                end sub
+                sub Human_Versus_Zombie_main2()
+                    print "Human.Versus.Zombie.main2"
+                end sub
+            `);
+        });
+
+        it('SOURCE_FUNCTION_NAME computes nested anon', async () => {
+            await testTranspile(`
+                namespace NameA
+                    sub main()
+                        speak = sub()
+                            innerSpeak = sub()
+                                print SOURCE_FUNCTION_NAME
+                                print FUNCTION_NAME
+                            end sub
+                        end sub
+                    end sub
+                end namespace
+            `, `
+                sub NameA_main()
+                    speak = sub()
+                        innerSpeak = sub()
+                            print "NameA.main$anon0$anon0"
+                            print "NameA_main$anon0$anon0"
+                        end sub
+                    end sub
+                end sub
+            `);
+        });
+
+        it('computes SOURCE_LOCATION', async () => {
+            await testTranspile(`
+                sub main()
+                    print SOURCE_LOCATION
+                end sub
+            `, `
+                sub main()
+                    print "file:/${s`${rootDir}/source/main.bs:3`}"
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('computes PKG_PATH', async () => {
+            await testTranspile(`
+                sub main()
+                    print PKG_PATH
+                end sub
+            `, `
+                sub main()
+                    print "pkg:/source/main.brs"
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('computes PKG_LOCATION', async () => {
+            await testTranspile(`
+                sub main()
+                    print PKG_LOCATION
+                end sub
+            `, `
+                sub main()
+                    print "pkg:/source/main.brs:" + str(LINE_NUM)
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('retains LINE_NUM', async () => {
+            await testTranspile(`
+                sub main()
+                    print LINE_NUM
+                end sub
+            `);
+        });
+    });
+});

--- a/src/parser/tests/expression/SourceLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/SourceLiteralExpression.spec.ts
@@ -1,9 +1,10 @@
 import { getTestTranspile } from '../../../files/BrsFile.spec';
 import { Program } from '../../../Program';
 import { standardizePath as s } from '../../../util';
+import * as fileUrl from 'file-url';
 
 describe('SourceLiteralExpression', () => {
-    let rootDir = process.cwd();
+    let rootDir = s`${process.cwd()}/rootDir`;
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 
@@ -46,7 +47,7 @@ describe('SourceLiteralExpression', () => {
                 end sub
             `, `
                 sub main()
-                    print "file:/${s`${rootDir}/source/main.bs`}"
+                    print "${fileUrl(`${rootDir}/source/main.bs`)}"
                 end sub
             `, undefined, 'source/main.bs');
         });
@@ -138,7 +139,7 @@ describe('SourceLiteralExpression', () => {
                 end sub
             `, `
                 sub main()
-                    print "file:/${s`${rootDir}/source/main.bs:3`}"
+                    print "${fileUrl(`${rootDir}/source/main.bs`)}:3"
                 end sub
             `, undefined, 'source/main.bs');
         });
@@ -173,6 +174,40 @@ describe('SourceLiteralExpression', () => {
                     print LINE_NUM
                 end sub
             `);
+        });
+
+        it('accounts for sourceRoot in SOURCE_FILE_PATH', async () => {
+            let sourceRoot = s`${process.cwd()} / sourceRoot`;
+            program = new Program({
+                rootDir: rootDir,
+                sourceRoot: sourceRoot
+            });
+            await testTranspile(`
+                sub main()
+                    print SOURCE_FILE_PATH
+                end sub
+            `, `
+                sub main()
+                    print "${fileUrl(s`${sourceRoot}/source/main.bs`)}"
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('accounts for sourceRoot in SOURCE_LOCATION', async () => {
+            let sourceRoot = s`${process.cwd()} / sourceRoot`;
+            program = new Program({
+                rootDir: rootDir,
+                sourceRoot: sourceRoot
+            });
+            await testTranspile(`
+                sub main()
+                    print SOURCE_LOCATION
+                end sub
+            `, `
+                sub main()
+                    print "${fileUrl(`${sourceRoot}/source/main.bs`)}:3"
+                end sub
+            `, undefined, 'source/main.bs');
         });
     });
 });


### PR DESCRIPTION
This PR adds several brighterscript-only source literals that get replaced at transpile-time. 
 - source_file_path
 - source_line_num
 - function_name
 - source_function_name
 - source_location
 - pkg_path
 - pkg_location

Resolves #13