### PR TITLE
Silence invalid "override" hints

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1136,11 +1136,13 @@ describe('Program', () => {
             await program.validate();
             let diagnostics = program.getDiagnostics();
 
+            //the children shouldn't have diagnostics about shadowing their parent lib.brs file.
             let shadowedDiagnositcs = diagnostics.filter((x) => x.code === DiagnosticMessages.overridesAncestorFunction('', '', '', '').code);
+            expect(shadowedDiagnositcs).to.be.lengthOf(0);
 
-            //the children should all have diagnostics about shadowing their parent lib.brs file.
-            //If not, then the parent-child attachment was severed somehow
-            expect(shadowedDiagnositcs).to.be.lengthOf(childCount);
+            //the children all include a redundant import of lib.brs file which is imported by the parent.
+            let importDiagnositcs = diagnostics.filter((x) => x.code === DiagnosticMessages.unnecessaryScriptImportInChildFromParent('').code);
+            expect(importDiagnositcs).to.be.lengthOf(childCount);
         });
 
         it('detects script import changes', async () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -625,6 +625,10 @@ export class Scope {
                     //skip the init function (because every component will have one of those){
                     if (lowerName !== 'init') {
                         let shadowedCallable = ancestorNonGlobalCallables[ancestorNonGlobalCallables.length - 1];
+                        if (!!shadowedCallable && shadowedCallable.callable.file === container.callable.file) {
+                            //same file: skip redundant imports
+                            continue;
+                        }
                         this.diagnostics.push({
                             ...DiagnosticMessages.overridesAncestorFunction(
                                 container.callable.name,


### PR DESCRIPTION
When an `import` is redundant (e.g. component and parent import the same script) the compile produces "override" hints (BS1010) pointing to the same file, which are just noise while the important information is the redundant import warning.

Fixes #113 