### PR TITLE
Source root

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ These are the options available in the `bsconfig.json` file.
         ```
  - **autoImportComponentScript**: `bool` - BrighterScript only: will automatically import a script at transpile-time for a component with the same name if it exists.
 
+ - **sourceRoot*: `string` - Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.
+
 
 ## Ignore errors and warnings on a per-line basis
 In addition to disabling an entire class of errors in `bsconfig.json` by using `ignoreErrorCodes`, you may also disable errors for a subset of the complier rules within a file with the following comment flags:

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -183,6 +183,10 @@
                 "debug",
                 "trace"
             ]
+        },
+        "sourceRoot": {
+            "description": "Override the path to source files in source maps. Use this if you have a preprocess step and want to ensure the source maps point to the original location.This will only alter source maps for files within rootDir. Any files found outside of rootDir will not have their source maps changed.",
+            "type": "string"
         }
     }
 }

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -185,7 +185,7 @@
             ]
         },
         "sourceRoot": {
-            "description": "Override the path to source files in source maps. Use this if you have a preprocess step and want to ensure the source maps point to the original location.This will only alter source maps for files within rootDir. Any files found outside of rootDir will not have their source maps changed.",
+            "description": "Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.",
             "type": "string"
         }
     }

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -117,4 +117,11 @@ export interface BsConfig {
      * @default LogLevel.log
      */
     logLevel?: LogLevel;
+    /**
+     * Override the path to source files in source maps. Use this if you have a preprocess step and want
+     * to ensure the source maps point to the original location.
+     * This will only alter source maps for files within rootDir. Any files found outside of rootDir will not
+     * have their source maps changed.
+     */
+    sourceRoot?: string;
 }

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1381,4 +1381,26 @@ describe('Program', () => {
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/bslib.brs`)).is.true;
     });
 
+    describe('transpile', () => {
+        it.only('uses sourceRoot when provided', async () => {
+            program = new Program({
+                rootDir: rootDir,
+                stagingFolderPath: stagingFolderPath,
+                sourceRoot: s`${tmpPath}/sourceRootFolder`
+            });
+            await program.addOrReplaceFile('source/main.brs', `
+                sub main()
+                end sub
+            `);
+            await program.transpile([{
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`${stagingFolderPath}/source/main.bs`
+            }], stagingFolderPath);
+
+            let contents = fsExtra.readFileSync(s`${stagingFolderPath}/source/main.brs.map`).toString();
+            let map = JSON.parse(contents);
+            expect(map).to.eql({});
+        });
+    });
+
 });

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1382,7 +1382,7 @@ describe('Program', () => {
     });
 
     describe('transpile', () => {
-        it('uses sourceRoot when provided', async () => {
+        it('uses sourceRoot when provided for brs files', async () => {
             let sourceRoot = s`${tmpPath}/sourceRootFolder`;
             program = new Program({
                 rootDir: rootDir,
@@ -1395,7 +1395,7 @@ describe('Program', () => {
             `);
             await program.transpile([{
                 src: s`${rootDir}/source/main.brs`,
-                dest: s`source/main.bs`
+                dest: s`source/main.brs`
             }], stagingFolderPath);
 
             let contents = fsExtra.readFileSync(s`${stagingFolderPath}/source/main.brs.map`).toString();
@@ -1404,6 +1404,31 @@ describe('Program', () => {
                 s`${map.sources[0]}`
             ).to.eql(
                 s`${sourceRoot}/source/main.brs`
+            );
+        });
+
+        it('uses sourceRoot when provided for bs files', async () => {
+            let sourceRoot = s`${tmpPath}/sourceRootFolder`;
+            program = new Program({
+                rootDir: rootDir,
+                stagingFolderPath: stagingFolderPath,
+                sourceRoot: sourceRoot
+            });
+            await program.addOrReplaceFile('source/main.bs', `
+                sub main()
+                end sub
+            `);
+            await program.transpile([{
+                src: s`${rootDir}/source/main.bs`,
+                dest: s`source/main.bs`
+            }], stagingFolderPath);
+
+            let contents = fsExtra.readFileSync(s`${stagingFolderPath}/source/main.brs.map`).toString();
+            let map = JSON.parse(contents);
+            expect(
+                s`${map.sources[0]}`
+            ).to.eql(
+                s`${sourceRoot}/source/main.bs`
             );
         });
     });

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1382,11 +1382,12 @@ describe('Program', () => {
     });
 
     describe('transpile', () => {
-        it.only('uses sourceRoot when provided', async () => {
+        it('uses sourceRoot when provided', async () => {
+            let sourceRoot = s`${tmpPath}/sourceRootFolder`;
             program = new Program({
                 rootDir: rootDir,
                 stagingFolderPath: stagingFolderPath,
-                sourceRoot: s`${tmpPath}/sourceRootFolder`
+                sourceRoot: sourceRoot
             });
             await program.addOrReplaceFile('source/main.brs', `
                 sub main()
@@ -1394,12 +1395,16 @@ describe('Program', () => {
             `);
             await program.transpile([{
                 src: s`${rootDir}/source/main.brs`,
-                dest: s`${stagingFolderPath}/source/main.bs`
+                dest: s`source/main.bs`
             }], stagingFolderPath);
 
             let contents = fsExtra.readFileSync(s`${stagingFolderPath}/source/main.brs.map`).toString();
             let map = JSON.parse(contents);
-            expect(map).to.eql({});
+            expect(
+                s`${map.sources[0]}`
+            ).to.eql(
+                s`${sourceRoot}/source/main.brs`
+            );
         });
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ let args = [
     { name: 'root-dir', type: String, description: 'Path to the root of your project files (where the manifest lives). Defaults to current directory.' },
     { name: 'staging-folder-path', type: String, description: 'The path where the files should be staged (right before being zipped up).' },
     { name: 'username', type: String, description: 'The username for deploying to a Roku. Defaults to "rokudev".' },
+    { name: 'source-root', type: String, description: 'Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.' },
     { name: 'watch', type: Boolean, description: 'Watch input files.' }
 ];
 const options = commandLineArgs(args, { camelCase: true });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -984,15 +984,14 @@ export class BrsFile {
      * Convert the brightscript/brighterscript source code into valid brightscript
      */
     public transpile() {
+        const state = new TranspileState(this);
         if (this.needsTranspiled) {
-            const state = new TranspileState(this);
             let programNode = new SourceNode(null, null, this.pathAbsolute, this.ast.transpile(state));
             let result = programNode.toStringWithSourceMap({
                 file: this.pathAbsolute
             });
             return result;
         } else {
-            //create a sourcemap
             //create a source map from the original source code
             let chunks = [] as (SourceNode | string)[];
             let lines = this.fileContents.split(/\r?\n/g);
@@ -1000,10 +999,10 @@ export class BrsFile {
                 let line = lines[lineIndex];
                 chunks.push(
                     lineIndex > 0 ? '\n' : '',
-                    new SourceNode(lineIndex + 1, 0, this.pathAbsolute, line)
+                    new SourceNode(lineIndex + 1, 0, state.pathAbsolute, line)
                 );
             }
-            return new SourceNode(null, null, this.pathAbsolute, chunks).toStringWithSourceMap();
+            return new SourceNode(null, null, state.pathAbsolute, chunks).toStringWithSourceMap();
         }
     }
 

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -2,7 +2,6 @@ import { SourceNode } from 'source-map';
 import { ClassStatement } from './ClassStatement';
 import { Range } from 'vscode-languageserver';
 import { BrsFile } from '../files/BrsFile';
-import { standardizePath as s } from '../util';
 
 /**
  * Holds the state of a transpile operation as it works its way through the transpile process

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -2,6 +2,7 @@ import { SourceNode } from 'source-map';
 import { ClassStatement } from './ClassStatement';
 import { Range } from 'vscode-languageserver';
 import { BrsFile } from '../files/BrsFile';
+import { standardizePath as s } from '../util';
 
 /**
  * Holds the state of a transpile operation as it works its way through the transpile process
@@ -11,23 +12,30 @@ export class TranspileState {
         file: BrsFile
     ) {
         this.file = file;
+
+        //if a sourceRoot is specified, use that instead of the rootDir
+        if (this.file.program.options.sourceRoot) {
+            this.pathAbsolute = this.file.pathAbsolute.replace(
+                this.file.program.options.rootDir,
+                this.file.program.options.sourceRoot
+            );
+        } else {
+            this.pathAbsolute = this.file.pathAbsolute;
+        }
     }
+
     /**
      * The BrsFile that is currently being transpiled
      */
-    file: BrsFile;
+    public file: BrsFile;
+
     /**
-     * the path for this file relative to the root of the output package
+     * The absolute path to the source location of this file. If sourceRoot is specified,
+     * this path will be full path to the file in sourceRoot instead of rootDir.
+     * If the file resides outside of rootDir, then no changes will be made to this path.
      */
-    get pkgPath() {
-        return this.file.pkgPath;
-    }
-    /**
-     * the absolute path to the source location of this file
-     */
-    get pathAbsolute() {
-        return this.file.pathAbsolute;
-    }
+    public pathAbsolute: string;
+
     /**
      * The number of active parent blocks for the current location of the state.
      */

--- a/src/util.ts
+++ b/src/util.ts
@@ -268,6 +268,7 @@ export class Util {
         config.diagnosticFilters = config.diagnosticFilters ?? [];
         config.autoImportComponentScript = config.autoImportComponentScript === true ? true : false;
         config.showDiagnosticsInConsole = config.showDiagnosticsInConsole === false ? false : true;
+        config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];
         }


### PR DESCRIPTION
Support for the `sourceRoot` property. This allows developers to copy their files to a staging area, and then run the BrighterScript compiler on the code, but have the source maps point to the original file location (instead of the staging location). 

Similar to the [--sourceRoot](https://www.typescriptlang.org/docs/handbook/compiler-options.html) compiler flag in typescript 