### PR TITLE
Adds begin and end template string literal tokens, so we can better format and understand the code down stream.

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -579,6 +579,11 @@ export let DiagnosticMessages = {
         message: `Unterminated template string at end of file`,
         code: 1113,
         severity: DiagnosticSeverity.Error
+    }),
+    unterminatedTemplateExpression: () => ({
+        message: `Unterminated template string expression. '\${' must be followed by expression, then '}'`,
+        code: 1114,
+        severity: DiagnosticSeverity.Error
     })
 
 };

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -447,9 +447,9 @@ describe('lexer', () => {
             let { tokens } = Lexer.scan('`"`');
             expect(tokens.map(t => t.kind)).to.deep.equal([
                 TokenKind.BackTick,
-                TokenKind.TemplateStringQuasi, //empty
-                TokenKind.EscapedCharCodeLiteral, // quote
-                TokenKind.TemplateStringQuasi, // empty
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
                 TokenKind.BackTick,
                 TokenKind.Eof
             ]);
@@ -486,12 +486,99 @@ describe('lexer', () => {
             expect(tokens.map(t => t.kind)).to.deep.equal([
                 TokenKind.BackTick,
                 TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
                 TokenKind.StringLiteral,
+                TokenKind.TemplateStringExpressionEnd,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.BackTick,
                 TokenKind.Eof
             ]);
             expect(tokens[1].literal).to.deep.equal(new BrsString(`hello `));
+        });
+        it('real example, which is causing issues in the formatter', () => {
+            let { tokens } = Lexer.scan(`    function getItemXML(item)
+            return \`<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+      <channel>
+      <title>smithsonian</title>
+      <item>
+      <title>\${item.title}</title>
+      <guid>\${item.vamsId}</guid>
+      <media:rating scheme="urn:v-chip">\${item.ratings.first.code.name}</media:rating>
+      </item>
+      </channel>
+      </rss>\`
+      end function
+      `);
+            expect(tokens.map(t => t.kind)).to.deep.equal([
+                TokenKind.Function,
+                TokenKind.Identifier,
+                TokenKind.LeftParen,
+                TokenKind.Identifier,
+                TokenKind.RightParen,
+                TokenKind.Newline,
+                TokenKind.Return,
+                TokenKind.BackTick,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.BackTick,
+                TokenKind.Newline,
+                TokenKind.EndFunction,
+                TokenKind.Newline,
+                TokenKind.Eof
+            ]);
         });
 
         it('complicated example', () => {
@@ -501,24 +588,26 @@ describe('lexer', () => {
             expect(tokens.map(t => t.kind)).to.eql([
                 TokenKind.BackTick, // `
                 TokenKind.TemplateStringQuasi, // hello
-                // ${
+                TokenKind.TemplateStringExpressionBegin, //$ {
                 TokenKind.StringLiteral, // "world"
-                // }
+                TokenKind.TemplateStringExpressionEnd, // }
                 TokenKind.TemplateStringQuasi, //!I am a
-                // ${
+                TokenKind.TemplateStringExpressionBegin, // ${
                 TokenKind.StringLiteral, // "template"
                 TokenKind.Plus, // +
                 TokenKind.StringLiteral, //"string"
-                // }
+                TokenKind.TemplateStringExpressionEnd, // }
                 TokenKind.TemplateStringQuasi, // and I am very
+                TokenKind.TemplateStringExpressionBegin, // ${
                 TokenKind.LeftSquareBracket, // [
                 TokenKind.StringLiteral, // "pleased"
                 TokenKind.RightSquareBracket, // ]
                 TokenKind.LeftSquareBracket, // [
                 TokenKind.IntegerLiteral, // 0
                 TokenKind.RightSquareBracket, // ]
-                // }
+                TokenKind.TemplateStringExpressionEnd, // }
                 TokenKind.TemplateStringQuasi, // to meet you
+                TokenKind.TemplateStringExpressionBegin, // ${
                 TokenKind.Identifier, // m
                 TokenKind.Dot, // .
                 TokenKind.Identifier, // top
@@ -526,7 +615,7 @@ describe('lexer', () => {
                 TokenKind.Identifier, //getChildCount,
                 TokenKind.LeftParen, // (
                 TokenKind.RightParen, // )
-                // }
+                TokenKind.TemplateStringExpressionEnd, // }
                 TokenKind.TemplateStringQuasi, // .The end
                 TokenKind.BackTick,
                 TokenKind.Eof
@@ -578,13 +667,14 @@ describe('lexer', () => {
 
         it('Example that tripped up the expression tests', () => {
             let { tokens } = Lexer.scan(
-                '`I am a complex example\n${a.isRunning(["a","b","c"])}\nmore ${m.finish(true)}\`'
+                '`I am a complex example\n${a.isRunning(["a","b","c"])}\nmore ${m.finish(true)}`'
             );
             expect(tokens.map(t => t.kind)).to.deep.equal([
                 TokenKind.BackTick,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
                 TokenKind.Identifier,
                 TokenKind.Dot,
                 TokenKind.Identifier,
@@ -597,15 +687,18 @@ describe('lexer', () => {
                 TokenKind.StringLiteral,
                 TokenKind.RightSquareBracket,
                 TokenKind.RightParen,
+                TokenKind.TemplateStringExpressionEnd,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
                 TokenKind.Identifier,
                 TokenKind.Dot,
                 TokenKind.Identifier,
                 TokenKind.LeftParen,
                 TokenKind.True,
                 TokenKind.RightParen,
+                TokenKind.TemplateStringExpressionEnd,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.BackTick,
                 TokenKind.Eof

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -495,21 +495,26 @@ describe('lexer', () => {
             ]);
             expect(tokens[1].literal).to.deep.equal(new BrsString(`hello `));
         });
+
         it('real example, which is causing issues in the formatter', () => {
-            let { tokens } = Lexer.scan(`    function getItemXML(item)
-            return \`<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
-      <channel>
-      <title>smithsonian</title>
-      <item>
-      <title>\${item.title}</title>
-      <guid>\${item.vamsId}</guid>
-      <media:rating scheme="urn:v-chip">\${item.ratings.first.code.name}</media:rating>
-      </item>
-      </channel>
-      </rss>\`
-      end function
-      `);
+            let { tokens } = Lexer.scan(`
+                function getItemXML(item)
+                    return \`
+                        <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                        <channel>
+                            <title>smithsonian</title>
+                            <item>
+                                <title>\${item.title}</title>
+                                <guid>\${item.vamsId}</guid>
+                                <media:rating scheme="urn:v-chip">\${item.ratings.first.code.name}</media:rating>
+                            </item>
+                        </channel>
+                        </rss>
+                    \`
+                end function
+            `);
             expect(tokens.map(t => t.kind)).to.deep.equal([
+                TokenKind.Newline,
                 TokenKind.Function,
                 TokenKind.Identifier,
                 TokenKind.LeftParen,
@@ -535,12 +540,6 @@ describe('lexer', () => {
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
-                TokenKind.TemplateStringExpressionBegin,
-                TokenKind.Identifier,
-                TokenKind.Dot,
-                TokenKind.Identifier,
-                TokenKind.TemplateStringExpressionEnd,
-                TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.TemplateStringExpressionBegin,
@@ -551,6 +550,14 @@ describe('lexer', () => {
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.Identifier,
+                TokenKind.Dot,
+                TokenKind.Identifier,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
+                TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
@@ -566,6 +573,8 @@ describe('lexer', () => {
                 TokenKind.Dot,
                 TokenKind.Identifier,
                 TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,
                 TokenKind.EscapedCharCodeLiteral,
                 TokenKind.TemplateStringQuasi,

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -563,13 +563,26 @@ export class Lexer {
                 this.templateQuasiString();
                 this.advance();
                 this.advance();
+                this.addToken(TokenKind.TemplateStringExpressionBegin);
                 while (!this.isAtEnd() && !this.check('}')) {
                     this.start = this.current;
                     this.scanToken();
                 }
-                this.start = this.current + 1;
+                if (this.check('}')) {
+                    this.current++;
+                    this.addToken(TokenKind.TemplateStringExpressionEnd);
+                } else {
+
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.unexpectedConditionalCompilationString(),
+                        range: this.rangeOf(this.source.slice(this.start, this.current))
+                    });
+                }
+
+                this.start = this.current;
+            } else {
+                this.advance();
             }
-            this.advance();
         }
 
         //get last quasi
@@ -584,7 +597,9 @@ export class Lexer {
 
     private templateQuasiString() {
         let value = this.source.slice(this.start, this.current);
-        this.addToken(TokenKind.TemplateStringQuasi, new BrsString(value));
+        if (value !== '`') { // if this is an empty string straight after an expressoin, then we'll accidentally consume the backtick
+            this.addToken(TokenKind.TemplateStringQuasi, new BrsString(value));
+        }
     }
 
     /**

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -597,7 +597,7 @@ export class Lexer {
 
     private templateQuasiString() {
         let value = this.source.slice(this.start, this.current);
-        if (value !== '`') { // if this is an empty string straight after an expressoin, then we'll accidentally consume the backtick
+        if (value !== '`') { // if this is an empty string straight after an expression, then we'll accidentally consume the backtick
             this.addToken(TokenKind.TemplateStringQuasi, new BrsString(value));
         }
     }

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -1,55 +1,64 @@
 export enum TokenKind {
     // parens (and friends)
-    LeftParen = 'LeftParen', // (
-    RightParen = 'RightParen', // )
-    LeftSquareBracket = 'LeftSquareBracket', // [
-    RightSquareBracket = 'RightSquareBracket', // ]
-    LeftCurlyBrace = 'LeftCurlyBrace', // {
-    RightCurlyBrace = 'RightCurlyBrace', // }
+    LeftParen = 'LeftParen',
+    RightParen = 'RightParen',
+    LeftSquareBracket = 'LeftSquareBracket',
+    RightSquareBracket = 'RightSquareBracket',
+    LeftCurlyBrace = 'LeftCurlyBrace',
+    RightCurlyBrace = 'RightCurlyBrace',
+
 
     // operators
-    Caret = 'Caret', // ^
-    Minus = 'Minus', // -
-    Plus = 'Plus', // +
-    Star = 'Star', // *
-    Forwardslash = 'Forwardslash', // /
-    Mod = 'Mod', // mod
-    Backslash = 'Backslash', // \
+    Caret = 'Caret',
+    Minus = 'Minus',
+    Plus = 'Plus',
+    Star = 'Star',
+    Forwardslash = 'Forwardslash',
+    Mod = 'Mod',
+    Backslash = 'Backslash',
+
 
     // postfix operators
-    PlusPlus = 'PlusPlus', // ++
-    MinusMinus = 'MinusMinus', // --
+    PlusPlus = 'PlusPlus',
+    MinusMinus = 'MinusMinus',
+
 
     // bitshift
-    LeftShift = 'LeftShift', // <<
-    RightShift = 'RightShift', // >>
+    LeftShift = 'LeftShift',
+    RightShift = 'RightShift',
+
 
     // assignment operators
-    MinusEqual = 'MinusEqual', // -=
-    PlusEqual = 'PlusEqual', // +=
-    StarEqual = 'StarEqual', // *=
-    ForwardslashEqual = 'ForwardslashEqual', // /=
-    BackslashEqual = 'BackslashEqual', // \=
-    LeftShiftEqual = 'LeftShiftEqual', // <<=
-    RightShiftEqual = 'RightShiftEqual', // >>=
+    MinusEqual = 'MinusEqual',
+    PlusEqual = 'PlusEqual',
+    StarEqual = 'StarEqual',
+    ForwardslashEqual = 'ForwardslashEqual',
+    BackslashEqual = 'BackslashEqual',
+    LeftShiftEqual = 'LeftShiftEqual',
+    RightShiftEqual = 'RightShiftEqual',
+
 
     // comparators
-    Less = 'Less', // <
-    LessEqual = 'LessEqual', // <=
-    Greater = 'Greater', // >
-    GreaterEqual = 'GreaterEqual', // >=
-    Equal = 'Equal', // =
-    LessGreater = 'LessGreater', // BrightScript uses `<>` for "not equal"
+    Less = 'Less',
+    LessEqual = 'LessEqual',
+    Greater = 'Greater',
+    GreaterEqual = 'GreaterEqual',
+    Equal = 'Equal',
+    LessGreater = 'LessGreater',
+
 
     // literals
     Identifier = 'Identifier',
     StringLiteral = 'StringLiteral',
     TemplateStringQuasi = 'TemplateStringQuasi',
+    TemplateStringExpressionBegin = 'TemplateStringExpressionBegin',
+    TemplateStringExpressionEnd = 'TemplateStringExpressionEnd',
     IntegerLiteral = 'IntegerLiteral',
     FloatLiteral = 'FloatLiteral',
     DoubleLiteral = 'DoubleLiteral',
     LongIntegerLiteral = 'LongIntegerLiteral',
-    EscapedCharCodeLiteral = 'EscapedCharCodeLiteral', //this is used to capture things like `\n`, `\r\n` in template strings
+    EscapedCharCodeLiteral = 'EscapedCharCodeLiteral',
+
 
     //types
     Void = 'Void',
@@ -65,23 +74,23 @@ export enum TokenKind {
     Dynamic = 'Dynamic',
 
     // other symbols
-    Dot = 'Dot', // .
-    Comma = 'Comma', // ,
-    Colon = 'Colon', // :
-    Semicolon = 'Semicolon', // ;
-    At = 'At', // @
-    Callfunc = 'Callfunc', // @.
+    Dot = 'Dot',
+    Comma = 'Comma',
+    Colon = 'Colon',
+    Semicolon = 'Semicolon',
+    At = 'At',
+    Callfunc = 'Callfunc',
 
-    BackTick = 'BackTick', // `
-
+    // template strings
+    BackTick = 'BackTick',
 
     // conditional compilation
-    HashIf = 'HashIf', // #if
-    HashElseIf = 'HashElseIf', // #elseif
-    HashElse = 'HashElse', // #else
-    HashEndIf = 'HashEndIf', // #endif
-    HashConst = 'HashConst', // #const
-    HashError = 'HashError', // #error
+    HashIf = 'HashIf',
+    HashElseIf = 'HashElseIf',
+    HashElse = 'HashElse',
+    HashEndIf = 'HashEndIf',
+    HashConst = 'HashConst',
+    HashError = 'HashError',
     HashErrorMessage = 'HashErrorMessage',
 
     // keywords
@@ -102,7 +111,7 @@ export enum TokenKind {
     EndWhile = 'EndWhile',
     Eval = 'Eval',
     Exit = 'Exit',
-    ExitFor = 'ExitFor', // not technically a reserved word, but definitely a tokenKind
+    ExitFor = 'ExitFor',
     ExitWhile = 'ExitWhile',
     False = 'False',
     For = 'For',
@@ -164,7 +173,7 @@ export enum TokenKind {
     // structural
     Whitespace = 'Whitespace',
     Newline = 'Newline',
-    Eof = 'Eof'
+    Eof = 'Eof',
 }
 
 /**

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -1,51 +1,45 @@
 export enum TokenKind {
     // parens (and friends)
-    LeftParen = 'LeftParen',
-    RightParen = 'RightParen',
-    LeftSquareBracket = 'LeftSquareBracket',
-    RightSquareBracket = 'RightSquareBracket',
-    LeftCurlyBrace = 'LeftCurlyBrace',
-    RightCurlyBrace = 'RightCurlyBrace',
-
+    LeftParen = 'LeftParen', // (
+    RightParen = 'RightParen', // )
+    LeftSquareBracket = 'LeftSquareBracket', // [
+    RightSquareBracket = 'RightSquareBracket', // ]
+    LeftCurlyBrace = 'LeftCurlyBrace', // {
+    RightCurlyBrace = 'RightCurlyBrace', // }
 
     // operators
-    Caret = 'Caret',
-    Minus = 'Minus',
-    Plus = 'Plus',
-    Star = 'Star',
-    Forwardslash = 'Forwardslash',
-    Mod = 'Mod',
-    Backslash = 'Backslash',
-
+    Caret = 'Caret', // ^
+    Minus = 'Minus', // -
+    Plus = 'Plus', // +
+    Star = 'Star', // *
+    Forwardslash = 'Forwardslash', // /
+    Mod = 'Mod', // mod
+    Backslash = 'Backslash', // \
 
     // postfix operators
-    PlusPlus = 'PlusPlus',
-    MinusMinus = 'MinusMinus',
-
+    PlusPlus = 'PlusPlus', // ++
+    MinusMinus = 'MinusMinus', // --
 
     // bitshift
-    LeftShift = 'LeftShift',
-    RightShift = 'RightShift',
-
+    LeftShift = 'LeftShift', // <<
+    RightShift = 'RightShift', // >>
 
     // assignment operators
-    MinusEqual = 'MinusEqual',
-    PlusEqual = 'PlusEqual',
-    StarEqual = 'StarEqual',
-    ForwardslashEqual = 'ForwardslashEqual',
-    BackslashEqual = 'BackslashEqual',
-    LeftShiftEqual = 'LeftShiftEqual',
-    RightShiftEqual = 'RightShiftEqual',
-
+    MinusEqual = 'MinusEqual', // -=
+    PlusEqual = 'PlusEqual', // +=
+    StarEqual = 'StarEqual', // *=
+    ForwardslashEqual = 'ForwardslashEqual', // /=
+    BackslashEqual = 'BackslashEqual', // \=
+    LeftShiftEqual = 'LeftShiftEqual', // <<=
+    RightShiftEqual = 'RightShiftEqual', // >>=
 
     // comparators
-    Less = 'Less',
-    LessEqual = 'LessEqual',
-    Greater = 'Greater',
-    GreaterEqual = 'GreaterEqual',
-    Equal = 'Equal',
-    LessGreater = 'LessGreater',
-
+    Less = 'Less', // <
+    LessEqual = 'LessEqual', // <=
+    Greater = 'Greater', // >
+    GreaterEqual = 'GreaterEqual', // >=
+    Equal = 'Equal', // =
+    LessGreater = 'LessGreater', // BrightScript uses `<>` for "not equal"
 
     // literals
     Identifier = 'Identifier',
@@ -57,8 +51,7 @@ export enum TokenKind {
     FloatLiteral = 'FloatLiteral',
     DoubleLiteral = 'DoubleLiteral',
     LongIntegerLiteral = 'LongIntegerLiteral',
-    EscapedCharCodeLiteral = 'EscapedCharCodeLiteral',
-
+    EscapedCharCodeLiteral = 'EscapedCharCodeLiteral', //this is used to capture things like `\n`, `\r\n` in template strings
 
     //types
     Void = 'Void',
@@ -74,23 +67,23 @@ export enum TokenKind {
     Dynamic = 'Dynamic',
 
     // other symbols
-    Dot = 'Dot',
-    Comma = 'Comma',
-    Colon = 'Colon',
-    Semicolon = 'Semicolon',
-    At = 'At',
-    Callfunc = 'Callfunc',
+    Dot = 'Dot', // .
+    Comma = 'Comma', // ,
+    Colon = 'Colon', // :
+    Semicolon = 'Semicolon', // ;
+    At = 'At', // @
+    Callfunc = 'Callfunc', // @.
 
-    // template strings
-    BackTick = 'BackTick',
+    BackTick = 'BackTick', // `
+
 
     // conditional compilation
-    HashIf = 'HashIf',
-    HashElseIf = 'HashElseIf',
-    HashElse = 'HashElse',
-    HashEndIf = 'HashEndIf',
-    HashConst = 'HashConst',
-    HashError = 'HashError',
+    HashIf = 'HashIf', // #if
+    HashElseIf = 'HashElseIf', // #elseif
+    HashElse = 'HashElse', // #else
+    HashEndIf = 'HashEndIf', // #endif
+    HashConst = 'HashConst', // #const
+    HashError = 'HashError', // #error
     HashErrorMessage = 'HashErrorMessage',
 
     // keywords
@@ -111,7 +104,7 @@ export enum TokenKind {
     EndWhile = 'EndWhile',
     Eval = 'Eval',
     Exit = 'Exit',
-    ExitFor = 'ExitFor',
+    ExitFor = 'ExitFor', // not technically a reserved word, but definitely a tokenKind
     ExitWhile = 'ExitWhile',
     False = 'False',
     For = 'For',
@@ -173,7 +166,7 @@ export enum TokenKind {
     // structural
     Whitespace = 'Whitespace',
     Newline = 'Newline',
-    Eof = 'Eof',
+    Eof = 'Eof'
 }
 
 /**

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1281,8 +1281,23 @@ export class Parser {
                 );
                 currentQuasiExpressionParts = [];
 
+                if (next.kind === TokenKind.TemplateStringExpressionBegin) {
+                    this.advance();
+                }
                 //now keep this expression
                 expressions.push(this.expression());
+                if (!this.isAtEnd() && this.check(TokenKind.TemplateStringExpressionEnd)) {
+                    //TODO is it an error if this is not present?
+                    this.advance();
+                } else {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.unterminatedTemplateExpression(),
+                        range: util.getRange(openingBacktick, this.peek())
+                    });
+                    throw this.lastDiagnosticAsError();
+
+                }
+
             }
         }
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1295,9 +1295,7 @@ export class Parser {
                         range: util.getRange(openingBacktick, this.peek())
                     });
                     throw this.lastDiagnosticAsError();
-
                 }
-
             }
         }
 


### PR DESCRIPTION
Added this so I can fix the formatter; it's more correct, as well, as we discussed.