### PR TITLE
Support optional `project` and `extends` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,36 @@ The `files` property from the inheriting config file overwrite those from the ba
 
 All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
+### Optional `extends` and `project`
+There are situations where you want to store some compiler settings in a config file, but not fail if that config file doesn't exist. To do this, you can denote that your `extends` or `project` path is optional by prefixing it with a question mark (`?`). For example:
+
+ - **bsconfig.json** `extends`
+    ```json
+    {
+      "extends": "?path/to/optional/bsconfig.json"
+    }
+    ```
+ - CLI "extends"
+    ```
+    bsc --extends "?path/to/optional/bsconfig.json"
+    ```
+ 
+ - CLI `project` argument
+    ```
+    bsc --project "?path/to/optional/bsconfig.json"
+    ```
+ - Node.js API `extends`
+    ```
+    var programBuilder = new ProgramBuilder({
+        "extends": "?path/to/optional/bsconfig.json"
+    });
+    ```
+ - Node.js API `project`
+    ```
+    var programBuilder = new ProgramBuilder({
+        "project": "?path/to/optional/bsconfig.json"
+    });
+    ```
 
 ### bsconfig.json options
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ There are situations where you want to store some compiler settings in a config 
 
 These are the options available in the `bsconfig.json` file. 
 
- - **project**: `string` - A path to a project file. This is really only passed in from the command line, and should not be present in `bsconfig.json` files
+ - **project**: `string` - A path to a project file. This is really only passed in from the command line or the NodeJS API, and should not be present in `bsconfig.json` files. Prefix with a question mark (?) to prevent throwing an exception when the file does not exist.
 
- - **extends**: `string` - Relative or absolute path to another `bsconfig.json` file that this `bsconfig.json` file should import and then override
+ - **extends**: `string` - Relative or absolute path to another `bsconfig.json` file that this `bsconfig.json` file should import and then override. Prefix with a question mark (?) to prevent throwing an exception when the file does not exist.
 
  - **cwd**: `string` - Override the current working directory
 

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -10,7 +10,7 @@
     },
     "properties": {
         "extends": {
-            "description": "Relative or absolute path to another bsconfig.json file that this file should use as a base, and then override",
+            "description": "Relative or absolute path to another bsconfig.json file that this file should use as a base and then override. Prefix with a question mark (?) to prevent throwing an exception if the file does not exist.",
             "type": "string"
         },
         "cwd": {

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -7,12 +7,14 @@ export interface BsConfig {
     _ancestors?: string[];
 
     /**
-     * A path to a project file. This is really only passed in from the command line, and should not be present in bsconfig.json files
+     * A path to a project file. This is really only passed in from the command line, and should not be present in bsconfig.json files.
+     * Prefix with a question mark (?) to prevent throwing an exception if the file does not exist.
      */
     project?: string;
 
     /**
-     * Relative or absolute path to another bsconfig.json file that this file should import and then override
+     * Relative or absolute path to another bsconfig.json file that this file should import and then override.
+     * Prefix with a question mark (?) to prevent throwing an exception if the file does not exist.
      */
     extends?: string;
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -142,6 +142,39 @@ describe('util', () => {
 
     });
 
+    describe('normalizeAndResolveConfig', () => {
+        it('throws for missing project file', async () => {
+            await expectThrowAsync(async () => {
+                await util.normalizeAndResolveConfig({ project: 'path/does/not/exist/bsconfig.json' });
+            });
+        });
+
+        it('does not throw for optional missing', async () => {
+            await expectNotThrowAsync(async () => {
+                await util.normalizeAndResolveConfig({ project: '?path/does/not/exist/bsconfig.json' });
+
+            });
+        });
+
+        it('throws for missing extends file', async () => {
+            vfs[rootConfigPath] = `{"extends": "path/does/not/exist/bsconfig.json"}`;
+            await expectThrowAsync(async () => {
+                await util.normalizeAndResolveConfig({
+                    project: rootConfigPath
+                });
+            });
+        });
+
+        it('throws for missing extends file', async () => {
+            vfs[rootConfigPath] = `{"extends": "?path/does/not/exist/bsconfig.json"}`;
+            await expectNotThrowAsync(async () => {
+                await util.normalizeAndResolveConfig({
+                    project: rootConfigPath
+                });
+            });
+        });
+    });
+
     describe('normalizeConfig', () => {
         it('loads project from disc', async () => {
             vfs[rootConfigPath] = `{"outFile": "customOutDir/pkg.zip"}`;
@@ -455,3 +488,23 @@ describe('util', () => {
         });
     });
 });
+
+async function expectThrowAsync(callback) {
+    let ex;
+    try {
+        await Promise.resolve(callback());
+    } catch (e) {
+        ex = e;
+    }
+    expect(ex, 'Expected to throw error').to.exist;
+}
+
+async function expectNotThrowAsync(callback) {
+    let ex;
+    try {
+        await Promise.resolve(callback());
+    } catch (e) {
+        ex = e;
+    }
+    expect(ex, 'Expected not to throw error').not.to.exist;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -170,7 +170,6 @@ export class Util {
             process.chdir(path.dirname(configFilePath));
 
             let result: BsConfig;
-            debugger;
             //if the project has a base file, load it
             if (projectConfig && typeof projectConfig.extends === 'string') {
                 let baseProjectConfig = await this.loadConfigFile(projectConfig.extends, [...parentProjectPaths, configFilePath]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -133,6 +133,15 @@ export class Util {
         let cwd = process.cwd();
 
         if (configFilePath) {
+
+            //if the config file path starts with question mark, then it's optional. return undefined if it doesn't exist
+            if (configFilePath.startsWith('?')) {
+                //remove leading question mark
+                configFilePath = configFilePath.substring(1);
+                if (await fsExtra.pathExists(configFilePath) === false) {
+                    return undefined;
+                }
+            }
             //keep track of the inheritance chain
             parentProjectPaths = parentProjectPaths ? parentProjectPaths : [];
             configFilePath = path.resolve(configFilePath);
@@ -161,6 +170,7 @@ export class Util {
             process.chdir(path.dirname(configFilePath));
 
             let result: BsConfig;
+            debugger;
             //if the project has a base file, load it
             if (projectConfig && typeof projectConfig.extends === 'string') {
                 let baseProjectConfig = await this.loadConfigFile(projectConfig.extends, [...parentProjectPaths, configFilePath]);


### PR DESCRIPTION
Adds ability to specify that a config path (via `extends` or `project`) is optional, so the parser should not fail if the file is not found.
Fixes #171