### PR TITLE
Fix typo for deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - ability to filter out diagnostics by using the `diagnosticFilters` option in bsconfig
 ### Changed
- - depricated the `ignoreErrorCodes` in favor of `diagnosticFilters`
+ - deprecated the `ignoreErrorCodes` in favor of `diagnosticFilters`
 ### Fixed
  - Bug in the language server that wasn't reloading the project when changing the `bsconfig.json`
 
@@ -439,7 +439,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - bsconfig.json validation
  - slightly smarter intellisense that knows when you're trying to complete an object property.
- - diagnostic for depricated brsconfig.json
+ - diagnostic for deprecated brsconfig.json
  - basic transpile support including sourcemaps. Most lines also support transpiling including comments, but there may still be bugs
  - parser now includes all comments as tokens in the AST.
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -109,8 +109,8 @@ export let DiagnosticMessages = {
         code: 1019,
         severity: DiagnosticSeverity.Error
     }),
-    brsConfigJsonIsDepricated: () => ({
-        message: `'brsconfig.json' is depricated. Please rename to 'bsconfig.json'`,
+    brsConfigJsonIsDeprecated: () => ({
+        message: `'brsconfig.json' is deprecated. Please rename to 'bsconfig.json'`,
         code: 1020,
         severity: DiagnosticSeverity.Warning
     }),

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -328,7 +328,7 @@ export class LanguageServer {
             return configFilePath;
         }
 
-        //look for the depricated `brsconfig.json` file
+        //look for the deprecated `brsconfig.json` file
         configFilePath = path.resolve(workspacePath, 'brsconfig.json');
         if (await util.fileExists(configFilePath)) {
             return configFilePath;
@@ -399,10 +399,10 @@ export class LanguageServer {
             newWorkspace.isFirstRunComplete = true;
             newWorkspace.isFirstRunSuccessful = false;
         }).then(() => {
-            //if we found a depricated brsconfig.json, add a diagnostic warning the user
+            //if we found a deprecated brsconfig.json, add a diagnostic warning the user
             if (configFilePath && path.basename(configFilePath) === 'brsconfig.json') {
                 builder.addDiagnostic(configFilePath, {
-                    ...DiagnosticMessages.brsConfigJsonIsDepricated(),
+                    ...DiagnosticMessages.brsConfigJsonIsDeprecated(),
                     range: Range.create(0, 0, 0, 0)
                 });
                 return this.sendDiagnostics();

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -250,7 +250,7 @@ let runtimeFunctions = [{
     shortDescription: `Eval can be used to run a code snippet in the context of the current function. It performs a compile, and then the bytecode execution.\nIf a compilation error occurs, no bytecode execution is performed, and Eval returns an roList with one or more compile errors. Each list entry is an roAssociativeArray with ERRNO and ERRSTR keys describing the error.\nIf compilation succeeds, bytecode execution is performed and the integer runtime error code is returned. These are the same error codes as returned by GetLastRunRuntimeError().\nEval() can be usefully in two cases. The first is when you need to dynamically generate code at runtime.\nThe other is if you need to execute a statement that could result in a runtime error, but you don't want code execution to stop. '`,
     type: new FunctionType(new DynamicType()),
     file: globalFile,
-    isDepricated: true,
+    isDeprecated: true,
     params: [{
         name: 'code',
         type: new StringType()

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,7 +37,7 @@ export interface Callable {
      * The range of the name of this callable
      */
     nameRange?: Range;
-    isDepricated?: boolean;
+    isDeprecated?: boolean;
     getName: (parseMode: ParseMode) => string;
     /**
      * Indicates whether or not this callable has an associated namespace


### PR DESCRIPTION
We incorrectly use the word "depricate" several places when it should be with an `e` "deprecate". This PR fixes that issue.