### PR TITLE
Upgrade BS1104 and BS1105 to DiagnosticSeverity.Error

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -536,14 +536,14 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Warning
     }),
     localVarShadowedByScopedFunction: () => ({
-        message: `Local var has same name as scoped function and will not be accessible`,
+        message: `Local variable will not be accessible because it has the same name as scoped function`,
         code: 1104,
-        severity: DiagnosticSeverity.Warning
+        severity: DiagnosticSeverity.Error
     }),
     scopeFunctionShadowedByBuiltInFunction: () => ({
-        message: `Scope function has same name as built-in function and will not be accessible`,
+        message: `Scope function will not be accessible because it has the same name as built-in function`,
         code: 1105,
-        severity: DiagnosticSeverity.Warning
+        severity: DiagnosticSeverity.Error
     }),
     brighterscriptScriptTagMissingTypeAttribute: () => ({
         message: `All BrighterScript script tags must include the type="text/brighterscript" attribute`,

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -536,12 +536,12 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Warning
     }),
     localVarShadowedByScopedFunction: () => ({
-        message: `Local variable will not be accessible because it has the same name as scoped function`,
+        message: `Local variable will not be accessible because it has the same name as a scoped function`,
         code: 1104,
         severity: DiagnosticSeverity.Error
     }),
     scopeFunctionShadowedByBuiltInFunction: () => ({
-        message: `Scope function will not be accessible because it has the same name as built-in function`,
+        message: `Scope function will not be accessible because it has the same name as a built-in function`,
         code: 1105,
         severity: DiagnosticSeverity.Error
     }),


### PR DESCRIPTION
BS1104 and BS1105 are fairly critical issues and should be marked as errors instead of warnings.

Also, the wording is a bit off, so this fixes that.