### PR TITLE
Detect and flag duplicate component names.

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -584,6 +584,11 @@ export let DiagnosticMessages = {
         message: `Unterminated template string expression. '\${' must be followed by expression, then '}'`,
         code: 1114,
         severity: DiagnosticSeverity.Error
+    }),
+    duplicateComponentName: (componentName: string) => ({
+        message: `There are multiple components with the name '${componentName}'`,
+        code: 1115,
+        severity: DiagnosticSeverity.Error
     })
 
 };

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -195,7 +195,7 @@ describe('Program', () => {
             `);
             await program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, `
                 <?xml version="1.0" encoding="utf-8" ?>
-                <component name="Component1" extends="Scene" extends="Scene">
+                <component name="Component1" extends="Scene">
                 </component>
             `);
             await program.validate();

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import * as pick from 'object.pick';
 import * as sinonImport from 'sinon';
-import { CompletionItemKind, Position, Range, DiagnosticSeverity } from 'vscode-languageserver';
+import { CompletionItemKind, Position, Range, DiagnosticSeverity, Location } from 'vscode-languageserver';
 import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
@@ -9,6 +9,7 @@ import { XmlFile } from './files/XmlFile';
 import { BsDiagnostic } from './interfaces';
 import { Program } from './Program';
 import { standardizePath as s, util } from './util';
+import { URI } from 'vscode-uri';
 
 let testProjectsPath = s`${__dirname}/../testProjects`;
 
@@ -185,6 +186,46 @@ describe('Program', () => {
     });
 
     describe('validate', () => {
+        it('catches duplicate XML component names', async () => {
+            //add 2 components which both reference the same errored file
+            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Component1" extends="Scene">
+                </component>
+            `);
+            await program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Component1" extends="Scene" extends="Scene">
+                </component>
+            `);
+            await program.validate();
+            expect(program.getDiagnostics()).to.be.lengthOf(2);
+            expect(program.getDiagnostics().map(x => {
+                delete x.file;
+                return x;
+            })).to.eql([{
+                ...DiagnosticMessages.duplicateComponentName('Component1'),
+                range: Range.create(2, 33, 2, 43),
+                relatedInformation: [{
+                    location: Location.create(
+                        URI.file(s`${rootDir}/components/component1.xml`).toString(),
+                        Range.create(2, 33, 2, 43)
+                    ),
+                    message: 'Also defined here'
+                }]
+            }, {
+                ...DiagnosticMessages.duplicateComponentName('Component1'),
+                range: Range.create(2, 33, 2, 43),
+                relatedInformation: [{
+                    location: Location.create(
+                        URI.file(s`${rootDir}/components/component2.xml`).toString(),
+                        Range.create(2, 33, 2, 43)
+                    ),
+                    message: 'Also defined here'
+                }]
+            }]);
+        });
+
         it('does not produce duplicate parse errors for different component scopes', async () => {
             //add a file with a parse error
             await program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
@@ -630,7 +671,7 @@ describe('Program', () => {
                     end sub
                 end namespace
                 sub main()
-                    
+
                 end sub
             `);
             let completions = (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 23))).map(x => x.label);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'eventemitter3';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import { StandardizedFileEntry } from 'roku-deploy';
-import { CompletionItem, Location, Position, Range, CompletionItemKind, DiagnosticRelatedInformation } from 'vscode-languageserver';
+import { CompletionItem, Location, Position, Range, CompletionItemKind } from 'vscode-languageserver';
 import { BsConfig } from './BsConfig';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -491,7 +491,7 @@ export class Program {
         }, {} as { [lowerComponentName: string]: XmlFile[] });
 
         for (let componentName in componentsByName) {
-            let xmlFiles = componentsByName[componentName];
+            const xmlFiles = componentsByName[componentName];
             //add diagnostics for every duplicate component with this name
             if (xmlFiles.length > 1) {
                 for (let xmlFile of xmlFiles) {

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -184,8 +184,8 @@ export class XmlFile {
                             Position.create(lineIndex, idx),
                             Position.create(lineIndex, idx + 10)
                         );
-                        //calculate the rane of the component's name (if it exists)
-                        let match = /(.*?name\s*=\s*(?:'|"))(.*?)('|")/.exec(this.lines[lineIndex]);
+                        //calculate the range of the component's name (if it exists)
+                        const match = /(.*?name\s*=\s*(?:'|"))(.*?)('|")/.exec(this.lines[lineIndex]);
                         if (match) {
                             this.componentNameRange = Range.create(
                                 lineIndex,

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -41,6 +41,14 @@ export class XmlFile {
      */
     private unsubscribeFromDependencyGraph: () => void;
 
+    /**
+     * The range of the component's name value
+     */
+    public componentNameRange: Range;
+
+    /**
+     * The range of the component's parent name (if exist
+     */
     public parentNameRange: Range;
 
     /**
@@ -176,6 +184,16 @@ export class XmlFile {
                             Position.create(lineIndex, idx),
                             Position.create(lineIndex, idx + 10)
                         );
+                        //calculate the rane of the component's name (if it exists)
+                        let match = /(.*?name\s*=\s*(?:'|"))(.*?)('|")/.exec(this.lines[lineIndex]);
+                        if (match) {
+                            this.componentNameRange = Range.create(
+                                lineIndex,
+                                match[1].length,
+                                lineIndex,
+                                match[1].length + match[2].length
+                            );
+                        }
                         break;
                     }
                 }
@@ -192,6 +210,7 @@ export class XmlFile {
                         file: this
                     });
                 }
+
                 //parent component name not defined
                 if (!this.parentComponentName) {
                     this.diagnostics.push({


### PR DESCRIPTION
Detect when there are multiple components with the same name, and flag each occurrence as an error.

Resolves #185 