### PR TITLE
Various performance tweaks

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -14,7 +14,6 @@ import {
     InitializeParams,
     Location,
     ProposedFeatures,
-    Range,
     ServerCapabilities,
     TextDocumentPositionParams,
     TextDocuments,
@@ -403,7 +402,7 @@ export class LanguageServer {
             if (configFilePath && path.basename(configFilePath) === 'brsconfig.json') {
                 builder.addDiagnostic(configFilePath, {
                     ...DiagnosticMessages.brsConfigJsonIsDeprecated(),
-                    range: Range.create(0, 0, 0, 0)
+                    range: util.createRange(0, 0, 0, 0)
                 });
                 return this.sendDiagnostics();
             }
@@ -527,7 +526,7 @@ export class LanguageServer {
         //     label: 'bronley',
         //     textEdit: {
         //         newText: 'bronley2',
-        //         range: Range.create(position, position)
+        //         range: util.createRange(position, position)
         //     }
         // }] as CompletionItem[];
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
-import { CompletionItem, Location, Position, Range, CompletionItemKind } from 'vscode-languageserver';
+import { CompletionItem, Location, Position, CompletionItemKind } from 'vscode-languageserver';
 import { BsConfig } from './BsConfig';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
@@ -516,7 +516,7 @@ export class Program {
                     this.diagnostics.push({
                         ...DiagnosticMessages.fileNotReferencedByAnyOtherFile(),
                         file: file,
-                        range: Range.create(0, 0, 0, Number.MAX_VALUE)
+                        range: util.createRange(0, 0, 0, Number.MAX_VALUE)
                     });
                 }
             }

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -649,7 +649,7 @@ export class Scope {
 
                     this.diagnostics.push({
                         ...DiagnosticMessages.duplicateFunctionImplementation(callable.name, callableContainer.scope.name),
-                        range: Range.create(
+                        range: util.createRange(
                             callable.nameRange.start.line,
                             callable.nameRange.start.character,
                             callable.nameRange.start.line,

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -1,5 +1,4 @@
-import { Location, Position, Range } from 'vscode-languageserver';
-
+import { Location, Position } from 'vscode-languageserver';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
@@ -110,7 +109,7 @@ export class XmlScope extends Scope {
             util.rangeContains(file.parentNameRange, position)
         ) {
             results.push({
-                range: Range.create(0, 0, 0, 0),
+                range: util.createRange(0, 0, 0, 0),
                 uri: util.pathToUri(file.parentComponent.pathAbsolute)
             });
         }

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -1,11 +1,12 @@
-import { Range, Position } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver';
 import { Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
 import { LiteralExpression, Expression, CallExpression, NamespacedVariableNameExpression, DottedGetExpression, VariableExpression } from '../parser/Expression';
 import { BrsType, BrsString, BrsInvalid, Int32, Float } from '../brsTypes';
+import util from '../util';
 
 export function createRange(pos: Position) {
-    return Range.create(pos.line, pos.character, pos.line, pos.character);
+    return util.createRange(pos.line, pos.character, pos.line, pos.character);
 }
 
 export function createToken<T extends TokenKind>(kind: T, pos: Position, text?: string, literal?: BrsType): Token & { kind: T } {

--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -6,6 +6,7 @@ import { Identifier, Token } from '../lexer';
 import { SourceNode } from 'source-map';
 import { Range } from 'vscode-languageserver';
 import { TranspileState } from '../parser/TranspileState';
+import util from '../util';
 
 /** An argument to a BrightScript `function` or `sub`. */
 export interface Argument {
@@ -55,7 +56,7 @@ export class StdlibArgument implements Argument {
     }
 
     /** A fake location exists only within the BRS runtime. */
-    static InternalRange = Range.create(-1, -1, -1, -1);
+    static InternalRange = util.createRange(-1, -1, -1, -1);
 }
 
 export class FunctionParameter {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -197,7 +197,7 @@ export class BrsFile {
             this.parser = new Parser();
             this.diagnostics.push({
                 file: this,
-                range: Range.create(0, 0, 0, Number.MAX_VALUE),
+                range: util.createRange(0, 0, 0, Number.MAX_VALUE),
                 ...DiagnosticMessages.genericParserMessage('Critical error parsing file: ' + JSON.stringify(serializeError(e)))
             });
         }
@@ -366,9 +366,9 @@ export class BrsFile {
 
             let affectedRange: Range;
             if (tokenized.disableType === 'line') {
-                affectedRange = Range.create(token.range.start.line, 0, token.range.start.line, token.range.start.character);
+                affectedRange = util.createRange(token.range.start.line, 0, token.range.start.line, token.range.start.character);
             } else if (tokenized.disableType === 'next-line') {
-                affectedRange = Range.create(token.range.start.line + 1, 0, token.range.start.line + 1, Number.MAX_SAFE_INTEGER);
+                affectedRange = util.createRange(token.range.start.line + 1, 0, token.range.start.line + 1, Number.MAX_SAFE_INTEGER);
             }
 
             let commentFlag: CommentFlag;
@@ -656,11 +656,11 @@ export class BrsFile {
                     }
                 }
                 let functionCall: FunctionCall = {
-                    range: Range.create(expression.range.start, expression.closingParen.range.end),
+                    range: util.createRangeFromPositions(expression.range.start, expression.closingParen.range.end),
                     functionScope: this.getFunctionScopeAtPosition(Position.create(callee.range.start.line, callee.range.start.character)),
                     file: this,
                     name: functionName,
-                    nameRange: Range.create(callee.range.start.line, columnIndexBegin, callee.range.start.line, columnIndexEnd),
+                    nameRange: util.createRange(callee.range.start.line, columnIndexBegin, callee.range.start.line, columnIndexEnd),
                     //TODO keep track of parameters
                     args: args
                 };

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -210,7 +210,7 @@ export class XmlFile {
         this.parentNameRange = this.findExtendsPosition(fileContents);
 
         //create a range of the entire file
-        this.fileRange = Range.create(0, 0, this.lines.length, this.lines[this.lines.length - 1].length - 1);
+        this.fileRange = util.createRange(0, 0, this.lines.length, this.lines[this.lines.length - 1].length - 1);
 
         this.parsedXml = {};
         try {
@@ -230,14 +230,16 @@ export class XmlFile {
                 for (let lineIndex = 0; lineIndex < this.lines.length; lineIndex++) {
                     let idx = this.lines[lineIndex].indexOf('<component');
                     if (idx > -1) {
-                        componentRange = Range.create(
-                            Position.create(lineIndex, idx),
-                            Position.create(lineIndex, idx + 10)
+                        componentRange = util.createRange(
+                            lineIndex,
+                            idx,
+                            lineIndex,
+                            idx + 10
                         );
                         //calculate the range of the component's name (if it exists)
                         const match = /(.*?name\s*=\s*(?:'|"))(.*?)('|")/.exec(this.lines[lineIndex]);
                         if (match) {
-                            this.componentNameRange = Range.create(
+                            this.componentNameRange = util.createRange(
                                 lineIndex,
                                 match[1].length,
                                 lineIndex,
@@ -251,7 +253,7 @@ export class XmlFile {
                 if (!this.componentName) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.xmlComponentMissingNameAttribute(),
-                        range: Range.create(
+                        range: util.createRange(
                             componentRange.start.line,
                             componentRange.start.character,
                             componentRange.start.line,
@@ -265,7 +267,7 @@ export class XmlFile {
                 if (!this.parentComponentName) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.xmlComponentMissingExtendsAttribute(),
-                        range: Range.create(
+                        range: util.createRange(
                             componentRange.start.line,
                             componentRange.start.character,
                             componentRange.start.line,
@@ -278,7 +280,7 @@ export class XmlFile {
                 //the component xml element was not found in the file
                 this.diagnostics.push({
                     ...DiagnosticMessages.xmlComponentMissingComponentDeclaration(),
-                    range: Range.create(
+                    range: util.createRange(
                         0,
                         0,
                         0,
@@ -295,7 +297,7 @@ export class XmlFile {
                 //add basic xml parse diagnostic errors
                 this.diagnostics.push({
                     ...DiagnosticMessages.xmlGenericParseError(match[1]),
-                    range: Range.create(
+                    range: util.createRange(
                         lineIndex,
                         columnIndex,
                         lineIndex,
@@ -343,7 +345,7 @@ export class XmlFile {
                     let endColumnIndex = startColumnIndex + uri.length;
 
                     uriRanges[uri].push(
-                        Range.create(
+                        util.createRange(
                             lineIndex,
                             startColumnIndex,
                             lineIndex,
@@ -361,7 +363,7 @@ export class XmlFile {
                             ...DiagnosticMessages.brighterscriptScriptTagMissingTypeAttribute(),
                             file: this,
                             //just flag the whole line; we'll get better location tracking when we have a formal xml parser
-                            range: Range.create(lineIndex, 0, lineIndex, line.length - 1)
+                            range: util.createRange(lineIndex, 0, lineIndex, line.length - 1)
                         });
                     }
                     lineIndexOffset += match[0].length;
@@ -520,7 +522,7 @@ export class XmlFile {
                 if (extendsIdx > -1) {
                     let colStartIndex = extendsIdx + extendsToFirstQuote.length;
                     let colEndIndex = colStartIndex + componentName.length;
-                    return Range.create(lineIndex, colStartIndex, lineIndex, colEndIndex);
+                    return util.createRange(lineIndex, colStartIndex, lineIndex, colEndIndex);
                 }
             }
         }

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -1,5 +1,3 @@
-import { Range } from 'vscode-languageserver';
-
 import { BrsFile } from './files/BrsFile';
 import { Callable } from './interfaces';
 import { ArrayType } from './types/ArrayType';
@@ -13,6 +11,7 @@ import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';
 import { VoidType } from './types/VoidType';
 import { Parser } from './parser';
+import util from './util';
 
 export let globalFile = new BrsFile('global', 'global', null);
 globalFile.parser = new Parser();
@@ -728,7 +727,7 @@ let programStatementFunctions = [
 export let globalCallables = [...mathFunctions, ...runtimeFunctions, ...globalUtilityFunctions, ...globalStringFunctions, ...programStatementFunctions];
 for (let callable of globalCallables) {
     //give each callable a dummy location
-    callable.nameRange = Range.create(0, 0, 0, callable.name.length);
+    callable.nameRange = util.createRange(0, 0, 0, callable.name.length);
 
     //add each parameter to the type
     for (let param of callable.params) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -331,7 +331,7 @@ export class Lexer {
                 } else {
                     this.diagnostics.push({
                         ...DiagnosticMessages.unexpectedCharacter(c),
-                        range: this.rangeOf(c)
+                        range: this.rangeOf()
                     });
                 }
                 break;
@@ -442,7 +442,7 @@ export class Lexer {
                 // BrightScript doesn't support multi-line strings
                 this.diagnostics.push({
                     ...DiagnosticMessages.unterminatedStringAtEndOfLine(),
-                    range: this.rangeOf(this.source.slice(this.start, this.current))
+                    range: this.rangeOf()
                 });
                 isUnterminated = true;
                 break;
@@ -455,7 +455,7 @@ export class Lexer {
             // terminating a string with EOF is also not allowed
             this.diagnostics.push({
                 ...DiagnosticMessages.unterminatedStringAtEndOfFile(),
-                range: this.rangeOf(this.source.slice(this.start, this.current))
+                range: this.rangeOf()
             });
             isUnterminated = true;
         }
@@ -582,7 +582,7 @@ export class Lexer {
 
                     this.diagnostics.push({
                         ...DiagnosticMessages.unexpectedConditionalCompilationString(),
-                        range: this.rangeOf(this.source.slice(this.start, this.current))
+                        range: this.rangeOf()
                     });
                 }
 
@@ -734,7 +734,7 @@ export class Lexer {
             this.advance(); // consume the "."
             this.diagnostics.push({
                 ...DiagnosticMessages.fractionalHexLiteralsAreNotSupported(),
-                range: this.rangeOf(this.source.slice(this.start, this.current))
+                range: this.rangeOf()
             });
             return;
         }
@@ -929,7 +929,7 @@ export class Lexer {
             default:
                 this.diagnostics.push({
                     ...DiagnosticMessages.unexpectedConditionalCompilationString(),
-                    range: this.rangeOf(this.source.slice(this.start, this.current))
+                    range: this.rangeOf()
                 });
         }
     }
@@ -946,7 +946,7 @@ export class Lexer {
             text: text,
             isReserved: ReservedWords.has(text.toLowerCase()),
             literal: literal,
-            range: this.rangeOf(text)
+            range: this.rangeOf()
         };
         this.tokens.push(token);
         this.sync();
@@ -967,7 +967,7 @@ export class Lexer {
      * @param text the text to create a range for
      * @returns the range of `text` as a `TokenLocation`
      */
-    private rangeOf(text: string): Range {
+    private rangeOf(): Range {
         return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
     }
 }

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -98,9 +98,17 @@ export class Lexer {
             kind: TokenKind.Eof,
             isReserved: false,
             text: '',
-            range: Range.create(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
+            range: {
+                start: {
+                    line: this.lineBegin,
+                    character: this.columnBegin
+                },
+                end: {
+                    line: this.lineEnd,
+                    character: this.columnEnd + 1
+                }
+            } as Range
         });
-
         return this;
     }
 
@@ -961,12 +969,16 @@ export class Lexer {
      * @returns the range of `text` as a `TokenLocation`
      */
     private rangeOf(text: string): Range {
-        return Range.create(
-            this.lineBegin,
-            this.columnBegin,
-            this.lineEnd,
-            this.columnEnd
-        );
+        return {
+            start: {
+                line: this.lineBegin,
+                character: this.columnBegin
+            },
+            end: {
+                line: this.lineEnd,
+                character: this.columnEnd
+            }
+        };
     }
 }
 

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -5,6 +5,7 @@ import { isAlpha, isDecimalDigit, isAlphaNumeric, isHexDigit } from './Character
 import { BrsType, BrsString, Int32, Int64, Float, Double } from '../brsTypes/index';
 import { Range, Diagnostic } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
+import util from '../util';
 
 export class Lexer {
     /**
@@ -98,16 +99,7 @@ export class Lexer {
             kind: TokenKind.Eof,
             isReserved: false,
             text: '',
-            range: {
-                start: {
-                    line: this.lineBegin,
-                    character: this.columnBegin
-                },
-                end: {
-                    line: this.lineEnd,
-                    character: this.columnEnd + 1
-                }
-            } as Range
+            range: util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
         });
         return this;
     }
@@ -969,16 +961,7 @@ export class Lexer {
      * @returns the range of `text` as a `TokenLocation`
      */
     private rangeOf(text: string): Range {
-        return {
-            start: {
-                line: this.lineBegin,
-                character: this.columnBegin
-            },
-            end: {
-                line: this.lineEnd,
-                character: this.columnEnd
-            }
-        };
+        return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
     }
 }
 

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -129,7 +129,8 @@ export class Lexer {
      * Accepts and returns nothing, because it's side-effect driven.
      */
     private scanToken(): void {
-        let c = this.advance();
+        this.advance();
+        let c = this.previous();
         if (isAlpha(c)) {
             this.identifier();
             return;
@@ -379,9 +380,15 @@ export class Lexer {
      * Reads and returns the next character from `string` while **moving the current position forward**.
      * @returns the new "current" character.
      */
-    private advance(): string {
+    private advance(): void {
         this.current++;
         this.columnEnd++;
+    }
+
+    /**
+     * Get the token at the previous position
+     */
+    private previous() {
         return this.source.charAt(this.current - 1);
     }
 

--- a/src/parser/ClassStatement.ts
+++ b/src/parser/ClassStatement.ts
@@ -33,7 +33,7 @@ export class ClassStatement implements Statement {
             }
         }
 
-        this.range = Range.create(this.classKeyword.range.start, this.end.range.end);
+        this.range = util.createRangeFromPositions(this.classKeyword.range.start, this.end.range.end);
     }
 
     public getName(parseMode: ParseMode) {
@@ -336,7 +336,7 @@ export class ClassMethodStatement implements Statement {
         readonly func: FunctionExpression,
         readonly overrides: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             (this.accessModifier ?? this.func).range.start,
             this.func.range.end
         );
@@ -457,7 +457,7 @@ export class ClassMethodStatement implements Statement {
                         new LiteralExpression(
                             BrsInvalid.Instance,
                             //set the range to the end of the name so locations don't get broken
-                            Range.create(field.name.range.end, field.name.range.end)
+                            util.createRangeFromPositions(field.name.range.end, field.name.range.end)
                         ),
                         this.func
                     )
@@ -478,7 +478,7 @@ export class ClassFieldStatement implements Statement {
         readonly equal?: Token,
         readonly initialValue?: Expression
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             (this.accessModifier ?? this.name).range.start,
             (this.initialValue ?? this.type ?? this.as ?? this.name).range.end
         );

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -26,7 +26,7 @@ export class BinaryExpression implements Expression {
         readonly operator: Token,
         readonly right: Expression
     ) {
-        this.range = Range.create(this.left.range.start, this.right.range.end);
+        this.range = util.createRangeFromPositions(this.left.range.start, this.right.range.end);
     }
 
     public readonly range: Range;
@@ -60,7 +60,7 @@ export class CallExpression implements Expression {
         readonly args: Expression[],
         readonly namespaceName: NamespacedVariableNameExpression
     ) {
-        this.range = Range.create(this.callee.range.start, this.closingParen.range.end);
+        this.range = util.createRangeFromPositions(this.callee.range.start, this.closingParen.range.end);
     }
 
     public readonly range: Range;
@@ -136,7 +136,7 @@ export class FunctionExpression implements Expression {
      * and ending with the last n' in 'end function' or 'b' in 'end sub'
      */
     public get range() {
-        return Range.create(
+        return util.createRangeFromPositions(
             (this.functionType ?? this.leftParen).range.start,
             (this.end ?? this.body ?? this.returnTypeToken ?? this.asToken ?? this.rightParen).range.end
         );
@@ -264,7 +264,7 @@ export class DottedGetExpression implements Expression {
         readonly name: Identifier,
         readonly dot: Token
     ) {
-        this.range = Range.create(this.obj.range.start, this.name.range.end);
+        this.range = util.createRangeFromPositions(this.obj.range.start, this.name.range.end);
     }
 
     public readonly range: Range;
@@ -296,7 +296,7 @@ export class XmlAttributeGetExpression implements Expression {
         readonly name: Identifier,
         readonly at: Token
     ) {
-        this.range = Range.create(this.obj.range.start, this.name.range.end);
+        this.range = util.createRangeFromPositions(this.obj.range.start, this.name.range.end);
     }
 
     public readonly range: Range;
@@ -324,7 +324,7 @@ export class IndexedGetExpression implements Expression {
         readonly openingSquare: Token,
         readonly closingSquare: Token
     ) {
-        this.range = Range.create(this.obj.range.start, this.closingSquare.range.end);
+        this.range = util.createRangeFromPositions(this.obj.range.start, this.closingSquare.range.end);
     }
 
     public readonly range: Range;
@@ -355,7 +355,7 @@ export class GroupingExpression implements Expression {
         },
         readonly expression: Expression
     ) {
-        this.range = Range.create(this.tokens.left.range.start, this.tokens.right.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.left.range.start, this.tokens.right.range.end);
     }
 
     public readonly range: Range;
@@ -381,7 +381,7 @@ export class LiteralExpression implements Expression {
         readonly value: BrsType,
         range: Range
     ) {
-        this.range = range ?? Range.create(-1, -1, -1, -1);
+        this.range = range ?? util.createRange(-1, -1, -1, -1);
     }
 
     public readonly range: Range;
@@ -448,7 +448,7 @@ export class ArrayLiteralExpression implements Expression {
         readonly open: Token,
         readonly close: Token
     ) {
-        this.range = Range.create(this.open.range.start, this.close.range.end);
+        this.range = util.createRangeFromPositions(this.open.range.start, this.close.range.end);
     }
 
     public readonly range: Range;
@@ -534,7 +534,7 @@ export class AALiteralExpression implements Expression {
         readonly open: Token,
         readonly close: Token
     ) {
-        this.range = Range.create(this.open.range.start, this.close.range.end);
+        this.range = util.createRangeFromPositions(this.open.range.start, this.close.range.end);
     }
 
     public readonly range: Range;
@@ -639,7 +639,7 @@ export class UnaryExpression implements Expression {
         readonly operator: Token,
         readonly right: Expression
     ) {
-        this.range = Range.create(this.operator.range.start, this.right.range.end);
+        this.range = util.createRangeFromPositions(this.operator.range.start, this.right.range.end);
     }
 
     public readonly range: Range;
@@ -795,7 +795,7 @@ export class NewExpression implements Expression {
         readonly newKeyword: Token,
         readonly call: CallExpression
     ) {
-        this.range = Range.create(this.newKeyword.range.start, this.call.range.end);
+        this.range = util.createRangeFromPositions(this.newKeyword.range.start, this.call.range.end);
     }
 
     /**
@@ -834,7 +834,7 @@ export class CallfuncExpression implements Expression {
         readonly args: Expression[],
         readonly closingParen: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             callee.range.start,
             (closingParen ?? args[args.length - 1] ?? openingParen ?? methodName ?? operator).range.end
         );
@@ -894,7 +894,7 @@ export class TemplateStringQuasiExpression implements Expression {
     constructor(
         readonly expressions: Array<LiteralExpression | EscapedCharCodeLiteral>
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.expressions[0].range.start,
             this.expressions[this.expressions.length - 1].range.end
         );
@@ -937,7 +937,7 @@ export class TemplateStringExpression implements Expression {
         readonly expressions: Expression[],
         readonly closingBacktick: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             quasis[0].range.start,
             quasis[quasis.length - 1].range.end
         );
@@ -1028,7 +1028,7 @@ export class TaggedTemplateStringExpression implements Expression {
         readonly expressions: Expression[],
         readonly closingBacktick: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             quasis[0].range.start,
             quasis[quasis.length - 1].range.end
         );

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -33,7 +33,7 @@ export class Body implements Statement {
     }
 
     public get range() {
-        return Range.create(
+        return util.createRangeFromPositions(
             this.statements[0]?.range.start ?? Position.create(0, 0),
             this.statements[this.statements.length - 1]?.range.end ?? Position.create(0, 0)
         );
@@ -80,7 +80,7 @@ export class AssignmentStatement implements Statement {
         readonly value: Expression,
         readonly containingFunction: FunctionExpression
     ) {
-        this.range = Range.create(this.name.range.start, this.value.range.end);
+        this.range = util.createRangeFromPositions(this.name.range.start, this.value.range.end);
     }
 
     public readonly range: Range;
@@ -106,7 +106,7 @@ export class Block implements Statement {
         readonly statements: Statement[],
         readonly startingRange: Range
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.startingRange.start,
             this.statements.length
                 ? this.statements[this.statements.length - 1].range.end
@@ -168,7 +168,7 @@ export class CommentStatement implements Statement, Expression {
     constructor(
         public comments: Token[]
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.comments[0].range.start,
             this.comments[this.comments.length - 1].range.end
         );
@@ -297,7 +297,7 @@ export class IfStatement implements Statement {
         readonly elseIfs: ElseIf[],
         readonly elseBranch?: Block
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.tokens.if.range.start,
             (this.tokens.endIf ?? this.elseBranch ?? this.elseIfs?.[this.elseIfs?.length - 1]?.thenBranch ?? this.thenBranch).range.end
         );
@@ -398,7 +398,7 @@ export class IncrementStatement implements Statement {
         readonly value: Expression,
         readonly operator: Token
     ) {
-        this.range = Range.create(this.value.range.start, this.operator.range.end);
+        this.range = util.createRangeFromPositions(this.value.range.start, this.operator.range.end);
     }
 
     public readonly range: Range;
@@ -437,7 +437,7 @@ export class PrintStatement implements Statement {
         },
         readonly expressions: Array<Expression | PrintSeparatorTab | PrintSeparatorSpace>
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.tokens.print.range.start,
             this.expressions.length
                 ? this.expressions[this.expressions.length - 1].range.end
@@ -475,7 +475,7 @@ export class GotoStatement implements Statement {
             label: Token;
         }
     ) {
-        this.range = Range.create(this.tokens.goto.range.start, this.tokens.label.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.goto.range.start, this.tokens.label.range.end);
     }
 
     public readonly range: Range;
@@ -496,7 +496,7 @@ export class LabelStatement implements Statement {
             colon: Token;
         }
     ) {
-        this.range = Range.create(this.tokens.identifier.range.start, this.tokens.colon.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.identifier.range.start, this.tokens.colon.range.end);
     }
 
     public readonly range: Range;
@@ -517,7 +517,7 @@ export class ReturnStatement implements Statement {
         },
         readonly value?: Expression
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.tokens.return.range.start,
             (this.value && this.value.range.end) || this.tokens.return.range.end
         );
@@ -544,7 +544,7 @@ export class EndStatement implements Statement {
             end: Token;
         }
     ) {
-        this.range = Range.create(this.tokens.end.range.start, this.tokens.end.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.end.range.start, this.tokens.end.range.end);
     }
 
     public readonly range: Range;
@@ -562,7 +562,7 @@ export class StopStatement implements Statement {
             stop: Token;
         }
     ) {
-        this.range = Range.create(this.tokens.stop.range.start, this.tokens.stop.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.stop.range.start, this.tokens.stop.range.end);
     }
 
     public readonly range: Range;
@@ -587,7 +587,7 @@ export class ForStatement implements Statement {
         readonly increment: Expression,
         readonly body: Block
     ) {
-        this.range = Range.create(this.tokens.for.range.start, this.tokens.endFor.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.for.range.start, this.tokens.endFor.range.end);
     }
 
     public readonly range: Range;
@@ -648,7 +648,7 @@ export class ForEachStatement implements Statement {
         readonly target: Expression,
         readonly body: Block
     ) {
-        this.range = Range.create(this.tokens.forEach.range.start, this.tokens.endFor.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.forEach.range.start, this.tokens.endFor.range.end);
     }
 
     public readonly range: Range;
@@ -697,7 +697,7 @@ export class WhileStatement implements Statement {
         readonly condition: Expression,
         readonly body: Block
     ) {
-        this.range = Range.create(this.tokens.while.range.start, this.tokens.endWhile.range.end);
+        this.range = util.createRangeFromPositions(this.tokens.while.range.start, this.tokens.endWhile.range.end);
     }
 
     public readonly range: Range;
@@ -737,7 +737,7 @@ export class DottedSetStatement implements Statement {
         readonly name: Identifier,
         readonly value: Expression
     ) {
-        this.range = Range.create(this.obj.range.start, this.value.range.end);
+        this.range = util.createRangeFromPositions(this.obj.range.start, this.value.range.end);
     }
 
     public readonly range: Range;
@@ -769,7 +769,7 @@ export class IndexedSetStatement implements Statement {
         readonly openingSquare: Token,
         readonly closingSquare: Token
     ) {
-        this.range = Range.create(this.obj.range.start, this.value.range.end);
+        this.range = util.createRangeFromPositions(this.obj.range.start, this.value.range.end);
     }
 
     public readonly range: Range;
@@ -804,7 +804,7 @@ export class LibraryStatement implements Statement {
             filePath: Token | undefined;
         }
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.tokens.library.range.start,
             this.tokens.filePath ? this.tokens.filePath.range.end : this.tokens.library.range.end
         );
@@ -845,7 +845,7 @@ export class NamespaceStatement implements Statement {
     public name: string;
 
     public get range() {
-        return Range.create(
+        return util.createRangeFromPositions(
             this.keyword.range.start,
             (this.endKeyword ?? this.body ?? this.nameExpression ?? this.keyword).range.end
         );
@@ -866,7 +866,7 @@ export class ImportStatement implements Statement {
         readonly importToken: Token,
         readonly filePathToken: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             importToken.range.start,
             (filePathToken ?? importToken).range.end
         );
@@ -874,7 +874,7 @@ export class ImportStatement implements Statement {
             //remove quotes
             this.filePath = this.filePathToken.text.replace(/"/g, '');
             //adjust the range to exclude the quotes
-            this.filePathToken.range = Range.create(
+            this.filePathToken.range = util.createRange(
                 this.filePathToken.range.start.line,
                 this.filePathToken.range.start.character + 1,
                 this.filePathToken.range.end.line,

--- a/src/preprocessor/Chunk.ts
+++ b/src/preprocessor/Chunk.ts
@@ -1,5 +1,6 @@
 import { Token } from '../lexer';
 import { Range } from 'vscode-languageserver';
+import util from '../util';
 
 /**
  * A set of operations that must be implemented to properly handle conditional compilation chunks.
@@ -92,7 +93,7 @@ export class ErrorChunk implements Chunk {
         readonly hashError: Token,
         readonly message: Token
     ) {
-        this.range = Range.create(
+        this.range = util.createRangeFromPositions(
             this.hashError.range.start,
             (this.message ?? this.hashError).range.end
         );

--- a/src/util.ts
+++ b/src/util.ts
@@ -121,7 +121,7 @@ export class Util {
                 colIndex++;
             }
         }
-        return Range.create(lineIndex, colIndex, lineIndex, colIndex + length);
+        return util.createRange(lineIndex, colIndex, lineIndex, colIndex + length);
     }
 
     /**
@@ -747,7 +747,7 @@ export class Util {
         for (let item of items) {
             codes.push({
                 code: item.text,
-                range: Range.create(
+                range: util.createRange(
                     token.range.start.line,
                     token.range.start.character + offset + item.startIndex,
                     token.range.start.line,
@@ -879,7 +879,7 @@ export class Util {
      * Get a location object back by extracting location information from other objects that contain location
      */
     public getRange(startObj: { range: Range }, endObj: { range: Range }): Range {
-        return Range.create(startObj.range.start, endObj.range.end);
+        return util.createRangeFromPositions(startObj.range.start, endObj.range.end);
     }
 
     /**
@@ -952,9 +952,9 @@ export class Util {
     }
 
     /**
-     * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower
+     * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `util.createRange()` is significantly slower
      */
-    public createRange(startLine, startCharacter, endLine, endCharacter): Range {
+    public createRange(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         return {
             start: {
                 line: startLine,
@@ -964,6 +964,26 @@ export class Util {
                 line: endLine,
                 character: endCharacter
             }
+        };
+    }
+
+    /**
+     * Create a `Range` from two `Position`s
+     */
+    public createRangeFromPositions(startPosition: Position, endPosition: Position): Range {
+        return {
+            start: startPosition,
+            end: endPosition
+        };
+    }
+
+    /**
+     * Create a `Position` object. Prefer this over `Position.create` for performance reasons
+     */
+    public createPosition(line: number, character: number) {
+        return {
+            line: line,
+            character: character
         };
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -950,6 +950,22 @@ export class Util {
             return className;
         }
     }
+
+    /**
+     * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower
+     */
+    public createRange(startLine, startCharacter, endLine, endCharacter): Range {
+        return {
+            start: {
+                line: startLine,
+                character: startCharacter
+            },
+            end: {
+                line: endLine,
+                character: endCharacter
+            }
+        };
+    }
 }
 
 /**


### PR DESCRIPTION
`vscode-languageserver`'s `Range.create()` seems to be significantly slower than creating the ranges manually. 
![image](https://user-images.githubusercontent.com/2544493/94374228-be441180-00d8-11eb-8c38-da1c4e7b42a0.png)

So, by switching the Lexer to use our own `createRange` function, we can improve its performance. With this change, scanning a 400 line file went from 746 ops/sec to 931 ops/sec
![image](https://user-images.githubusercontent.com/2544493/94374490-95248080-00da-11eb-8a6f-ad0c837100d0.png)

All benchmarks were performed against a 400 line brighterscript file. 

**Notable Changes:**

1. eliminate `Range.create()` in favor of `util.createRange()` and `util.createRangeFromPositions()`. 
    - ~25% increase in `Lexer` performance
    - ~12% increase in `Parser` performance
2. In `Lexer.ts`, don't return previous character in the `advance()` method.
    - ~3% increase in `Lexer` performance
3. In `Lexer.ts`, replace switch statement with a static map.
    - ~27% increase in `Lexer` performance


Overall, this has improved the performance of the the `Lexer+Parser` cycle by ~16% (from 300 ops/sec to 350 ops/sec) for my 400 line test file.