### PR TITLE
Pass cwd instead of using process.chdir

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -130,22 +130,19 @@ export class Util {
      * @param configFilePath
      * @param parentProjectPaths
      */
-    public async loadConfigFile(configFilePath: string, parentProjectPaths?: string[]) {
-        let cwd = process.cwd();
-
+    public async loadConfigFile(configFilePath: string, parentProjectPaths?: string[], cwd = process.cwd()) {
         if (configFilePath) {
-
             //if the config file path starts with question mark, then it's optional. return undefined if it doesn't exist
             if (configFilePath.startsWith('?')) {
                 //remove leading question mark
                 configFilePath = configFilePath.substring(1);
-                if (await fsExtra.pathExists(configFilePath) === false) {
+                if (await fsExtra.pathExists(path.resolve(cwd, configFilePath)) === false) {
                     return undefined;
                 }
             }
             //keep track of the inheritance chain
             parentProjectPaths = parentProjectPaths ? parentProjectPaths : [];
-            configFilePath = path.resolve(configFilePath);
+            configFilePath = path.resolve(cwd, configFilePath);
             if (parentProjectPaths?.includes(configFilePath)) {
                 parentProjectPaths.push(configFilePath);
                 parentProjectPaths.reverse();
@@ -168,13 +165,12 @@ export class Util {
             }
             this.resolvePluginPaths(projectConfig, configFilePath);
 
-            //set working directory to the location of the project file
-            process.chdir(path.dirname(configFilePath));
+            let projectFileCwd = path.dirname(configFilePath);
 
             let result: BsConfig;
             //if the project has a base file, load it
             if (projectConfig && typeof projectConfig.extends === 'string') {
-                let baseProjectConfig = await this.loadConfigFile(projectConfig.extends, [...parentProjectPaths, configFilePath]);
+                let baseProjectConfig = await this.loadConfigFile(projectConfig.extends, [...parentProjectPaths, configFilePath], projectFileCwd);
                 //extend the base config with the current project settings
                 result = { ...baseProjectConfig, ...projectConfig };
             } else {
@@ -186,17 +182,15 @@ export class Util {
 
             //make any paths in the config absolute (relative to the CURRENT config file)
             if (result.outFile) {
-                result.outFile = path.resolve(result.outFile);
+                result.outFile = path.resolve(projectFileCwd, result.outFile);
             }
             if (result.rootDir) {
-                result.rootDir = path.resolve(result.rootDir);
+                result.rootDir = path.resolve(projectFileCwd, result.rootDir);
             }
             if (result.cwd) {
-                result.cwd = path.resolve(result.cwd);
+                result.cwd = path.resolve(projectFileCwd, result.cwd);
             }
 
-            //restore working directory
-            process.chdir(cwd);
             return result;
         }
     }
@@ -270,7 +264,7 @@ export class Util {
             result.project = config.project;
         }
         if (result.project) {
-            let configFile = await this.loadConfigFile(result.project);
+            let configFile = await this.loadConfigFile(result.project, null, config?.cwd);
             result = Object.assign(result, configFile);
         }
 


### PR DESCRIPTION
Currently, util.loadConfigFile uses `process.chdir`, which can run the risk of permanently changing `process.cwd` if the function fails. 

This PR addresses that concern by passing `cwd` in (and defaulting to `process.cwd()`), and utilizing that `cwd` parameter to resolve paths.