### PR TITLE
bugfix: don't crash if component is missing name

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -534,7 +534,8 @@ export class Program {
     private detectDuplicateComponentNames() {
         const componentsByName = Object.keys(this.files).reduce((map, filePath) => {
             const file = this.files[filePath];
-            if (file instanceof XmlFile) {
+            //if this is an XmlFile, and it has a valid `componentName` property
+            if (file instanceof XmlFile && file.componentName) {
                 let lowerName = file.componentName.toLowerCase();
                 if (!map[lowerName]) {
                     map[lowerName] = [];


### PR DESCRIPTION
If the xml parse fails, we don't get a component name, which caused issues downstream and ultimately resulted in an annoying popup in the vscode interface. This should fix some of those issues.