### PR TITLE
Track leading whitespace on tokens.

### DIFF
--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -15,7 +15,8 @@ export function createToken<T extends TokenKind>(kind: T, pos: Position, text?: 
         text: text || kind.toString(),
         isReserved: !text || text === kind.toString(),
         range: createRange(pos),
-        literal: literal
+        literal: literal,
+        leadingWhitespace: ''
     };
 }
 

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -220,7 +220,8 @@ describe('reflection', () => {
                 text: '0',
                 range: range,
                 isReserved: false,
-                charCode: 0
+                charCode: 0,
+                leadingWhitespace: ''
             };
             nsVar = new NamespacedVariableNameExpression(createIdentifier('a', pos));
             binary = new BinaryExpression(expr, token, expr);

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -7,6 +7,7 @@ import { Lexer } from './Lexer';
 import { isToken } from './Token';
 import { rangeToArray } from '../parser/Parser.spec';
 import { Range } from 'vscode-languageserver';
+import util from '../util';
 
 describe('lexer', () => {
     it('recognizes namespace keywords', () => {
@@ -1171,5 +1172,17 @@ describe('lexer', () => {
             TokenKind.PkgLocationLiteral,
             TokenKind.Eof
         ]);
+    });
+
+    it('properly tracks leadingWhitespace', () => {
+        const text = `
+            sub main()
+
+                print "main"\r\n\n
+
+            end sub
+        `;
+        const { tokens } = Lexer.scan(text, { includeWhitespace: false });
+        expect(util.tokensToString(tokens)).to.equal(text);
     });
 });

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -16,6 +16,10 @@ export interface Token {
     literal?: BrsType;
     /** Where the token was found. */
     range: Range;
+    /**
+     * Any leading whitespace found prior to this token. Excludes newline characters.
+     */
+    leadingWhitespace: string;
 }
 
 /**

--- a/src/parser/ClassStatement.ts
+++ b/src/parser/ClassStatement.ts
@@ -405,7 +405,8 @@ export class ClassMethodStatement implements Statement {
                             kind: TokenKind.Identifier,
                             text: 'super',
                             isReserved: false,
-                            range: state.classStatement.name.range
+                            range: state.classStatement.name.range,
+                            leadingWhitespace: ''
                         },
                         null
                     ),
@@ -413,13 +414,15 @@ export class ClassMethodStatement implements Statement {
                         kind: TokenKind.LeftParen,
                         text: '(',
                         isReserved: false,
-                        range: state.classStatement.name.range
+                        range: state.classStatement.name.range,
+                        leadingWhitespace: ''
                     },
                     {
                         kind: TokenKind.RightParen,
                         text: ')',
                         isReserved: false,
-                        range: state.classStatement.name.range
+                        range: state.classStatement.name.range,
+                        leadingWhitespace: ''
                     },
                     [],
                     null
@@ -451,7 +454,8 @@ export class ClassMethodStatement implements Statement {
                             kind: TokenKind.Equal,
                             isReserved: false,
                             range: field.name.range,
-                            text: '='
+                            text: '=',
+                            leadingWhitespace: ''
                         },
                         thisQualifiedName,
                         new LiteralExpression(

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -549,7 +549,8 @@ export class Parser {
                     range: {
                         start: this.peek().range.start,
                         end: this.peek().range.start
-                    }
+                    },
+                    leadingWhitespace: ''
                 };
             }
             let isSub = functionType && functionType.kind === TokenKind.Sub;

--- a/src/parser/tests/Parser.spec.ts
+++ b/src/parser/tests/Parser.spec.ts
@@ -16,7 +16,8 @@ export function token(kind, text?, literal?): Token {
         text: text,
         isReserved: ReservedWords.has((text || '').toLowerCase()),
         literal: literal,
-        range: Range.create(-9, -9, -9, -9)
+        range: Range.create(-9, -9, -9, -9),
+        leadingWhitespace: ''
     };
 }
 

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -68,20 +68,23 @@ describe('parser print statements', () => {
                 kind: TokenKind.Print,
                 text: 'print',
                 isReserved: true,
-                range: Range.create(0, 0, 1, 5)
+                range: Range.create(0, 0, 1, 5),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.StringLiteral,
                 text: `"foo"`,
                 literal: new BrsString('foo'),
                 isReserved: false,
-                range: Range.create(0, 6, 0, 11)
+                range: Range.create(0, 6, 0, 11),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
                 isReserved: false,
-                range: Range.create(0, 11, 0, 12)
+                range: Range.create(0, 11, 0, 12),
+                leadingWhitespace: ''
             }
         ]);
 

--- a/src/parser/tests/statement/Set.spec.ts
+++ b/src/parser/tests/statement/Set.spec.ts
@@ -132,82 +132,95 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Identifier,
                 text: 'arr',
                 isReserved: false,
-                range: Range.create(0, 0, 0, 3)
+                range: Range.create(0, 0, 0, 3),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.LeftSquareBracket,
                 text: '[',
                 isReserved: false,
-                range: Range.create(0, 3, 0, 4)
+                range: Range.create(0, 3, 0, 4),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '0',
                 literal: new Int32(0),
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                range: Range.create(0, 4, 0, 5),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.RightSquareBracket,
                 text: ']',
                 isReserved: false,
-                range: Range.create(0, 5, 0, 6)
+                range: Range.create(0, 5, 0, 6),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
                 isReserved: false,
-                range: Range.create(0, 7, 0, 8)
+                range: Range.create(0, 7, 0, 8),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '1',
                 literal: new Int32(1),
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10)
+                range: Range.create(0, 9, 0, 10),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
                 isReserved: false,
-                range: Range.create(0, 10, 0, 11)
+                range: Range.create(0, 10, 0, 11),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'obj',
                 isReserved: false,
-                range: Range.create(1, 0, 1, 3)
+                range: Range.create(1, 0, 1, 3),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Dot,
                 text: '.',
                 isReserved: false,
-                range: Range.create(1, 3, 1, 4)
+                range: Range.create(1, 3, 1, 4),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
                 isReserved: false,
-                range: Range.create(1, 4, 1, 5)
+                range: Range.create(1, 4, 1, 5),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
                 isReserved: false,
-                range: Range.create(1, 6, 1, 7)
+                range: Range.create(1, 6, 1, 7),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '5',
                 literal: new Int32(5),
                 isReserved: false,
-                range: Range.create(1, 8, 1, 9)
+                range: Range.create(1, 8, 1, 9),
+                leadingWhitespace: ''
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
                 isReserved: false,
-                range: Range.create(1, 10, 1, 11)
+                range: Range.create(1, 10, 1, 11),
+                leadingWhitespace: ''
             }
         ]);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -980,6 +980,19 @@ export class Util {
             character: character
         };
     }
+
+    /**
+     * Convert a list of tokens into a string, including their leading whitespace
+     */
+    public tokensToString(tokens: Token[]) {
+        let result = '';
+        //skip iterating the final token
+        for (let i = 0; i < tokens.length; i++) {
+            let token = tokens[i];
+            result += token.leadingWhitespace + token.text;
+        }
+        return result;
+    }
 }
 
 /**


### PR DESCRIPTION
Adds `token.leadingWhitespace` which contains anywhitespace encountered between the previous token and the current token (excluding newlines which are their own token kind and would have `leadingWhitespace` of their own). At a later date, we will be deprecating emitting whitespace tokens from the Lexer in favor of this approach, but brighterscript-formatter current depends on those tokens so we will need to update that project first before deprecating. 

We also need this to support `ropm` in its prefixing efforts. `ropm` will use the parser, then prefix certain tokens, and then join everything back together as a single string. As the parser does not handle whitespace tokens properly, and it's inefficient to add logic to the parser to skip whitespace tokens, this seems like a better approach. 

Currently we store the entire file contents in memory as `BrsFile.fileContents` anyway, so this is one step closer to removing that in-memory copy of the file since we now have all the information necessary to rebuild the file from AST. 