### PR TITLE
AST improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.16.0] - 2020-10-02
+### Added
+ -
+### Changed
+ -
+### Removed
+ -
+
+
+
 ## [0.15.2] - 2020-10-01
 ### Fixed
  - Bug in component validation that would throw errors if component name was undefined (generally due to an XML parse error). ([#194](https://github.com/rokucommunity/brighterscript/pull/194))
@@ -545,3 +555,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.15.0]:   https://github.com/rokucommunity/brighterscript/compare/v0.14.0...v0.15.0
 [0.15.1]:   https://github.com/rokucommunity/brighterscript/compare/v0.15.0...v0.15.1
 [0.15.2]:   https://github.com/rokucommunity/brighterscript/compare/v0.15.1...v0.15.2
+[0.16.0]:   https://github.com/rokucommunity/brighterscript/compare/v0.15.2...v0.16.0

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -18,6 +18,7 @@ import { globalFile } from './globalCallables';
 import { parseManifest, ManifestValue } from './preprocessor/Manifest';
 import { URI } from 'vscode-uri';
 import PluginInterface from './PluginInterface';
+import { isXmlFile } from './astUtils/reflection';
 const startOfSourcePkgPath = `source${path.sep}`;
 
 export interface SourceObj {
@@ -485,7 +486,7 @@ export class Program {
             }
 
             //if this is a component, remove it from our components map
-            if (file instanceof XmlFile) {
+            if (isXmlFile(file)) {
                 this.unregisterComponent(file);
             }
             this.plugins.emit('afterFileDispose', file);
@@ -535,7 +536,7 @@ export class Program {
         const componentsByName = Object.keys(this.files).reduce((map, filePath) => {
             const file = this.files[filePath];
             //if this is an XmlFile, and it has a valid `componentName` property
-            if (file instanceof XmlFile && file.componentName) {
+            if (isXmlFile(file) && file.componentName) {
                 let lowerName = file.componentName.toLowerCase();
                 if (!map[lowerName]) {
                     map[lowerName] = [];

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -9,10 +9,10 @@ import { BsClassValidator } from './validators/ClassValidator';
 import { NamespaceStatement, ParseMode, Statement, NewExpression, FunctionStatement, ClassStatement } from './parser';
 import { standardizePath as s, util } from './util';
 import { globalCallableMap } from './globalCallables';
-import { FunctionType } from './types/FunctionType';
 import { Cache } from './Cache';
 import { URI } from 'vscode-uri';
 import { LogLevel } from './Logger';
+import { isBrsFile, isClassStatement, isFunctionStatement, isFunctionType, isXmlFile } from './astUtils/reflection';
 
 /**
  * A class to keep track of all declarations within a given scope (like source scope, component scope)
@@ -261,9 +261,9 @@ export class Scope {
                 let ns = namespaceLookup[name.toLowerCase()];
                 ns.statements.push(...namespace.body.statements);
                 for (let statement of namespace.body.statements) {
-                    if (statement instanceof ClassStatement) {
+                    if (isClassStatement(statement)) {
                         ns.classStatements[statement.name.text.toLowerCase()] = statement;
-                    } else if (statement instanceof FunctionStatement) {
+                    } else if (isFunctionStatement(statement)) {
                         ns.functionStatements[statement.name.text.toLowerCase()] = statement;
                     }
                 }
@@ -511,7 +511,7 @@ export class Scope {
                 let lowerVarName = varDeclaration.name.toLowerCase();
 
                 //if the var is a function
-                if (varDeclaration.type instanceof FunctionType) {
+                if (isFunctionType(varDeclaration.type)) {
                     //local var function with same name as stdlib function
                     if (
                         //has same name as stdlib
@@ -668,9 +668,9 @@ export class Scope {
         let result = [] as FileReference[];
         let files = this.getFiles();
         for (let file of files) {
-            if (file instanceof BrsFile) {
+            if (isBrsFile(file)) {
                 result.push(...file.ownScriptImports);
-            } else if (file instanceof XmlFile) {
+            } else if (isXmlFile(file)) {
                 result.push(...file.scriptTagImports);
             }
         }

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -6,6 +6,7 @@ import { XmlFile } from './files/XmlFile';
 import { FileReference } from './interfaces';
 import { Program } from './Program';
 import util from './util';
+import { isXmlFile } from './astUtils/reflection';
 
 export class XmlScope extends Scope {
     constructor(
@@ -103,7 +104,7 @@ export class XmlScope extends Scope {
         let results = [] as Location[];
         //if the position is within the file's parent component name
         if (
-            file instanceof XmlFile &&
+            isXmlFile(file) &&
             file.parentComponent &&
             file.parentNameRange &&
             util.rangeContains(file.parentNameRange, position)

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -5,7 +5,7 @@ import { PrintStatement, Block, Body, AssignmentStatement, CommentStatement, Exi
 import { FunctionExpression, NamespacedVariableNameExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, LiteralExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression } from '../parser/Expression';
 import { TokenKind, Token } from '../lexer';
 import { BrsString } from '../brsTypes';
-import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isNamespacedVariableNameExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteral, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement } from './reflection';
+import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isNamespacedVariableNameExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement } from './reflection';
 import { createRange, createToken, createStringLiteral, createIdentifier } from './creators';
 import { Program } from '../Program';
 import { BrsFile } from '../files/BrsFile';
@@ -247,8 +247,8 @@ describe('reflection', () => {
             expect(isLiteralExpression(fun)).to.be.false;
         });
         it('isEscapedCharCodeLiteral', () => {
-            expect(isEscapedCharCodeLiteral(escapedCarCode)).to.be.true;
-            expect(isEscapedCharCodeLiteral(fun)).to.be.false;
+            expect(isEscapedCharCodeLiteralExpression(escapedCarCode)).to.be.true;
+            expect(isEscapedCharCodeLiteralExpression(fun)).to.be.false;
         });
         it('isArrayLiteralExpression', () => {
             expect(isArrayLiteralExpression(arrayLit)).to.be.true;

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,19 +1,22 @@
 import { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, Statement } from '../parser/Statement';
 import { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression } from '../parser/Expression';
-import { BrsString, ValueKind, BrsInvalid, BrsBoolean } from '../brsTypes';
+import { BrsString, ValueKind, BrsInvalid, BrsBoolean, RoString, RoArray, RoAssociativeArray, RoSGNode, FunctionParameterExpression } from '../brsTypes';
 import { BrsNumber } from '../brsTypes/BrsNumber';
 import { BrsFile } from '../files/BrsFile';
 import { XmlFile } from '../files/XmlFile';
 import { InternalWalkMode } from './visitors';
+import { FunctionType } from '../types/FunctionType';
+import { File } from '../interfaces';
+import { StringType } from '../types/StringType';
 
 // File reflection
 
-export function isBrsFile(file: (BrsFile | XmlFile)): file is BrsFile {
-    return file.extension === '.brs' || file.extension === '.bs';
+export function isBrsFile(file: (BrsFile | XmlFile | File)): file is BrsFile {
+    return file?.constructor.name === 'BrsFile';
 }
 
 export function isXmlFile(file: (BrsFile | XmlFile)): file is XmlFile {
-    return file.extension === '.xml';
+    return file?.constructor.name === 'XmlFile';
 }
 
 // Statements reflection
@@ -104,10 +107,10 @@ export function isClassStatement(element: Statement | Expression): element is Cl
 export function isImportStatement(element: Statement | Expression): element is ImportStatement {
     return element?.constructor?.name === 'ImportStatement';
 }
-export function isClassMethod(element: Statement | Expression): element is ClassMethodStatement {
+export function isClassMethodStatement(element: Statement | Expression): element is ClassMethodStatement {
     return element?.constructor.name === 'ClassMethodStatement';
 }
-export function isClassField(element: Statement | Expression): element is ClassFieldStatement {
+export function isClassFieldStatement(element: Statement | Expression): element is ClassFieldStatement {
     return element?.constructor.name === 'ClassFieldStatement';
 }
 
@@ -151,7 +154,7 @@ export function isGroupingExpression(element: Expression | Statement): element i
 export function isLiteralExpression(element: Expression | Statement): element is LiteralExpression {
     return element?.constructor.name === 'LiteralExpression';
 }
-export function isEscapedCharCodeLiteral(element: Expression | Statement): element is EscapedCharCodeLiteralExpression {
+export function isEscapedCharCodeLiteralExpression(element: Expression | Statement): element is EscapedCharCodeLiteralExpression {
     return element?.constructor.name === 'EscapedCharCodeLiteralExpression';
 }
 export function isArrayLiteralExpression(element: Expression | Statement): element is ArrayLiteralExpression {
@@ -184,8 +187,11 @@ export function isTemplateStringExpression(element: Expression | Statement): ele
 export function isTaggedTemplateStringExpression(element: Expression | Statement): element is TaggedTemplateStringExpression {
     return element?.constructor.name === 'TaggedTemplateStringExpression';
 }
+export function isFunctionParameterExpression(element: Expression | Statement): element is FunctionParameterExpression {
+    return element?.constructor.name === 'FunctionParameterExpression';
+}
 
-// Values reflection
+// Value/Type reflection
 
 export function isInvalid(value: any): value is BrsInvalid {
     return value?.kind === ValueKind.Invalid;
@@ -204,6 +210,22 @@ export function isNumber(value: any): value is BrsNumber {
         value.kind === ValueKind.Double
     );
 }
+export function isStringType(value: any): value is StringType {
+    return value?.constructor.name === 'StringType';
+}
+
+export function isFunctionType(e: any): e is FunctionType {
+    return e?.constructor.name === 'FunctionType';
+}
+export function isRoArray(e: any): e is RoArray {
+    return e?.constructor.name === 'RoArray';
+}
+export function isRoAssociativeArray(e: any): e is RoAssociativeArray {
+    return e?.constructor.name === 'RoAssociativeArray';
+}
+export function isRoSGNode(e: any): e is RoSGNode {
+    return e?.constructor.name === 'RoSGNode';
+}
 
 // Literal reflection
 
@@ -218,4 +240,7 @@ export function isLiteralString(e: any): e is LiteralExpression & { value: BrsSt
 }
 export function isLiteralNumber(e: any): e is LiteralExpression & { value: BrsNumber } {
     return isLiteralExpression(e) && isNumber(e.value);
+}
+export function isRoString(s: any): s is RoString {
+    return s.constructor.name === 'RoString';
 }

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -682,6 +682,7 @@ describe('astUtils visitors', () => {
                 'AssignmentStatement',
                 'AALiteralExpression',
                 'CommentStatement',
+                'AAMemberExpression',
                 'LiteralExpression'
             ]);
         });

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -592,12 +592,12 @@ describe('astUtils visitors', () => {
             `, [
                 'FunctionStatement',
                 'FunctionExpression',
-                'FunctionParameter',
+                'FunctionParameterExpression',
                 'Block',
                 'AssignmentStatement',
                 'FunctionExpression',
-                'FunctionParameter',
-                'FunctionParameter',
+                'FunctionParameterExpression',
+                'FunctionParameterExpression',
                 'Block'
             ]);
         });
@@ -878,7 +878,7 @@ describe('astUtils visitors', () => {
             `, [
                 'FunctionExpression',
                 'FunctionExpression',
-                'FunctionParameter',
+                'FunctionParameterExpression',
                 'BinaryExpression',
                 'LiteralExpression',
                 'VariableExpression',

--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -60,7 +60,7 @@ export class StdlibArgument implements Argument {
     static InternalRange = util.createRange(-1, -1, -1, -1);
 }
 
-export class FunctionParameter extends Expression {
+export class FunctionParameterExpression extends Expression {
     constructor(
         public name: Identifier,
         public type: {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -7,22 +7,21 @@ import { diagnosticCodes, DiagnosticMessages } from '../DiagnosticMessages';
 import { FunctionScope } from '../FunctionScope';
 import { Callable, CallableArg, CallableParam, CommentFlag, FunctionCall, BsDiagnostic, FileReference } from '../interfaces';
 import { Deferred } from '../deferred';
-import { FunctionParameter } from '../brsTypes';
 import { Lexer, Token, TokenKind, Identifier, AllowedLocalIdentifiers, Keywords } from '../lexer';
 import { Parser, ParseMode } from '../parser';
-import { AALiteralExpression, DottedGetExpression, FunctionExpression, LiteralExpression, CallExpression, VariableExpression, Expression } from '../parser/Expression';
-import { AssignmentStatement, ClassStatement, CommentStatement, FunctionStatement, IfStatement, LibraryStatement, ImportStatement } from '../parser/Statement';
+import { FunctionExpression, VariableExpression, Expression } from '../parser/Expression';
+import { AssignmentStatement, ClassStatement, LibraryStatement, ImportStatement } from '../parser/Statement';
 import { Program } from '../Program';
 import { BrsType } from '../types/BrsType';
 import { DynamicType } from '../types/DynamicType';
 import { FunctionType } from '../types/FunctionType';
-import { StringType } from '../types/StringType';
 import { VoidType } from '../types/VoidType';
 import { standardizePath as s, util } from '../util';
 import { TranspileState } from '../parser/TranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { LogLevel } from '../Logger';
 import { serializeError } from 'serialize-error';
+import { isAALiteralExpression, isAssignmentStatement, isCallExpression, isClassStatement, isCommentStatement, isDottedGetExpression, isFunctionExpression, isFunctionParameterExpression, isFunctionStatement, isFunctionType, isIfStatement, isImportStatement, isLibraryStatement, isLiteralExpression, isStringType, isVariableExpression } from '../astUtils/reflection';
 
 /**
  * Holds all details about this file within the scope of the whole program
@@ -209,11 +208,11 @@ export class BrsFile {
 
         for (let stmt of this.ast.statements) {
             //skip comments
-            if (stmt instanceof CommentStatement) {
+            if (isCommentStatement(stmt)) {
                 continue;
             }
             //if we found a non-library statement, this statement is not at the top of the file
-            if (stmt instanceof LibraryStatement || stmt instanceof ImportStatement) {
+            if (isLibraryStatement(stmt) || isImportStatement(stmt)) {
                 topOfFileIncludeStatements.push(stmt);
             } else {
                 //break out of the loop, we found all of our library statements
@@ -227,7 +226,7 @@ export class BrsFile {
         ];
         for (let result of statements) {
             //register import statements
-            if (result instanceof ImportStatement && result.filePathToken) {
+            if (isImportStatement(result) && result.filePathToken) {
                 this.ownScriptImports.push({
                     filePathRange: result.filePathToken.range,
                     pkgPath: util.getPkgPathFromTarget(this.pkgPath, result.filePath),
@@ -239,13 +238,13 @@ export class BrsFile {
             //if this statement is not one of the top-of-file statements,
             //then add a diagnostic explaining that it is invalid
             if (!topOfFileIncludeStatements.includes(result)) {
-                if (result instanceof LibraryStatement) {
+                if (isLibraryStatement(result)) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile(),
                         range: result.range,
                         file: this
                     });
-                } else if (result instanceof ImportStatement) {
+                } else if (isImportStatement(result)) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.importStatementMustBeDeclaredAtTopOfFile(),
                         range: result.range,
@@ -314,20 +313,20 @@ export class BrsFile {
             let ancestors = this.getAncestors(identifier.key);
             let parent = ancestors[ancestors.length - 1];
 
-            let isObjectProperty = !!ancestors.find(x => (x instanceof DottedGetExpression) || (x instanceof AALiteralExpression));
+            let isObjectProperty = !!ancestors.find(x => (isDottedGetExpression(x)) || (isAALiteralExpression(x)));
 
             //filter out certain text items
             if (
                 //don't filter out any object properties
                 isObjectProperty === false && (
                     //top-level functions (they are handled elsewhere)
-                    parent instanceof FunctionStatement ||
+                    isFunctionStatement(parent) ||
                     //local variables created or used by assignments
-                    ancestors.find(x => x instanceof AssignmentStatement) ||
+                    isAssignmentStatement(ancestors.find(x => x)) ||
                     //local variables used in conditional statements
-                    ancestors.find(x => x instanceof IfStatement) ||
+                    isIfStatement(ancestors.find(x => x)) ||
                     //the 'as' keyword (and parameter types) when used in a type statement
-                    ancestors.find(x => x instanceof FunctionParameter)
+                    ancestors.find(x => isFunctionParameterExpression(x))
                 )
             ) {
                 continue;
@@ -506,7 +505,7 @@ export class BrsFile {
     private getBRSTypeFromAssignment(assignment: AssignmentStatement, scope: FunctionScope): BrsType {
         try {
             //function
-            if (assignment.value instanceof FunctionExpression) {
+            if (isFunctionExpression(assignment.value)) {
                 let functionType = new FunctionType(util.valueKindToBrsType(assignment.value.returns));
                 functionType.isSub = assignment.value.functionType.text === 'sub';
                 if (functionType.isSub) {
@@ -522,11 +521,11 @@ export class BrsFile {
                 return functionType;
 
                 //literal
-            } else if (assignment.value instanceof LiteralExpression) {
+            } else if (isLiteralExpression(assignment.value)) {
                 return util.valueKindToBrsType((assignment.value as any).value.kind);
 
                 //function call
-            } else if (assignment.value instanceof CallExpression) {
+            } else if (isCallExpression(assignment.value)) {
                 let calleeName = (assignment.value.callee as any).name.text;
                 if (calleeName) {
                     let func = this.getCallableByName(calleeName);
@@ -534,7 +533,7 @@ export class BrsFile {
                         return func.type.returnType;
                     }
                 }
-            } else if (assignment.value instanceof VariableExpression) {
+            } else if (isVariableExpression(assignment.value)) {
                 let variableName = assignment.value.name.text;
                 let variable = scope.getVariableByName(variableName);
                 return variable.type;
@@ -642,7 +641,7 @@ export class BrsFile {
                             text: text
                         };
                         //wrap the value in quotes because that's how it appears in the code
-                        if (callableArg.type instanceof StringType) {
+                        if (isStringType(callableArg.type)) {
                             callableArg.text = '"' + callableArg.text + '"';
                         }
                         args.push(callableArg);
@@ -756,7 +755,7 @@ export class BrsFile {
                 names[variable.name.toLowerCase()] = true;
                 result.push({
                     label: variable.name,
-                    kind: variable.type instanceof FunctionType ? CompletionItemKind.Function : CompletionItemKind.Variable
+                    kind: isFunctionType(variable.type) ? CompletionItemKind.Function : CompletionItemKind.Variable
                 });
             }
 
@@ -811,12 +810,12 @@ export class BrsFile {
 
                 //add function and class statement completions
                 for (let stmt of namespace.statements) {
-                    if (stmt instanceof ClassStatement) {
+                    if (isClassStatement(stmt)) {
                         result.push({
                             label: stmt.name.text,
                             kind: CompletionItemKind.Class
                         });
-                    } else if (stmt instanceof FunctionStatement) {
+                    } else if (isFunctionStatement(stmt)) {
                         result.push({
                             label: stmt.name.text,
                             kind: CompletionItemKind.Function
@@ -889,11 +888,11 @@ export class BrsFile {
      */
     public calleeStartsWithNamespace(callee: Expression) {
         let left = callee as any;
-        while (left instanceof DottedGetExpression) {
+        while (isDottedGetExpression(left)) {
             left = left.obj;
         }
 
-        if (left instanceof VariableExpression) {
+        if (isVariableExpression(left)) {
             let lowerName = left.name.text.toLowerCase();
             //find the first scope that contains this namespace
             let scopes = this.program.getScopesForFile(this);
@@ -911,7 +910,7 @@ export class BrsFile {
      */
     public calleeIsKnownNamespaceFunction(callee: Expression, namespaceName: string) {
         //if we have a variable and a namespace
-        if (callee instanceof VariableExpression && namespaceName) {
+        if (isVariableExpression(callee) && namespaceName) {
             let lowerCalleeName = callee.name.text.toLowerCase();
             let scopes = this.program.getScopesForFile(this);
             for (let scope of scopes) {
@@ -977,7 +976,7 @@ export class BrsFile {
                     //we found a variable declaration with this token text!
                     if (varDeclaration.name.toLowerCase() === lowerTokenText) {
                         let typeText: string;
-                        if (varDeclaration.type instanceof FunctionType) {
+                        if (isFunctionType(varDeclaration.type)) {
                             typeText = varDeclaration.type.toString();
                         } else {
                             typeText = `${varDeclaration.name} as ${varDeclaration.type.toString()}`;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -556,6 +556,7 @@ export class AAMemberExpression extends Expression {
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
+        walk(this, 'value', visitor, options);
     }
 
 }
@@ -659,7 +660,7 @@ export class AALiteralExpression extends Expression {
                 if (isCommentStatement(this.elements[i])) {
                     walk(this.elements, i, visitor, options, this);
                 } else {
-                    walk((this.elements[i] as AAMemberExpression), 'value', visitor, options, this);
+                    walk(this.elements, i, visitor, options, this);
                 }
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,6 @@ import * as xml2js from 'xml2js';
 
 import { BsConfig } from './BsConfig';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import { BrsFile } from './files/BrsFile';
 import { CallableContainer, ValueKind, BsDiagnostic, FileReference, CallableContainerMap } from './interfaces';
 import { BooleanType } from './types/BooleanType';
 import { BrsType } from './types/BrsType';
@@ -29,6 +28,7 @@ import { DottedGetExpression, VariableExpression } from './parser/Expression';
 import { LogLevel } from './Logger';
 import { TokenKind, Token } from './lexer';
 import { CompilerPlugin } from '.';
+import { isBrsFile, isDottedGetExpression, isVariableExpression } from './astUtils';
 
 export class Util {
 
@@ -482,9 +482,9 @@ export class Util {
     public findBeginningVariableExpression(dottedGet: DottedGetExpression): VariableExpression | undefined {
         let left: any = dottedGet;
         while (left) {
-            if (left instanceof VariableExpression) {
+            if (isVariableExpression(left)) {
                 return left;
-            } else if (left instanceof DottedGetExpression) {
+            } else if (isDottedGetExpression(left)) {
                 left = left.obj;
             } else {
                 break;
@@ -680,7 +680,7 @@ export class Util {
      */
     public diagnosticIsSuppressed(diagnostic: BsDiagnostic) {
         //for now, we only support suppressing brs file diagnostics
-        if (diagnostic.file instanceof BrsFile) {
+        if (isBrsFile(diagnostic.file)) {
             for (let flag of diagnostic.file.commentFlags) {
                 //this diagnostic is affected by this flag
                 if (this.rangeContains(flag.affectedRange, diagnostic.range.start)) {


### PR DESCRIPTION
A few minor AST tweaks:

**Notable changes:**
 - Remove usage of `instanceof` in favor of `is` functions from reflections.ts. This will help with plugin interoperability.
 - rename `isEscapedCharCodeLiteral` to `isEscapedCharCodeLiteralExpression` to match other expression class names
 - rename `FunctionParameter` to `FunctionParameterExpression` to match other expression class names
 - convert `AAMemberExpression` interface into an expression class.
 - convert `isBrsFile` and `isXmlFile` to check for constructor file name rather than file extension.