### PR TITLE
Add generic type param for addReplaceFile.

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -129,12 +129,12 @@ export interface CompilerPlugin {
     beforeScopeValidate?: ValidateHandler;
     afterScopeValidate?: ValidateHandler;
     beforeFileParse?: (source: SourceObj) => void;
-    afterFileParse?: (file: (BrsFile | XmlFile)) => void;
-    afterFileValidate?: (file: (BrsFile | XmlFile)) => void;
+    afterFileParse?: (file: BscFile) => void;
+    afterFileValidate?: (file: BscFile) => void;
     beforeFileTranspile?: (entry: TranspileObj) => void;
     afterFileTranspile?: (entry: TranspileObj) => void;
-    beforeFileDispose?: (file: (BrsFile | XmlFile)) => void;
-    afterFileDispose?: (file: (BrsFile | XmlFile)) => void;
+    beforeFileDispose?: (file: BscFile) => void;
+    afterFileDispose?: (file: BscFile) => void;
 }
 
 // related types:
@@ -149,11 +149,11 @@ interface SourceObj {
 }
 
 interface TranspileObj {
-    file: (BrsFile | XmlFile);
+    file: (BscFile);
     outputPath: string;
 }
 
-type ValidateHandler = (scope: Scope, files: (BrsFile | XmlFile)[], callables: CallableContainerMap) => void;
+type ValidateHandler = (scope: Scope, files: BscFile[], callables: CallableContainerMap) => void;
 interface CallableContainerMap {
     [name: string]: CallableContainer[];
 }
@@ -206,7 +206,7 @@ const pluginInterface: CompilerPlugin = {
 export default pluginInterface;
 
 // post-parsing validation
-function afterFileValidate(file: BrsFile | XmlFile) {
+function afterFileValidate(file: BscFile) {
     if (!isBrsFile(file)) {
         return;
     }

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -7,7 +7,7 @@ import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import { BsDiagnostic, File, FileReference, FileObj } from './interfaces';
+import { BsDiagnostic, File, FileReference, FileObj, BscFile } from './interfaces';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
@@ -27,7 +27,7 @@ export interface SourceObj {
 }
 
 export interface TranspileObj {
-    file: (BrsFile | XmlFile);
+    file: BscFile;
     outputPath: string;
 }
 
@@ -111,7 +111,7 @@ export class Program {
     /**
      * A map of every file loaded into this program
      */
-    public files = {} as { [pathAbsolute: string]: BrsFile | XmlFile };
+    public files = {} as { [pathAbsolute: string]: BscFile };
 
     private scopes = {} as { [name: string]: Scope };
 
@@ -235,14 +235,14 @@ export class Program {
      * contents from the file system.
      * @param filePaths
      */
-    public async addOrReplaceFiles(fileObjects: Array<FileObj>) {
+    public async addOrReplaceFiles<T extends BscFile[]>(fileObjects: Array<FileObj>) {
         let promises = [];
         for (let fileObject of fileObjects) {
             promises.push(
                 this.addOrReplaceFile(fileObject)
             );
         }
-        return Promise.all(promises);
+        return Promise.all(promises) as Promise<T>;
     }
 
     public getPkgPath(...args: any[]): any { //eslint-disable-line
@@ -284,15 +284,15 @@ export class Program {
      * @param relativePath the file path relative to the root dir
      * @param fileContents the file contents. If not provided, the file will be loaded from disk
      */
-    public async addOrReplaceFile(relativePath: string, fileContents?: string): Promise<XmlFile | BrsFile>;
+    public async addOrReplaceFile<T extends BscFile>(relativePath: string, fileContents?: string): Promise<T>;
     /**
      * Load a file into the program. If that file already exists, it is replaced.
      * If file contents are provided, those are used, Otherwise, the file is loaded from the file system
      * @param fileEntry an object that specifies src and dest for the file.
      * @param fileContents the file contents. If not provided, the file will be loaded from disk
      */
-    public async addOrReplaceFile(fileEntry: FileObj, fileContents?: string): Promise<XmlFile | BrsFile>;
-    public async addOrReplaceFile(fileParam: FileObj | string, fileContents?: string): Promise<XmlFile | BrsFile> {
+    public async addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents?: string): Promise<T>;
+    public async addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents?: string): Promise<T> {
         assert.ok(fileParam, 'fileEntry is required');
         let pathAbsolute: string;
         let pkgPath: string;
@@ -313,7 +313,7 @@ export class Program {
                 this.removeFile(pathAbsolute);
             }
             let fileExtension = path.extname(pathAbsolute).toLowerCase();
-            let file: BrsFile | XmlFile | undefined;
+            let file: BscFile | undefined;
 
             //load the file contents by file path if not provided
             let getFileContents = async () => {
@@ -391,7 +391,7 @@ export class Program {
             }
             return file;
         });
-        return file;
+        return file as T;
     }
 
     /**
@@ -424,7 +424,7 @@ export class Program {
      * Get a list of files for the given pkgPath array.
      * Missing files are just ignored.
      */
-    public getFilesByPkgPaths(pkgPaths: string[]) {
+    public getFilesByPkgPaths<T extends BscFile[]>(pkgPaths: string[]) {
         pkgPaths = pkgPaths.map(x => s`${x}`.toLowerCase());
 
         let result = [] as Array<XmlFile | BrsFile>;
@@ -434,15 +434,15 @@ export class Program {
                 result.push(file);
             }
         }
-        return result;
+        return result as T;
     }
 
     /**
      * Get a file with the specified pkg path.
      * If not found, return undefined
      */
-    public getFileByPkgPath(pkgPath: string) {
-        return this.getFilesByPkgPaths([pkgPath])[0];
+    public getFileByPkgPath<T extends BscFile>(pkgPath: string) {
+        return this.getFilesByPkgPaths([pkgPath])[0] as T;
     }
 
     /**
@@ -573,7 +573,7 @@ export class Program {
     /**
      * Determine if the given file is included in at least one scope in this program
      */
-    private fileIsIncludedInAnyScope(file: BrsFile | XmlFile) {
+    private fileIsIncludedInAnyScope(file: BscFile) {
         for (let scopeName in this.scopes) {
             if (this.scopes[scopeName].hasFile(file)) {
                 return true;
@@ -586,9 +586,9 @@ export class Program {
      * Get the file at the given path
      * @param pathAbsolute
      */
-    private getFile(pathAbsolute: string) {
+    private getFile<T extends BscFile>(pathAbsolute: string) {
         pathAbsolute = s`${pathAbsolute}`;
-        return this.files[pathAbsolute];
+        return this.files[pathAbsolute] as T;
     }
 
     /**

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -1,9 +1,7 @@
 import { CompletionItem, CompletionItemKind, Location, Position, Range } from 'vscode-languageserver';
 import chalk from 'chalk';
 import { DiagnosticMessages, DiagnosticInfo } from './DiagnosticMessages';
-import { BrsFile } from './files/BrsFile';
-import { XmlFile } from './files/XmlFile';
-import { CallableContainer, BsDiagnostic, FileReference } from './interfaces';
+import { CallableContainer, BsDiagnostic, FileReference, BscFile } from './interfaces';
 import { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
 import { NamespaceStatement, ParseMode, Statement, NewExpression, FunctionStatement, ClassStatement } from './parser';
@@ -131,7 +129,7 @@ export class Scope {
 
     public getFiles() {
         return this.cache.getOrAdd('files', () => {
-            let result = [] as Array<BrsFile | XmlFile>;
+            let result = [] as BscFile[];
             let dependencies = this.program.dependencyGraph.getAllDependencies(this.dependencyGraphKey);
             for (let dependency of dependencies) {
                 //skip scopes and components
@@ -380,7 +378,7 @@ export class Scope {
         this.cache.clear();
     }
 
-    private detectVariableNamespaceCollisions(file: BrsFile | XmlFile) {
+    private detectVariableNamespaceCollisions(file: BscFile) {
         //find all function parameters
         for (let func of file.parser.references.functionExpressions) {
             for (let param of func.parameters) {
@@ -428,7 +426,7 @@ export class Scope {
     /**
      * Find function declarations with the same name as a stdlib function
      */
-    private diagnosticDetectFunctionCollisions(file: BrsFile | XmlFile) {
+    private diagnosticDetectFunctionCollisions(file: BscFile) {
         for (let func of file.callables) {
             if (globalCallableMap[func.getName(ParseMode.BrighterScript).toLowerCase()]) {
                 this.diagnostics.push({
@@ -464,7 +462,7 @@ export class Scope {
      * @param file
      * @param callableContainersByLowerName
      */
-    private diagnosticDetectFunctionCallsWithWrongParamCount(file: BrsFile | XmlFile, callableContainersByLowerName: { [lowerName: string]: CallableContainer[] }) {
+    private diagnosticDetectFunctionCallsWithWrongParamCount(file: BscFile, callableContainersByLowerName: { [lowerName: string]: CallableContainer[] }) {
         //validate all function calls
         for (let expCall of file.functionCalls) {
             let callableContainersWithThisName = callableContainersByLowerName[expCall.name.toLowerCase()];
@@ -503,7 +501,7 @@ export class Scope {
      * @param file
      * @param callableContainerMap
      */
-    private diagnosticDetectShadowedLocalVars(file: BrsFile | XmlFile, callableContainerMap: { [lowerName: string]: CallableContainer[] }) {
+    private diagnosticDetectShadowedLocalVars(file: BscFile, callableContainerMap: { [lowerName: string]: CallableContainer[] }) {
         //loop through every function scope
         for (let scope of file.functionScopes) {
             //every var declaration in this scope
@@ -558,7 +556,7 @@ export class Scope {
      * @param file
      * @param callablesByLowerName
      */
-    private diagnosticDetectCallsToUnknownFunctions(file: BrsFile | XmlFile, callablesByLowerName: { [lowerName: string]: CallableContainer[] }) {
+    private diagnosticDetectCallsToUnknownFunctions(file: BscFile, callablesByLowerName: { [lowerName: string]: CallableContainer[] }) {
         //validate all expression calls
         for (let expCall of file.functionCalls) {
             let lowerName = expCall.name.toLowerCase();
@@ -727,7 +725,7 @@ export class Scope {
      * Determine if this scope is referenced and known by the file.
      * @param file
      */
-    public hasFile(file: BrsFile | XmlFile) {
+    public hasFile(file: BscFile) {
         let files = this.getFiles();
         let hasFile = files.includes(file);
         return hasFile;
@@ -759,7 +757,7 @@ export class Scope {
     /**
      * Get the definition (where was this thing first defined) of the symbol under the position
      */
-    public getDefinition(file: BrsFile | XmlFile, position: Position): Location[] { //eslint-disable-line
+    public getDefinition(file: BscFile, position: Position): Location[] { //eslint-disable-line
         //TODO implement for brs files
         return [];
     }
@@ -778,7 +776,7 @@ export class Scope {
 }
 
 interface NamespaceContainer {
-    file: BrsFile | XmlFile;
+    file: BscFile;
     fullName: string;
     nameRange: Range;
     lastPartName: string;
@@ -789,5 +787,5 @@ interface NamespaceContainer {
 }
 
 interface AugmentedNewExpression extends NewExpression {
-    file: BrsFile | XmlFile;
+    file: BscFile;
 }

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -19,21 +19,21 @@ describe('XmlScope', () => {
 
     describe('constructor', () => {
         it('listens for attach/detach parent events', async () => {
-            let parentXmlFile = await program.addOrReplaceFile('components/parent.xml', `
+            let parentXmlFile = await program.addOrReplaceFile<XmlFile>('components/parent.xml', `
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                 </component>
-            `) as XmlFile;
+            `);
             let scope = program.getScopeByName(parentXmlFile.pkgPath);
 
             //should default to global scope
             expect(scope.getParentScope()).to.equal(program.globalScope);
 
-            let childXmlFile = await program.addOrReplaceFile('components/child.xml', `
+            let childXmlFile = await program.addOrReplaceFile<XmlFile>('components/child.xml', `
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
-            `) as XmlFile;
+            `);
             let childScope = program.getComponentScope('Child');
 
             await program.validate();

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -1,9 +1,8 @@
 import { Location, Position } from 'vscode-languageserver';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import { FileReference } from './interfaces';
+import { BscFile, FileReference } from './interfaces';
 import { Program } from './Program';
 import util from './util';
 import { isXmlFile } from './astUtils/reflection';
@@ -85,7 +84,7 @@ export class XmlScope extends Scope {
         return this.cache.getOrAdd('files', () => {
             let result = [
                 this.xmlFile
-            ] as Array<BrsFile | XmlFile>;
+            ] as BscFile[];
             let scriptPkgPaths = this.xmlFile.getAllScriptImports();
             for (let scriptPkgPath of scriptPkgPaths) {
                 let file = this.program.getFileByPkgPath(scriptPkgPath);
@@ -100,7 +99,7 @@ export class XmlScope extends Scope {
     /**
      * Get the definition (where was this thing first defined) of the symbol under the position
      */
-    public getDefinition(file: BrsFile | XmlFile, position: Position): Location[] {
+    public getDefinition(file: BscFile, position: Position): Location[] {
         let results = [] as Location[];
         //if the position is within the file's parent component name
         if (

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -6,16 +6,16 @@ import { BrsFile } from '../files/BrsFile';
 import { XmlFile } from '../files/XmlFile';
 import { InternalWalkMode } from './visitors';
 import { FunctionType } from '../types/FunctionType';
-import { File } from '../interfaces';
+import { BscFile, File } from '../interfaces';
 import { StringType } from '../types/StringType';
 
 // File reflection
 
-export function isBrsFile(file: (BrsFile | XmlFile | File)): file is BrsFile {
+export function isBrsFile(file: (BscFile | File)): file is BrsFile {
     return file?.constructor.name === 'BrsFile';
 }
 
-export function isXmlFile(file: (BrsFile | XmlFile)): file is XmlFile {
+export function isXmlFile(file: (BscFile)): file is XmlFile {
     return file?.constructor.name === 'XmlFile';
 }
 

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -311,7 +311,7 @@ describe('astUtils visitors', () => {
 
     describe('walk', () => {
         async function testWalk(text: string, expectedConstructors: string[], walkMode = WalkMode.visitAllRecursive) {
-            const file = await program.addOrReplaceFile('source/main.bs', text) as BrsFile;
+            const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', text);
             const items = [];
             let index = 1;
             file.ast.walk((element: any) => {
@@ -325,14 +325,14 @@ describe('astUtils visitors', () => {
         }
 
         it('Walks through all expressions until cancelled', async () => {
-            const file = await program.addOrReplaceFile('source/main.bs', `
+            const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', `
                 sub logger(message = "nil" as string)
                     innerLog = sub(message = "nil" as string)
                         print message
                     end sub
                     innerLog(message)
                 end sub
-            `) as BrsFile;
+            `);
 
             const cancel = new CancellationTokenSource();
             let count = 0;

--- a/src/examples/plugins/removePrint.ts
+++ b/src/examples/plugins/removePrint.ts
@@ -1,8 +1,6 @@
 import { isBrsFile } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
-import { BrsFile } from '../../files/BrsFile';
-import { XmlFile } from '../../files/XmlFile';
-import { CompilerPlugin } from '../../interfaces';
+import { BscFile, CompilerPlugin } from '../../interfaces';
 import { EmptyStatement } from '../../parser/Statement';
 
 // entry point
@@ -14,7 +12,7 @@ export default pluginInterface;
 
 // note: it is normally not recommended to modify the AST too much at this stage,
 // because if the plugin runs in a language-server context it could break intellisense
-function afterFileParse(file: (BrsFile | XmlFile)) {
+function afterFileParse(file: BscFile) {
     if (!isBrsFile(file)) {
         return;
     }

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -24,29 +24,29 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     async function addFile(relativePath: string, text: string) {
-        return await program.addOrReplaceFile({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text) as BrsFile;
+        return program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
     }
 
     it('detects all classes after parse', async () => {
-        let file = (await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
             end class
             class Duck
             end class
-        `) as BrsFile);
+        `);
         expect(file.parser.references.classStatements.map(x => x.getName(ParseMode.BrighterScript)).sort()).to.eql(['Animal', 'Duck']);
     });
 
     it('does not cause errors with incomplete class statement', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class
-        `) as BrsFile);
+        `);
         await program.validate();
         //if no exception was thrown, this test passes
     });
 
     it('catches child class missing super call in constructor', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Person
                 sub new()
                 end sub
@@ -55,7 +55,7 @@ describe('BrsFile BrighterScript classes', () => {
                 sub new()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(
             program.getDiagnostics()[0]?.message
@@ -65,7 +65,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('access modifier is option for override', async () => {
-        let file = (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub move()
                 end sub
@@ -75,7 +75,7 @@ describe('BrsFile BrighterScript classes', () => {
                 override sub move()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
         let duckClass = file.parser.references.classStatements.find(x => x.name.text.toLowerCase() === 'duck');
@@ -484,13 +484,13 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects using `new` keyword on non-classes', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             sub quack()
             end sub
             sub main()
                 duck = new quack()
             end sub
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(
             program.getDiagnostics()[0]?.message
@@ -500,7 +500,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects missing call to super', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                 end sub
@@ -509,7 +509,7 @@ describe('BrsFile BrighterScript classes', () => {
                 sub new()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(
             program.getDiagnostics()[0]?.message
@@ -519,13 +519,13 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it.skip('detects calls to unknown m methods', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                     m.methodThatDoesNotExist()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(
             program.getDiagnostics()[0]?.message
@@ -535,7 +535,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects duplicate member names', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
                 public name
@@ -547,7 +547,7 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
                 public age
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         let diagnostics = program.getDiagnostics().map(x => {
             return {
@@ -573,7 +573,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects mismatched member type in child class', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -582,7 +582,7 @@ describe('BrsFile BrighterScript classes', () => {
                     return "Donald"
                 end function
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(
             program.getDiagnostics().map(x => x.message).sort()[0]
@@ -592,14 +592,14 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden property name in child class', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
             class Duck extends Animal
                 public name
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         let diagnostics = program.getDiagnostics().map(x => x.message);
         expect(diagnostics).to.eql([
@@ -608,7 +608,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods without override keyword', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub speak()
                 end sub
@@ -617,7 +617,7 @@ describe('BrsFile BrighterScript classes', () => {
                 sub speak()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]).to.exist.and.to.include({
             ...DiagnosticMessages.missingOverrideKeyword('Animal')
@@ -625,12 +625,12 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects extending unknown parent class', async () => {
-        (await program.addOrReplaceFile('source/main.brs', `
+        await program.addOrReplaceFile('source/main.brs', `
             class Duck extends Animal
                 sub speak()
                 end sub
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]).to.exist.and.to.deep.include({
             ...DiagnosticMessages.classCouldNotBeFound('Animal', 'source'),
@@ -639,7 +639,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches newable class without namespace name', async () => {
-        (await program.addOrReplaceFile('source/main.bs', `
+        await program.addOrReplaceFile('source/main.bs', `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -648,7 +648,7 @@ describe('BrsFile BrighterScript classes', () => {
                 ' this should be an error because the proper name is NameA.NameB.Duck"
                 d = new Duck()
             end sub
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.classCouldNotBeFound('Duck', 'source').message
@@ -656,7 +656,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports newable class namespace inference', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -664,20 +664,20 @@ describe('BrsFile BrighterScript classes', () => {
                     d = new Duck()
                 end sub
             end namespace
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
 
     it('catches extending unknown namespaced class', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
                 class Duck extends NameA.NameB.Animal1
                 end class
             end namespace
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.classCouldNotBeFound('NameA.NameB.Animal1', 'source').message
@@ -685,24 +685,24 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports omitting namespace prefix for items in same namespace', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
                 class Duck extends Animal
                 end class
             end namespace
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
 
     it('catches duplicate root-level class declarations', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
             end class
             class Animal
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.duplicateClassDeclaration('source', 'Animal').message
@@ -710,13 +710,13 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate namespace-level class declarations', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
                 class Animal
             end namespace
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.duplicateClassDeclaration('source', 'NameA.NameB.Animal').message
@@ -724,14 +724,14 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches namespaced class name which is the same as a global class', async () => {
-        (await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
             end namespace
             class Animal
             end class
-        `) as BrsFile);
+        `);
         await program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.namespacedClassCannotShareNamewithNonNamespacedClass('Animal').message

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -238,12 +238,12 @@ describe('BrsFile', () => {
             });
 
             it('works for all', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line
                         name = "bob
                     end sub
-                `) as BrsFile;
+                `);
                 expect(file.commentFlags[0]).to.exist;
                 expect(file.commentFlags[0]).to.deep.include({
                     codes: null,
@@ -256,12 +256,12 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: 1083, 1001
                         name = "bob
                     end sub
-                `) as BrsFile;
+                `);
                 expect(file.commentFlags[0]).to.exist;
                 expect(file.commentFlags[0]).to.deep.include({
                     codes: [1083, 1001],
@@ -297,11 +297,11 @@ describe('BrsFile', () => {
 
         describe('bs:disable-line', () => {
             it('works for all', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         z::;;%%%%%% 'bs:disable-line
                     end sub
-                `) as BrsFile;
+                `);
                 expect(file.commentFlags[0]).to.exist;
                 expect(file.commentFlags[0]).to.deep.include({
                     codes: null,
@@ -2124,7 +2124,7 @@ export function getTestTranspile(scopeGetter: () => [Program, string]) {
     return async (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
         let [program, rootDir] = scopeGetter();
         expected = expected ? expected : source;
-        let file = await program.addOrReplaceFile({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source) as BrsFile;
+        let file = await program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
         await program.validate();
         let diagnostics = file.getDiagnostics();
         if (diagnostics.length > 0 && failOnDiagnostic !== false) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,8 +14,10 @@ export interface BsDiagnostic extends Diagnostic {
     file: File;
 }
 
+export type BscFile = BrsFile | XmlFile;
+
 export interface Callable {
-    file: BrsFile | XmlFile;
+    file: BscFile;
     name: string;
     /**
      * Is the callable declared as "sub". If falsey, assumed declared as "function"
@@ -169,7 +171,7 @@ export interface CommentFlag {
     codes: number[] | null;
 }
 
-type ValidateHandler = (scope: Scope, files: (BrsFile | XmlFile)[], callables: CallableContainerMap) => void;
+type ValidateHandler = (scope: Scope, files: BscFile[], callables: CallableContainerMap) => void;
 
 export interface CompilerPlugin {
     name: string;
@@ -189,10 +191,10 @@ export interface CompilerPlugin {
     beforeScopeValidate?: ValidateHandler;
     afterScopeValidate?: ValidateHandler;
     beforeFileParse?: (source: SourceObj) => void;
-    afterFileParse?: (file: (BrsFile | XmlFile)) => void;
-    afterFileValidate?: (file: (BrsFile | XmlFile)) => void;
+    afterFileParse?: (file: BscFile) => void;
+    afterFileValidate?: (file: BscFile) => void;
     beforeFileTranspile?: (entry: TranspileObj) => void;
     afterFileTranspile?: (entry: TranspileObj) => void;
-    beforeFileDispose?: (file: (BrsFile | XmlFile)) => void;
-    afterFileDispose?: (file: (BrsFile | XmlFile)) => void;
+    beforeFileDispose?: (file: BscFile) => void;
+    afterFileDispose?: (file: BscFile) => void;
 }

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -1,6 +1,4 @@
 import { Scope } from '../Scope';
-import { XmlFile } from '../files/XmlFile';
-import { BrsFile } from '../files/BrsFile';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { BsDiagnostic } from '..';
 import { CallExpression, VariableExpression } from '../parser/Expression';
@@ -10,6 +8,7 @@ import { Location } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import util from '../util';
 import { isCallExpression, isClassFieldStatement, isClassMethodStatement, isVariableExpression } from '../astUtils/reflection';
+import { BscFile } from '../interfaces';
 
 export class BsClassValidator {
     private scope: Scope;
@@ -351,6 +350,6 @@ export class BsClassValidator {
 
 }
 type AugmentedClassStatement = ClassStatement & {
-    file: BrsFile | XmlFile;
+    file: BscFile;
     parentClass: AugmentedClassStatement;
 };


### PR DESCRIPTION
**Notable changes:**
 - define new type called `BscFile` which is the union of `BrsFile` and `XmlFile` to simplify types across the project.
 - Add generic type parameter for the "add file(s)" functions on `Program` to simplify code and tests. 