### PR TITLE
Safer diagnostic printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.16.2] - 2020-10-09
+### Fixed
+ - critical bug in diagnostic printing that would crash the program if a diagnostic was missing a valid range.
+
+
+
 ## [0.16.1] - 2020-10-03
 ### Changed
  - rename isEscapedCharCodeLiteral to isEscapedCharCodeLiteralExpression to match other expression class names
@@ -571,3 +577,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.15.2]:   https://github.com/rokucommunity/brighterscript/compare/v0.15.1...v0.15.2
 [0.16.0]:   https://github.com/rokucommunity/brighterscript/compare/v0.15.2...v0.16.0
 [0.16.1]:   https://github.com/rokucommunity/brighterscript/compare/v0.16.0...v0.16.1
+[0.16.2]:   https://github.com/rokucommunity/brighterscript/compare/v0.16.1...v0.16.2

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -4,13 +4,38 @@ import * as util from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 
 describe('diagnosticUtils', () => {
+    let options: ReturnType<typeof util.getPrintDiagnosticOptions>;
+    beforeEach(() => {
+        options = util.getPrintDiagnosticOptions({});
+    });
+
+    describe('printDiagnostic', () => {
+        it('does not crash when range is undefined', () => {
+            //print a diagnostic that doesn't have a range...it should not explode
+            util.printDiagnostic(options, DiagnosticSeverity.Error, './temp/file.brs', [], {
+                message: 'Bad thing happened',
+                range: null, //important...this needs to be null for the test to pass,
+                code: 1234
+            } as any);
+        });
+
+        it('does not crash when filie path is missing', () => {
+            //print a diagnostic that doesn't have a range...it should not explode
+            util.printDiagnostic(options, DiagnosticSeverity.Error, undefined, [], {
+                message: 'Bad thing happened',
+                range: Range.create(0, 0, 2, 2), //important...this needs to be null for the test to pass,
+                code: 1234
+            } as any);
+        });
+    });
+
     describe('getPrintDiagnosticOptions', () => {
         let options: ReturnType<typeof util.getPrintDiagnosticOptions>;
         it('prepares cwd value', () => {
             options = util.getPrintDiagnosticOptions({ cwd: 'cwd' });
             expect(options.cwd).to.equal('cwd');
             // default value
-            options = util.getPrintDiagnosticOptions({ });
+            options = util.getPrintDiagnosticOptions({});
             expect(options.cwd).to.equal(process.cwd());
         });
         it('prepares emitFullPaths value', () => {
@@ -19,7 +44,7 @@ describe('diagnosticUtils', () => {
             options = util.getPrintDiagnosticOptions({ emitFullPaths: false });
             expect(options.emitFullPaths).to.equal(false);
             // default value
-            options = util.getPrintDiagnosticOptions({ });
+            options = util.getPrintDiagnosticOptions({});
             expect(options.emitFullPaths).to.equal(false);
         });
         it('maps diagnosticLevel to severityLevel', () => {
@@ -32,7 +57,7 @@ describe('diagnosticUtils', () => {
             options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'error' });
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Error);
             // default value
-            options = util.getPrintDiagnosticOptions({ });
+            options = util.getPrintDiagnosticOptions({});
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Warning);
             options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'x' } as any);
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Warning);

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -65,14 +65,15 @@ export function printDiagnostic(
     }
 
     let severityText = severityTextMap[severity];
+
     console.log('');
     console.log(
-        chalk.cyan(filePath) +
+        chalk.cyan(filePath ?? '<unknown file>') +
         ':' +
         chalk.yellow(
-            (diagnostic.range.start.line + 1) +
-            ':' +
-            (diagnostic.range.start.character + 1)
+            diagnostic.range
+                ? (diagnostic.range.start.line + 1) + ':' + (diagnostic.range.start.character + 1)
+                : 'line?:col?'
         ) +
         ' - ' +
         typeColor[severity](severityText) +
@@ -85,14 +86,17 @@ export function printDiagnostic(
 
     //Get the line referenced by the diagnostic. if we couldn't find a line,
     // default to an empty string so it doesn't crash the error printing below
-    let diagnosticLine = lines[diagnostic.range.start.line] ?? '';
+    let diagnosticLine = lines[diagnostic.range?.start?.line ?? -1] ?? '';
 
     let squigglyText = getDiagnosticSquigglyText(diagnostic, diagnosticLine);
 
-    let lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
-    let blankLineNumberText = chalk.bgWhite(' ' + chalk.bgWhite((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
-    console.log(lineNumberText + diagnosticLine);
-    console.log(blankLineNumberText + typeColor[severity](squigglyText));
+    //only print the line information if we have some
+    if (diagnostic.range && diagnosticLine) {
+        let lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
+        let blankLineNumberText = chalk.bgWhite(' ' + chalk.bgWhite((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
+        console.log(lineNumberText + diagnosticLine);
+        console.log(blankLineNumberText + typeColor[severity](squigglyText));
+    }
     console.log('');
 }
 


### PR DESCRIPTION
Fixes issue where diagnostic printing fails critically whenever it encounters a diagnostic that has an invalid `Range`. 