### PR TITLE
New statement namespace bugfix

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -83,6 +83,30 @@ describe('BrsFile BrighterScript classes', () => {
         expect(duckClass.memberMap['move']).to.exist;
     });
 
+    it('supports various namespace configurations', async () => {
+        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+            class Animal
+                sub new()
+                    bigBird = new Birds.Bird()
+                    donald = new Birds.Duck()
+                end sub
+            end class
+
+            namespace Birds
+                class Bird
+                    sub new()
+                        dog = new Animal()
+                        donald = new Duck()
+                    end sub
+                end class
+                class Duck
+                end class
+            end namespace
+        `);
+        await program.validate();
+        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+    });
+
     describe('transpile', () => {
         it('follows correct sequence for property initializers', async () => {
             await testTranspile(`

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -305,6 +305,44 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
+        it('properly transpiles classes from outside current namespace', async () => {
+            await addFile('source/Animals.bs', `
+                namespace Animals
+                    class Duck
+                    end class
+                end namespace
+                class Bird
+                end class
+            `);
+            await testTranspile(`
+                namespace Animals
+                    sub init()
+                        donaldDuck = new Duck()
+                        daffyDuck = new Animals.Duck()
+                        bigBird = new Bird()
+                    end sub
+                end namespace
+            `, `
+                sub Animals_init()
+                    donaldDuck = Animals_Duck()
+                    daffyDuck = Animals_Duck()
+                    bigBird = Bird()
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('properly transpiles new statement for missing class ', async () => {
+            await testTranspile(`
+            sub main()
+                bob = new Human()
+            end sub
+        `, `
+            sub main()
+                bob = Human()
+            end sub
+        `, undefined, 'source/main.bs');
+        });
+
         it('new keyword transpiles correctly', async () => {
             await addFile('source/Animal.bs', `
                 class Animal

--- a/src/util.ts
+++ b/src/util.ts
@@ -934,8 +934,8 @@ export class Util {
     /**
      * Given the class name text, return a namespace-prefixed name.
      * If the name already has a period in it, or the namespaceName was not provided, return the class name as is.
-     * If the name does not have a period, and a namespaceName was provided, return the class name prepended
-     * by the namespace name
+     * If the name does not have a period, and a namespaceName was provided, return the class name prepended by the namespace name.
+     * If no namespace is provided, return the `className` unchanged.
      */
     public getFulllyQualifiedClassName(className: string, namespaceName?: string) {
         if (className.includes('.') === false && namespaceName) {

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -35,7 +35,12 @@ export class BsClassValidator {
      */
     private getClassByName(className: string, namespaceName?: string) {
         let fullName = util.getFulllyQualifiedClassName(className, namespaceName);
-        return this.classes[fullName.toLowerCase()];
+        let cls = this.classes[fullName.toLowerCase()];
+        //if we couldn't find the class by its full namespaced name, look for a global class with that name
+        if (!cls) {
+            cls = this.classes[className.toLowerCase()];
+        }
+        return cls;
     }
 
     /**


### PR DESCRIPTION
Fixes some bugs related to constructing new BrighterScript classes.

**Notable changes:**
 - fixed bug that wouldn't find the correct root-level class when calling `new` from within a namespace (fixes #203)
 - fixed bug that was not adding an omitted namespace to a class whenever that class resides in the same namespace as the `new` statement.