### PR TITLE
Exclude CallfuncExpression from parser callExpression list

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2023,6 +2023,16 @@ describe('BrsFile', () => {
 
     describe('callfunc operator', () => {
         describe('transpile', () => {
+            it('does not produce diagnostics', async () => {
+                await program.addOrReplaceFile('source/main.bs', `
+                    sub main()
+                        someObject@.someFunction(paramObject.value)
+                    end sub
+                `);
+                await program.validate();
+                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            });
+
             it('sets invalid on empty callfunc', async () => {
                 await testTranspile(`
                     sub main()

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1970,7 +1970,7 @@ export class Parser {
         // force it into an identifier so the AST makes some sense
         methodName.kind = TokenKind.Identifier;
         let openParen = this.consume(DiagnosticMessages.expectedOpenParenToFollowCallfuncIdentifier(), TokenKind.LeftParen);
-        let call = this.finishCall(openParen, callee);
+        let call = this.finishCall(openParen, callee, false);
 
         return new CallfuncExpression(callee, operator, methodName as Identifier, openParen, call.args, call.closingParen);
     }
@@ -2025,7 +2025,7 @@ export class Parser {
         return expr;
     }
 
-    private finishCall(openingParen: Token, callee: Expression) {
+    private finishCall(openingParen: Token, callee: Expression, addToCallExpressionList = true) {
         let args = [] as Expression[];
         while (this.match(TokenKind.Newline)) {
         }
@@ -2057,7 +2057,9 @@ export class Parser {
         }
 
         let expression = new CallExpression(callee, openingParen, closingParen, args, this.currentNamespaceName);
-        this.callExpressions.push(expression);
+        if (addToCallExpressionList) {
+            this.callExpressions.push(expression);
+        }
         return expression;
     }
 


### PR DESCRIPTION
CallfuncExpression is NOT the same as a `CallExpression`, and therefore should not be included in the parser's `callExpressions` list. This PR fixes that issue.

Fixes #205 