### PR TITLE
Skip validation for "super" function calls.

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -520,8 +520,8 @@ export let DiagnosticMessages = {
         code: 1100,
         severity: DiagnosticSeverity.Error
     }),
-    classConstructorSuperMustBeFirstStatement: () => ({
-        message: `A call to 'super()' must be the first statement in this constructor method.`,
+    classConstructorIllegalUseOfMBeforeSuperCall: () => ({
+        message: `Illegal use of "m" before calling "super()"`,
         code: 1101,
         severity: DiagnosticSeverity.Error
     }),
@@ -590,7 +590,6 @@ export let DiagnosticMessages = {
         code: 1115,
         severity: DiagnosticSeverity.Error
     })
-
 };
 
 let allCodes = [] as number[];

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -559,7 +559,12 @@ export class Scope {
     private diagnosticDetectCallsToUnknownFunctions(file: BscFile, callablesByLowerName: { [lowerName: string]: CallableContainer[] }) {
         //validate all expression calls
         for (let expCall of file.functionCalls) {
-            let lowerName = expCall.name.toLowerCase();
+            const lowerName = expCall.name.toLowerCase();
+            //for now, skip validation on any method named "super" within `.bs` contexts.
+            //TODO revise this logic so we know if this function call resides within a class constructor function
+            if (file.extension === '.bs' && lowerName === 'super') {
+                continue;
+            }
 
             //get the local scope for this expression
             let scope = file.getFunctionScopeAtPosition(expCall.nameRange.start);

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -143,6 +143,8 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
                 class Duck extends Bird
                     sub new()
+                        thing = { m: "m"}
+                        print thing.m
                         name = "Donald" + "Duck"
                         super(name)
                     end sub

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1113,7 +1113,6 @@ export class ImportStatement extends Statement {
     }
 }
 
-
 export class ClassStatement extends Statement {
 
     constructor(


### PR DESCRIPTION
Calling `super()` in class constructor methods are current emitting bs1001 ("Cannot find function with name..."). This PR adds temporary relief for that issue by skipping bs1001 checks for any function call with the exact text "super" that is found in `.bs` files. This is slightly heavy-handed, but the current validation logic does not provide enough information to know if the parent function is a class method or not. 

In future validation enhancements we will tighten up this logic.

Also, this PR adds the ability for class constructors to have non-`m.` based statements before a `super()`  call. 

Fixes #202 