### PR TITLE
Pass cwd when finding `bsconfig.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## Unreleased
+### Fixed
+ - bug when finding `bsconfig.json` that would use the wrong cwd in multi-workspace language server situations.
+
+
+
 ## [0.16.6] - 2020-10-13
 ### Fixed
  - quirk in the GitHub actions workflow that didn't publish the correct code.

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';
-import * as sinonImport from 'sinon';
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
 import { Program } from './Program';
 import { ProgramBuilder } from './ProgramBuilder';
 import { standardizePath as s, util } from './util';
 import { Logger, LogLevel } from './Logger';
 
-let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;
 let rootDir = s`${tmpPath}/rootDir`;
 let stagingFolderPath = s`${tmpPath}/staging`;
@@ -24,26 +24,13 @@ describe('ProgramBuilder', () => {
 
     let builder: ProgramBuilder;
     let b: any;
-    let setVfsFile: (filePath: string, contents: string) => void;
     beforeEach(async () => {
         builder = new ProgramBuilder();
         b = builder;
         b.options = await util.normalizeAndResolveConfig(undefined);
         b.program = new Program(b.options);
         b.logger = new Logger();
-        let vfs = {};
-        setVfsFile = (filePath, contents) => {
-            vfs[filePath] = contents;
-        };
-        sinon.stub(b.program.util, 'getFileContents').callsFake((filePath) => {
-            if (vfs[filePath]) {
-                return vfs[filePath];
-            } else {
-                throw new Error(`Cannot find file "${filePath}"`);
-            }
-        });
     });
-
 
     afterEach(() => {
         builder.dispose();
@@ -76,7 +63,7 @@ describe('ProgramBuilder', () => {
             //supress the console log statements for the bsconfig parse errors
             sinon.stub(console, 'log').returns(undefined);
             //totally bogus config file
-            setVfsFile(s`${rootDir}/bsconfig.json`, '{');
+            fsExtra.outputFileSync(s`${rootDir}/bsconfig.json`, '{');
             await builder.run({
                 project: s`${rootDir}/bsconfig.json`,
                 username: 'john'

--- a/src/util.ts
+++ b/src/util.ts
@@ -91,7 +91,7 @@ export class Util {
      * @param configFilePath
      */
     public async getConfigFilePath(cwd?: string) {
-        cwd = cwd ? cwd : process.cwd();
+        cwd = cwd ?? process.cwd();
         let configPath = path.join(cwd, 'bsconfig.json');
         //find the nearest config file path
         for (let i = 0; i < 100; i++) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -258,7 +258,7 @@ export class Util {
 
         //if no options were provided, try to find a bsconfig.json file
         if (!config || !config.project) {
-            result.project = await this.getConfigFilePath();
+            result.project = await this.getConfigFilePath(config?.cwd);
         } else {
             //use the config's project link
             result.project = config.project;


### PR DESCRIPTION
This fixes a bug when finding `bsconfig.json` that would use the wrong `cwd` in multi-workspace LanguageServer situations.

Fixes #207 