### PR TITLE
Performance refactoring: property names completion, classes transpilation

### DIFF
--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -7,7 +7,7 @@ import { diagnosticCodes, DiagnosticMessages } from '../DiagnosticMessages';
 import { FunctionScope } from '../FunctionScope';
 import { Callable, CallableArg, CallableParam, CommentFlag, FunctionCall, BsDiagnostic, FileReference } from '../interfaces';
 import { Deferred } from '../deferred';
-import { Lexer, Token, TokenKind, Identifier, AllowedLocalIdentifiers, Keywords } from '../lexer';
+import { Lexer, Token, TokenKind, AllowedLocalIdentifiers, Keywords } from '../lexer';
 import { Parser, ParseMode } from '../parser';
 import { FunctionExpression, VariableExpression, Expression } from '../parser/Expression';
 import { AssignmentStatement, ClassStatement, LibraryStatement, ImportStatement } from '../parser/Statement';
@@ -21,7 +21,7 @@ import { TranspileState } from '../parser/TranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { LogLevel } from '../Logger';
 import { serializeError } from 'serialize-error';
-import { isAALiteralExpression, isAssignmentStatement, isCallExpression, isClassStatement, isCommentStatement, isDottedGetExpression, isFunctionExpression, isFunctionParameterExpression, isFunctionStatement, isFunctionType, isIfStatement, isImportStatement, isLibraryStatement, isLiteralExpression, isStringType, isVariableExpression } from '../astUtils/reflection';
+import { isCallExpression, isClassStatement, isCommentStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isImportStatement, isLibraryStatement, isLiteralExpression, isStringType, isVariableExpression } from '../astUtils/reflection';
 
 /**
  * Holds all details about this file within the scope of the whole program
@@ -302,57 +302,24 @@ export class BrsFile {
         }
     }
 
-    public findPropertyNameCompletions() {
-        //Find every identifier in the whole file
-        let identifiers = util.findAllDeep<Identifier>(this.ast.statements, (x) => {
-            return x && x.kind === TokenKind.Identifier;
-        });
-
-        this._propertyNameCompletions = [];
-        let names = {};
-        for (let identifier of identifiers) {
-            let ancestors = this.getAncestors(identifier.key);
-            let parent = ancestors[ancestors.length - 1];
-
-            let isObjectProperty = !!ancestors.find(x => (isDottedGetExpression(x)) || (isAALiteralExpression(x)));
-
-            //filter out certain text items
-            if (
-                //don't filter out any object properties
-                isObjectProperty === false && (
-                    //top-level functions (they are handled elsewhere)
-                    isFunctionStatement(parent) ||
-                    //local variables created or used by assignments
-                    isAssignmentStatement(ancestors.find(x => x)) ||
-                    //local variables used in conditional statements
-                    isIfStatement(ancestors.find(x => x)) ||
-                    //the 'as' keyword (and parameter types) when used in a type statement
-                    ancestors.find(x => isFunctionParameterExpression(x))
-                )
-            ) {
-                continue;
-            }
-
-            let name = identifier.value.text;
-
-            //filter duplicate names
-            if (names[name]) {
-                continue;
-            }
-
-            names[name] = true;
-            this._propertyNameCompletions.push({
-                label: name,
+    public findPropertyNameCompletions(): CompletionItem[] {
+        //Build completion items from all the "properties" found in the file
+        const { propertyHints } = this.parser.references;
+        const results = [] as CompletionItem[];
+        for (const key of Object.keys(propertyHints)) {
+            results.push({
+                label: propertyHints[key],
                 kind: CompletionItemKind.Text
             });
         }
+        return results;
     }
 
     private _propertyNameCompletions: CompletionItem[];
 
     public get propertyNameCompletions(): CompletionItem[] {
         if (!this._propertyNameCompletions) {
-            this.findPropertyNameCompletions();
+            this._propertyNameCompletions = this.findPropertyNameCompletions();
         }
         return this._propertyNameCompletions;
     }
@@ -491,25 +458,6 @@ export class BrsFile {
                 });
             }
         }
-    }
-
-    /**
-     * Get all ancenstors of an object with the given key
-     * @param statements
-     * @param key
-     */
-    private getAncestors(key: string) {
-        let parts = key.split('.');
-        //throw out the last part (because that's the "child")
-        parts.pop();
-
-        let current = this.ast.statements;
-        let ancestors = [];
-        for (let part of parts) {
-            current = current[part];
-            ancestors.push(current);
-        }
-        return ancestors;
     }
 
     private getBRSTypeFromAssignment(assignment: AssignmentStatement, scope: FunctionScope): BrsType {

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -278,4 +278,46 @@ describe('parser', () => {
         expect((statements[0] as any).func.body.statements[0].value.elements[0].keyToken.text).to.equal('"has-second-layer"');
         expect((statements[0] as any).func.body.statements[0].value.elements[0].key.value).to.equal('has-second-layer');
     });
+
+    it('extracts property names for completion', () => {
+        const { tokens } = Lexer.scan(`
+            function main(arg as string)
+                aa1 = {
+                    "sprop1": 0,
+                    prop1: 1
+                    prop2: {
+                        prop3: 2
+                    }
+                }
+                aa2 = {
+                    prop4: {
+                        prop5: 5,
+                        "sprop2": 0,
+                        prop6: 6
+                    },
+                    prop7: 7
+                }
+                calling({
+                    prop8: 8,
+                    prop9: 9
+                })
+                aa1.field1 = 1
+                aa1.field2.field3 = 2
+                calling(aa2.field4, 3 + aa2.field5.field6)
+            end function
+        `);
+
+        const expected = [
+            'field1', 'field2', 'field3', 'field4', 'field5', 'field6',
+            'prop1', 'prop2', 'prop3', 'prop4', 'prop5', 'prop6', 'prop7', 'prop8', 'prop9'
+        ];
+
+        const parser = Parser.parse(tokens);
+        const { propertyHints: initialHints } = parser.references;
+        expect(Object.keys(initialHints).sort()).to.deep.equal(expected, 'Initial hints');
+
+        parser.invalidateReferences();
+        const { propertyHints: refreshedHints } = parser.references;
+        expect(Object.keys(refreshedHints).sort()).to.deep.equal(expected, 'Refreshed hints');
+    });
 });

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -379,67 +379,6 @@ describe('util', () => {
         });
     });
 
-    describe('findAllDeep', () => {
-        class Person {
-            constructor(
-                public name: string,
-                public parent?: Person
-            ) {
-            }
-        }
-        it('finds all properties deep', () => {
-            let grandpa = new Person('grandpa');
-            let dad = new Person('dad', grandpa);
-            let me = new Person('me', dad);
-            let people = util.findAllDeep(me, (x) => x instanceof Person);
-            expect(people[0]).to.deep.include({ key: undefined, value: me });
-            expect(people[1]).to.deep.include({ key: 'parent', value: dad });
-            expect(people[2]).to.deep.include({ key: 'parent.parent', value: grandpa });
-        });
-
-        it('finds properties in arrays', () => {
-            let results = util.findAllDeep<{ id: number }>({
-                children: [{
-                    id: 1,
-                    name: 'bob',
-                    children: [{
-                        id: 2,
-                        name: 'john'
-                    }, {
-                        id: 3,
-                        name: 'bob'
-                    }]
-                }, {
-                    id: 4,
-                    name: 'bob'
-                }]
-            }, (x) => {
-                return x.name === 'bob';
-            });
-
-            expect(results[0].key).to.eql('children.0');
-            expect(results[0].value.id).to.eql(1);
-
-            expect(results[1].key).to.eql('children.0.children.1');
-            expect(results[1].value.id).to.eql(3);
-
-            expect(results[2].key).to.eql('children.1');
-            expect(results[2].value.id).to.eql(4);
-        });
-
-        it('prevents recursive infinite loop', () => {
-            let objA = { name: 'a', sibling: undefined };
-            let objB = { name: 'b', sibling: objA };
-            objA.sibling = objB;
-            expect(
-                util.findAllDeep<any>(objA, x => ['a', 'b'].includes(x.name)).map(x => x.value.name)
-            ).to.eql([
-                'a',
-                'b'
-            ]);
-        });
-    });
-
     describe('padLeft', () => {
         it('stops at an upper limit to prevent terrible memory explosions', () => {
             expect(util.padLeft('', Number.MAX_VALUE, ' ')).to.be.lengthOf(1000);

--- a/src/util.ts
+++ b/src/util.ts
@@ -493,52 +493,6 @@ export class Util {
     }
 
     /**
-     * Find all properties in an object that match the predicate.
-     * @param seenMap - used to prevent circular dependency infinite loops
-     */
-    public findAllDeep<T>(obj: any, predicate: (value: any) => boolean | undefined, parentKey?: string, ancestors?: any[], seenMap?: Map<any, boolean>) {
-        seenMap = seenMap ?? new Map<any, boolean>();
-        let result = [] as Array<{ key: string; value: T; ancestors: any[] }>;
-
-        //skip this object if we've already seen it
-        if (seenMap.has(obj)) {
-            return result;
-        }
-
-        //base case. If this object maches, keep it as a result
-        if (predicate(obj) === true) {
-            result.push({
-                key: parentKey,
-                ancestors: ancestors,
-                value: obj
-            });
-        }
-
-        seenMap.set(obj, true);
-
-        //look through all children
-        if (obj instanceof Object) {
-            for (let key in obj) {
-                let value = obj[key];
-                let fullKey = parentKey ? parentKey + '.' + key : key;
-                if (typeof value === 'object') {
-                    result = [...result, ...this.findAllDeep<T>(
-                        value,
-                        predicate,
-                        fullKey,
-                        [
-                            ...(ancestors ?? []),
-                            obj
-                        ],
-                        seenMap
-                    )];
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
      * Test if `position` is in `range`. If the position is at the edges, will return true.
      * Adapted from core vscode
      * @param range


### PR DESCRIPTION
- Drop expensive AST walking for collecting property names and instead collect them as part of parsing.
- Use visitor for `super` AST mod.
- Removed `util.findAllDeep`