### PR TITLE
Use in-memory source code for diagnostic printing

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -190,10 +190,7 @@ describe('ProgramBuilder', () => {
         });
 
         it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
-            builder = new ProgramBuilder();
-            builder.options = {
-                showDiagnosticsInConsole: false
-            };
+            builder.options.showDiagnosticsInConsole = false;
 
             let stub = sinon.stub(builder, 'getDiagnostics').returns([]);
             expect(stub.called).to.be.false;
@@ -202,11 +199,8 @@ describe('ProgramBuilder', () => {
 
 
         it('prints nothing when there are no diagnostics', () => {
+            builder.options.showDiagnosticsInConsole = true;
 
-            builder = new ProgramBuilder();
-            builder.options = {
-                showDiagnosticsInConsole: true
-            };
             sinon.stub(builder, 'getDiagnostics').returns([]);
             let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
@@ -216,18 +210,11 @@ describe('ProgramBuilder', () => {
         });
 
         it('prints diagnostic, when file is present in project', () => {
-
-            builder = new ProgramBuilder();
-            builder.options = {
-                showDiagnosticsInConsole: true
-            };
-            builder.program = new Program({});
+            builder.options.showDiagnosticsInConsole = true;
 
             let diagnostics = createBsDiagnostic('p1', ['m1']);
             let f1 = diagnostics[0].file as BrsFile;
-            f1.fileContents = `l1
-l2
-l3`;
+            f1.fileContents = `l1\nl2\nl3`;
             sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
             sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
@@ -241,12 +228,7 @@ l3`;
     });
 
     it('prints diagnostic, when file has no lines', () => {
-
-        builder = new ProgramBuilder();
-        builder.options = {
-            showDiagnosticsInConsole: true
-        };
-        builder.program = new Program({});
+        builder.options.showDiagnosticsInConsole = true;
 
         let diagnostics = createBsDiagnostic('p1', ['m1']);
         let f1 = diagnostics[0].file as BrsFile;
@@ -263,12 +245,7 @@ l3`;
     });
 
     it('prints diagnostic, when no file present', () => {
-
-        builder = new ProgramBuilder();
-        builder.options = {
-            showDiagnosticsInConsole: true
-        };
-        builder.program = new Program({});
+        builder.options.showDiagnosticsInConsole = true;
 
         let diagnostics = createBsDiagnostic('p1', ['m1']);
         sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
@@ -286,7 +263,7 @@ l3`;
 function createBsDiagnostic(filePath: string, messages: string[]): BsDiagnostic[] {
     let file = new BrsFile(filePath, filePath, null);
     let diagnostics = [];
-    for (let message in messages) {
+    for (let message of messages) {
         let d = createDiagnostic(file, 1, message);
         d.file = file;
         diagnostics.push(d);

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -6,6 +6,10 @@ import { Program } from './Program';
 import { ProgramBuilder } from './ProgramBuilder';
 import { standardizePath as s, util } from './util';
 import { Logger, LogLevel } from './Logger';
+import * as diagnosticUtils from './diagnosticUtils';
+import { Range, BscFile, BsDiagnostic } from '.';
+import { DiagnosticSeverity } from './astUtils';
+import { BrsFile } from './files/BrsFile';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let rootDir = s`${tmpPath}/rootDir`;
@@ -172,4 +176,140 @@ describe('ProgramBuilder', () => {
         expect(beforeProgramValidate.callCount).to.equal(1);
         expect(afterProgramValidate.callCount).to.equal(1);
     });
+
+
+    describe('printDiagnostics', () => {
+
+      beforeEach(() => {
+          fsExtra.ensureDirSync(tmpPath);
+          fsExtra.emptyDirSync(tmpPath);
+      });
+
+      afterEach(() => {
+          sinon.restore();
+      });
+
+      it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
+          builder = new ProgramBuilder();
+          builder.options = {
+              showDiagnosticsInConsole: false
+          };
+
+          let stub = sinon.stub(builder, 'getDiagnostics').returns([]);
+          expect(stub.called).to.be.false;
+          builder['printDiagnostics']();
+      });
+
+
+      it('prints nothing when there are no diagnostics', () => {
+
+          builder = new ProgramBuilder();
+          builder.options = {
+              showDiagnosticsInConsole: true
+          };
+          sinon.stub(builder, 'getDiagnostics').returns([]);
+          let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+
+          builder['printDiagnostics']();
+
+          expect(printStub.called).to.be.false;
+      });
+
+      it('prints diagnostic, when file is present in project', () => {
+
+          builder = new ProgramBuilder();
+          builder.options = {
+              showDiagnosticsInConsole: true
+          };
+          builder.program = new Program({});
+
+          let diagnostics = createBsDiagnostic('p1', ['m1']);
+          let f1 = diagnostics[0].file as BrsFile;
+          f1.fileContents = `l1
+l2
+l3`;
+          sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
+
+          sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
+
+          let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+
+          builder['printDiagnostics']();
+
+          expect(printStub.called).to.be.true;
+      });
+    });
+
+    it('prints diagnostic, when file has no lines', () => {
+
+        builder = new ProgramBuilder();
+        builder.options = {
+            showDiagnosticsInConsole: true
+        };
+        builder.program = new Program({});
+
+        let diagnostics = createBsDiagnostic('p1', ['m1']);
+        let f1 = diagnostics[0].file as BrsFile;
+        f1.fileContents = null;
+        sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
+
+        sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
+
+        let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+
+        builder['printDiagnostics']();
+
+        expect(printStub.called).to.be.true;
+    });
+
+    it('prints diagnostic, when no file present', () => {
+
+        builder = new ProgramBuilder();
+        builder.options = {
+            showDiagnosticsInConsole: true
+        };
+        builder.program = new Program({});
+
+        let diagnostics = createBsDiagnostic('p1', ['m1']);
+        sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
+
+        sinon.stub(builder.program, 'getFileByPathAbsolute').returns(null);
+
+        let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+
+        builder['printDiagnostics']();
+
+        expect(printStub.called).to.be.true;
+    });
 });
+
+function createBsDiagnostic(filePath: string, messages: string[]): BsDiagnostic[] {
+  let file = new BrsFile(filePath, filePath, null);
+  let diagnostics = [];
+  for (let message in messages) {
+    let d = createDiagnostic(file, 1, message);
+    d.file = file;
+    diagnostics.push(d);
+  }
+  return diagnostics;
+}
+function createDiagnostic(
+    bscFile: BscFile,
+    code: number,
+    message: string,
+    startLine: number = 0,
+    startCol: number = 99999,
+    endLine: number = 0,
+    endCol: number = 99999,
+    severity: DiagnosticSeverity = DiagnosticSeverity.Error
+) {
+    const diagnostic = {
+        code: code,
+        message: message,
+        range: Range.create(startLine, startCol, endLine, endCol),
+        file: bscFile,
+        severity: severity
+    };
+    return diagnostic;
+}
+

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -180,64 +180,64 @@ describe('ProgramBuilder', () => {
 
     describe('printDiagnostics', () => {
 
-      beforeEach(() => {
-          fsExtra.ensureDirSync(tmpPath);
-          fsExtra.emptyDirSync(tmpPath);
-      });
+        beforeEach(() => {
+            fsExtra.ensureDirSync(tmpPath);
+            fsExtra.emptyDirSync(tmpPath);
+        });
 
-      afterEach(() => {
-          sinon.restore();
-      });
+        afterEach(() => {
+            sinon.restore();
+        });
 
-      it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
-          builder = new ProgramBuilder();
-          builder.options = {
-              showDiagnosticsInConsole: false
-          };
+        it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
+            builder = new ProgramBuilder();
+            builder.options = {
+                showDiagnosticsInConsole: false
+            };
 
-          let stub = sinon.stub(builder, 'getDiagnostics').returns([]);
-          expect(stub.called).to.be.false;
-          builder['printDiagnostics']();
-      });
+            let stub = sinon.stub(builder, 'getDiagnostics').returns([]);
+            expect(stub.called).to.be.false;
+            builder['printDiagnostics']();
+        });
 
 
-      it('prints nothing when there are no diagnostics', () => {
+        it('prints nothing when there are no diagnostics', () => {
 
-          builder = new ProgramBuilder();
-          builder.options = {
-              showDiagnosticsInConsole: true
-          };
-          sinon.stub(builder, 'getDiagnostics').returns([]);
-          let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+            builder = new ProgramBuilder();
+            builder.options = {
+                showDiagnosticsInConsole: true
+            };
+            sinon.stub(builder, 'getDiagnostics').returns([]);
+            let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
-          builder['printDiagnostics']();
+            builder['printDiagnostics']();
 
-          expect(printStub.called).to.be.false;
-      });
+            expect(printStub.called).to.be.false;
+        });
 
-      it('prints diagnostic, when file is present in project', () => {
+        it('prints diagnostic, when file is present in project', () => {
 
-          builder = new ProgramBuilder();
-          builder.options = {
-              showDiagnosticsInConsole: true
-          };
-          builder.program = new Program({});
+            builder = new ProgramBuilder();
+            builder.options = {
+                showDiagnosticsInConsole: true
+            };
+            builder.program = new Program({});
 
-          let diagnostics = createBsDiagnostic('p1', ['m1']);
-          let f1 = diagnostics[0].file as BrsFile;
-          f1.fileContents = `l1
+            let diagnostics = createBsDiagnostic('p1', ['m1']);
+            let f1 = diagnostics[0].file as BrsFile;
+            f1.fileContents = `l1
 l2
 l3`;
-          sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
+            sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
-          sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
+            sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
 
-          let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
+            let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
-          builder['printDiagnostics']();
+            builder['printDiagnostics']();
 
-          expect(printStub.called).to.be.true;
-      });
+            expect(printStub.called).to.be.true;
+        });
     });
 
     it('prints diagnostic, when file has no lines', () => {
@@ -284,23 +284,23 @@ l3`;
 });
 
 function createBsDiagnostic(filePath: string, messages: string[]): BsDiagnostic[] {
-  let file = new BrsFile(filePath, filePath, null);
-  let diagnostics = [];
-  for (let message in messages) {
-    let d = createDiagnostic(file, 1, message);
-    d.file = file;
-    diagnostics.push(d);
-  }
-  return diagnostics;
+    let file = new BrsFile(filePath, filePath, null);
+    let diagnostics = [];
+    for (let message in messages) {
+        let d = createDiagnostic(file, 1, message);
+        d.file = file;
+        diagnostics.push(d);
+    }
+    return diagnostics;
 }
 function createDiagnostic(
     bscFile: BscFile,
     code: number,
     message: string,
-    startLine: number = 0,
-    startCol: number = 99999,
-    endLine: number = 0,
-    endCol: number = 99999,
+    startLine = 0,
+    startCol = 99999,
+    endLine = 0,
+    endCol = 99999,
     severity: DiagnosticSeverity = DiagnosticSeverity.Error
 ) {
     const diagnostic = {

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -180,15 +180,6 @@ describe('ProgramBuilder', () => {
 
     describe('printDiagnostics', () => {
 
-        beforeEach(() => {
-            fsExtra.ensureDirSync(tmpPath);
-            fsExtra.emptyDirSync(tmpPath);
-        });
-
-        afterEach(() => {
-            sinon.restore();
-        });
-
         it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
             builder.options.showDiagnosticsInConsole = false;
 
@@ -196,7 +187,6 @@ describe('ProgramBuilder', () => {
             expect(stub.called).to.be.false;
             builder['printDiagnostics']();
         });
-
 
         it('prints nothing when there are no diagnostics', () => {
             builder.options.showDiagnosticsInConsole = true;

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -79,7 +79,7 @@ export class ProgramBuilder {
                 //if this is not a diagnostic, something else is wrong...
                 throw e;
             }
-            await this.printDiagnostics();
+            this.printDiagnostics();
 
             //we added diagnostics, so hopefully that draws attention to the underlying issues.
             //For now, just use a default options object so we have a functioning program
@@ -204,7 +204,7 @@ export class ProgramBuilder {
         return runPromise;
     }
 
-    private async printDiagnostics() {
+    private printDiagnostics() {
         if (this.options.showDiagnosticsInConsole === false) {
             return;
         }
@@ -238,23 +238,16 @@ export class ProgramBuilder {
             if (!emitFullPaths) {
                 filePath = path.relative(cwd, filePath);
             }
-            let linesByFile = {};
             //load the file text
-            try {
-                let file = this.program.getFileByPathAbsolute(pathAbsolute);
-                let lines = linesByFile[pathAbsolute];
-                if (!lines) {
-                  lines = file && file.fileContents ? file.fileContents.split(/\r?\n/g) : [];
-                  linesByFile[pathAbsolute] = lines
-                }
+            const file = this.program.getFileByPathAbsolute(pathAbsolute);
+            //get the file's in-memory contents if available
+            const lines = file?.fileContents?.split(/\r?\n/g) ?? [];
 
-                for (let diagnostic of sortedDiagnostics) {
-                    //default the severity to error if undefined
-                    let severity = typeof diagnostic.severity === 'number' ? diagnostic.severity : DiagnosticSeverity.Error;
-                    //format output
-                    diagnosticUtils.printDiagnostic(options, severity, filePath, lines, diagnostic);
-                }
-            } catch (e) {
+            for (let diagnostic of sortedDiagnostics) {
+                //default the severity to error if undefined
+                let severity = typeof diagnostic.severity === 'number' ? diagnostic.severity : DiagnosticSeverity.Error;
+                //format output
+                diagnosticUtils.printDiagnostic(options, severity, filePath, lines, diagnostic);
             }
         }
     }
@@ -280,7 +273,7 @@ export class ProgramBuilder {
                 return -1;
             }
 
-            await this.printDiagnostics();
+            this.printDiagnostics();
             wereDiagnosticsPrinted = true;
             let errorCount = this.getDiagnostics().filter(x => x.severity === DiagnosticSeverity.Error).length;
 
@@ -303,7 +296,7 @@ export class ProgramBuilder {
             return 0;
         } catch (e) {
             if (wereDiagnosticsPrinted === false) {
-                await this.printDiagnostics();
+                this.printDiagnostics();
             }
             throw e;
         }


### PR DESCRIPTION
improves diagnostic printing, by going to program to retrieve file contents, and allowing in-memory files to be used, not failing when there is no content, and improving efficiency