### PR TITLE
Performance: refactored getFileByPkgPath

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1123,21 +1123,21 @@ describe('Program', () => {
 
     describe('getFileByPkgPath', () => {
         it('finds file in source folder', async () => {
-            expect(program.getFileByPkgPath('source/main.brs')).not.to.exist;
-            expect(program.getFileByPkgPath('source/main2.brs')).not.to.exist;
+            expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
+            expect(program.getFileByPkgPath(s`source/main2.brs`)).not.to.exist;
             await program.addOrReplaceFile({ src: `${rootDir}/source/main2.brs`, dest: 'source/main2.brs' }, '');
             await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
-            expect(program.getFileByPkgPath('source/main.brs')).to.exist;
-            expect(program.getFileByPkgPath('source/main2.brs')).to.exist;
+            expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
+            expect(program.getFileByPkgPath(s`source/main2.brs`)).to.exist;
         });
     });
 
     describe('removeFiles', () => {
         it('removes files by absolute paths', async () => {
             await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
-            expect(program.getFileByPkgPath('source/main.brs')).to.exist;
+            expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
             program.removeFiles([`${rootDir}/source/main.brs`]);
-            expect(program.getFileByPkgPath('source/main.brs')).not.to.exist;
+            expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
         });
     });
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -425,7 +425,7 @@ export class Program {
     }
 
     /**
-     * Get a list of files for the given pkgPath array.
+     * Get a list of files for the given (platform-normalized) pkgPath array.
      * Missing files are just ignored.
      */
     public getFilesByPkgPaths<T extends BscFile[]>(pkgPaths: string[]) {
@@ -435,7 +435,7 @@ export class Program {
     }
 
     /**
-     * Get a file with the specified pkg path.
+     * Get a file with the specified (platform-normalized) pkg path.
      * If not found, return undefined
      */
     public getFileByPkgPath<T extends BscFile>(pkgPath: string) {

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -243,8 +243,8 @@ describe('import statements', () => {
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="AuthManager.brs" />
-                <script type="text/brightscript" uri="pkg:/source/maestro/ioc/IOCMixin.brs" />
                 <script type="text/brightscript" uri="pkg:/source/BaseClass.brs" />
+                <script type="text/brightscript" uri="pkg:/source/maestro/ioc/IOCMixin.brs" />
                 <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
             </component>
         `, null, 'components/AuthenticationService.xml');


### PR DESCRIPTION
Massively improve validation performance by refactoring `getFileByPkgPath`.
Like 40% faster validation for me.