### PR TITLE
Crash: reserved JS names

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -481,7 +481,7 @@ describe('Scope', () => {
                 end sub
             `);
             await program.validate();
-            expect(program.getDiagnostics().length).to.equal(1); //'constructor' is Brs reserved
+            expect(program.getDiagnostics().length).to.equal(0);
         });
 
         it('Emits validation events', async () => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -469,6 +469,21 @@ describe('Scope', () => {
             );
         });
 
+        it('handles JavaScript reserved names', async () => {
+            await program.addOrReplaceFile('source/file.brs', `
+                sub constructor()
+                end sub
+                sub toString()
+                end sub
+                sub valueOf()
+                end sub
+                sub getPrototypeOf()
+                end sub
+            `);
+            await program.validate();
+            expect(program.getDiagnostics().length).to.equal(1); //'constructor' is Brs reserved
+        });
+
         it('Emits validation events', async () => {
             const validateStartScope = sinon.spy();
             const validateEndScope = sinon.spy();

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -3,7 +3,7 @@ import { CompletionItemKind, Location } from 'vscode-languageserver';
 import chalk from 'chalk';
 import type { DiagnosticInfo } from './DiagnosticMessages';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import type { CallableContainer, BsDiagnostic, FileReference, BscFile } from './interfaces';
+import type { CallableContainer, BsDiagnostic, FileReference, BscFile, CallableContainerMap } from './interfaces';
 import type { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
 import type { NamespaceStatement, Statement, NewExpression, FunctionStatement, ClassStatement } from './parser';
@@ -465,10 +465,10 @@ export class Scope {
      * @param file
      * @param callableContainersByLowerName
      */
-    private diagnosticDetectFunctionCallsWithWrongParamCount(file: BscFile, callableContainersByLowerName: Record<string, CallableContainer[]>) {
+    private diagnosticDetectFunctionCallsWithWrongParamCount(file: BscFile, callableContainersByLowerName: CallableContainerMap) {
         //validate all function calls
         for (let expCall of file.functionCalls) {
-            let callableContainersWithThisName = callableContainersByLowerName[expCall.name.toLowerCase()];
+            let callableContainersWithThisName = callableContainersByLowerName.get(expCall.name.toLowerCase());
 
             //use the first item from callablesByLowerName, because if there are more, that's a separate error
             let knownCallableContainer = callableContainersWithThisName ? callableContainersWithThisName[0] : undefined;
@@ -504,7 +504,7 @@ export class Scope {
      * @param file
      * @param callableContainerMap
      */
-    private diagnosticDetectShadowedLocalVars(file: BscFile, callableContainerMap: Record<string, CallableContainer[]>) {
+    private diagnosticDetectShadowedLocalVars(file: BscFile, callableContainerMap: CallableContainerMap) {
         //loop through every function scope
         for (let scope of file.functionScopes) {
             //every var declaration in this scope
@@ -528,7 +528,7 @@ export class Scope {
                         //in the scope function list
                     } else if (
                         //has same name as scope function
-                        callableContainerMap[lowerVarName]
+                        callableContainerMap.has(lowerVarName)
                     ) {
                         this.diagnostics.push({
                             ...DiagnosticMessages.localVarFunctionShadowsParentFunction('scope'),
@@ -540,7 +540,7 @@ export class Scope {
                     //var is not a function
                 } else if (
                     //is same name as a callable
-                    callableContainerMap[lowerVarName] &&
+                    callableContainerMap.has(lowerVarName) &&
                     //is NOT a callable from stdlib (because non-function local vars can have same name as stdlib names)
                     !globalCallableMap[lowerVarName]
                 ) {
@@ -559,7 +559,7 @@ export class Scope {
      * @param file
      * @param callablesByLowerName
      */
-    private diagnosticDetectCallsToUnknownFunctions(file: BscFile, callablesByLowerName: Record<string, CallableContainer[]>) {
+    private diagnosticDetectCallsToUnknownFunctions(file: BscFile, callablesByLowerName: CallableContainerMap) {
         //validate all expression calls
         for (let expCall of file.functionCalls) {
             const lowerName = expCall.name.toLowerCase();
@@ -574,7 +574,7 @@ export class Scope {
 
             //if we don't already have a variable with this name.
             if (!scope?.getVariableByName(lowerName)) {
-                let callablesWithThisName = callablesByLowerName[lowerName];
+                let callablesWithThisName = callablesByLowerName.get(lowerName);
 
                 //use the first item from callablesByLowerName, because if there are more, that's a separate error
                 let knownCallable = callablesWithThisName ? callablesWithThisName[0] : undefined;
@@ -598,10 +598,9 @@ export class Scope {
      * Create diagnostics for any duplicate function declarations
      * @param callablesByLowerName
      */
-    private diagnosticFindDuplicateFunctionDeclarations(callableContainersByLowerName: Record<string, CallableContainer[]>) {
+    private diagnosticFindDuplicateFunctionDeclarations(callableContainersByLowerName: CallableContainerMap) {
         //for each list of callables with the same name
-        for (let lowerName in callableContainersByLowerName) {
-            let callableContainers = callableContainersByLowerName[lowerName];
+        for (let [lowerName, callableContainers] of callableContainersByLowerName) {
 
             let globalCallables = [] as CallableContainer[];
             let nonGlobalCallables = [] as CallableContainer[];

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -431,7 +431,7 @@ export class Scope {
      */
     private diagnosticDetectFunctionCollisions(file: BscFile) {
         for (let func of file.callables) {
-            if (globalCallableMap[func.getName(ParseMode.BrighterScript).toLowerCase()]) {
+            if (globalCallableMap.has(func.getName(ParseMode.BrighterScript).toLowerCase())) {
                 this.diagnostics.push({
                     ...DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction(),
                     range: func.nameRange,
@@ -516,7 +516,7 @@ export class Scope {
                     //local var function with same name as stdlib function
                     if (
                         //has same name as stdlib
-                        globalCallableMap[lowerVarName]
+                        globalCallableMap.has(lowerVarName)
                     ) {
                         this.diagnostics.push({
                             ...DiagnosticMessages.localVarFunctionShadowsParentFunction('stdlib'),
@@ -542,7 +542,7 @@ export class Scope {
                     //is same name as a callable
                     callableContainerMap.has(lowerVarName) &&
                     //is NOT a callable from stdlib (because non-function local vars can have same name as stdlib names)
-                    !globalCallableMap[lowerVarName]
+                    !globalCallableMap.has(lowerVarName)
                 ) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.localVarShadowedByScopedFunction(),

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -251,7 +251,7 @@ describe('import statements', () => {
         `, null, 'components/AuthenticationService.xml');
     });
 
-    it.only('handles malformed imports', async () => {
+    it('handles malformed imports', async () => {
         //shouldn't crash
         const brsFile = await program.addOrReplaceFile<BrsFile>('source/SomeFile.bs', `
             import ""

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -749,6 +749,6 @@ globalFile.callables = globalCallables;
  * so keep a single copy in memory to improve performance
  */
 export const globalCallableMap = globalCallables.reduce((map, x) => {
-    map[x.name.toLowerCase()] = x;
+    map.set(x.name.toLowerCase(), x);
     return map;
-}, {});
+}, new Map<string, Callable>());

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -154,7 +154,7 @@ export interface CallableContainer {
     scope: Scope;
 }
 
-export type CallableContainerMap = Record<string, CallableContainer[]>;
+export type CallableContainerMap = Map<string, CallableContainer[]>;
 
 export interface CommentFlag {
     file: BrsFile;

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -337,7 +337,7 @@ describe('parser', () => {
         `);
 
         const expected = [
-            'constructor', 'valueOf', 'toString'
+            'constructor', 'tostring', 'valueof'
         ];
 
         const parser = Parser.parse(tokens);

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -320,4 +320,32 @@ describe('parser', () => {
         const { propertyHints: refreshedHints } = parser.references;
         expect(Object.keys(refreshedHints).sort()).to.deep.equal(expected, 'Refreshed hints');
     });
+
+    it('extracts property names matching JavaScript reserved names', () => {
+        const { tokens } = Lexer.scan(`
+            function main(arg as string)
+                aa1 = {
+                    "constructor": 0,
+                    constructor: 1
+                    valueOf: {
+                        toString: 2
+                    }
+                }
+                aa1.constructor = 1
+                aa1.valueOf.toString = 2
+            end function
+        `);
+
+        const expected = [
+            'constructor', 'valueOf', 'toString'
+        ];
+
+        const parser = Parser.parse(tokens);
+        const { propertyHints: initialHints } = parser.references;
+        expect(Object.keys(initialHints).sort()).to.deep.equal(expected, 'Initial hints');
+
+        parser.invalidateReferences();
+        const { propertyHints: refreshedHints } = parser.references;
+        expect(Object.keys(refreshedHints).sort()).to.deep.equal(expected, 'Refreshed hints');
+    });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -374,18 +374,20 @@ export class Util {
      * Given a list of callables as a dictionary indexed by their full name (namespace included, transpiled to underscore-separated.
      * @param callables
      */
-    public getCallableContainersByLowerName(callables: CallableContainer[]) {
+    public getCallableContainersByLowerName(callables: CallableContainer[]): CallableContainerMap {
         //find duplicate functions
-        let result = {} as CallableContainerMap;
+        const result = new Map<string, CallableContainer[]>();
 
         for (let callableContainer of callables) {
             let lowerName = callableContainer.callable.getName(ParseMode.BrightScript).toLowerCase();
 
             //create a new array for this name
-            if (result[lowerName] === undefined) {
-                result[lowerName] = [];
+            const list = result.get(lowerName);
+            if (list) {
+                list.push(callableContainer);
+            } else {
+                result.set(lowerName, [callableContainer]);
             }
-            result[lowerName].push(callableContainer);
         }
         return result;
     }


### PR DESCRIPTION
Declaring a `sub constructor()` crashes the compiler.
Seems ok for properties, somehow, but I've added tests to control.