### PR TITLE
Feature: AST annotations

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,0 +1,74 @@
+# BrighterScript Annotations
+
+Annotations are metadata you can attach to any statement, though more often to functions or classes. This extra information will be available to [plugins](plugins.md) walking the AST of the code.
+
+> Annotations completely disappear when transpiled to BrightScript, and are not available at run time.
+
+## Syntax
+
+Annotations should precede a statement, either on a previous line, or inline separated by whitespace.
+A statement can have multiple annotations.
+
+The name of the annotation should be a valid identifier and can not be a keyword (e.g. `for`, `while`, `else`...).
+
+Annotations can have parameters - these parameters should be a list of valid BrighterScript expressions separated by commas.
+
+```
+@<annotation_name>[(parameters)]
+[more annotations]
+<statement>
+
+@<annotation_name>[(parameters)] [more annotations] <statement>
+```
+
+## Examples
+
+```brighterscript
+@translate print "hello"
+
+@expose
+class MyComp
+end class
+
+@task @export_fields([content, result])
+function init()
+end function
+
+@configure(
+    "value",
+    42,
+    true,
+    {
+        hello: "world",
+        scene: "MainScene"
+    }
+)
+function main()
+end
+```
+
+## Plugin usage
+
+Annotation are parsed and stored in the AST as "expressions" and attached to the statement following their declaration.
+
+```typescript
+class Statement {
+    ...
+    annotations: AnnotationExpression[];
+    ...
+}
+```
+
+Usage:
+
+```typescript
+const main: FunctionStatement = pluginFindMainFunction();
+if (main.annotations) {
+    main.annotations.forEach(a => {
+        if (a.name === 'configure') {
+            const args = a.getArguments();
+            // ['value', 42, true, { hello: 'world', scene: 'MainScene' }]
+        }
+    });
+}
+```

--- a/docs/callfunc-operator.md
+++ b/docs/callfunc-operator.md
@@ -1,7 +1,8 @@
-# callfunc operator
+# BrighterScript 'callfunc' operator
+
 In BrightScript, calling a function on a custom comment requires you to use the [callfunc](https://developer.roku.com/docs/developer-program/core-concepts/handling-application-events.md) function. A standard callfunc expression looks something like this: `node.callFunc("functionName", someArg, someOtherArg)`. This deviates from the conventional `object.someMethod()` synax you are used to with standard objects.
 
-Which leads us to the callfunc operator in BrighterScript. This is denoted by an at symbol followed by a period. ( `@.` ). Whenever BrighterScript encounters the callfunc operator, it will transpile the code into a valid callfunc expression, while allowing you to write _mostly_ the same type of syntax you're used to for object method calls. 
+Which leads us to the callfunc operator in BrighterScript. This is denoted by an at symbol followed by a period. ( `@.` ). Whenever BrighterScript encounters the callfunc operator, it will transpile the code into a valid callfunc expression, while allowing you to write _mostly_ the same type of syntax you're used to for object method calls.
 
 Here's a simple example:
 
@@ -17,7 +18,7 @@ node.callfunc("someMethod", 1, 2, 3)
 ## Callfunc evaluation with no arguments
 It is a well-known issue in BrightScript development that calling `callfunc` without at least one parameter has the potential to result in the function not being called at all. So to mitigate this issue, BrighterScript will automatically insert `invalid` as the first argument if you use the callfunc operator with no parameters.
 
-For example, this: 
+For example, this:
 
 ```BrighterScript
 node@.doSomething()

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -1,4 +1,5 @@
-# Classes
+# BrighterScript Classes
+
 Traditional BrightScript supports object creation (see [roAssociativeArray](https://developer.roku.com/docs/references/brightscript/components/roassociativearray.md)), but these can get a bit complicated at times, are generally created in a factory function. These objects are also difficult to track from a type-checking perspective, as their shape can morph over time. In BrighterScript, you can declare actual classes, and compile them into pure BrightScript which can be used on any Roku device.
 
 ## Classes
@@ -16,7 +17,7 @@ end class
 ```
 
 And here's the transpiled BrightScript code
-  
+
 ```BrightScript
 function __Animal_builder()
     instance = {}
@@ -34,7 +35,7 @@ function Animal()
 end function
 ```
 
-Notice that there are two functions created in the transpiled code for the `Animal` class. At runtime, BrighterScript classes are built in two steps in order to support class inheritance. The first step uses the `__ClassName_Build()` method to create the skeleton structure of the class. Then the class's constructor function will be run. Child classes will call the parent's `__ParentClassName_Build()` method, then rename overridden  methods, and then call the child's constructor (without calling the parent constructor). Take a look at the transpiled output of the other examples below for more information on this. 
+Notice that there are two functions created in the transpiled code for the `Animal` class. At runtime, BrighterScript classes are built in two steps in order to support class inheritance. The first step uses the `__ClassName_Build()` method to create the skeleton structure of the class. Then the class's constructor function will be run. Child classes will call the parent's `__ParentClassName_Build()` method, then rename overridden  methods, and then call the child's constructor (without calling the parent constructor). Take a look at the transpiled output of the other examples below for more information on this.
 
 
 ## Inheritance
@@ -68,21 +69,21 @@ end class
 
 sub Main()
     smokey = new Animal("Smokey")
-    smokey.move(1) 
+    smokey.move(1)
     '> Bear moved 1 meters
 
     donald = new Duck("Donald")
-    donald.move(2) 
+    donald.move(2)
     '> Waddling...\nDonald moved 2 meters
 
     dewey = new BabyDuck("Dewey")
-    dewey.move(3) 
+    dewey.move(3)
     '> Waddling...\nDewey moved 2 meters\nFell over...I'm new at this
 end sub
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Animal_builder()
     instance = {}
@@ -153,7 +154,7 @@ end sub
 
 
 ## Constructor function
-The constructor function for a class is called `new`. 
+The constructor function for a class is called `new`.
 
 ```vb
 class Duck
@@ -167,7 +168,7 @@ end sub
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Duck_builder()
     instance = {}
@@ -209,7 +210,7 @@ end sub
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Duck_builder()
     instance = {}
@@ -246,7 +247,7 @@ end function
 </details>
 
 ## Overrides
-Child classes can override methods on parent classes. In this example, the `BabyDuck.Eat()` method completely overrides the parent method. Note: the `override` keyword is mandatory, and you will get a compile error if it is not included in the child class and there is a matching method on the base class. Also, you will get a compile error if the override keyword is present in a child class, but that method doesn't exist in the parent class. 
+Child classes can override methods on parent classes. In this example, the `BabyDuck.Eat()` method completely overrides the parent method. Note: the `override` keyword is mandatory, and you will get a compile error if it is not included in the child class and there is a matching method on the base class. Also, you will get a compile error if the override keyword is present in a child class, but that method doesn't exist in the parent class.
 
 ```vb
 class Duck
@@ -265,7 +266,7 @@ end sub
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Duck_builder()
     instance = {}
@@ -301,7 +302,7 @@ end function
 </details>
 
 ### Calling parent method from child
-You can also call the original methods on the base class from within an overridden method on a child class. 
+You can also call the original methods on the base class from within an overridden method on a child class.
 
 ```vb
 class Duck
@@ -320,7 +321,7 @@ end class
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Duck_builder()
     instance = {}
@@ -358,7 +359,7 @@ end function
 </details>
 
 ## Public by default
-Class fields and methods are public by default, which aligns with the general BrightScript approach that "everything is public". 
+Class fields and methods are public by default, which aligns with the general BrightScript approach that "everything is public".
 
 ```vb
 class Person
@@ -381,7 +382,7 @@ end class
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Person_builder()
     instance = {}
@@ -430,7 +431,7 @@ end class
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Person_builder()
     instance = {}
@@ -455,7 +456,7 @@ end function
 </details>
 
 ## Property initialization
-Like most other object-oriented classes, you can initialze a property with a default value. 
+Like most other object-oriented classes, you can initialze a property with a default value.
 
 ```BrighterScript
 class Duck
@@ -465,7 +466,7 @@ end class
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Duck_builder()
     instance = {}
@@ -493,7 +494,7 @@ daisy = new Person("Daisy")
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 donald = Person("Donald")
 daisy = Person("Daisy")
@@ -515,7 +516,7 @@ end namespace
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function __Vertibrates_Birds_Animal_builder()
     instance = {}

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -1,4 +1,5 @@
-# Imports
+# BrighterScript Imports
+
 Managing script tags in component XML files can be tedius and time consuming. BrighterScript provides the `import` statement, which can be added to the top of your `.bs` files. Any xml file that includes that `.bs` file will automatically have all of its imports added as `<script` includes.
 
 ## Basic example

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,13 @@
 # BrighterScript
-BrighterScript is a superset of Roku's BrightScript language. Its goal is to provide new functionality and enhanced syntax support to enhance the Roku channel developer experience. 
+BrighterScript is a superset of Roku's BrightScript language. Its goal is to provide new functionality and enhanced syntax support to enhance the Roku channel developer experience.
 
 See the following pages for more information
 
+ - [Annotations](annotations.md)
  - [Callfunc Operator](callfunc-operator.md)
  - [Classes](classes.md)
  - [Imports](imports.md)
  - [Namespaces](namespaces.md)
+ - [Plugins](plugins.md)
  - [Source Literals](source-literals.md)
  - [Template Strings (Template Literals)](template-strings.md)

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -1,5 +1,6 @@
-# Classes
-BrighterScript provides a means of grouping functions and classes into Namespaces. BrightScript has no support for namespaces. Generally Roku developers will simulate namespaces by using underscores. However, that causes a large amount of clutter for the intellisense results. 
+# BrighterScript Namespaces
+
+BrighterScript provides a means of grouping functions and classes into Namespaces. BrightScript has no support for namespaces. Generally Roku developers will simulate namespaces by using underscores. However, that causes a large amount of clutter for the intellisense results.
 
 ## Basic function example
 ```BrighterScript
@@ -23,26 +24,26 @@ sub main()
 end sub
 ```
 
-As you can see, behind the scenes, BrighterScript will convert all periods found within namespace names into underscores so that it will be compatible with regular BrightScript. 
+As you can see, behind the scenes, BrighterScript will convert all periods found within namespace names into underscores so that it will be compatible with regular BrightScript.
 
 ## Classes
 Namespaces can also contain classes. See the [classes](classes.md#Namespaces) for more detailed information.
 
 ## Namespace inference
-Functions and classes within a namespace do not need to be prefixed with the full namespace name when called from another location in the same namespace. For example, 
+Functions and classes within a namespace do not need to be prefixed with the full namespace name when called from another location in the same namespace. For example,
 
 ```
 namespace Vertibrates.Birds
     function GetAllBirds()
         return [
-            GetDuck(), 
+            GetDuck(),
             GetGoose()
         ]
     end function
 
     function GetDuck()
     end function
-    
+
     function GetGoose()
     end function
 end namespace
@@ -50,7 +51,7 @@ end namespace
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function Vertibrates_Birds_GetAllBirds()
     return [
@@ -67,7 +68,7 @@ end function
 ```
 </details>
 
-Notice how we didn't need to specify `Vertibrates.Birds` in front of `GetDuck()` and `GetGoose()`. That's because the compiler is smart enough to recognize where those functions come from. 
+Notice how we didn't need to specify `Vertibrates.Birds` in front of `GetDuck()` and `GetGoose()`. That's because the compiler is smart enough to recognize where those functions come from.
 
 ## Works in assignments as well
 The compiler is smart enough to recognize namespaces in assignments as well.
@@ -76,14 +77,14 @@ The compiler is smart enough to recognize namespaces in assignments as well.
 namespace Vertibrates.Birds
     sub Quack()
     end sub
-    
+
     sub Waddle()
     end sub
 
     sub Live()
         'assign based on fully-qualified namespace name
         speak = Vertibrates.Birds.Quack
-        
+
         'infer Current namespace
         walk = Waddle
     end sub
@@ -92,7 +93,7 @@ end namespace
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 sub Vertibrates_Birds_Quack()
 end sub
@@ -123,7 +124,7 @@ end namespace
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 sub Quack()
 end sub

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,4 +1,4 @@
-# BrighterScript plugins
+# BrighterScript Plugins
 
 The brighterscript compiler is extensible using **JavaScript** plugins.
 

--- a/docs/source-literals.md
+++ b/docs/source-literals.md
@@ -1,4 +1,5 @@
-# Source Literals
+# BrighterScript Source Literals
+
 BrightScript provides the `LINE_NUM` literal, which represents the runtime 1-based line number of the current line of code. In a similar fashion, BrighterScript provides several more source literals.
 
 These source literals are converted into inline variables at transpile-time, so keep in mind that any post-processing to the transpiled files could  cause these values to be incorrect.
@@ -10,21 +11,21 @@ The absolute path to the source file, including a leading `file:/` scheme indica
 print SOURCE_FILE_PATH
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 print "file:///c:/projects/roku/brighterscript/scripts/rootDir/source/main.bs"
 ```
 
 ## SOURCE_LINE_NUM
-The 1-based line number of the source file. 
+The 1-based line number of the source file.
 
 ```BrighterScript
 'I am line 1
 print SOURCE_LINE_NUM 'I am line 2
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 'I am line 1
@@ -40,7 +41,7 @@ function RunFromZombie()
 end function
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function RunFromZombie()
@@ -58,7 +59,7 @@ namespace Human.Versus.Zombie
 end namespace
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function Human_Versus_Zombie_RunFromZombie()
@@ -91,7 +92,7 @@ namespace Human.Versus.Zombie
 end namespace
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function main()
@@ -128,7 +129,7 @@ namespace Human.Versus.Zombie
 end namespace
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function Human_Versus_Zombie_Eat()
@@ -148,7 +149,7 @@ function main()
 end function
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function main()
@@ -165,7 +166,7 @@ function main()
 end function
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 function main()
@@ -174,12 +175,12 @@ end function
 ```
 
 ## PKG_LOCATION
-A combination of PKG_PATH and LINE_NUM. Keep in mind, LINE_NUM is a runtime variable provided by Roku. 
+A combination of PKG_PATH and LINE_NUM. Keep in mind, LINE_NUM is a runtime variable provided by Roku.
 ```BrighterScript
 print PKG_LOCATION
 ```
 
-transpiles to: 
+transpiles to:
 
 ```BrightScript
 print "pkg:/source/main.brs:" + str(LINE_NUM)

--- a/docs/template-strings.md
+++ b/docs/template-strings.md
@@ -1,5 +1,6 @@
-# Template strings (Template literals)
-Template strings are string literals that can have embedded expressions and also capture newlines. 
+# BrighterScript Template Strings (Template Literals)
+
+Template strings are string literals that can have embedded expressions and also capture newlines.
 
 ## Syntax
 ```BrighterScript
@@ -38,7 +39,7 @@ line2
 Transpiles to
 ```BrightScript
 text = "line1" + chr(10) + "line2" + chr(10)
-``` 
+```
 
 You can also use escape characters in your text. For example, `\n` for unix-style line endings and `\r\n` for windows-style line endings.
 ```BrighterScript
@@ -47,7 +48,7 @@ windowsText = `line1\r\nline2`
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 unixText = "line1" + chr(10) + "line2"
 windowsText = "line1" + chr(13) + chr(10) + "line2"
@@ -60,7 +61,7 @@ textWithBacktick = `this is a backtick \` character`
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 textWithBacktick = "this is a backtick " + chr(96) + " character"
 ```
@@ -72,7 +73,7 @@ text = `look \${here}`
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 text = "look " + chr(36) + "{here}"
 ```
@@ -86,7 +87,7 @@ text = `abc\c22def`
 ```
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 text = "abc" + chr(22) + "def"
 ```
@@ -106,7 +107,7 @@ stringWithQuotes = "hello " + chr(34) + "John" + chr(34)
 
 
 ## Tagged Template Strings
-If a template string is preceeded by an expression, this is called a tagged template. In this situation, the tag expression will be called with all of the values of the template string. The tag function is not limited to returning strings: it can return whatever you want. 
+If a template string is preceeded by an expression, this is called a tagged template. In this situation, the tag expression will be called with all of the values of the template string. The tag function is not limited to returning strings: it can return whatever you want.
 
 The tag function accepts two arguments: an array of strings and an array of expressions. There will always be one more string than expression, and generally you should iterate through as follows: `strings[0] + values[0] + strings[1] values[1] + strings[2] ...`
 
@@ -133,7 +134,7 @@ end function
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function zombify(strings, values)
     result = ""
@@ -171,7 +172,7 @@ end function
 
 <details>
   <summary>View the transpiled BrightScript code</summary>
-  
+
 ```BrightScript
 function zombify(strings, values)
     return Zombie(values[0])

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -2,11 +2,11 @@
 import { Position, Range } from 'vscode-languageserver';
 import { expect } from 'chai';
 import { PrintStatement, Block, Body, AssignmentStatement, CommentStatement, ExitForStatement, ExitWhileStatement, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EmptyStatement } from '../parser/Statement';
-import { FunctionExpression, NamespacedVariableNameExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, LiteralExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression } from '../parser/Expression';
+import { FunctionExpression, NamespacedVariableNameExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, LiteralExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression } from '../parser/Expression';
 import type { Token } from '../lexer';
 import { TokenKind } from '../lexer';
 import { BrsString } from '../brsTypes';
-import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isNamespacedVariableNameExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement } from './reflection';
+import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isNamespacedVariableNameExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression } from './reflection';
 import { createRange, createToken, createStringLiteral, createIdentifier } from './creators';
 import { Program } from '../Program';
 import { BrsFile } from '../files/BrsFile';
@@ -54,7 +54,6 @@ describe('reflection', () => {
         const namespace = new NamespaceStatement(token, new NamespacedVariableNameExpression(createIdentifier('a', pos)), body, token);
         const cls = new ClassStatement(token, ident, [], token);
         const imports = new ImportStatement(token, token);
-
 
         it('isStatement', () => {
             expect(isStatement(library)).to.be.true;
@@ -206,6 +205,7 @@ describe('reflection', () => {
         const tplQuasi = new TemplateStringQuasiExpression([expr]);
         const tplString = new TemplateStringExpression(token, [tplQuasi], [], token);
         const taggedTpl = new TaggedTemplateStringExpression(ident, token, [tplQuasi], [], token);
+        const annotation = new AnnotationExpression(token, token);
 
         it('isExpression', () => {
             expect(isExpression(binary)).to.be.true;
@@ -290,6 +290,10 @@ describe('reflection', () => {
         it('isTaggedTemplateStringExpression', () => {
             expect(isTaggedTemplateStringExpression(taggedTpl)).to.be.true;
             expect(isTaggedTemplateStringExpression(fun)).to.be.false;
+        });
+        it('isAnnotationExpression', () => {
+            expect(isAnnotationExpression(annotation)).to.be.true;
+            expect(isAnnotationExpression(fun)).to.be.false;
         });
 
         it('isExpression', () => {

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, Statement } from '../parser/Statement';
-import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression } from '../parser/Expression';
+import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression } from '../parser/Expression';
 import type { BrsString, BrsInvalid, BrsBoolean, RoString, RoArray, RoAssociativeArray, RoSGNode, FunctionParameterExpression } from '../brsTypes';
 import { ValueKind } from '../brsTypes';
 import type { BrsNumber } from '../brsTypes/BrsNumber';
@@ -190,6 +190,9 @@ export function isTaggedTemplateStringExpression(element: Expression | Statement
 }
 export function isFunctionParameterExpression(element: Expression | Statement): element is FunctionParameterExpression {
     return element?.constructor.name === 'FunctionParameterExpression';
+}
+export function isAnnotationExpression(element: Statement | Expression): element is AnnotationExpression {
+    return element?.constructor.name === 'AnnotationExpression';
 }
 
 // Value/Type reflection

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -12,7 +12,7 @@ import { ParseMode } from './Parser';
 import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { walk, InternalWalkMode } from '../astUtils/visitors';
-import { isCommentStatement, isEscapedCharCodeLiteralExpression, isLiteralExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isArrayLiteralExpression, isCommentStatement, isEscapedCharCodeLiteralExpression, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isVariableExpression } from '../astUtils/reflection';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -1155,4 +1155,71 @@ export class TaggedTemplateStringExpression extends Expression {
             }
         }
     }
+}
+
+export class AnnotationExpression extends Expression {
+    constructor(
+        readonly atToken: Token,
+        readonly nameToken: Token
+    ) {
+        super();
+        this.range = util.createRangeFromPositions(
+            atToken.range.start,
+            nameToken.range.end
+        );
+    }
+
+    public range: Range;
+    public call: CallExpression;
+
+    /**
+     * Convert annotation arguments to JavaScript types
+     * @param strict If false, keep Expression objects not corresponding to JS types
+     */
+    getArguments(strict = true): ExpressionValue[] {
+        if (!this.call) {
+            return [];
+        }
+        return this.call.args.map(e => expressionToValue(e, strict));
+    }
+
+    transpile(state: TranspileState) {
+        return [];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+type ExpressionValue = string | number | boolean | Expression | ExpressionValue[] | { [key: string]: ExpressionValue };
+
+function expressionToValue(expr: Expression, strict: boolean): ExpressionValue {
+    if (!expr) {
+        return null;
+    }
+    if (isLiteralString(expr)) {
+        return expr.value.value;
+    }
+    if (isLiteralNumber(expr)) {
+        return expr.value.getValue();
+    }
+    if (isLiteralBoolean(expr)) {
+        return expr.value.toBoolean();
+    }
+    if (isArrayLiteralExpression(expr)) {
+        return expr.elements
+            .filter(e => !isCommentStatement(e))
+            .map(e => expressionToValue(e, strict));
+    }
+    if (isAALiteralExpression(expr)) {
+        return expr.elements.reduce((acc, e) => {
+            if (!isCommentStatement(e)) {
+                acc[e.keyToken.text] = expressionToValue(e.value, strict);
+            }
+            return acc;
+        }, {});
+    }
+    return strict ? null : expr;
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1163,12 +1163,14 @@ export class AnnotationExpression extends Expression {
         readonly nameToken: Token
     ) {
         super();
+        this.name = nameToken.text;
         this.range = util.createRangeFromPositions(
             atToken.range.start,
             nameToken.range.end
         );
     }
 
+    public name: string;
     public range: Range;
     public call: CallExpression;
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -639,8 +639,7 @@ describe('parser', () => {
         it('attaches multiple annotations to next statement', () => {
             let { statements, diagnostics } = parse(`
                 @meta1
-                @meta2
-                @meta3
+                @meta2 @meta3
                 function main()
                 end function
             `, ParseMode.BrighterScript);

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -611,6 +611,7 @@ describe('parser', () => {
             expect(fn.annotations).to.exist;
             expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
             expect(fn.annotations[0].nameToken.text).to.equal('meta1');
+            expect(fn.annotations[0].name).to.equal('meta1');
 
             expect(statements[1]).to.be.instanceof(FunctionStatement);
             fn = statements[1] as FunctionStatement;

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { Lexer, ReservedWords } from '../lexer';
-import { DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression } from './Expression';
+import { DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
 import type { AssignmentStatement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
@@ -575,6 +575,130 @@ describe('parser', () => {
                 DiagnosticMessages.expectedStringLiteralAfterKeyword('import').message
             );
             expect(statements[0]).to.be.instanceof(ImportStatement);
+        });
+    });
+
+    describe('Annotations', () => {
+        it('parses without errors', () => {
+            let { statements, diagnostics } = parse(`
+                @meta1
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            expect(statements.length).to.equal(0);
+        });
+
+        it('parses with error if malformed', () => {
+            let { diagnostics } = parse(`
+                @
+                sub main()
+                end sub
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.code).to.equal(1081); //unexpected token '@'
+        });
+
+        it('attaches an annotation to next statement', () => {
+            let { statements, diagnostics } = parse(`
+                @meta1
+                function main()
+                end function
+
+                @meta2 sub init()
+                end sub
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            expect(statements[0]).to.be.instanceof(FunctionStatement);
+            let fn = statements[0] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[0].nameToken.text).to.equal('meta1');
+
+            expect(statements[1]).to.be.instanceof(FunctionStatement);
+            fn = statements[1] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[0].nameToken.text).to.equal('meta2');
+        });
+
+        it('attaches annotations inside a function body', () => {
+            let { statements, diagnostics } = parse(`
+                function main()
+                    @meta1
+                    print "hello"
+                end function
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let fn = statements[0] as FunctionStatement;
+            let fnStatements = fn.func.body.statements;
+            let stat = fnStatements[0];
+            expect(stat).to.exist;
+            expect(stat.annotations?.length).to.equal(1);
+            expect(stat.annotations[0]).to.be.instanceof(AnnotationExpression);
+        });
+
+        it('attaches multiple annotations to next statement', () => {
+            let { statements, diagnostics } = parse(`
+                @meta1
+                @meta2
+                @meta3
+                function main()
+                end function
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            expect(statements[0]).to.be.instanceof(FunctionStatement);
+            let fn = statements[0] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations.length).to.equal(3);
+            expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[1]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[2]).to.be.instanceof(AnnotationExpression);
+        });
+
+        it('allows annotations with parameters', () => {
+            let { statements, diagnostics } = parse(`
+                @meta1("arg", 2, true, { prop: "value" })
+                function main()
+                end function
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let fn = statements[0] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[0].nameToken.text).to.equal('meta1');
+            expect(fn.annotations[0].call).to.be.instanceof(CallExpression);
+        });
+
+        it('can convert argument of an annotation to JS types', () => {
+            let { statements, diagnostics } = parse(`
+                @meta1
+                function main()
+                end function
+
+                @meta2(
+                    "arg", 2, true,
+                    { prop: "value" }, [1, 2],
+                    sub()
+                    end sub
+                )
+                sub init()
+                end sub
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            expect(statements[0]).to.be.instanceof(FunctionStatement);
+            let fn = statements[0] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations[0].getArguments()).to.deep.equal([]);
+
+            expect(statements[1]).to.be.instanceof(FunctionStatement);
+            fn = statements[1] as FunctionStatement;
+            expect(fn.annotations).to.exist;
+            expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(fn.annotations[0].getArguments()).to.deep.equal([
+                'arg', 2, true,
+                { prop: 'value' }, [1, 2],
+                null
+            ]);
+            let allArgs = fn.annotations[0].getArguments(false);
+            expect(allArgs.pop()).to.be.instanceOf(FunctionExpression);
         });
     });
 });

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -85,7 +85,8 @@ import {
     EscapedCharCodeLiteralExpression,
     TemplateStringQuasiExpression,
     TaggedTemplateStringExpression,
-    SourceLiteralExpression
+    SourceLiteralExpression,
+    AnnotationExpression
 } from './Expression';
 import type { Diagnostic, Range } from 'vscode-languageserver';
 import { Logger } from '../Logger';
@@ -188,6 +189,11 @@ export class Parser {
     private allowedLocalIdentifiers: TokenKind[];
 
     /**
+     * A meta statement which should be attached to the next statement
+     */
+    private pendingAnnotations: AnnotationExpression[] = [];
+
+    /**
      * Get the currently active global terminators
      */
     private peekGlobalTerminators() {
@@ -246,6 +252,11 @@ export class Parser {
                 ) {
                     let dec = this.declaration();
                     if (dec) {
+                        //attach annotations to statements
+                        if (this.pendingAnnotations.length) {
+                            dec.annotations = this.pendingAnnotations;
+                            this.pendingAnnotations = [];
+                        }
                         body.statements.push(dec);
                     }
                 }
@@ -312,6 +323,11 @@ export class Parser {
 
             if (this.check(TokenKind.Namespace)) {
                 return this.namespaceStatement();
+            }
+
+            if (this.check(TokenKind.At) && this.checkNext(TokenKind.Identifier)) {
+                this.annotationExpression();
+                return;
             }
 
             // BrightScript is like python, in that variables can be declared without a `var`,
@@ -1265,6 +1281,23 @@ export class Parser {
         return importStatement;
     }
 
+    private annotationExpression(): void {
+        let annotation = new AnnotationExpression(
+            this.advance(),
+            this.advance()
+        );
+        this.pendingAnnotations.push(annotation);
+
+        //optional arguments
+        if (this.check(TokenKind.LeftParen)) {
+            let leftParen = this.advance();
+            annotation.call = this.finishCall(leftParen, annotation, false);
+        }
+
+        //consume to the next newline, eof, or colon
+        while (this.matchAny(TokenKind.Newline, TokenKind.Eof, TokenKind.Colon)) { }
+    }
+
     private templateString(isTagged: boolean): TemplateStringExpression | TaggedTemplateStringExpression {
         this.warnIfNotBrighterScriptMode('template string');
 
@@ -1820,6 +1853,11 @@ export class Parser {
             let dec = this.declaration();
 
             if (dec) {
+                //attach annotations to statements
+                if (this.pendingAnnotations.length) {
+                    dec.annotations = this.pendingAnnotations;
+                    this.pendingAnnotations = [];
+                }
                 statements.push(dec);
             } else {
                 //something went wrong. reset to the top of the loop
@@ -2314,9 +2352,8 @@ export class Parser {
      * @param tokenKinds
      */
     private tryConsume(diagnostic: DiagnosticInfo, ...tokenKinds: TokenKind[]): Token | undefined {
-        let foundTokenKind = tokenKinds
-            .map(tokenKind => this.peek().kind === tokenKind)
-            .reduce((foundAny, foundCurrent) => foundAny || foundCurrent, false);
+        const nextKind = this.peek().kind;
+        let foundTokenKind = tokenKinds.some(tokenKind => nextKind === tokenKind);
 
         if (foundTokenKind) {
             return this.advance();
@@ -2503,11 +2540,11 @@ function createReferences(): References {
 export interface References {
     assignmentStatements: AssignmentStatement[];
     classStatements: ClassStatement[];
-    namespaceStatements: NamespaceStatement[];
     functionStatements: FunctionStatement[];
     functionExpressions: FunctionExpression[];
     importStatements: ImportStatement[];
     libraryStatements: LibraryStatement[];
+    namespaceStatements: NamespaceStatement[];
     newExpressions: NewExpression[];
     propertyHints: Record<string, string>;
 }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -189,7 +189,7 @@ export class Parser {
     private allowedLocalIdentifiers: TokenKind[];
 
     /**
-     * A meta statement which should be attached to the next statement
+     * Annotations collected which should be attached to the next statement
      */
     private pendingAnnotations: AnnotationExpression[] = [];
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -253,7 +253,7 @@ export class Parser {
                     let dec = this.declaration();
                     if (dec) {
                         //attach annotations to statements
-                        if (this.pendingAnnotations.length) {
+                        if (this.pendingAnnotations.length > 0) {
                             dec.annotations = this.pendingAnnotations;
                             this.pendingAnnotations = [];
                         }
@@ -2527,8 +2527,8 @@ function createReferences(): References {
     return {
         assignmentStatements: [],
         classStatements: [],
-        functionStatements: [],
         functionExpressions: [],
+        functionStatements: [],
         importStatements: [],
         libraryStatements: [],
         namespaceStatements: [],
@@ -2540,8 +2540,8 @@ function createReferences(): References {
 export interface References {
     assignmentStatements: AssignmentStatement[];
     classStatements: ClassStatement[];
-    functionStatements: FunctionStatement[];
     functionExpressions: FunctionExpression[];
+    functionStatements: FunctionStatement[];
     importStatements: ImportStatement[];
     libraryStatements: LibraryStatement[];
     namespaceStatements: NamespaceStatement[];

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2,7 +2,7 @@
 import type { Token, Identifier } from '../lexer';
 import { TokenKind, CompoundAssignmentOperators } from '../lexer';
 import { SourceNode } from 'source-map';
-import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression } from './Expression';
+import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression, AnnotationExpression } from './Expression';
 import { CallExpression, VariableExpression, LiteralExpression } from './Expression';
 import { util } from '../util';
 import { Range, Position } from 'vscode-languageserver';
@@ -22,6 +22,11 @@ export abstract class Statement {
      *  The starting and ending location of the statement.
      **/
     public abstract range: Range;
+
+    /**
+     * Statement annotations
+     */
+    public annotations: AnnotationExpression[];
 
     public abstract transpile(state: TranspileState): Array<SourceNode | string>;
 


### PR DESCRIPTION
Annotations are metadata expressions attached to AST statements.

- any statement can receive multiple annotations,
- annotations can be on the same line as the statement,
- annotations can have arguments; arguments can be any valid BrightScript expression,
- name of the annotation must be a valid identifier; it can't be a keyword (e.g. `sub`, `while`...),
- annotations have a method to obtain JS-friendly types (`annotation.getArguments()`); basic types, arrays and roAssocArrays are converted.

Limitation:

- annotations aren't validated if they are mis-named; could be declared by the plugins using them in the future,
- currently these expressions are not walked, for various reasons.

Example:
```brightscript
@someFlag
sub someFunction()
  '...
end sub

@configuration("param", [1, 2, 3], { prop: "value" })
@andAnotherFlag
function anotherFunction()
  @translate print "this can also have meta"
end function

@replaceWith(45 * 3, sub ()
  print "you could have whole expressions here - why tho?"
end sub)
sub replaceMe()
    '...
end sub
```

A plugin can explore the AST and look at the annotations:
```typescript
const annotations = statement.annotations;
if (annotations) {
    annotations.forEach(a => console.log(a.name, a.getArguments()));
    // ex: configuration ["param", [1, 2, 3], { prop: "value" }]
}
```
