### PR TITLE
emitDefinition fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [unreleased]
+### Changed
+ - `emitDefinitions` now defaults to `false` (it previously defaulted to `true`)
+### Fixed
+ - don't transpile `d.bs` files (which would produce `d.brs` files with duplicate information in them)
+
+
+
 ## [0.18.2] - 2020-11-2
 ### Fixed
  - support on-demand parse for typedef-shadowed files ([#237](https://github.com/rokucommunity/brighterscript/pull/237))

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -131,7 +131,7 @@
         "emitDefinitions": {
             "description": "Emit type definition files (`d.bs`) during transpile",
             "type": "boolean",
-            "default": true
+            "default": false
         },
         "diagnosticFilters": {
             "description": "A collection of filters used to hide diagnostics for certain files",

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1400,6 +1400,35 @@ describe('Program', () => {
     });
 
     describe('typedef', () => {
+        describe('emitDefinitions', () => {
+            it('generates typedef for .bs files', async () => {
+                await program.addOrReplaceFile<BrsFile>('source/Duck.bs', `
+                    class Duck
+                    end class
+                `);
+                program.options.emitDefinitions = true;
+                await program.validate();
+                await program.transpile([], stagingFolderPath);
+
+                expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.brs`)).to.be.true;
+                expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.d.bs`)).to.be.true;
+                expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.d.brs`)).to.be.false;
+            });
+
+            it('does not generate typedef for typedef file', async () => {
+                await program.addOrReplaceFile<BrsFile>('source/Duck.d.bs', `
+                    class Duck
+                    end class
+                `);
+                program.options.emitDefinitions = true;
+                await program.validate();
+                await program.transpile([], stagingFolderPath);
+
+                expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.d.brs`)).to.be.false;
+                expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.brs`)).to.be.false;
+            });
+        });
+
         it('ignores bs1018 for d.bs files', async () => {
             await program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
                 class Duck

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -779,6 +779,10 @@ export class Program {
         this.plugins.emit('beforeProgramTranspile', this, entries);
 
         const promises = entries.map(async (entry) => {
+            //skip transpiling typedef files
+            if (isBrsFile(entry.file) && entry.file.isTypedef) {
+                return;
+            }
             this.plugins.emit('beforeFileTranspile', entry);
             const { file, outputPath } = entry;
             const result = file.transpile();
@@ -795,7 +799,7 @@ export class Program {
                 writeMapPromise
             ]);
 
-            if (isBrsFile(file) && this.options.emitDefinitions !== false) {
+            if (isBrsFile(file) && this.options.emitDefinitions) {
                 const typedef = file.getTypedef();
                 const typedefPath = outputPath.replace(/\.brs$/i, '.d.bs');
                 await fsExtra.writeFile(typedefPath, typedef);

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -239,6 +239,14 @@ describe('util', () => {
     });
 
     describe('normalizeConfig', () => {
+        it('sets emitDefinitions to false by default and in edge cases', () => {
+            expect(util.normalizeConfig({}).emitDefinitions).to.be.false;
+            expect((util as any).normalizeConfig().emitDefinitions).to.be.false;
+            expect(util.normalizeConfig(<any>{ emitDefinitions: 123 }).emitDefinitions).to.be.false;
+            expect(util.normalizeConfig(<any>{ emitDefinitions: undefined }).emitDefinitions).to.be.false;
+            expect(util.normalizeConfig(<any>{ emitDefinitions: 'true' }).emitDefinitions).to.be.false;
+        });
+
         it('loads project from disc', async () => {
             fsExtra.outputFileSync(s`${tempDir}/rootDir/bsconfig.json`, `{ "outFile": "customOutDir/pkg.zip" }`);
             let config = await util.normalizeAndResolveConfig({

--- a/src/util.ts
+++ b/src/util.ts
@@ -300,6 +300,7 @@ export class Util {
         config.showDiagnosticsInConsole = config.showDiagnosticsInConsole === false ? false : true;
         config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
         config.cwd = config.cwd ?? process.cwd();
+        config.emitDefinitions = config.emitDefinitions === true ? true : false;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];
         }


### PR DESCRIPTION
### Changed
 - `emitDefinitions` now defaults to `false` (it previously defaulted to `true`)
### Fixed
 - don't transpile `d.bs` files (which would produce `d.brs` files with duplicate information in them)

