### PR TITLE
AST parser refactoring

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -363,8 +363,8 @@ export let DiagnosticMessages = {
         code: 1069,
         severity: DiagnosticSeverity.Error
     }),
-    labelsMustBeDeclaredOnTheirOwnLine: () => ({
-        message: `Labels must be declared on their own line`,
+    __unused1070: () => ({
+        message: ``,
         code: 1070,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -205,8 +205,8 @@ export let DiagnosticMessages = {
         code: 1038,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineOrColonAfterCallableSignature: (callableType: string) => ({
-        message: `Expected newline or ':' after ${callableType} signature`,
+    expectedNewlineOrColon: () => ({
+        message: `Expected newline or ':' at the end of a statement`,
         code: 1039,
         severity: DiagnosticSeverity.Error
     }),
@@ -248,13 +248,13 @@ export let DiagnosticMessages = {
             severity: DiagnosticSeverity.Error
         };
     },
-    expectedNewlineOrColonAfterAssignment: () => ({
-        message: `Expected newline or ':' after assignment`,
+    expectedInlineIfStatement: () => ({
+        message: `If/else statement within an inline if should be also inline`,
         code: 1047,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineAfterWhileCondition: () => ({
-        message: `Expected newline after while condition`,
+    expectedFinalNewline: () => ({
+        message: `Expected newline at the end of an inline if statement`,
         code: 1048,
         severity: DiagnosticSeverity.Error
     }),
@@ -263,8 +263,8 @@ export let DiagnosticMessages = {
         code: 1049,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineAfterExitWhile: () => ({
-        message: `Expected newline after 'exit while'`,
+    __unused1050: () => ({
+        message: ``,
         code: 1050,
         severity: DiagnosticSeverity.Error
     }),
@@ -283,8 +283,8 @@ export let DiagnosticMessages = {
         code: 1053,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineAfterExitFor: () => ({
-        message: `Expected newline after 'exit for'`,
+    unexpectedColonBeforeIfStatement: () => ({
+        message: `Colon before 'if' statement is not allowed`,
         code: 1054,
         severity: DiagnosticSeverity.Error
     }),
@@ -308,8 +308,8 @@ export let DiagnosticMessages = {
         code: 1058,
         severity: DiagnosticSeverity.Error
     }),
-    expectedColonToPreceedEndIf: () => ({
-        message: `Expected ':' to preceed 'end if'`,
+    __unused1059: () => ({
+        message: ``,
         code: 1059,
         severity: DiagnosticSeverity.Error
     }),
@@ -338,8 +338,8 @@ export let DiagnosticMessages = {
         code: 1064,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineOrColonAfterExpressionStatement: () => ({
-        message: `Expected newline or ':' after expression statement`,
+    __unused1065: () => ({
+        message: ``,
         code: 1065,
         severity: DiagnosticSeverity.Error
     }),
@@ -348,18 +348,18 @@ export let DiagnosticMessages = {
         code: 1066,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineOrColonAfterIndexedSetStatement: () => ({
-        message: `Expected newline or ':' after indexed set statement`,
+    __unused1067: () => ({
+        message: ``,
         code: 1067,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineOrColonAfterDottedSetStatement: () => ({
-        message: `Expected newline or ':' after dotted set statement`,
+    __unused1068: () => ({
+        message: ``,
         code: 1068,
         severity: DiagnosticSeverity.Error
     }),
-    expectedNewlineOrColonAfterPrintedValues: () => ({
-        message: `Expected newline or ':' after printed values`,
+    __unused1069: () => ({
+        message: ``,
         code: 1069,
         severity: DiagnosticSeverity.Error
     }),
@@ -531,8 +531,8 @@ export let DiagnosticMessages = {
         code: 1102,
         severity: DiagnosticSeverity.Error
     }),
-    autoImportComponentScriptCollision: () => ({
-        message: `Component script auto-import found '.bs' and '.brs' files with the same name and will import only the '.bs' file`,
+    __unused1103: () => ({
+        message: ``,
         code: 1103,
         severity: DiagnosticSeverity.Warning
     }),
@@ -561,8 +561,8 @@ export let DiagnosticMessages = {
         code: 1108,
         severity: DiagnosticSeverity.Error
     }),
-    callfuncExpressionMustHaveAtLeastOneArgument: () => ({
-        message: `A callfunc expression must have at least one argument`,
+    __unused1109: () => ({
+        message: ``,
         code: 1109,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -263,8 +263,8 @@ export let DiagnosticMessages = {
         code: 1049,
         severity: DiagnosticSeverity.Error
     }),
-    __unused1050: () => ({
-        message: ``,
+    expectedCatchBlockInTryCatch: () => ({
+        message: `Expected 'catch' block in 'try' statement`,
         code: 1050,
         severity: DiagnosticSeverity.Error
     }),
@@ -308,8 +308,8 @@ export let DiagnosticMessages = {
         code: 1058,
         severity: DiagnosticSeverity.Error
     }),
-    __unused1059: () => ({
-        message: ``,
+    expectedEndTryToTerminateTryCatch: () => ({
+        message: `Expected 'end try' to terminate 'try-catch' statement`,
         code: 1059,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -36,6 +36,7 @@ describe('reflection', () => {
         const exitWhile = new ExitWhileStatement({ exitWhile: token });
         const funs = new FunctionStatement(ident, new FunctionExpression([], block, token, token, token, token), undefined);
         const ifs = new IfStatement({ if: token }, expr, block, []);
+        const elseifs = new ElseIfStatement({ elseIfToken: token }, expr, block);
         const increment = new IncrementStatement(expr, token);
         const print = new PrintStatement({ print: token }, []);
         const gotos = new GotoStatement({ goto: token, label: token });
@@ -99,6 +100,10 @@ describe('reflection', () => {
         it('isIfStatement', () => {
             expect(isIfStatement(ifs)).to.be.true;
             expect(isIfStatement(body)).to.be.false;
+        });
+        it('isElseIfStatement', () => {
+            expect(isElseIfStatement(elseifs)).to.be.true;
+            expect(isElseIfStatement(body)).to.be.false;
         });
         it('isIncrementStatement', () => {
             expect(isIncrementStatement(increment)).to.be.true;

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -35,8 +35,7 @@ describe('reflection', () => {
         const exitFor = new ExitForStatement({ exitFor: token });
         const exitWhile = new ExitWhileStatement({ exitWhile: token });
         const funs = new FunctionStatement(ident, new FunctionExpression([], block, token, token, token, token), undefined);
-        const ifs = new IfStatement({ if: token }, expr, block, []);
-        const elseifs = new ElseIfStatement({ elseIfToken: token }, expr, block);
+        const ifs = new IfStatement({ if: token }, expr, block);
         const increment = new IncrementStatement(expr, token);
         const print = new PrintStatement({ print: token }, []);
         const gotos = new GotoStatement({ goto: token, label: token });
@@ -100,10 +99,6 @@ describe('reflection', () => {
         it('isIfStatement', () => {
             expect(isIfStatement(ifs)).to.be.true;
             expect(isIfStatement(body)).to.be.false;
-        });
-        it('isElseIfStatement', () => {
-            expect(isElseIfStatement(elseifs)).to.be.true;
-            expect(isElseIfStatement(body)).to.be.false;
         });
         it('isIncrementStatement', () => {
             expect(isIncrementStatement(increment)).to.be.true;

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -64,6 +64,9 @@ export function isFunctionStatement(element: Statement | Expression | undefined)
 export function isIfStatement(element: Statement | Expression | undefined): element is IfStatement {
     return element?.constructor?.name === 'IfStatement';
 }
+export function isElseIfStatement(element: Statement | Expression | undefined): element is ElseIfStatement {
+    return element?.constructor?.name === 'ElseIfStatement';
+}
 export function isIncrementStatement(element: Statement | Expression | undefined): element is IncrementStatement {
     return element?.constructor?.name === 'IncrementStatement';
 }

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -64,9 +64,6 @@ export function isFunctionStatement(element: Statement | Expression | undefined)
 export function isIfStatement(element: Statement | Expression | undefined): element is IfStatement {
     return element?.constructor?.name === 'IfStatement';
 }
-export function isElseIfStatement(element: Statement | Expression | undefined): element is ElseIfStatement {
-    return element?.constructor?.name === 'ElseIfStatement';
-}
 export function isIncrementStatement(element: Statement | Expression | undefined): element is IncrementStatement {
     return element?.constructor?.name === 'IncrementStatement';
 }

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -114,11 +114,11 @@ describe('astUtils visitors', () => {
                 'IfStatement:1',          // if a = 1
                 'Block:2',                // then block
                 'PrintStatement:3',       // print 3
-                'ElseIfStatement:2',      // elseif statement
+                'IfStatement:2',          // elseif statement
                 'Block:3',                // elseif block
                 'PrintStatement:4',       // print 4
-                'Block:2',                // else block
-                'PrintStatement:3',       // print 5
+                'Block:3',                // else block
+                'PrintStatement:4',       // print 5
                 'WhileStatement:1',       // while a <> invalid
                 'Block:2',                // while block
                 'PrintStatement:3',       // print 6
@@ -151,7 +151,7 @@ describe('astUtils visitors', () => {
                 'IfStatement',          // if a = 1
                 'Block',                // then block
                 'PrintStatement',       // print 3
-                'ElseIfStatement',      // elseif statement
+                'IfStatement',          // elseif statement
                 'Block',                // elseif block
                 'PrintStatement',       // print 4
                 'Block',                // else block
@@ -196,7 +196,7 @@ describe('astUtils visitors', () => {
                 'IfStatement',          // if a = 1
                 'Block',                // then block
                 'PrintStatement',       // print 3
-                'ElseIfStatement',      // elseif statement
+                'IfStatement',          // elseif statement
                 'Block',                // elseif block
                 'PrintStatement'        // print 4
             ]);
@@ -303,10 +303,10 @@ describe('astUtils visitors', () => {
                 'IfStatement:1:BinaryExpression',                 // if <j > 0>
                 'IfStatement:1:VariableExpression',               // if <j> > 0
                 'IfStatement:1:LiteralExpression',                // if j > <0>
-                'ElseIfStatement:2:BinaryExpression',             // else if <j < -10>
-                'ElseIfStatement:2:VariableExpression',           // else if <j> < -10
-                'ElseIfStatement:2:UnaryExpression',              // else if j < <-10>
-                'ElseIfStatement:2:LiteralExpression',            // else if j < -<10>
+                'IfStatement:2:BinaryExpression',                 // else if <j < -10>
+                'IfStatement:2:VariableExpression',               // else if <j> < -10
+                'IfStatement:2:UnaryExpression',                  // else if j < <-10>
+                'IfStatement:2:LiteralExpression',                // else if j < -<10>
                 'ReturnStatement:1:LiteralExpression'             // return <invalid>
             ]);
         });
@@ -376,7 +376,7 @@ describe('astUtils visitors', () => {
                 'PrintStatement',
                 'LiteralExpression',
                 //else if
-                'ElseIfStatement',
+                'IfStatement',
                 'LiteralExpression',
                 'Block',
                 'PrintStatement',
@@ -751,7 +751,7 @@ describe('astUtils visitors', () => {
                 'Block',
                 'ReturnStatement',
                 //else if
-                'ElseIfStatement',
+                'IfStatement',
                 'BinaryExpression',
                 'VariableExpression',
                 'LiteralExpression',

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -114,8 +114,9 @@ describe('astUtils visitors', () => {
                 'IfStatement:1',          // if a = 1
                 'Block:2',                // then block
                 'PrintStatement:3',       // print 3
-                'Block:2',                // elseif block
-                'PrintStatement:3',       // print 4
+                'ElseIfStatement:2',      // elseif statement
+                'Block:3',                // elseif block
+                'PrintStatement:4',       // print 4
                 'Block:2',                // else block
                 'PrintStatement:3',       // print 5
                 'WhileStatement:1',       // while a <> invalid
@@ -150,6 +151,7 @@ describe('astUtils visitors', () => {
                 'IfStatement',          // if a = 1
                 'Block',                // then block
                 'PrintStatement',       // print 3
+                'ElseIfStatement',      // elseif statement
                 'Block',                // elseif block
                 'PrintStatement',       // print 4
                 'Block',                // else block
@@ -194,6 +196,7 @@ describe('astUtils visitors', () => {
                 'IfStatement',          // if a = 1
                 'Block',                // then block
                 'PrintStatement',       // print 3
+                'ElseIfStatement',      // elseif statement
                 'Block',                // elseif block
                 'PrintStatement'        // print 4
             ]);
@@ -300,10 +303,10 @@ describe('astUtils visitors', () => {
                 'IfStatement:1:BinaryExpression',                 // if <j > 0>
                 'IfStatement:1:VariableExpression',               // if <j> > 0
                 'IfStatement:1:LiteralExpression',                // if j > <0>
-                'IfStatement:1:BinaryExpression',                 // else if <j < -10>
-                'IfStatement:1:VariableExpression',               // else if <j> < -10
-                'IfStatement:1:UnaryExpression',                  // else if j < <-10>
-                'IfStatement:1:LiteralExpression',                // else if j < -<10>
+                'ElseIfStatement:2:BinaryExpression',             // else if <j < -10>
+                'ElseIfStatement:2:VariableExpression',           // else if <j> < -10
+                'ElseIfStatement:2:UnaryExpression',              // else if j < <-10>
+                'ElseIfStatement:2:LiteralExpression',            // else if j < -<10>
                 'ReturnStatement:1:LiteralExpression'             // return <invalid>
             ]);
         });
@@ -373,6 +376,7 @@ describe('astUtils visitors', () => {
                 'PrintStatement',
                 'LiteralExpression',
                 //else if
+                'ElseIfStatement',
                 'LiteralExpression',
                 'Block',
                 'PrintStatement',
@@ -739,18 +743,22 @@ describe('astUtils visitors', () => {
                 'Block',
                 'AssignmentStatement',
                 'LiteralExpression',
+                //if
                 'IfStatement',
                 'BinaryExpression',
                 'VariableExpression',
                 'LiteralExpression',
                 'Block',
                 'ReturnStatement',
+                //else if
+                'ElseIfStatement',
                 'BinaryExpression',
                 'VariableExpression',
                 'LiteralExpression',
                 'Block',
                 'ReturnStatement',
                 'LiteralExpression',
+                //else
                 'Block',
                 'ReturnStatement',
                 'CommentStatement'

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -33,6 +33,8 @@ describe('BrsFile BrighterScript classes', () => {
             class Animal
             end class
             class Duck
+
+
             end class
         `);
         expect(file.parser.references.classStatements.map(x => x.getName(ParseMode.BrighterScript)).sort()).to.eql(['Animal', 'Duck']);

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -135,12 +135,15 @@ describe('lexer', () => {
         expect(tokens[5].text.charCodeAt(0), 'should contain \\r\\n').to.eql(10);
     });
 
-    it('correctly identifies the elseif token', () => {
+    it('correctly splits the elseif token', () => {
         let { tokens } = Lexer.scan('else if elseif else   if');
         expect(tokens.map(t => t.kind)).to.deep.equal([
-            TokenKind.ElseIf,
-            TokenKind.ElseIf,
-            TokenKind.ElseIf,
+            TokenKind.Else,
+            TokenKind.If,
+            TokenKind.Else,
+            TokenKind.If,
+            TokenKind.Else,
+            TokenKind.If,
             TokenKind.Eof
         ]);
     });
@@ -867,9 +870,8 @@ describe('lexer', () => {
         });
 
         it('matches multi-word keywords', () => {
-            let { tokens } = Lexer.scan('else if end if end while End Sub end Function Exit wHILe');
+            let { tokens } = Lexer.scan('end if end while End Sub end Function Exit wHILe');
             expect(tokens.map(w => w.kind)).to.deep.equal([
-                TokenKind.ElseIf,
                 TokenKind.EndIf,
                 TokenKind.EndWhile,
                 TokenKind.EndSub,
@@ -1071,21 +1073,6 @@ describe('lexer', () => {
                 TokenKind.ForEach,
                 TokenKind.ForEach,
                 TokenKind.ForEach,
-                TokenKind.Eof
-            ]);
-        });
-        it('supports various spacing between else if', () => {
-            let { tokens } = Lexer.scan(
-                'else if else  if else    if else\tif else\t if else \tif else \t if'
-            );
-            expect(tokens.map(t => t.kind)).to.deep.equal([
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
-                TokenKind.ElseIf,
                 TokenKind.Eof
             ]);
         });

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -747,13 +747,11 @@ export class Lexer {
 
         // some identifiers can be split into two words, so check the "next" word and see what we get
         if (
-            (lowerText === 'end' || lowerText === 'else' || lowerText === 'exit' || lowerText === 'for') &&
+            (lowerText === 'end' || lowerText === 'exit' || lowerText === 'for') &&
             (this.peek() === ' ' || this.peek() === '\t')
         ) {
-            let endOfFirstWord = {
-                position: this.current,
-                column: this.columnEnd
-            };
+            let savedCurrent = this.current;
+            let savedColumnEnd = this.columnEnd;
 
             // skip past any whitespace
             let whitespace = '';
@@ -767,7 +765,7 @@ export class Lexer {
             } // read the next word
 
             let twoWords = this.source.slice(this.start, this.current);
-            //replace all of the whitespace with a single space character so we can properly match keyword token types
+            // replace all of the whitespace with a single space character so we can properly match keyword token types
             twoWords = twoWords.replace(whitespace, ' ');
             let maybeTokenType = Keywords[twoWords.toLowerCase()];
             if (maybeTokenType) {
@@ -775,9 +773,25 @@ export class Lexer {
                 return;
             } else {
                 // reset if the last word and the current word didn't form a multi-word TokenKind
-                this.current = endOfFirstWord.position;
-                this.columnEnd = endOfFirstWord.column;
+                this.current = savedCurrent;
+                this.columnEnd = savedColumnEnd;
             }
+        }
+
+        // split `elseif` into `else` and `if` tokens
+        if (lowerText === 'elseif' && !this.checkPreviousToken(TokenKind.Dot)) {
+            let savedCurrent = this.current;
+            let savedColumnEnd = this.columnEnd;
+            this.current -= 2;
+            this.columnEnd -= 2;
+            this.addToken(TokenKind.Else);
+
+            this.start = savedCurrent - 2;
+            this.current = savedCurrent;
+            this.columnBegin = savedColumnEnd - 2;
+            this.columnEnd = savedColumnEnd;
+            this.addToken(TokenKind.If);
+            return;
         }
 
         // look for a type designator character ($ % ! # &). vars may have them, but functions

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -540,7 +540,6 @@ export const DisallowedFunctionIdentifiers = [
     TokenKind.Dim,
     TokenKind.Each,
     TokenKind.Else,
-    TokenKind.ElseIf,
     TokenKind.End,
     TokenKind.EndFunction,
     TokenKind.EndIf,

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -95,7 +95,7 @@ export enum TokenKind {
     Each = 'Each',
     Else = 'Else',
     Then = 'Then',
-    ElseIf = 'ElseIf',
+    // ElseIf = 'ElseIf',
     End = 'End',
     EndFunction = 'EndFunction',
     EndFor = 'EndFor',
@@ -185,7 +185,6 @@ export const ReservedWords = new Set([
     'dim',
     'each',
     'else',
-    'elseif',
     'endsub',
     'endwhile',
     'eval',
@@ -235,7 +234,6 @@ export const Keywords: Record<string, TokenKind> = {
     end: TokenKind.End,
     then: TokenKind.Then,
     else: TokenKind.Else,
-    elseif: TokenKind.ElseIf,
     void: TokenKind.Void,
     boolean: TokenKind.Boolean,
     integer: TokenKind.Integer,
@@ -246,7 +244,6 @@ export const Keywords: Record<string, TokenKind> = {
     object: TokenKind.Object,
     interface: TokenKind.Interface,
     dynamic: TokenKind.Dynamic,
-    'else if': TokenKind.ElseIf,
     endfor: TokenKind.EndFor,
     'end for': TokenKind.EndFor,
     endfunction: TokenKind.EndFunction,
@@ -314,7 +311,6 @@ Keywords.constructor = undefined;
 
 /** Set of all keywords that end blocks. */
 export type BlockTerminator =
-    | TokenKind.ElseIf
     | TokenKind.Else
     | TokenKind.EndFor
     | TokenKind.Next
@@ -357,7 +353,6 @@ export const AllowedProperties = [
     TokenKind.Dim,
     TokenKind.Then,
     TokenKind.Else,
-    TokenKind.ElseIf,
     TokenKind.End,
     TokenKind.EndFunction,
     TokenKind.EndFor,
@@ -484,7 +479,6 @@ export const DisallowedLocalIdentifiers = [
     TokenKind.Dim,
     TokenKind.Each,
     TokenKind.Else,
-    TokenKind.ElseIf,
     TokenKind.End,
     TokenKind.EndFunction,
     TokenKind.EndIf,

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -95,7 +95,6 @@ export enum TokenKind {
     Each = 'Each',
     Else = 'Else',
     Then = 'Then',
-    // ElseIf = 'ElseIf',
     End = 'End',
     EndFunction = 'EndFunction',
     EndFor = 'EndFor',

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -264,7 +264,7 @@ describe('parser', () => {
         });
 
         it('supports single-line if statements', () => {
-            expect(parse(`If true Then print "error"\nStop`).diagnostics[0]?.message).to.not.exist;
+            expect(parse(`If true Then print "error" : Stop`).diagnostics[0]?.message).to.not.exist;
         });
 
         it('works with excess newlines', () => {

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,11 +1,12 @@
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { Lexer, ReservedWords } from '../lexer';
 import { DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
-import type { AssignmentStatement } from './Statement';
+import type { AssignmentStatement, Statement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
+import { isBlock, isCommentStatement, isFunctionStatement, isIfStatement } from '../astUtils';
 
 describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {
@@ -72,7 +73,8 @@ describe('parser', () => {
                     call()a
                 end sub
             `).diagnostics.map(x => rangeToArray(x.range))).to.eql([
-                [2, 26, 2, 27]
+                [2, 26, 2, 27],
+                [2, 27, 2, 28]
             ]);
         });
 
@@ -255,14 +257,14 @@ describe('parser', () => {
                     if true then
                         print 1
                     else if true
-                        print 2
+                        return false
                     end if
                 end function
             `).diagnostics[0]?.message).not.to.exist;
         });
 
         it('supports single-line if statements', () => {
-            expect(parse(`If true Then print "error" : Stop`).diagnostics[0]?.message).to.not.exist;
+            expect(parse(`If true Then print "error"\nStop`).diagnostics[0]?.message).to.not.exist;
         });
 
         it('works with excess newlines', () => {
@@ -414,24 +416,41 @@ describe('parser', () => {
                         end if 'comment 10
                     end function
                 `);
-                let { diagnostics, statements } = Parser.parse(tokens) as any;
+                let { diagnostics, statements } = Parser.parse(tokens);
                 expect(diagnostics).to.be.lengthOf(0, 'Should have zero diagnostics');
-                let ifStmt = statements[0].func.body.statements[0];
+                let fnSmt = statements[0];
+                if (isFunctionStatement(fnSmt)) {
+                    let ifStmt = fnSmt.func.body.statements[0];
+                    if (isIfStatement(ifStmt)) {
+                        expectCommentWithText(ifStmt.thenBranch.statements[0], `'comment 1`);
+                        expectCommentWithText(ifStmt.thenBranch.statements[1], `'comment 2`);
+                        expectCommentWithText(ifStmt.thenBranch.statements[3], `'comment 3`);
 
-                expect(ifStmt.thenBranch.statements[0].text).to.equal(`'comment 1`);
-                expect(ifStmt.thenBranch.statements[1].text).to.equal(`'comment 2`);
-                expect(ifStmt.thenBranch.statements[3].text).to.equal(`'comment 3`);
+                        let elseIfBranch = ifStmt.elseBranch;
+                        if (isIfStatement(elseIfBranch)) {
+                            expectCommentWithText(elseIfBranch.thenBranch.statements[0], `'comment 4`);
+                            expectCommentWithText(elseIfBranch.thenBranch.statements[1], `'comment 5`);
+                            expectCommentWithText(elseIfBranch.thenBranch.statements[3], `'comment 6`);
 
-                expect(ifStmt.elseIfs[0].thenBranch.statements[0].text).to.equal(`'comment 4`);
-                expect(ifStmt.elseIfs[0].thenBranch.statements[1].text).to.equal(`'comment 5`);
-                expect(ifStmt.elseIfs[0].thenBranch.statements[3].text).to.equal(`'comment 6`);
+                            let elseBranch = elseIfBranch.elseBranch;
+                            if (isBlock(elseBranch)) {
+                                expectCommentWithText(elseBranch.statements[0], `'comment 7`);
+                                expectCommentWithText(elseBranch.statements[1], `'comment 8`);
+                                expectCommentWithText(elseBranch.statements[3], `'comment 9`);
+                            } else {
+                                failStatementType(elseBranch, 'Block');
+                            }
 
-                expect(ifStmt.elseBranch.statements[0].text).to.equal(`'comment 7`);
-                expect(ifStmt.elseBranch.statements[1].text).to.equal(`'comment 8`);
-                expect(ifStmt.elseBranch.statements[3].text).to.equal(`'comment 9`);
-
-                expect(statements[0].func.body.statements[1].text).to.equal(`'comment 10`);
-
+                        } else {
+                            failStatementType(elseIfBranch, 'If');
+                        }
+                        expectCommentWithText(fnSmt.func.body.statements[1], `'comment 10`);
+                    } else {
+                        failStatementType(ifStmt, 'If');
+                    }
+                } else {
+                    failStatementType(fnSmt, 'Function');
+                }
             });
 
             it('while', () => {
@@ -529,7 +548,7 @@ describe('parser', () => {
                     end = true
                 end sub
             `);
-            expect(diagnostics).to.be.lengthOf(1);
+            expect(diagnostics).to.be.length.greaterThan(0);
         });
         it('none of them can be used as local variables', () => {
             let reservedWords = new Set(ReservedWords);
@@ -717,4 +736,16 @@ export function rangeToArray(range: Range) {
         range.end.line,
         range.end.character
     ];
+}
+
+function expectCommentWithText(stat: Statement, text: string) {
+    if (isCommentStatement(stat)) {
+        expect(stat.text).to.equal(text);
+    } else {
+        failStatementType(stat, 'Comment');
+    }
+}
+
+export function failStatementType(stat: Statement, type: string) {
+    assert.fail(`Statement ${stat.constructor.name} line ${stat.range.start.line} is not a ${type}`);
 }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -17,10 +17,10 @@ import {
 import type {
     Statement,
     PrintSeparatorTab,
-    PrintSeparatorSpace,
-    ElseIf
+    PrintSeparatorSpace
 } from './Statement';
 import {
+    ElseIfStatement,
     FunctionStatement,
     CommentStatement,
     AssignmentStatement,
@@ -1416,7 +1416,7 @@ export class Parser {
 
         const condition = this.expression();
         let thenBranch: Block;
-        let elseIfBranches: ElseIf[] = [];
+        let elseIfBranches: ElseIfStatement[] = [];
         let elseBranch: Block | undefined;
 
         let thenToken: Token | undefined;
@@ -1507,12 +1507,14 @@ export class Parser {
                     endIfToken = blockEnd;
                 }
 
-                elseIfBranches.push({
-                    condition: elseIfCondition,
-                    thenBranch: elseIfThen,
-                    thenToken: thenToken,
-                    elseIfToken: elseIfToken
-                });
+                elseIfBranches.push(new ElseIfStatement(
+                    {
+                        thenToken: thenToken,
+                        elseIfToken: elseIfToken
+                    },
+                    elseIfCondition,
+                    elseIfThen
+                ));
             }
 
             if (this.match(TokenKind.Else)) {
@@ -1593,12 +1595,14 @@ export class Parser {
                     throw this.lastDiagnosticAsError();
                 }
 
-                elseIfBranches.push({
-                    condition: elseIfCondition,
-                    thenBranch: new Block([elseIfThen], this.peek().range),
-                    thenToken: thenToken,
-                    elseIfToken: elseIf
-                });
+                elseIfBranches.push(new ElseIfStatement(
+                    {
+                        thenToken: thenToken,
+                        elseIfToken: elseIf
+                    },
+                    elseIfCondition,
+                    new Block([elseIfThen], this.peek().range)
+                ));
             }
             if (this.previous().kind !== TokenKind.Newline && this.match(TokenKind.Else)) {
                 elseToken = this.previous();

--- a/src/parser/tests/controlFlow/For.spec.ts
+++ b/src/parser/tests/controlFlow/For.spec.ts
@@ -49,6 +49,18 @@ describe('parser for loops', () => {
         expect((statements[0] as ForStatement).increment).not.to.exist;
     });
 
+    it('catches unterminated for reaching function boundary', () => {
+        const parser = Parser.parse(`
+            function test()
+                for i = 1 to 10
+                    print "while"
+            end function
+        `);
+        expect(parser.diagnostics).to.be.lengthOf(1);
+        expect(parser.statements).to.be.lengthOf(1);
+        expect(parser.references.functionStatements[0].func.body.statements).to.be.lengthOf(1);
+    });
+
     it('allows \'next\' to terminate loop', () => {
         let { statements, diagnostics } = Parser.parse([
             token(TokenKind.For, 'for'),

--- a/src/parser/tests/controlFlow/While.spec.ts
+++ b/src/parser/tests/controlFlow/While.spec.ts
@@ -50,6 +50,18 @@ describe('parser while statements', () => {
         expect(parser.diagnostics[0]?.message).to.be.undefined;
     });
 
+    it('catches unterminated while reaching function boundary', () => {
+        const parser = Parser.parse(`
+            function test()
+                while i > 0:
+                    print "while"
+            end function
+        `);
+        expect(parser.diagnostics).to.be.lengthOf(1);
+        expect(parser.statements).to.be.lengthOf(1);
+        expect(parser.references.functionStatements[0].func.body.statements).to.be.lengthOf(1);
+    });
+
     it('location tracking', () => {
         /**
          *    0   0   0   1   1

--- a/src/parser/tests/statement/Goto.spec.ts
+++ b/src/parser/tests/statement/Goto.spec.ts
@@ -34,4 +34,16 @@ describe('parser goto statements', () => {
         let { diagnostics } = Parser.parse(tokens);
         expect(diagnostics).to.be.lengthOf(0);
     });
+
+    it('ignores "labels" not alone on their line', () => {
+        let { tokens } = Lexer.scan(`
+            sub Main()
+                label1: 'some comment
+                notalabel1: print "ko"
+                print "ko": notalabel2:
+            end sub
+        `);
+        let { diagnostics } = Parser.parse(tokens);
+        expect(diagnostics).to.be.lengthOf(2);
+    });
 });

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -103,7 +103,6 @@ describe('parser', () => {
             TokenKind.Dim,
             TokenKind.Then,
             TokenKind.Else,
-            TokenKind.ElseIf,
             TokenKind.End,
             TokenKind.EndFunction,
             TokenKind.EndFor,

--- a/src/parser/tests/statement/Stop.spec.ts
+++ b/src/parser/tests/statement/Stop.spec.ts
@@ -14,7 +14,7 @@ describe('stop statement', () => {
         ]);
 
         //should be an error
-        expect(diagnostics).to.be.lengthOf(1);
+        expect(diagnostics).to.be.length.greaterThan(0);
         expect(statements).to.exist;
         expect(statements).not.to.be.null;
     });

--- a/src/parser/tests/statement/TryCatch.spec.ts
+++ b/src/parser/tests/statement/TryCatch.spec.ts
@@ -82,24 +82,24 @@ describe('parser try/catch', () => {
             : print a.b.c : catch e : print "error" : end try
         `);
 
-        // expectNoParseErrors(`
-        //     try : print a.b.c
-        //     : catch e : print "error" : end try
-        // `);
+        expectNoParseErrors(`
+            try : print a.b.c
+            : catch e : print "error" : end try
+        `);
 
-        // expectNoParseErrors(`
-        //     try : print a.b.c
-        //     : catch e
-        //     : print "error" : end try
-        // `);
+        expectNoParseErrors(`
+            try : print a.b.c
+            : catch e
+            : print "error" : end try
+        `);
 
-        // expectNoParseErrors(`
-        //     try
-        //     : print a.b.c
-        //     : catch e
-        //     : print "error"
-        //     : end try
-        // `);
+        expectNoParseErrors(`
+            try
+            : print a.b.c
+            : catch e
+            : print "error"
+            : end try
+        `);
     });
 
     it('recovers gracefully with syntax errors', () => {
@@ -113,5 +113,40 @@ describe('parser try/catch', () => {
             end sub
         `);
         expect(parser.diagnostics[0]?.message).not.to.exist;
+    });
+
+    it('recovers from missing end-try when reaching function boundary', () => {
+        const parser = Parser.parse(`
+            sub new()
+                try
+                    print "hello"
+                catch e
+                    print "error"
+            end sub
+        `);
+        expect(parser.diagnostics).to.be.lengthOf(1);
+    });
+
+    it('recovers from missing catch', () => {
+        const parser = Parser.parse(`
+            sub new()
+                try
+                    print "hello"
+                    print "error"
+                end try
+            end sub
+        `);
+        expect(parser.diagnostics).to.be.lengthOf(1);
+    });
+
+    it('recovers from missing catch and end-try when reaching function boundary', () => {
+        const parser = Parser.parse(`
+            sub new()
+                try
+                    print "hello"
+                    print "error"
+            end sub
+        `);
+        expect(parser.diagnostics).to.be.lengthOf(1);
     });
 });


### PR DESCRIPTION
- Make `ElseIf` into an `ElseIfStatement` so that `elseif`'s condition expression is in the context of an obvious statement,
- Refactored statement parsing wrt newline/colon,
- Improved error recovery with unclosed blocks when reaching `end sub/function`.