### PR TITLE
Class name collision

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -547,7 +547,7 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     localVarSameNameAsClass: (className: string) => ({
-        message: `Local variable has same name as class ${className}`,
+        message: `Local variable has same name as class '${className}'`,
         code: 1106,
         severity: DiagnosticSeverity.Error
     }),
@@ -592,7 +592,7 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     functionCannotHaveSameNameAsClass: (className: string) => ({
-        message: `Function cannot have the same name as class '${className}'`,
+        message: `Function has same name as class '${className}'`,
         code: 1116,
         severity: DiagnosticSeverity.Error
     })

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -590,6 +590,11 @@ export let DiagnosticMessages = {
         message: `There are multiple components with the name '${componentName}'`,
         code: 1115,
         severity: DiagnosticSeverity.Error
+    }),
+    functionCannotHaveSameNameAsClass: (className: string) => ({
+        message: `Function cannot have the same name as class '${className}'`,
+        code: 1116,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -546,8 +546,8 @@ export let DiagnosticMessages = {
         code: 1105,
         severity: DiagnosticSeverity.Error
     }),
-    __unused: () => ({
-        message: ``,
+    localVarSameNameAsClass: (className: string) => ({
+        message: `Local variable has same name as class ${className}`,
         code: 1106,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -481,7 +481,7 @@ describe('Scope', () => {
                 end sub
             `);
             await program.validate();
-            expect(program.getDiagnostics().length).to.equal(0);
+            expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
 
         it('Emits validation events', async () => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -297,12 +297,12 @@ describe('Scope', () => {
                 });
             });
 
-            it('detects scope function with same name as built-in function', async () => {
+            it('flags scope function with same name (but different case) as built-in function', async () => {
                 await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         print str(12345) ' prints 12345 (i.e. our str() function below is ignored)
                     end sub
-                    function str(num)
+                    function STR(num)
                         return "override"
                     end function
                 `);

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -54,6 +54,15 @@ export class Scope {
     }
 
     /**
+     * Get the class with the specified name.
+     * @param className - the all-lower-case namespace-included class name
+     */
+    public getClass(className: string) {
+        const classMap = this.getClassMap();
+        return classMap.get(className);
+    }
+
+    /**
      * A dictionary of all classes in this scope. This includes namespaced classes always with their full name.
      * The key is stored in lower case
      */
@@ -71,15 +80,6 @@ export class Scope {
             });
             return map;
         });
-    }
-
-    /**
-     * Get the class with the specified name.
-     * @param className - the all-lower-case namespace-included class name
-     */
-    public getClass(className: string) {
-        const classMap = this.getClassMap();
-        return classMap.get(className);
     }
 
     /**

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -57,8 +57,29 @@ export class Scope {
      * A dictionary of all classes in this scope. This includes namespaced classes always with their full name.
      * The key is stored in lower case
      */
-    public get classLookup() {
-        return this.cache.getOrAdd('classLookup', () => this.buildClassLookup());
+    private getClassMap() {
+        return this.cache.getOrAdd('classMap', () => {
+            const map = new Map<string, ClassStatement>();
+            this.enumerateFiles((file) => {
+                for (let cls of file.parser.references.classStatements) {
+                    const lowerClassName = cls.getName(ParseMode.BrighterScript)?.toLowerCase();
+                    //only track classes with a defined name (i.e. exclude nameless malformed classes)
+                    if (lowerClassName) {
+                        map.set(lowerClassName, cls);
+                    }
+                }
+            });
+            return map;
+        });
+    }
+
+    /**
+     * Get the class with the specified name.
+     * @param className - the all-lower-case namespace-included class name
+     */
+    public getClass(className: string) {
+        const classMap = this.getClassMap();
+        return classMap.get(className);
     }
 
     /**
@@ -292,20 +313,6 @@ export class Scope {
         return namespaceLookup;
     }
 
-    private buildClassLookup() {
-        let lookup = {} as Record<string, ClassStatement>;
-        this.enumerateFiles((file) => {
-            for (let cls of file.parser.references.classStatements) {
-                const name = cls.getName(ParseMode.BrighterScript)?.toLowerCase();
-                //only track classes with a defined name (i.e. exclude nameless malformed classes)
-                if (name) {
-                    lookup[name] = cls;
-                }
-            }
-        });
-        return lookup;
-    }
-
     public getNamespaceStatements() {
         let result = [] as NamespaceStatement[];
         this.enumerateFiles((file) => {
@@ -435,16 +442,32 @@ export class Scope {
     }
 
     /**
-     * Find function declarations with the same name as a stdlib function
+     * Find various function collisions
      */
     private diagnosticDetectFunctionCollisions(file: BscFile) {
+        const classMap = this.getClassMap();
         for (let func of file.callables) {
-            if (globalCallableMap.has(func.getName(ParseMode.BrighterScript).toLowerCase())) {
-                this.diagnostics.push({
-                    ...DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction(),
-                    range: func.nameRange,
-                    file: file
-                });
+            const funcName = func.getName(ParseMode.BrighterScript);
+            const lowerFuncName = funcName?.toLowerCase();
+            if (lowerFuncName) {
+
+                //find function declarations with the same name as a stdlib function
+                if (globalCallableMap.has(func.getName(ParseMode.BrighterScript))) {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction(),
+                        range: func.nameRange,
+                        file: file
+                    });
+                }
+
+                //find any functions that have the same name as a class
+                if (classMap.has(lowerFuncName)) {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.functionCannotHaveSameNameAsClass(funcName),
+                        range: func.nameRange,
+                        file: file
+                    });
+                }
             }
         }
     }
@@ -512,12 +535,13 @@ export class Scope {
      * @param callableContainerMap
      */
     private diagnosticDetectShadowedLocalVars(file: BscFile, callableContainerMap: CallableContainerMap) {
-        const classLookup = this.classLookup;
+        const classMap = this.getClassMap();
         //loop through every function scope
         for (let scope of file.functionScopes) {
             //every var declaration in this function scope
             for (let varDeclaration of scope.variableDeclarations) {
-                let lowerVarName = varDeclaration.name.toLowerCase();
+                const varName = varDeclaration.name;
+                const lowerVarName = varName.toLowerCase();
 
                 //if the var is a function
                 if (isFunctionType(varDeclaration.type)) {
@@ -559,9 +583,9 @@ export class Scope {
                             file: file
                         });
                         //has the same name as an in-scope class
-                    } else if (classLookup[lowerVarName]) {
+                    } else if (classMap.has(lowerVarName)) {
                         this.diagnostics.push({
-                            ...DiagnosticMessages.localVarSameNameAsClass(classLookup[lowerVarName].getName(ParseMode.BrighterScript)),
+                            ...DiagnosticMessages.localVarSameNameAsClass(classMap.get(lowerVarName).getName(ParseMode.BrighterScript)),
                             range: varDeclaration.nameRange,
                             file: file
                         });

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -452,7 +452,7 @@ export class Scope {
             if (lowerFuncName) {
 
                 //find function declarations with the same name as a stdlib function
-                if (globalCallableMap.has(func.getName(ParseMode.BrighterScript))) {
+                if (globalCallableMap.has(lowerFuncName)) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction(),
                         range: func.nameRange,

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -875,4 +875,18 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
+
+    it('catches variable with same name as class', async () => {
+        await program.addOrReplaceFile('source/main.bs', `
+            class Animal
+            end class
+            sub main()
+                animal = new Animal()
+            end sub
+        `);
+        await program.validate();
+        expect(program.getDiagnostics()[0]?.message).to.equal(
+            DiagnosticMessages.localVarSameNameAsClass('Animal').message
+        );
+    });
 });

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -875,6 +875,18 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
+    it('catches class with same name as function', async () => {
+        await program.addOrReplaceFile('source/main.bs', `
+            class Animal
+            end class
+            sub Animal()
+            end sub
+        `);
+        await program.validate();
+        expect(program.getDiagnostics()[0]?.message).to.equal(
+            DiagnosticMessages.functionCannotHaveSameNameAsClass('Animal').message
+        );
+    });
 
     it('catches variable with same name as class', async () => {
         await program.addOrReplaceFile('source/main.bs', `

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -888,6 +888,19 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
+    it('catches class with same name (but different case) as function', async () => {
+        await program.addOrReplaceFile('source/main.bs', `
+            class ANIMAL
+            end class
+            sub animal()
+            end sub
+        `);
+        await program.validate();
+        expect(program.getDiagnostics()[0]?.message).to.equal(
+            DiagnosticMessages.functionCannotHaveSameNameAsClass('animal').message
+        );
+    });
+
     it('catches variable with same name as class', async () => {
         await program.addOrReplaceFile('source/main.bs', `
             class Animal

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -371,7 +371,7 @@ export class BrsFile {
         //if the class is namespace-prefixed, look only for this exact name
         if (className.includes('.')) {
             for (let scope of scopes) {
-                let cls = scope.classLookup[lowerClassName];
+                const cls = scope.getClass(lowerClassName);
                 if (cls) {
                     return cls;
                 }
@@ -383,12 +383,12 @@ export class BrsFile {
             let namespacedClass: ClassStatement;
             for (let scope of scopes) {
                 //get the global class if it exists
-                let possibleGlobalClass = scope.classLookup[lowerClassName];
+                let possibleGlobalClass = scope.getClass(lowerClassName);
                 if (possibleGlobalClass && !globalClass) {
                     globalClass = possibleGlobalClass;
                 }
                 if (namespaceName) {
-                    let possibleNamespacedClass = scope.classLookup[namespaceName.toLowerCase() + '.' + lowerClassName];
+                    let possibleNamespacedClass = scope.getClass(namespaceName.toLowerCase() + '.' + lowerClassName);
                     if (possibleNamespacedClass) {
                         namespacedClass = possibleNamespacedClass;
                         break;


### PR DESCRIPTION
Catch when local variables and scope functions have the same name as a class.

Fixes #245 