### PR TITLE
Fix Range.create rte due to bad vscode semver bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2480,10 +2480,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "is-binary-path": {
             "version": "2.1.0",

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -1,10 +1,23 @@
-import { Range } from 'vscode-languageserver';
+import type { Range } from 'vscode-languageserver';
 import type { Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
 import type { Expression, NamespacedVariableNameExpression } from '../parser/Expression';
 import { LiteralExpression, CallExpression, DottedGetExpression, VariableExpression } from '../parser/Expression';
 
-export const interpolatedRange = Range.create(-1, -1, -1, -1);
+/**
+ * A range that points to nowhere. Used to give non-null ranges to programmatically-added source code.
+ * (Hardcoded range to prevent circular dependency issue in `../util.ts`
+ */
+export const interpolatedRange = {
+    start: {
+        line: -1,
+        character: -1
+    },
+    end: {
+        line: -1,
+        character: -1
+    }
+} as Range;
 
 export function createToken<T extends TokenKind>(kind: T, text?: string, range = interpolatedRange): Token & { kind: T } {
     return {

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -1,18 +1,19 @@
 
 import { expect } from 'chai';
-import * as util from './diagnosticUtils';
+import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
+import { util } from './util';
 
 describe('diagnosticUtils', () => {
-    let options: ReturnType<typeof util.getPrintDiagnosticOptions>;
+    let options: ReturnType<typeof diagnosticUtils.getPrintDiagnosticOptions>;
     beforeEach(() => {
-        options = util.getPrintDiagnosticOptions({});
+        options = diagnosticUtils.getPrintDiagnosticOptions({});
     });
 
     describe('printDiagnostic', () => {
         it('does not crash when range is undefined', () => {
             //print a diagnostic that doesn't have a range...it should not explode
-            util.printDiagnostic(options, DiagnosticSeverity.Error, './temp/file.brs', [], {
+            diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, './temp/file.brs', [], {
                 message: 'Bad thing happened',
                 range: null, //important...this needs to be null for the test to pass,
                 code: 1234
@@ -21,7 +22,7 @@ describe('diagnosticUtils', () => {
 
         it('does not crash when filie path is missing', () => {
             //print a diagnostic that doesn't have a range...it should not explode
-            util.printDiagnostic(options, DiagnosticSeverity.Error, undefined, [], {
+            diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, undefined, [], {
                 message: 'Bad thing happened',
                 range: Range.create(0, 0, 2, 2), //important...this needs to be null for the test to pass,
                 code: 1234
@@ -30,58 +31,58 @@ describe('diagnosticUtils', () => {
     });
 
     describe('getPrintDiagnosticOptions', () => {
-        let options: ReturnType<typeof util.getPrintDiagnosticOptions>;
+        let options: ReturnType<typeof diagnosticUtils.getPrintDiagnosticOptions>;
         it('prepares cwd value', () => {
-            options = util.getPrintDiagnosticOptions({ cwd: 'cwd' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ cwd: 'cwd' });
             expect(options.cwd).to.equal('cwd');
             // default value
-            options = util.getPrintDiagnosticOptions({});
+            options = diagnosticUtils.getPrintDiagnosticOptions({});
             expect(options.cwd).to.equal(process.cwd());
         });
         it('prepares emitFullPaths value', () => {
-            options = util.getPrintDiagnosticOptions({ emitFullPaths: true });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ emitFullPaths: true });
             expect(options.emitFullPaths).to.equal(true);
-            options = util.getPrintDiagnosticOptions({ emitFullPaths: false });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ emitFullPaths: false });
             expect(options.emitFullPaths).to.equal(false);
             // default value
-            options = util.getPrintDiagnosticOptions({});
+            options = diagnosticUtils.getPrintDiagnosticOptions({});
             expect(options.emitFullPaths).to.equal(false);
         });
         it('maps diagnosticLevel to severityLevel', () => {
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'info' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'info' });
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Information);
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'hint' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'hint' });
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Hint);
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'warn' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'warn' });
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Warning);
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'error' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'error' });
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Error);
             // default value
-            options = util.getPrintDiagnosticOptions({});
+            options = diagnosticUtils.getPrintDiagnosticOptions({});
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Warning);
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'x' } as any);
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'x' } as any);
             expect(options.severityLevel).to.equal(DiagnosticSeverity.Warning);
         });
         it('prepares the include map', () => {
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'info' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'info' });
             expect(options.includeDiagnostic).to.deep.equal({
                 [DiagnosticSeverity.Information]: true,
                 [DiagnosticSeverity.Hint]: true,
                 [DiagnosticSeverity.Warning]: true,
                 [DiagnosticSeverity.Error]: true
             });
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'hint' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'hint' });
             expect(options.includeDiagnostic).to.deep.equal({
                 [DiagnosticSeverity.Hint]: true,
                 [DiagnosticSeverity.Warning]: true,
                 [DiagnosticSeverity.Error]: true
             });
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'warn' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'warn' });
             expect(options.includeDiagnostic).to.deep.equal({
                 [DiagnosticSeverity.Warning]: true,
                 [DiagnosticSeverity.Error]: true
             });
-            options = util.getPrintDiagnosticOptions({ diagnosticLevel: 'error' });
+            options = diagnosticUtils.getPrintDiagnosticOptions({ diagnosticLevel: 'error' });
             expect(options.includeDiagnostic).to.deep.equal({
                 [DiagnosticSeverity.Error]: true
             });
@@ -90,74 +91,74 @@ describe('diagnosticUtils', () => {
 
     describe('getDiagnosticSquiggly', () => {
         it('works for normal cases', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 0, 0, 4)
             }, 'asdf')).to.equal('~~~~');
         });
 
         it('highlights whole line if no range', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
             }, ' asdf ')).to.equal('~~~~~~');
         });
 
         it('returns empty string when no line is found', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 0, 0, 10)
             }, '')).to.equal('');
 
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 0, 0, 10)
             }, undefined)).to.equal('');
         });
 
         it('supports diagnostic not at start of line', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 2, 0, 6)
             }, '  asdf')).to.equal('  ~~~~');
         });
 
         it('supports diagnostic that does not finish at end of line', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 0, 0, 4)
             }, 'asdf  ')).to.equal('~~~~  ');
         });
 
         it('supports diagnostic with space on both sides', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 2, 0, 6)
             }, '  asdf  ')).to.equal('  ~~~~  ');
         });
 
         it('handles diagnostic that starts and stops on the same position', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 2, 0, 2)
             }, 'abcde')).to.equal('~~~~~');
         });
 
         it('handles single-character diagnostic', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 2, 0, 3)
             }, 'abcde')).to.equal('  ~  ');
         });
 
         it('handles diagnostics that are longer than the line', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 0, 0, 10)
             }, 'abcde')).to.equal('~~~~~');
 
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(0, 2, 0, 10)
             }, 'abcde')).to.equal('  ~~~');
         });
 
         it('handles Number.MAX_VALUE for end character', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, Number.MAX_VALUE)
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
+                range: util.createRange(0, 0, 0, Number.MAX_VALUE)
             }, 'abcde')).to.equal('~~~~~');
         });
 
         it.skip('handles edge cases', () => {
-            expect(util.getDiagnosticSquigglyText(<any>{
+            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(5, 16, 5, 18)
             }, 'end functionasdf')).to.equal('            ~~~~');
         });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -251,7 +251,7 @@ describe('BrsFile', () => {
                 expect(file.commentFlags[0]).to.deep.include({
                     codes: null,
                     range: Range.create(2, 24, 2, 45),
-                    affectedRange: Range.create(3, 0, 3, Number.MAX_SAFE_INTEGER)
+                    affectedRange: util.createRange(3, 0, 3, Number.MAX_SAFE_INTEGER)
                 } as CommentFlag);
                 await program.validate();
                 //the "unterminated string" error should be filtered out
@@ -269,7 +269,7 @@ describe('BrsFile', () => {
                 expect(file.commentFlags[0]).to.deep.include({
                     codes: [1083, 1001],
                     range: Range.create(2, 24, 2, 57),
-                    affectedRange: Range.create(3, 0, 3, Number.MAX_SAFE_INTEGER)
+                    affectedRange: util.createRange(3, 0, 3, Number.MAX_SAFE_INTEGER)
                 } as CommentFlag);
                 //the "unterminated string" error should be filtered out
                 expect(program.getDiagnostics()[0]?.message).to.not.exist;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -13,7 +13,7 @@ import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { InternalWalkMode, walk, createVisitor, WalkMode } from '../astUtils/visitors';
 import { isCallExpression, isClassFieldStatement, isClassMethodStatement, isCommentStatement, isExpression, isExpressionStatement, isFunctionStatement, isInvalidType, isLiteralExpression, isVoidType } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
-import { createInvalidLiteral, createToken } from '../astUtils/creators';
+import { createInvalidLiteral, createToken, interpolatedRange } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
 
 /**
@@ -46,7 +46,7 @@ export class EmptyStatement extends Statement {
         /**
          * Create a negative range to indicate this is an interpolated location
          */
-        public range: Range = util.createRange(-1, -1, -1, -1)
+        public range: Range = interpolatedRange
     ) {
         super();
     }

--- a/src/parser/tests/Parser.spec.ts
+++ b/src/parser/tests/Parser.spec.ts
@@ -1,6 +1,6 @@
 import type { Token } from '../../lexer';
 import { TokenKind, ReservedWords } from '../../lexer';
-import { Range } from 'vscode-languageserver';
+import { interpolatedRange } from '../../astUtils/creators';
 
 /* A set of utilities to be used while writing tests for the BRS parser. */
 
@@ -16,7 +16,7 @@ export function token(kind: TokenKind, text?: string): Token {
         kind: kind,
         text: text,
         isReserved: ReservedWords.has((text || '').toLowerCase()),
-        range: Range.create(-9, -9, -9, -9),
+        range: interpolatedRange,
         leadingWhitespace: ''
     };
 }


### PR DESCRIPTION
The `vscode-languageserver-types` package introduced a breaking change between `3.15.1` and `3.16.0`, causing any new installs of `brighterscript` to immediately fail. This PR addresses those issues by avoiding calling `Range.create()` _anywhere_ in the regular code (unit tests were ignored for now since they're not failing). 