### PR TITLE
Support integer type declaration char

### DIFF
--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -792,6 +792,12 @@ describe('lexer', () => {
     });
 
     describe('long integer literals', () => {
+        it('respects \'&\' suffix', () => {
+            let f = Lexer.scan('1&').tokens[0];
+            expect(f.kind).to.equal(TokenKind.LongIntegerLiteral);
+            expect(f.text).to.eql('1&');
+        });
+
         it('supports hexadecimal literals', () => {
             let i = Lexer.scan('&hf00d&').tokens[0];
             expect(i.kind).to.equal(TokenKind.LongIntegerLiteral);
@@ -812,6 +818,18 @@ describe('lexer', () => {
     });
 
     describe('integer literals', () => {
+        it('respects \'%\' suffix', () => {
+            let f = Lexer.scan('1%').tokens[0];
+            expect(f.kind).to.equal(TokenKind.IntegerLiteral);
+            expect(f.text).to.eql('1%');
+        });
+
+        it.only('does not allow decimal numbers to end with %', () => {
+            let f = Lexer.scan('1.2%').tokens[0];
+            expect(f.kind).to.equal(TokenKind.FloatLiteral);
+            expect(f.text).to.eql('1.2');
+        });
+
         it('supports hexadecimal literals', () => {
             let i = Lexer.scan('&hFf').tokens[0];
             expect(i.kind).to.equal(TokenKind.IntegerLiteral);

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -629,13 +629,10 @@ export class Lexer {
         if (numberOfDigits >= 10 && designator !== '&') {
             // numeric literals over 10 digits with no type designator are implicitly Doubles
             this.addToken(TokenKind.DoubleLiteral);
-            return;
         } else if (designator === '#') {
             // numeric literals ending with "#" are forced to Doubles
             this.advance();
-            asString = this.source.slice(this.start, this.current);
             this.addToken(TokenKind.DoubleLiteral);
-            return;
         } else if (designator === 'd') {
             // literals that use "D" as the exponent are also automatic Doubles
 
@@ -655,15 +652,10 @@ export class Lexer {
             // replace the exponential marker with a JavaScript-friendly "e"
             asString = this.source.slice(this.start, this.current).replace(/[dD]/, 'e');
             this.addToken(TokenKind.DoubleLiteral);
-            return;
-        }
-
-        if (designator === '!') {
+        } else if (designator === '!') {
             // numeric literals ending with "!" are forced to Floats
             this.advance();
-            asString = this.source.slice(this.start, this.current);
             this.addToken(TokenKind.FloatLiteral);
-            return;
         } else if (designator === 'e') {
             // literals that use "E" as the exponent are also automatic Floats
 
@@ -680,21 +672,18 @@ export class Lexer {
                 this.advance();
             }
 
-            asString = this.source.slice(this.start, this.current);
             this.addToken(TokenKind.FloatLiteral);
-            return;
         } else if (containsDecimal) {
             // anything with a decimal but without matching Double rules is a Float
             this.addToken(TokenKind.FloatLiteral);
-            return;
-        }
-
-        if (designator === '&') {
+        } else if (designator === '&') {
             // numeric literals ending with "&" are forced to LongIntegers
-            asString = this.source.slice(this.start, this.current);
             this.advance();
             this.addToken(TokenKind.LongIntegerLiteral);
-
+        } else if (designator === '%') {
+            //numeric literals ending with "%" are forced to Integer
+            this.advance();
+            this.addToken(TokenKind.IntegerLiteral);
         } else {
             // otherwise, it's a regular integer
             this.addToken(TokenKind.IntegerLiteral);


### PR DESCRIPTION
According to the [BrightScript documentation](https://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md#type-declaration-characters), a `%` can be appended to an integer literal to enforce that it becomes an integer type. 

![image](https://user-images.githubusercontent.com/2544493/102485933-47af1400-4036-11eb-8a0e-bf74d138941f.png)

Currently bsc shows a syntax error on that trailing `%`, so this PR fixes that. 

Fixes #233