### PR TITLE
Support long floats with exponents.

### DIFF
--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -778,6 +778,12 @@ describe('lexer', () => {
             expect(f.text).to.eql('2.5e3');
         });
 
+        it.only('supports larger-than-supported-precision floats to be defined with exponents', () => {
+            let f = Lexer.scan('2.3659475627512424e-38').tokens[0];
+            expect(f.kind).to.equal(TokenKind.FloatLiteral);
+            expect(f.text).to.eql('2.3659475627512424e-38');
+        });
+
         it('allows digits before `.` to be elided', () => {
             let f = Lexer.scan('.123').tokens[0];
             expect(f.kind).to.equal(TokenKind.FloatLiteral);

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -626,7 +626,7 @@ export class Lexer {
         let numberOfDigits = containsDecimal ? asString.length - 1 : asString.length;
         let designator = this.peek().toLowerCase();
 
-        if (numberOfDigits >= 10 && designator !== '&') {
+        if (numberOfDigits >= 10 && designator !== '&' && designator !== 'e') {
             // numeric literals over 10 digits with no type designator are implicitly Doubles
             this.addToken(TokenKind.DoubleLiteral);
             return;


### PR DESCRIPTION
Fix syntax error for floats with more than 5 decimal places that also have an exponent component. 

![image](https://user-images.githubusercontent.com/2544493/102487878-3adfef80-4039-11eb-901d-e449bd148620.png)

Fixes #231 