### PR TITLE
CreateObject can take 4 parameters (roScreen)

### DIFF
--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -186,6 +186,10 @@ let runtimeFunctions = [{
         name: 'param3',
         type: new DynamicType(),
         isOptional: true
+    }, {
+        name: 'param4',
+        type: new DynamicType(),
+        isOptional: true
     }]
 }, {
     name: 'Type',


### PR DESCRIPTION
This is to support calls like this:
```
CreateObject("roScreen", true, 720, 480)
```

See https://developer.roku.com/docs/references/brightscript/components/roscreen.md