### PR TITLE
Fix "invalid" literal reflection

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
         "serialize-error": "^7.0.1",
         "source-map": "^0.7.3",
         "vscode-languageserver": "^6.1.1",
+        "vscode-languageserver-protocol": "~3.15.3",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-uri": "^2.1.1",
         "xml2js": "^0.4.19",

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -241,7 +241,7 @@ export function isNumberType(e: any): e is IntegerType | LongIntegerType | Float
 // Literal reflection
 
 export function isLiteralInvalid(e: any): e is LiteralExpression & { type: InvalidType } {
-    return isLiteralExpression(e) && isLiteralInvalid(e.type);
+    return isLiteralExpression(e) && isInvalidType(e.type);
 }
 export function isLiteralBoolean(e: any): e is LiteralExpression & { type: BooleanType } {
     return isLiteralExpression(e) && isBooleanType(e.type);


### PR DESCRIPTION
Fix `isLiteralInvalid` function.

Also lock `vscode-languageserver-protocol` version to fix the broken transitive dependency resolution of `vscode-languageserver`.