### PR TITLE
Class annotation support

### DIFF
--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -726,7 +726,7 @@ describe('parser', () => {
             expect(fn.annotations[0].call).to.be.instanceof(CallExpression);
         });
 
-        it.only('attaches annotations to a class', () => {
+        it('attaches annotations to a class', () => {
             let { statements, diagnostics } = parse(`
             @meta1
             class MyClass

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -769,14 +769,14 @@ describe('parser', () => {
 
         it('attaches annotations to a namespaced class', () => {
             let { statements, diagnostics } = parse(`
-            namespace ns
-                @meta1
-                class MyClass
-                    function main()
-                        print "hello"
-                    end function
-                end class
-            end namespace
+                namespace ns
+                    @meta1
+                    class MyClass
+                        function main()
+                            print "hello"
+                        end function
+                    end class
+                end namespace
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let ns = statements[0] as NamespaceStatement;
@@ -787,20 +787,20 @@ describe('parser', () => {
 
         it('attaches annotations to a namespaced class - multiple', () => {
             let { statements, diagnostics } = parse(`
-            namespace ns
-                @meta1
-                class MyClass
-                    function main()
-                        print "hello"
-                    end function
-                end class
-                @meta2
-                class MyClass2
-                    function main()
-                        print "hello"
-                    end function
-                end class
-            end namespace
+                namespace ns
+                    @meta1
+                    class MyClass
+                        function main()
+                            print "hello"
+                        end function
+                    end class
+                    @meta2
+                    class MyClass2
+                        function main()
+                            print "hello"
+                        end function
+                    end class
+                end namespace
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let ns = statements[0] as NamespaceStatement;
@@ -817,15 +817,15 @@ describe('parser', () => {
 
         it('attaches annotations to a class constructor', () => {
             let { statements, diagnostics } = parse(`
-            class MyClass
-                @meta1
-                function new()
-                    print "hello"
-                end function
-                function methodA()
-                    print "hello"
-                end function
-            end class
+                class MyClass
+                    @meta1
+                    function new()
+                        print "hello"
+                    end function
+                    function methodA()
+                        print "hello"
+                    end function
+                end class
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;
@@ -836,15 +836,15 @@ describe('parser', () => {
 
         it('attaches annotations to a class methods', () => {
             let { statements, diagnostics } = parse(`
-            class MyClass
-                function new()
-                    print "hello"
-                end function
-                @meta1
-                function methodA()
-                    print "hello"
-                end function
-            end class
+                class MyClass
+                    function new()
+                        print "hello"
+                    end function
+                    @meta1
+                    function methodA()
+                        print "hello"
+                    end function
+                end class
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;
@@ -854,24 +854,24 @@ describe('parser', () => {
         });
         it('attaches annotations to a class methods, fields and constructor', () => {
             let { statements, diagnostics } = parse(`
-            @meta2
-            @meta1
-            class MyClass
-                @meta3
-                @meta4
-                function new()
-                    print "hello"
-                end function
-                @meta5
-                @meta6
-                function methodA()
-                    print "hello"
-                end function
+                @meta2
+                @meta1
+                class MyClass
+                    @meta3
+                    @meta4
+                    function new()
+                        print "hello"
+                    end function
+                    @meta5
+                    @meta6
+                    function methodA()
+                        print "hello"
+                    end function
 
-                @meta5
-                @meta6
-                public foo="bar"
-            end class
+                    @meta5
+                    @meta6
+                    public foo="bar"
+                end class
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -741,6 +741,80 @@ describe('parser', () => {
             expect(cs.annotations[0]).to.be.instanceof(AnnotationExpression);
         });
 
+        it('attaches annotations to multiple clases', () => {
+            let { statements, diagnostics } = parse(`
+            @meta1
+            class MyClass
+                function main()
+                    print "hello"
+                end function
+            end class
+            @meta2
+            class MyClass2
+                function main()
+                    print "hello"
+                end function
+            end class
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let cs = statements[0] as ClassStatement;
+            expect(cs.annotations?.length).to.equal(1);
+            expect(cs.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(cs.annotations[0].name).to.equal('meta1');
+            let cs2 = statements[1] as ClassStatement;
+            expect(cs2.annotations?.length).to.equal(1);
+            expect(cs2.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(cs2.annotations[0].name).to.equal('meta2');
+        });
+
+        it('attaches annotations to a namespaced class', () => {
+            let { statements, diagnostics } = parse(`
+            namespace ns
+                @meta1
+                class MyClass
+                    function main()
+                        print "hello"
+                    end function
+                end class
+            end namespace
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let ns = statements[0] as NamespaceStatement;
+            let cs = ns.body.statements[0] as ClassStatement;
+            expect(cs.annotations?.length).to.equal(1);
+            expect(cs.annotations[0]).to.be.instanceof(AnnotationExpression);
+        });
+
+        it('attaches annotations to a namespaced class - multiple', () => {
+            let { statements, diagnostics } = parse(`
+            namespace ns
+                @meta1
+                class MyClass
+                    function main()
+                        print "hello"
+                    end function
+                end class
+                @meta2
+                class MyClass2
+                    function main()
+                        print "hello"
+                    end function
+                end class
+            end namespace
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let ns = statements[0] as NamespaceStatement;
+            let cs = ns.body.statements[0] as ClassStatement;
+            expect(cs.annotations?.length).to.equal(1);
+            expect(cs.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(cs.annotations[0].name).to.equal('meta1');
+            let cs2 = ns.body.statements[1] as ClassStatement;
+            expect(cs2.annotations?.length).to.equal(1);
+            expect(cs2.annotations[0]).to.be.instanceof(AnnotationExpression);
+            expect(cs2.annotations[0].name).to.equal('meta2');
+
+        });
+
         it('attaches annotations to a class constructor', () => {
             let { statements, diagnostics } = parse(`
             class MyClass

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -2,7 +2,7 @@ import { expect, assert } from 'chai';
 import { Lexer, ReservedWords } from '../lexer';
 import { DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
-import type { AssignmentStatement, Statement } from './Statement';
+import type { AssignmentStatement, ClassStatement, Statement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
@@ -724,6 +724,21 @@ describe('parser', () => {
             expect(fn.annotations[0]).to.be.instanceof(AnnotationExpression);
             expect(fn.annotations[0].nameToken.text).to.equal('meta1');
             expect(fn.annotations[0].call).to.be.instanceof(CallExpression);
+        });
+
+        it.only('attaches annotations to a class', () => {
+            let { statements, diagnostics } = parse(`
+            @meta1
+            class MyClass
+                function main()
+                    print "hello"
+                end function
+                end class
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).not.to.exist;
+            let cs = statements[0] as ClassStatement;
+            expect(cs.annotations?.length).to.equal(1);
+            expect(cs.annotations[0]).to.be.instanceof(AnnotationExpression);
         });
 
         it('can convert argument of an annotation to JS types', () => {

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -728,12 +728,12 @@ describe('parser', () => {
 
         it('attaches annotations to a class', () => {
             let { statements, diagnostics } = parse(`
-            @meta1
-            class MyClass
-                function main()
-                    print "hello"
-                end function
-            end class
+                @meta1
+                class MyClass
+                    function main()
+                        print "hello"
+                    end function
+                end class
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;
@@ -743,18 +743,18 @@ describe('parser', () => {
 
         it('attaches annotations to multiple clases', () => {
             let { statements, diagnostics } = parse(`
-            @meta1
-            class MyClass
-                function main()
-                    print "hello"
-                end function
-            end class
-            @meta2
-            class MyClass2
-                function main()
-                    print "hello"
-                end function
-            end class
+                @meta1
+                class MyClass
+                    function main()
+                        print "hello"
+                    end function
+                end class
+                @meta2
+                class MyClass2
+                    function main()
+                        print "hello"
+                    end function
+                end class
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;
@@ -890,11 +890,11 @@ describe('parser', () => {
 
         it('ignores annotations on commented out lines', () => {
             let { statements, diagnostics } = parse(`
-            '@meta1
-            '   @meta1
-            function new()
-                print "hello"
-            end function
+                '@meta1
+                '   @meta1
+                function new()
+                    print "hello"
+                end function
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.message).not.to.exist;
             let cs = statements[0] as ClassStatement;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -250,11 +250,9 @@ export class Parser {
                         if (!isAnnotationExpression(dec)) {
                             this.consumePendingAnnotations(dec);
                             body.statements.push(dec);
-                            //ensure statement separator
-                            this.consumeStatementSeparators();
-                        } else {
-                            this.consumeStatementSeparators(true);
                         }
+                        //ensure statement separator
+                        this.consumeStatementSeparators();
                     }
                 }
             } catch (parseError) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -353,6 +353,9 @@ export class Parser {
      */
     private classDeclaration(): ClassStatement {
         this.warnIfNotBrighterScriptMode('class declarations');
+        let classAnnotations = this.pendingAnnotations;
+        this.pendingAnnotations = [];
+        
         let classKeyword = this.consume(
             DiagnosticMessages.expectedClassKeyword(),
             TokenKind.Class
@@ -460,6 +463,12 @@ export class Parser {
             parentClassName,
             this.currentNamespaceName
         );
+
+        //attach annotations to statements
+        if (classAnnotations?.length) {
+            result.annotations = classAnnotations;
+        }
+
         this._references.classStatements.push(result);
         return result;
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -255,10 +255,6 @@ export class Parser {
                         } else {
                             this.consumeStatementSeparators(true);
                         }
-
-                    } else {
-                        //consume potential separators
-                        this.consumeStatementSeparators(true);
                     }
                 }
             } catch (parseError) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -355,7 +355,7 @@ export class Parser {
         this.warnIfNotBrighterScriptMode('class declarations');
         let classAnnotations = this.pendingAnnotations;
         this.pendingAnnotations = [];
-        
+
         let classKeyword = this.consume(
             DiagnosticMessages.expectedClassKeyword(),
             TokenKind.Class

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -392,8 +392,9 @@ export class Parser {
 
                 //methods (function/sub keyword OR identifier followed by opening paren)
                 if (this.checkAny(TokenKind.Function, TokenKind.Sub) || (this.checkAny(TokenKind.Identifier, ...AllowedProperties) && this.checkNext(TokenKind.LeftParen))) {
-                    let memberAnnotations = this.pendingAnnotations;
                     //cache annotations to this point, for when we later create the class member, because statements inside blocks can otherwise inherit these annotations
+                    let memberAnnotations = this.pendingAnnotations;
+                    this.pendingAnnotations = [];
                     let funcDeclaration = this.functionDeclaration(false, false);
 
                     //remove this function from the lists because it's not a callable
@@ -414,7 +415,6 @@ export class Parser {
                     );
 
                     methodStatement.annotations = memberAnnotations;
-                    this.pendingAnnotations = [];
 
                     //refer to this statement as parent of the expression
                     functionStatement.func.functionStatement = methodStatement;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -390,11 +390,10 @@ export class Parser {
                     overrideKeyword = this.advance();
                 }
 
-                //cache annotations to this point, for when we later create the class member, because statements inside blocks can otherwise inherit these annotations
-                let memberAnnotations = this.pendingAnnotations;
-
                 //methods (function/sub keyword OR identifier followed by opening paren)
                 if (this.checkAny(TokenKind.Function, TokenKind.Sub) || (this.checkAny(TokenKind.Identifier, ...AllowedProperties) && this.checkNext(TokenKind.LeftParen))) {
+                    let memberAnnotations = this.pendingAnnotations;
+                    //cache annotations to this point, for when we later create the class member, because statements inside blocks can otherwise inherit these annotations
                     let funcDeclaration = this.functionDeclaration(false, false);
 
                     //remove this function from the lists because it's not a callable
@@ -426,7 +425,7 @@ export class Parser {
                 } else if (this.checkAny(TokenKind.Identifier, ...AllowedProperties)) {
 
                     const fieldStatement = this.classFieldDeclaration(accessModifier);
-                    fieldStatement.annotations = memberAnnotations;
+                    this.consumePendingAnnotations(fieldStatement);
                     body.push(fieldStatement);
 
                     //class fields cannot be overridden

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -250,9 +250,11 @@ export class Parser {
                         if (!isAnnotationExpression(dec)) {
                             this.consumePendingAnnotations(dec);
                             body.statements.push(dec);
+                            //ensure statement separator
+                            this.consumeStatementSeparators(false);
+                        } else {
+                            this.consumeStatementSeparators(true);
                         }
-                        //ensure statement separator
-                        this.consumeStatementSeparators();
                     }
                 }
             } catch (parseError) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1807,10 +1807,13 @@ export class Parser {
         return new Block(statements, startingToken.range);
     }
 
-    consumePendingAnnotations(dec: Statement) {
-        //attach pending annotations to statements
+    /**
+     * Attach pending annotations to the provided statement,
+     * and then reset the annotations array
+     */
+    consumePendingAnnotations(statement: Statement) {
         if (this.pendingAnnotations.length) {
-            dec.annotations = this.pendingAnnotations;
+            statement.annotations = this.pendingAnnotations;
             this.pendingAnnotations = [];
         }
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -395,8 +395,6 @@ export class Parser {
 
                 //methods (function/sub keyword OR identifier followed by opening paren)
                 if (this.checkAny(TokenKind.Function, TokenKind.Sub) || (this.checkAny(TokenKind.Identifier, ...AllowedProperties) && this.checkNext(TokenKind.LeftParen))) {
-                    //clear out pending annotations; only if we find a block
-                    this.pendingAnnotations = [];
                     let funcDeclaration = this.functionDeclaration(false, false);
 
                     //remove this function from the lists because it's not a callable
@@ -415,7 +413,10 @@ export class Parser {
                         funcDeclaration.func,
                         overrideKeyword
                     );
+
                     methodStatement.annotations = memberAnnotations;
+                    this.pendingAnnotations = [];
+
                     //refer to this statement as parent of the expression
                     functionStatement.func.functionStatement = methodStatement;
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -256,7 +256,6 @@ export class Parser {
                             this.consumeStatementSeparators(true);
                         }
 
-
                     } else {
                         //consume potential separators
                         this.consumeStatementSeparators(true);


### PR DESCRIPTION
Adds annotation support for classes, attaching any pending annotation…s that appear before a class keyword

@elsassph inspired (i.e goaded) me to add annotation support for maestro, perhaps knowing that this feature was missing and I would therefore have to write it :D Great delegation @elsassph 👏 

Hopefully this approach is okay - I'm sure we all concur that annotations are just as usefu on classes as other statements.