### PR TITLE
Better support of plugins diagnostics

### DIFF
--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -91,7 +91,7 @@ export interface BsConfig {
     /**
      * A list of error codes the compiler should NOT emit, even if encountered.
      */
-    ignoreErrorCodes?: number[];
+    ignoreErrorCodes?: (number|string)[];
 
     /**
      * Emit full paths to files when printing diagnostics to the console. Defaults to false
@@ -107,7 +107,7 @@ export interface BsConfig {
     /**
      * A list of filters used to exclude diagnostics from the output
      */
-    diagnosticFilters?: Array<number | string | { src: string; codes: number[] } | { src: string } | { codes: number[] }>;
+    diagnosticFilters?: Array<number | string | { src: string; codes: (number|string)[] } | { src: string } | { codes: (number|string)[] }>;
 
     /**
      * Specify what diagnostic types should be printed to the console. Defaults to 'warn'

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -10,7 +10,7 @@ describe('DiagnosticFilterer', () => {
         rootDir: rootDir,
         diagnosticFilters: [
             //ignore these codes globally
-            { codes: [1, 2, 3] },
+            { codes: [1, 2, 3, 'X4'] },
             //ignore all codes from lib
             { src: 'lib/**/*.brs' },
             //ignore all codes from `packages` with absolute path
@@ -38,7 +38,8 @@ describe('DiagnosticFilterer', () => {
                 filterer.filter(options, [
                     getDiagnostic(1, `${rootDir}/source/common.brs`),
                     getDiagnostic(2, `${rootDir}/source/common.brs`),
-                    getDiagnostic(4, `${rootDir}/source/common.brs`)
+                    getDiagnostic(4, `${rootDir}/source/common.brs`),
+                    getDiagnostic('X4', `${rootDir}/source/common.brs`)
                 ]).map(x => x.code)
             ).to.eql([4]);
         });
@@ -60,7 +61,8 @@ describe('DiagnosticFilterer', () => {
                     getDiagnostic(10, `${rootDir}/source/common.brs`), //keep
                     getDiagnostic(11, `${rootDir}/packages/a.brs`), //remove
                     getDiagnostic(12, `${rootDir}/packages/a/b/b.brs`), //remove
-                    getDiagnostic(13, `${rootDir}/packages/a/b/c/c.brs`) //remove
+                    getDiagnostic(13, `${rootDir}/packages/a/b/c/c.brs`), //remove
+                    getDiagnostic('X14', `${rootDir}/packages/a/b/c/c.brs`) //remove
                 ]).map(x => x.code)
             ).to.eql([10]);
         });
@@ -71,9 +73,10 @@ describe('DiagnosticFilterer', () => {
                     getDiagnostic(4, `${rootDir}/source/main.brs`), //remove
                     getDiagnostic(11, `${rootDir}/common/a.brs`), //keep
                     getDiagnostic(12, `${rootDir}/common/a/b/b.brs`), //keep
-                    getDiagnostic(13, `${rootDir}/common/a/b/c/c.brs`) //keep
+                    getDiagnostic(13, `${rootDir}/common/a/b/c/c.brs`), //keep
+                    getDiagnostic('X14', `${rootDir}/common/a/b/c/c.brs`) //keep
                 ]).map(x => x.code)
-            ).to.eql([11, 12, 13]);
+            ).to.eql([11, 12, 13, 'X14']);
         });
     });
     describe('standardizeDiagnosticFilters', () => {
@@ -105,9 +108,9 @@ describe('DiagnosticFilterer', () => {
         it('handles standard diagnostic filters', () => {
             expect(
                 filterer.getDiagnosticFilters({
-                    diagnosticFilters: [{ src: 'file.brs', codes: [1, 2, 3] }]
+                    diagnosticFilters: [{ src: 'file.brs', codes: [1, 2, 'X3'] }]
                 })
-            ).to.eql([{ src: 'file.brs', codes: [1, 2, 3] }]);
+            ).to.eql([{ src: 'file.brs', codes: [1, 2, 'X3'] }]);
         });
 
         it('handles string-only diagnostic filter object', () => {
@@ -120,9 +123,9 @@ describe('DiagnosticFilterer', () => {
 
         it('handles code-only diagnostic filter object', () => {
             expect(filterer.getDiagnosticFilters({
-                diagnosticFilters: [{ codes: [1, 2, 3] }]
+                diagnosticFilters: [{ codes: [1, 2, 'X3'] }]
             })).to.eql([
-                { codes: [1, 2, 3] }
+                { codes: [1, 2, 'X3'] }
             ]);
         });
 
@@ -136,16 +139,16 @@ describe('DiagnosticFilterer', () => {
 
         it('converts ignoreErrorCodes to diagnosticFilters', () => {
             expect(filterer.getDiagnosticFilters({
-                ignoreErrorCodes: [1, 2, 3]
+                ignoreErrorCodes: [1, 2, 'X3']
             })).to.eql([
-                { codes: [1, 2, 3] }
+                { codes: [1, 2, 'X3'] }
             ]);
         });
     });
 
 });
 
-function getDiagnostic(code: number, pathAbsolute: string) {
+function getDiagnostic(code: number|string, pathAbsolute: string) {
     return {
         file: {
             pathAbsolute: s`${pathAbsolute}`

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -97,7 +97,7 @@ export class DiagnosticFilterer {
         }
     }
 
-    private filterFile(filter: { src?: string; codes?: number[] }, filePath: string) {
+    private filterFile(filter: { src?: string; codes?: (number|string)[] }, filePath: string) {
         //if there are no codes, throw out all diagnostics for this file
         if (!filter.codes) {
             delete this.byFile[filePath];
@@ -109,7 +109,7 @@ export class DiagnosticFilterer {
             let fileDiagnostics = this.byFile[filePath];
             for (let i = 0; i < fileDiagnostics.length; i++) {
                 let diagnostic = fileDiagnostics[i];
-                if (filter.codes.includes(diagnostic.code as number)) {
+                if (filter.codes.includes(diagnostic.code)) {
                     //remove this diagnostic
                     fileDiagnostics.splice(i, 1);
                     //repeat this loop iteration (with the new item at this index)
@@ -121,7 +121,7 @@ export class DiagnosticFilterer {
 
     public getDiagnosticFilters(config1: BsConfig) {
 
-        let globalIgnoreCodes = [...config1.ignoreErrorCodes ?? []];
+        let globalIgnoreCodes: (number|string)[] = [...config1.ignoreErrorCodes ?? []];
         let diagnosticFilters = [...config1.diagnosticFilters ?? []];
 
         let result = [];
@@ -153,6 +153,6 @@ export class DiagnosticFilterer {
                 codes: globalIgnoreCodes
             });
         }
-        return result as Array<{ src?: string; codes: number[] }>;
+        return result as Array<{ src?: string; codes: (number|string)[] }>;
     }
 }

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -7,7 +7,7 @@ import { standardizePath as s } from './util';
 export class DiagnosticFilterer {
     private byFile: Record<string, BsDiagnostic[]>;
     private filePaths: string[];
-    private filters: Array<{ src?: string; codes?: number[] }>;
+    private filters: Array<{ src?: string; codes?: (number|string)[] }>;
     private rootDir: string;
 
     /**
@@ -74,7 +74,7 @@ export class DiagnosticFilterer {
         }
     }
 
-    private filterAllFiles(filter: { src?: string; codes?: number[] }) {
+    private filterAllFiles(filter: { src?: string; codes?: (number|string)[] }) {
         let matchedFilePaths: string[];
 
         //if there's a src, match against all files

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -465,6 +465,10 @@ export class BrsFile {
                 let codes = [] as number[];
                 for (let codeToken of tokenized.codes) {
                     let codeInt = parseInt(codeToken.code);
+                    if (isNaN(codeInt)) {
+                        //don't validate non-numeric codes
+                        continue;
+                    }
                     //add a warning for unknown codes
                     if (diagnosticCodes.includes(codeInt)) {
                         codes.push(codeInt);


### PR DESCRIPTION
E.g. accept `'bs:disable-next-line: CUSTOM123` and those in diagnostic filters.

- Support strings for diagnostic codes
- Don't validate strings for diagnostic codes