### PR TITLE
Plugins as factory

### DIFF
--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -5,7 +5,7 @@ import type { BsConfig } from './BsConfig';
 import type { BsDiagnostic, File, FileObj } from './interfaces';
 import type { FileResolver } from './Program';
 import { Program } from './Program';
-import { standardizePath as s, util, loadPlugins } from './util';
+import { standardizePath as s, util } from './util';
 import { Watcher } from './Watcher';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { Logger, LogLevel } from './Logger';
@@ -114,7 +114,7 @@ export class ProgramBuilder {
     }
 
     protected loadPlugins() {
-        const plugins = loadPlugins(
+        const plugins = util.loadPlugins(
             this.options.cwd ?? process.cwd(),
             this.options.plugins,
             (pathOrModule, err) => this.logger.error(`Error when loading plugin '${pathOrModule}':`, err)

--- a/src/examples/plugins/removePrint.ts
+++ b/src/examples/plugins/removePrint.ts
@@ -3,25 +3,24 @@ import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BscFile, CompilerPlugin } from '../../interfaces';
 import { EmptyStatement } from '../../parser/Statement';
 
-// entry point
-const pluginInterface: CompilerPlugin = {
-    name: 'removePrint',
-    afterFileParse: afterFileParse
-};
-export default pluginInterface;
-
-// note: it is normally not recommended to modify the AST too much at this stage,
-// because if the plugin runs in a language-server context it could break intellisense
-function afterFileParse(file: BscFile) {
-    if (!isBrsFile(file)) {
-        return;
-    }
-    // visit functions bodies and replace `PrintStatement` nodes with `EmptyStatement`
-    for (const func of file.parser.references.functionExpressions) {
-        func.body.walk(createVisitor({
-            PrintStatement: (statement) => new EmptyStatement()
-        }), {
-            walkMode: WalkMode.visitStatements
-        });
-    }
+export default function plugin() {
+    return {
+        name: 'removePrint',
+        // note: it is normally not recommended to modify the AST too much at this stage,
+        // because if the plugin runs in a language-server context it could break intellisense
+        afterFileParse: (file: BscFile) => {
+            if (!isBrsFile(file)) {
+                return;
+            }
+            // visit functions bodies and replace `PrintStatement` nodes with `EmptyStatement`
+            for (const func of file.parser.references.functionExpressions) {
+                func.body.walk(createVisitor({
+                    PrintStatement: (statement) => new EmptyStatement()
+                }), {
+                    walkMode: WalkMode.visitStatements
+                });
+            }
+        }
+    } as CompilerPlugin;
 }
+

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -14,7 +14,7 @@ import { SourceMapConsumer } from 'source-map';
 import { TokenKind, Lexer, Keywords } from '../lexer';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { StandardizedFileEntry } from 'roku-deploy';
-import util, { loadPlugins, standardizePath as s } from '../util';
+import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
 import { trim } from '../testHelpers.spec';
 import { ParseMode } from '../parser/Parser';
@@ -2527,7 +2527,7 @@ describe('BrsFile', () => {
 
         it('can use a plugin object which transforms the AST', async () => {
             program.plugins = new PluginInterface(
-                loadPlugins('', [
+                util.loadPlugins('', [
                     require.resolve('../examples/plugins/removePrint')
                 ]),
                 undefined
@@ -2537,7 +2537,7 @@ describe('BrsFile', () => {
 
         it('can load an absolute plugin which transforms the AST', async () => {
             program.plugins = new PluginInterface(
-                loadPlugins('', [
+                util.loadPlugins('', [
                     path.resolve(process.cwd(), './dist/examples/plugins/removePrint.js')
                 ]),
                 undefined
@@ -2547,7 +2547,7 @@ describe('BrsFile', () => {
 
         it('can load a relative plugin which transforms the AST', async () => {
             program.plugins = new PluginInterface(
-                loadPlugins(process.cwd(), [
+                util.loadPlugins(process.cwd(), [
                     './dist/examples/plugins/removePrint.js'
                 ]),
                 undefined

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -161,6 +161,8 @@ export interface CommentFlag {
 
 type ValidateHandler = (scope: Scope, files: BscFile[], callables: CallableContainerMap) => void;
 
+export type CompilerPluginFactory = () => CompilerPlugin;
+
 export interface CompilerPlugin {
     name: string;
     beforeProgramCreate?: (builder: ProgramBuilder) => void;

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -5,18 +5,21 @@ import { Range } from 'vscode-languageserver';
 import { Lexer } from './lexer';
 import type { BsConfig } from './BsConfig';
 import * as fsExtra from 'fs-extra';
-
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
 let tempDir = s`${process.cwd()}/.tmp`;
 let rootDir = s`${tempDir}/rootDir`;
 let cwd = process.cwd();
 
 describe('util', () => {
     beforeEach(() => {
+        sinon.restore();
         fsExtra.ensureDirSync(tempDir);
         fsExtra.emptyDirSync(tempDir);
     });
 
     afterEach(() => {
+        sinon.restore();
         fsExtra.ensureDirSync(tempDir);
         fsExtra.emptyDirSync(tempDir);
     });
@@ -530,6 +533,71 @@ describe('util', () => {
             expect(util.getExtension('main.d.bs')).to.eql('.d.bs');
             expect(util.getExtension('main.xml')).to.eql('.xml');
             expect(util.getExtension('main.component.xml')).to.eql('.xml');
+        });
+    });
+
+    describe('loadPlugins', () => {
+
+        let pluginPath: string;
+        let id = 1;
+
+        beforeEach(() => {
+            // `require` caches plugins, so  generate a unique plugin name for every test
+            pluginPath = `${tempDir}/plugin${id++}.js`;
+        });
+
+        it('shows warning when loading plugin with old "object" format', () => {
+            fsExtra.writeFileSync(pluginPath, `
+                module.exports = {
+                    name: 'AwesomePlugin'
+                };
+            `);
+            const stub = sinon.stub(console, 'warn').callThrough();
+            const plugins = util.loadPlugins(cwd, [pluginPath]);
+            expect(plugins[0].name).to.eql('AwesomePlugin');
+            expect(stub.callCount).to.equal(1);
+        });
+
+        it('shows warning when loading plugin with old "object" format and exports.default', () => {
+            fsExtra.writeFileSync(pluginPath, `
+                module.exports.default = {
+                    name: 'AwesomePlugin'
+                };
+            `);
+            const stub = sinon.stub(console, 'warn').callThrough();
+            const plugins = util.loadPlugins(cwd, [pluginPath]);
+            expect(plugins[0].name).to.eql('AwesomePlugin');
+            expect(stub.callCount).to.equal(1);
+        });
+
+        it('loads plugin with factory pattern', () => {
+            fsExtra.writeFileSync(pluginPath, `
+                module.exports = function() {
+                    return {
+                        name: 'AwesomePlugin'
+                    };
+                };
+            `);
+            const stub = sinon.stub(console, 'warn').callThrough();
+            const plugins = util.loadPlugins(cwd, [pluginPath]);
+            expect(plugins[0].name).to.eql('AwesomePlugin');
+            //does not warn about factory pattern
+            expect(stub.callCount).to.equal(0);
+        });
+
+        it('loads plugin with factory pattern and `default`', () => {
+            fsExtra.writeFileSync(pluginPath, `
+                module.exports.default = function() {
+                    return {
+                        name: 'AwesomePlugin'
+                    };
+                };
+            `);
+            const stub = sinon.stub(console, 'warn').callThrough();
+            const plugins = util.loadPlugins(cwd, [pluginPath]);
+            expect(plugins[0].name).to.eql('AwesomePlugin');
+            //does not warn about factory pattern
+            expect(stub.callCount).to.equal(0);
         });
     });
 });


### PR DESCRIPTION
There is a flaw in the plugins system right now that always creates a singleton. which pushes the oweness of multi-projects on to each plugin. to combat this, the plugin system has been refactored to require plugins to register a singleton FACTORY, which returns a new plugin instance every time it's called. 