### PR TITLE
Improve/fix annotations parsing

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -531,10 +531,10 @@ export let DiagnosticMessages = {
         code: 1102,
         severity: DiagnosticSeverity.Error
     }),
-    __unused1103: () => ({
-        message: ``,
+    unusedAnnotation: () => ({
+        message: `This annotation is not attached to any statement`,
         code: 1103,
-        severity: DiagnosticSeverity.Warning
+        severity: DiagnosticSeverity.Error
     }),
     localVarShadowedByScopedFunction: () => ({
         message: `Declaring a local variable with same name as scoped function can result in unexpected behavior`,

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -638,14 +638,6 @@ describe('parser', () => {
     });
 
     describe('Annotations', () => {
-        it('parses without errors', () => {
-            let { statements, diagnostics } = parse(`
-                @meta1
-            `, ParseMode.BrighterScript);
-            expect(diagnostics[0]?.message).not.to.exist;
-            expect(statements.length).to.equal(0);
-        });
-
         it('parses with error if malformed', () => {
             let { diagnostics } = parse(`
                 @
@@ -653,6 +645,32 @@ describe('parser', () => {
                 end sub
             `, ParseMode.BrighterScript);
             expect(diagnostics[0]?.code).to.equal(1081); //unexpected token '@'
+        });
+
+        it('parses with error if annotation is not followed by a statement', () => {
+            let { diagnostics } = parse(`
+                sub main()
+                    @meta2
+                end sub
+                class MyClass
+                    @meta3
+                    @meta4
+                end class
+                @meta1
+            `, ParseMode.BrighterScript);
+            expect(diagnostics.length).to.equal(4);
+            expect(diagnostics[0]?.message).to.equal(
+                DiagnosticMessages.unusedAnnotation().message
+            );
+            expect(diagnostics[1]?.message).to.equal(
+                DiagnosticMessages.unusedAnnotation().message
+            );
+            expect(diagnostics[2]?.message).to.equal(
+                DiagnosticMessages.unusedAnnotation().message
+            );
+            expect(diagnostics[3]?.message).to.equal(
+                DiagnosticMessages.unusedAnnotation().message
+            );
         });
 
         it('attaches an annotation to next statement', () => {


### PR DESCRIPTION
Annotations should be block-restricted:
- save/restore when entering/exiting a block
- error if an annotation isn't used within a block