### PR TITLE
Remove async file adding from program

### DIFF
--- a/benchmarks/targets/validate.js
+++ b/benchmarks/targets/validate.js
@@ -15,14 +15,18 @@ module.exports = async (suite, name, brighterscript, projectPath) => {
         throw new Error('No files found in program');
     }
 
-    suite.add(name, async (deferred) => {
+    suite.add(name, (deferred) => {
         const scopes = Object.values(builder.program.scopes);
         //mark all scopes as invalid so they'll re-validate
         for (let scope of scopes) {
             scope.invalidate();
         }
-        await builder.program.validate();
-        deferred.resolve();
+        let promise = builder.program.validate();
+        if (promise) {
+            promise.then(() => deferred.resolve());
+        } else {
+            deferred.resolve();
+        }
     }, {
         'defer': true
     });

--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -8,46 +8,46 @@ class DocCompiler {
     private docsFolder = path.resolve(path.join(__dirname, '..', 'docs'));
     public async run() {
 
-        var docs = glob.sync('**/*.md', {
+        let docs = glob.sync('**/*.md', {
             cwd: this.docsFolder,
             absolute: true
         });
 
         for (let docPath of docs) {
             console.log('\n', docPath);
-            await this.processDoc(docPath);
+            this.processDoc(docPath);
         }
     }
 
     private lines: string[];
     private index: number;
 
-    public async processDoc(docPath: string) {
+    public processDoc(docPath: string) {
         let contents = fsExtra.readFileSync(docPath).toString();
         this.lines = util.splitIntoLines(contents);
         this.index = 0;
         while (this.index < this.lines.length) {
             let line = this.lines[this.index];
             if (line.includes('```')) {
-                await this.processCodeBlock();
+                this.processCodeBlock();
             }
             this.index++;
         }
 
-        var result = this.lines.join('\n');
+        let result = this.lines.join('\n');
         fsExtra.writeFileSync(docPath, result);
         delete this.lines;
         this.index = -1;
     }
 
-    public async processCodeBlock() {
-        var sourceLines = [] as string[];
-        var sourceStartIndex = this.index + 1;
-        var sourceStopIndex: number;
+    public processCodeBlock() {
+        let sourceLines = [] as string[];
+        let sourceStartIndex = this.index + 1;
+        let sourceStopIndex: number;
 
         //find the rest of the source code block
         //+1 to step past the opening ```
-        for (var i = this.index + 1; i < this.lines.length; i++) {
+        for (let i = this.index + 1; i < this.lines.length; i++) {
             let line = this.lines[i];
             if (line.includes('```')) {
                 sourceStopIndex = i - 1;
@@ -59,11 +59,11 @@ class DocCompiler {
 
         let sourceCode = sourceLines.join('\n');
 
-        var transpiledStartIndex: number;
-        var transpiledStopIndex: number;
+        let transpiledStartIndex: number;
+        let transpiledStopIndex: number;
         //find the transpiled code block (there must be one after every
         //+2 to step past the last line of code, and the final ```
-        outer: for (var i = sourceStopIndex + 2; i < this.lines.length; i++) {
+        outer: for (let i = sourceStopIndex + 2; i < this.lines.length; i++) {
             let line = this.lines[i];
             //the next code block MUST be a brightscript block. hard-fail if it isn't
             if (line.includes('```')) {
@@ -88,9 +88,9 @@ class DocCompiler {
         //now that we have the range for the transpiled code, we need to transpile the source code
         if (transpiledStartIndex && transpiledStopIndex && sourceCode) {
             console.log(`Transpiling code block at lines ${sourceStartIndex}-${sourceStopIndex}`);
-            var transpiledCode = await this.transpile(sourceCode);
+            const transpiledCode = this.transpile(sourceCode);
             let transpiledLines = transpiledCode.split('\n');
-            let originalTranspiledLineCount = transpiledStopIndex - transpiledStartIndex
+            let originalTranspiledLineCount = transpiledStopIndex - transpiledStartIndex;
 
             //replace the old transpiled lines with the new ones
             this.lines.splice(
@@ -103,15 +103,15 @@ class DocCompiler {
         }
     }
 
-    public async transpile(code: string) {
-        var program = new Program({
+    public transpile(code: string) {
+        const program = new Program({
             rootDir: `${__dirname}/rootDir`,
             files: [
                 'source/main.brs'
             ]
         });
-        var file = await program.addOrReplaceFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code)
-        await program.validate();
+        const file = program.addOrReplaceFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code);
+        program.validate();
         let tranpileResult = file.transpile();
         return tranpileResult.code;
     }

--- a/src/FunctionScope.spec.ts
+++ b/src/FunctionScope.spec.ts
@@ -22,8 +22,8 @@ describe('FunctionScope', () => {
             expect(variables).to.be.lengthOf(0);
         });
 
-        it('returns variables defined above the specified line number', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('returns variables defined above the specified line number', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                     var1 = 1
                     var2 = 2

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -335,7 +335,7 @@ export class LanguageServer {
         //if there's a setting, we need to find the file or show error if it can't be found
         if (config?.configFile) {
             configFilePath = path.resolve(workspacePath, config.configFile);
-            if (await util.fileExists(configFilePath)) {
+            if (await util.pathExists(configFilePath)) {
                 return configFilePath;
             } else {
                 this.sendCriticalFailure(`Cannot find config file specified in user/workspace settings at '${configFilePath}'`);
@@ -344,13 +344,13 @@ export class LanguageServer {
 
         //default to config file path found in the root of the workspace
         configFilePath = path.resolve(workspacePath, 'bsconfig.json');
-        if (await util.fileExists(configFilePath)) {
+        if (await util.pathExists(configFilePath)) {
             return configFilePath;
         }
 
         //look for the deprecated `brsconfig.json` file
         configFilePath = path.resolve(workspacePath, 'brsconfig.json');
-        if (await util.fileExists(configFilePath)) {
+        if (await util.pathExists(configFilePath)) {
             return configFilePath;
         }
 
@@ -371,8 +371,9 @@ export class LanguageServer {
         builder.allowConsoleClearing = false;
 
         //look for files in our in-memory cache before going to the file system
-        builder.addFileResolver((pathAbsolute) => {
-            return this.documentFileResolver(pathAbsolute);
+        builder.addFileResolver({
+            readFile: (pathAbsolute) => this.documentFileResolver(pathAbsolute),
+            readFileSync: (pathAbsolute) => this.documentFileResolver(pathAbsolute)
         });
 
         let configFilePath = await this.getConfigFilePath(workspacePath);
@@ -380,7 +381,7 @@ export class LanguageServer {
         let cwd = workspacePath;
 
         //if the config file exists, use it and its folder as cwd
-        if (configFilePath && await util.fileExists(configFilePath)) {
+        if (configFilePath && await util.pathExists(configFilePath)) {
             cwd = path.dirname(configFilePath);
         } else {
             //config file doesn't exist...let `brighterscript` resolve the default way
@@ -442,8 +443,9 @@ export class LanguageServer {
         builder.allowConsoleClearing = false;
 
         //look for files in our in-memory cache before going to the file system
-        builder.addFileResolver((pathAbsolute) => {
-            return this.documentFileResolver(pathAbsolute);
+        builder.addFileResolver({
+            readFile: (pathAbsolute) => this.documentFileResolver(pathAbsolute),
+            readFileSync: (pathAbsolute) => this.documentFileResolver(pathAbsolute)
         });
 
         //get the path to the directory where this file resides
@@ -521,23 +523,9 @@ export class LanguageServer {
         //wait until the file has settled
         await this.keyedThrottler.onIdleOnce(filePath, true);
 
-        let workspaceCompletionPromises = [] as Array<Promise<CompletionItem[]>>;
-        let workspaces = this.getWorkspaces();
-        //get completions from every workspace
-        for (let workspace of workspaces) {
-            //if this workspace has the file in question, get its completions
-            if (workspace.builder.program.hasFile(filePath)) {
-                workspaceCompletionPromises.push(
-                    workspace.builder.program.getCompletions(filePath, position)
-                );
-            }
-        }
-
-        let completions = ([] as CompletionItem[])
-            //wait for all promises to resolve, and then flatten them into a single array
-            .concat(...await Promise.all(workspaceCompletionPromises))
-            //throw out falsey values
-            .filter(x => !!x);
+        let completions = this
+            .getWorkspaces()
+            .flatMap(workspace => workspace.builder.program.getCompletions(filePath, position));
 
         for (let completion of completions) {
             completion.commitCharacters = ['.'];
@@ -804,10 +792,13 @@ export class LanguageServer {
 
             //if we got a dest path, then the program wants this file
             if (destPath) {
-                await program.addOrReplaceFile({
-                    src: change.pathAbsolute,
-                    dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
-                });
+                program.addOrReplaceFile(
+                    {
+                        src: change.pathAbsolute,
+                        dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
+                    },
+                    await workspace.builder.getFileContents(change.pathAbsolute)
+                );
             } else {
                 //no dest path means the program doesn't want this file
             }
@@ -816,11 +807,14 @@ export class LanguageServer {
         } else if (program.hasFile(change.pathAbsolute)) {
             //sometimes "changed" events are emitted on files that were actually deleted,
             //so determine file existance and act accordingly
-            if (await util.fileExists(change.pathAbsolute)) {
-                await program.addOrReplaceFile({
-                    src: change.pathAbsolute,
-                    dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
-                });
+            if (await util.pathExists(change.pathAbsolute)) {
+                program.addOrReplaceFile(
+                    {
+                        src: change.pathAbsolute,
+                        dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
+                    },
+                    await workspace.builder.getFileContents(change.pathAbsolute)
+                );
             } else {
                 program.removeFile(change.pathAbsolute);
             }
@@ -875,26 +869,23 @@ export class LanguageServer {
         try {
 
             //throttle file processing. first call is run immediately, and then the last call is processed.
-            await this.keyedThrottler.run(filePath, async () => {
+            await this.keyedThrottler.run(filePath, () => {
 
                 this.connection.sendNotification('build-status', 'building');
 
                 let documentText = textDocument.getText();
-                let workspaces = this.getWorkspaces();
-                await Promise.all(
-                    workspaces.map(async (x) => {
-                        //only add or replace existing files. All of the files in the project should
-                        //have already been loaded by other means
-                        if (x.builder.program.hasFile(filePath)) {
-                            let rootDir = x.builder.program.options.rootDir ?? x.builder.program.options.cwd;
-                            let dest = rokuDeploy.getDestPath(filePath, x.builder.program.options.files, rootDir);
-                            await x.builder.program.addOrReplaceFile({
-                                src: filePath,
-                                dest: dest
-                            }, documentText);
-                        }
-                    })
-                );
+                for (const workspace of this.getWorkspaces()) {
+                    //only add or replace existing files. All of the files in the project should
+                    //have already been loaded by other means
+                    if (workspace.builder.program.hasFile(filePath)) {
+                        let rootDir = workspace.builder.program.options.rootDir ?? workspace.builder.program.options.cwd;
+                        let dest = rokuDeploy.getDestPath(filePath, workspace.builder.program.options.files, rootDir);
+                        workspace.builder.program.addOrReplaceFile({
+                            src: filePath,
+                            dest: dest
+                        }, documentText);
+                    }
+                }
             });
             // validate all workspaces
             await this.validateAllThrottled();

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -371,10 +371,7 @@ export class LanguageServer {
         builder.allowConsoleClearing = false;
 
         //look for files in our in-memory cache before going to the file system
-        builder.addFileResolver({
-            readFile: (pathAbsolute) => this.documentFileResolver(pathAbsolute),
-            readFileSync: (pathAbsolute) => this.documentFileResolver(pathAbsolute)
-        });
+        builder.addFileResolver(this.documentFileResolver.bind(this));
 
         let configFilePath = await this.getConfigFilePath(workspacePath);
 
@@ -443,10 +440,7 @@ export class LanguageServer {
         builder.allowConsoleClearing = false;
 
         //look for files in our in-memory cache before going to the file system
-        builder.addFileResolver({
-            readFile: (pathAbsolute) => this.documentFileResolver(pathAbsolute),
-            readFileSync: (pathAbsolute) => this.documentFileResolver(pathAbsolute)
-        });
+        builder.addFileResolver(this.documentFileResolver.bind(this));
 
         //get the path to the directory where this file resides
         let cwd = path.dirname(filePathAbsolute);

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -48,81 +48,41 @@ describe('Program', () => {
     });
 
     describe('addFile', () => {
-        it('adds various files to `pkgMap`', async () => {
-            await program.addOrReplaceFile('source/main.brs', '');
+        it('adds various files to `pkgMap`', () => {
+            program.addOrReplaceFile('source/main.brs', '');
             expect(program['pkgMap']).to.have.property(s`source/main.brs`);
 
-            await program.addOrReplaceFile('source/main.bs', '');
+            program.addOrReplaceFile('source/main.bs', '');
             expect(program['pkgMap']).to.have.property(s`source/main.bs`);
 
-            await program.addOrReplaceFile('components/comp1.xml', '');
+            program.addOrReplaceFile('components/comp1.xml', '');
             expect(program['pkgMap']).to.have.property(s`components/comp1.xml`);
         });
 
-        it('does not crash when given a totally bogus file', async () => {
-            await program.addOrReplaceFile({
+        it('does not crash when given a totally bogus file', () => {
+            program.addOrReplaceFile({
                 src: `${rootDir}/source/main.brs`,
                 dest: 'source/main.brs'
             }, `class Animalpublic name as stringpublic function walk()end functionend class`);
             //if the program didn't get stuck in an infinite loop, this test passes
         });
-        describe('fileResolvers', () => {
-            it('loads brs file contents from disk when necessary', async () => {
-                let stub = sinon.stub(util, 'getFileContents').returns(Promise.resolve(''));
-                expect(stub.called).to.be.false;
 
-                //resolve lib.brs from memory instead of going to disk
-                program.fileResolvers.push((pathAbsolute) => {
-                    if (
-                        pathAbsolute === s`${rootDir}/source/lib.brs` ||
-                        pathAbsolute === s`${rootDir}/source/lib.d.bs`
-                    ) {
-                        return `'comment`;
-                    }
-                });
-                await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' });
-
-                expect(stub.called).to.be.false;
-
-                //load main.brs from disk
-                await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' });
-                expect(stub.called).to.be.true;
-            });
-
-            it('loads xml file contents from disk when necessary', async () => {
-                let stub = sinon.stub(util, 'getFileContents').returns(Promise.resolve(''));
-                expect(stub.called).to.be.false;
-
-                program.fileResolvers.push((pathAbsolute) => {
-                    if (pathAbsolute === s`${rootDir}/components/A.xml`) {
-                        return `<?xml version="1.0" encoding="utf-8" ?>`;
-                    }
-                });
-                await program.addOrReplaceFile({ src: `${rootDir}/components/A.xml`, dest: 'components/A.xml' });
-                expect(stub.called).to.be.false;
-
-                await program.addOrReplaceFile({ src: `${rootDir}/components/B.brs`, dest: 'components/B.brs' });
-                expect(stub.called).to.be.true;
-
-            });
-        });
-
-        it('only parses xml files as components when file is found within the "components" folder', async () => {
+        it('only parses xml files as components when file is found within the "components" folder', () => {
             expect(Object.keys(program.files).length).to.equal(0);
 
-            await program.addOrReplaceFile({
+            program.addOrReplaceFile({
                 src: s`${rootDir}/components/comp1.xml`,
                 dest: util.pathSepNormalize(`components/comp1.xml`)
             }, '');
             expect(Object.keys(program.files).length).to.equal(1);
 
-            await program.addOrReplaceFile({
+            program.addOrReplaceFile({
                 src: s`${rootDir}/notComponents/comp1.xml`,
                 dest: util.pathSepNormalize(`notComponents/comp1.xml`)
             }, '');
             expect(Object.keys(program.files).length).to.equal(1);
 
-            await program.addOrReplaceFile({
+            program.addOrReplaceFile({
                 src: s`${rootDir}/componentsExtra/comp1.xml`,
                 dest: util.pathSepNormalize(`componentsExtra/comp1.xml`)
             }, '');
@@ -130,7 +90,7 @@ describe('Program', () => {
         });
 
         it('supports empty statements for transpile', async () => {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
                 sub main()
                     m.logError()
                     'some comment
@@ -140,37 +100,37 @@ describe('Program', () => {
             await program.transpile([{ src: file.pathAbsolute, dest: file.pkgPath }], tmpPath);
         });
 
-        it('works with different cwd', async () => {
+        it('works with different cwd', () => {
             let projectDir = s`${tmpPath}/project2`;
             fsExtra.ensureDirSync(projectDir);
             program = new Program({ cwd: projectDir });
-            await program.addOrReplaceFile({ src: 'source/lib.brs', dest: 'source/lib.brs' }, 'function main()\n    print "hello world"\nend function');
+            program.addOrReplaceFile({ src: 'source/lib.brs', dest: 'source/lib.brs' }, 'function main()\n    print "hello world"\nend function');
             // await program.reloadFile('source/lib.brs', `'this is a comment`);
             //if we made it to here, nothing exploded, so the test passes
         });
 
-        it(`adds files in the source folder to the 'source' scope`, async () => {
+        it(`adds files in the source folder to the 'source' scope`, () => {
             expect(program.getScopeByName('source')).to.exist;
             //no files in source scope
             expect(program.getScopeByName('source').getOwnFiles().length).to.equal(0);
 
             let mainPath = s`${rootDir}/source/main.brs`;
             //add a new source file
-            await program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
+            program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
             //file should be in source scope now
             expect(program.getScopeByName('source').getFile(mainPath)).to.exist;
 
             //add an unreferenced file from the components folder
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1/component1.brs`, dest: 'components/component1/component1.brs' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1/component1.brs`, dest: 'components/component1/component1.brs' }, '');
 
             //source scope should have the same number of files
             expect(program.getScopeByName('source').getFile(mainPath)).to.exist;
             expect(program.getScopeByName('source').getFile(`${rootDir}/components/component1/component1.brs`)).not.to.exist;
         });
 
-        it('normalizes file paths', async () => {
+        it('normalizes file paths', () => {
             let filePath = `${rootDir}/source\\main.brs`;
-            await program.addOrReplaceFile({ src: filePath, dest: 'source/main.brs' }, '');
+            program.addOrReplaceFile({ src: filePath, dest: 'source/main.brs' }, '');
 
             expect(program.getScopeByName('source').getFile(filePath)).to.exist;
 
@@ -188,7 +148,7 @@ describe('Program', () => {
             // await program.loadOrReloadFile('components', '')
         });
 
-        it(`emits events for scope and file creation`, async () => {
+        it(`emits events for scope and file creation`, () => {
             const beforeProgramValidate = sinon.spy();
             const afterProgramValidate = sinon.spy();
             const afterScopeCreate = sinon.spy();
@@ -211,14 +171,14 @@ describe('Program', () => {
 
             let mainPath = s`${rootDir}/source/main.brs`;
             //add a new source file
-            await program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
+            program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
             //add a component file
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
                 </component>`);
-            await program.validate();
+            program.validate();
 
             //program events
             expect(beforeProgramValidate.callCount).to.equal(1);
@@ -236,19 +196,19 @@ describe('Program', () => {
     });
 
     describe('validate', () => {
-        it('catches duplicate XML component names', async () => {
+        it('catches duplicate XML component names', () => {
             //add 2 components which both reference the same errored file
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.lengthOf(2);
             expect(program.getDiagnostics().map(x => {
                 delete x.file;
@@ -287,9 +247,9 @@ describe('Program', () => {
             expect(actual).to.deep.equal(expected);
         });
 
-        it('does not produce duplicate parse errors for different component scopes', async () => {
+        it('does not produce duplicate parse errors for different component scopes', () => {
             //add a file with a parse error
-            await program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 sub DoSomething()
                     'random out-of-place open paren, definitely causes parse error
                     (
@@ -297,173 +257,173 @@ describe('Program', () => {
             `);
 
             //add 2 components which both reference the same errored file
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
                 </component>
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component2" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
                 </component>
             `);
 
-            await program.validate();
+            program.validate();
 
             let diagnostics = program.getDiagnostics();
             expect(diagnostics).to.be.lengthOf(1);
         });
 
-        it('detects scripts not loaded by any file', async () => {
+        it('detects scripts not loaded by any file', () => {
             //add a main file for sanity check
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
-            await program.validate();
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            program.validate();
             expect(program.getDiagnostics()).to.be.lengthOf(0);
 
             //add the orphaned file
-            await program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, '');
-            await program.validate();
+            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, '');
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics).to.be.lengthOf(1);
             expect(diagnostics[0].code).to.equal(DiagnosticMessages.fileNotReferencedByAnyOtherFile().code);
         });
-        it('does not throw errors on shadowed init functions in components', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `
+        it('does not throw errors on shadowed init functions in components', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `
                 function DoSomething()
                     return true
                 end function
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/Parent.xml`, dest: 'components/Parent.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/Parent.xml`, dest: 'components/Parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/Child.xml`, dest: 'components/Child.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/Child.xml`, dest: 'components/Child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
             `);
 
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('recognizes global function calls', async () => {
+        it('recognizes global function calls', () => {
             expect(program.getDiagnostics().length).to.equal(0);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/file.brs`, dest: 'source/file.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/file.brs`, dest: 'source/file.brs' }, `
                 function DoB()
                     sleep(100)
                 end function
             `);
             //validate the scope
-            await program.validate();
+            program.validate();
             let diagnostics = program.getDiagnostics();
             //shouldn't have any errors
             expect(diagnostics).to.be.lengthOf(0);
         });
 
-        it('shows warning when a child component imports the same script as its parent', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+        it('shows warning when a child component imports the same script as its parent', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `'comment`);
-            await program.validate();
+            program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `'comment`);
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics).to.be.lengthOf(1);
             expect(diagnostics[0].code).to.equal(DiagnosticMessages.unnecessaryScriptImportInChildFromParent('').code);
             expect(diagnostics[0].severity).to.equal(DiagnosticSeverity.Warning);
         });
 
-        it('adds info diag when child component method shadows parent component method', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+        it('adds info diag when child component method shadows parent component method', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/parent.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="pkg:/child.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/parent.brs`, dest: 'parent.brs' }, `sub DoSomething()\nend sub`);
-            await program.addOrReplaceFile({ src: `${rootDir}/child.brs`, dest: 'child.brs' }, `sub DoSomething()\nend sub`);
-            await program.validate();
+            program.addOrReplaceFile({ src: `${rootDir}/parent.brs`, dest: 'parent.brs' }, `sub DoSomething()\nend sub`);
+            program.addOrReplaceFile({ src: `${rootDir}/child.brs`, dest: 'child.brs' }, `sub DoSomething()\nend sub`);
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics).to.be.lengthOf(1);
             expect(diagnostics[0].code).to.equal(DiagnosticMessages.overridesAncestorFunction('', '', '', '').code);
         });
 
-        it('does not add info diagnostic on shadowed "init" functions', async () => {
-            await program.addOrReplaceFile('components/parent.xml', trim`
+        it('does not add info diagnostic on shadowed "init" functions', () => {
+            program.addOrReplaceFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="parent.brs" />
                 </component>
                 `);
-            await program.addOrReplaceFile(`components/parent.brs`, `sub Init()\nend sub`);
-            await program.addOrReplaceFile(`components/child.brs`, `sub Init()\nend sub`);
+            program.addOrReplaceFile(`components/parent.brs`, `sub Init()\nend sub`);
+            program.addOrReplaceFile(`components/child.brs`, `sub Init()\nend sub`);
 
-            await program.addOrReplaceFile('components/child.xml', trim`
+            program.addOrReplaceFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="child.brs" />
                 </component>
             `);
             //run this validate separately so we can have an easier time debugging just the child component
-            await program.validate();
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics.map(x => x.message)).to.eql([]);
         });
 
-        it('catches duplicate methods in single file', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('catches duplicate methods in single file', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(2);
             expect(program.getDiagnostics()[0].message.indexOf('Duplicate sub declaration'));
         });
 
-        it('catches duplicate methods across multiple files', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('catches duplicate methods across multiple files', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub DoSomething()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(2);
             expect(program.getDiagnostics()[0].message.indexOf('Duplicate sub declaration'));
         });
 
-        it('maintains correct callables list', async () => {
+        it('maintains correct callables list', () => {
             let initialCallableCount = program.getScopeByName('source').getAllCallables().length;
-            await program.addOrReplaceFile('source/main.brs', `
+            program.addOrReplaceFile('source/main.brs', `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -471,7 +431,7 @@ describe('Program', () => {
             `);
             expect(program.getScopeByName('source').getAllCallables().length).equals(initialCallableCount + 2);
             //set the file contents again (resetting the wasProcessed flag)
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -482,82 +442,82 @@ describe('Program', () => {
             expect(program.getScopeByName('source').getAllCallables().length).equals(initialCallableCount);
         });
 
-        it('resets errors on revalidate', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('resets errors on revalidate', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(2);
             //set the file contents again (resetting the wasProcessed flag)
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(2);
 
             //load in a valid file, the errors should go to zero
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(0);
         });
 
-        it('identifies invocation of unknown function', async () => {
+        it('identifies invocation of unknown function', () => {
             //call a function that doesn't exist
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "Hello"
                     DoSomething(name)
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(1);
             expect(program.getDiagnostics()[0].code).to.equal(DiagnosticMessages.callToUnknownFunction('', '').code);
         });
 
-        it('detects methods from another file in a subdirectory', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('detects methods from another file in a subdirectory', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     DoSomething()
                 end sub
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/ui/lib.brs`, dest: 'source/ui/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/ui/lib.brs`, dest: 'source/ui/lib.brs' }, `
                 function DoSomething()
                     print "hello world"
                 end function
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(0);
         });
     });
 
     describe('hasFile', () => {
-        it('recognizes when it has a file loaded', async () => {
+        it('recognizes when it has a file loaded', () => {
             expect(program.hasFile('file1.brs')).to.be.false;
-            await program.addOrReplaceFile({ src: 'file1.brs', dest: 'file1.brs' }, `'comment`);
+            program.addOrReplaceFile({ src: 'file1.brs', dest: 'file1.brs' }, `'comment`);
             expect(program.hasFile('file1.brs')).to.be.true;
         });
     });
 
     describe('addOrReplaceFile', () => {
-        it('links xml scopes based on xml parent-child relationships', async () => {
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+        it('links xml scopes based on xml parent-child relationships', () => {
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                 </component>
@@ -566,7 +526,7 @@ describe('Program', () => {
             expect(program.getScopeByName('components/ChildScene.xml').getParentScope().name).to.equal(s`components/ParentScene.xml`);
 
             //change the parent's name.
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="NotParentScene" extends="Scene">
                 </component>
@@ -576,48 +536,48 @@ describe('Program', () => {
             expect(program.getScopeByName('components/ChildScene.xml').getParentScope().name).to.equal('global');
         });
 
-        it('creates a new scope for every added component xml', async () => {
+        it('creates a new scope for every added component xml', () => {
             //we have global callables, so get that initial number
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
             expect(program.getScopeByName(`components/component1.xml`)).to.exist;
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
-            await program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, '');
             expect(program.getScopeByName(`components/component1.xml`)).to.exist;
             expect(program.getScopeByName(`components/component2.xml`)).to.exist;
         });
 
-        it('includes referenced files in xml scopes', async () => {
+        it('includes referenced files in xml scopes', () => {
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
                 </component>
             `);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            await program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let scope = program.getScopeByName(`components/component1.xml`);
             expect(scope.getFile(xmlPath).pkgPath).to.equal(s`components/component1.xml`);
             expect(scope.getFile(brsPath).pkgPath).to.equal(s`components/component1.brs`);
         });
 
-        it('adds xml file to files map', async () => {
+        it('adds xml file to files map', () => {
             let xmlPath = `${rootDir}/components/component1.xml`;
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, '');
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, '');
             expect(program.getFileByPathAbsolute(xmlPath)).to.exist;
         });
 
-        it('detects missing script reference', async () => {
+        it('detects missing script reference', () => {
             let xmlPath = `${rootDir}/components/component1.xml`;
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
                 </component>
             `);
-            await program.validate();
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics.length).to.equal(1);
             expect(diagnostics[0]).to.deep.include(<BsDiagnostic>{
@@ -627,17 +587,17 @@ describe('Program', () => {
             });
         });
 
-        it('adds warning instead of error on mismatched upper/lower case script import', async () => {
-            await program.addOrReplaceFile('components/component1.xml', trim`
+        it('adds warning instead of error on mismatched upper/lower case script import', () => {
+            program.addOrReplaceFile('components/component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="component1.brs" />
                 </component>
             `);
-            await program.addOrReplaceFile('components/COMPONENT1.brs', '');
+            program.addOrReplaceFile('components/COMPONENT1.brs', '');
 
             //validate
-            await program.validate();
+            program.validate();
             let diagnostics = program.getDiagnostics();
             expect(diagnostics.map(x => x.message)).to.eql([
                 DiagnosticMessages.scriptImportCaseMismatch(s`components\\COMPONENT1.brs`).message
@@ -646,73 +606,73 @@ describe('Program', () => {
     });
 
     describe('reloadFile', () => {
-        it('picks up new files in a scope when an xml file is loaded', async () => {
+        it('picks up new files in a scope when an xml file is loaded', () => {
             program.options.ignoreErrorCodes.push(1013);
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/comonent1.xml' }, trim`
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/comonent1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]).to.deep.include(<BsDiagnostic>{
                 message: DiagnosticMessages.referencedFileDoesNotExist().message
             });
 
             //add the file, the error should go away
             let brsPath = s`${rootDir}/components/component1.brs`;
-            await program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
-            await program.validate();
+            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.validate();
             expect(program.getDiagnostics()).to.be.empty;
 
             //add the xml file back in, but change the component brs file name. Should have an error again
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component2.brs" />
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]).to.deep.include(<BsDiagnostic>{
                 message: DiagnosticMessages.referencedFileDoesNotExist().message
             });
         });
 
-        it('handles when the brs file is added before the component', async () => {
+        it('handles when the brs file is added before the component', () => {
             let brsPath = s`${rootDir}/components/component1.brs`;
-            await program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            let xmlFile = await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).to.exist;
         });
 
-        it('reloads referenced fles when xml file changes', async () => {
+        it('reloads referenced fles when xml file changes', () => {
             program.options.ignoreErrorCodes.push(1013);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            await program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            let xmlFile = await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
 
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).not.to.exist;
 
             //reload the xml file contents, adding a new script reference.
-            xmlFile = await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
@@ -725,8 +685,8 @@ describe('Program', () => {
     });
 
     describe('getCompletions', () => {
-        it('should include first-level namespace names for brighterscript files', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('should include first-level namespace names for brighterscript files', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
@@ -735,7 +695,7 @@ describe('Program', () => {
 
                 end sub
             `);
-            let completions = (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 23))).map(x => x.label);
+            let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 23)).map(x => x.label);
             expect(completions).to.include('NameA');
             expect(completions).not.to.include('NameB');
             expect(completions).not.to.include('NameA.NameB');
@@ -743,8 +703,8 @@ describe('Program', () => {
             expect(completions).not.to.include('NameA.NameB.NameC.DoSomething');
         });
 
-        it('resolves completions for namespaces with next namespace part for brighterscript file', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        it('resolves completions for namespaces with next namespace part for brighterscript file', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
@@ -753,7 +713,7 @@ describe('Program', () => {
                     NameA.
                 end sub
             `);
-            let completions = (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 26))).map(x => x.label);
+            let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 26)).map(x => x.label);
             expect(completions).to.include('NameB');
             expect(completions).not.to.include('NameA');
             expect(completions).not.to.include('NameA.NameB');
@@ -761,8 +721,8 @@ describe('Program', () => {
             expect(completions).not.to.include('NameA.NameB.NameC.DoSomething');
         });
 
-        it('finds namespace members for brighterscript file', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        it('finds namespace members for brighterscript file', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     NameA.
                     NameA.NameB.
@@ -786,20 +746,20 @@ describe('Program', () => {
                 end namespace
             `);
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 26))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 26)).map(x => x.label).sort()
             ).to.eql(['NameB', 'alertA', 'info']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 32))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 32)).map(x => x.label).sort()
             ).to.eql(['NameC', 'alertB']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 38))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 38)).map(x => x.label).sort()
             ).to.eql(['alertC']);
         });
 
-        it('finds namespace members for classes', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        it('finds namespace members for classes', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     NameA.
                     NameA.NameB.
@@ -827,20 +787,20 @@ describe('Program', () => {
                 end namespace
             `);
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 26))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 26)).map(x => x.label).sort()
             ).to.eql(['MyClassA', 'NameB', 'alertA', 'info']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 32))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 32)).map(x => x.label).sort()
             ).to.eql(['MyClassB', 'NameC', 'alertB']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 38))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 38)).map(x => x.label).sort()
             ).to.eql(['alertC']);
         });
 
-        it('finds only namespaces that have classes, when new keyword is used', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('finds only namespaces that have classes, when new keyword is used', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 sub main()
                     a = new NameA.
                     b = new NameA.NameB.
@@ -875,57 +835,57 @@ describe('Program', () => {
                 end namespace
             `);
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 34))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 34)).map(x => x.label).sort()
             ).to.eql(['MyClassA', 'NameB']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 40))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 40)).map(x => x.label).sort()
             ).to.eql(['MyClassB']);
 
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 46))).map(x => x.label).sort()
+                program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 46)).map(x => x.label).sort()
             ).to.be.empty;
         });
 
         //Bron.. pain to get this working.. do we realy need this? seems moot with ropm..
-        it.skip('should include translated namespace function names for brightscript files', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        it.skip('should include translated namespace function names for brightscript files', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
                 end namespace
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub test()
 
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/lib.brs`, Position.create(2, 23));
+            let completions = program.getCompletions(`${rootDir}/source/lib.brs`, Position.create(2, 23));
             expect(completions.map(x => x.label)).to.include('NameA_NameB_NameC_DoSomething');
         });
 
-        it('inlcudes global completions for file with no scope', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'main.brs' }, `
+        it('inlcudes global completions for file with no scope', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'main.brs' }, `
                 function Main()
                     age = 1
                 end function
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             expect(completions.filter(x => x.label.toLowerCase() === 'abs')).to.be.lengthOf(1);
         });
 
-        it('filters out text results for top-level function statements', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('filters out text results for top-level function statements', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main()
                     age = 1
                 end function
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             expect(completions.filter(x => x.label === 'Main')).to.be.lengthOf(1);
         });
 
-        it('does not filter text results for object properties used in conditional statements', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('does not filter text results for object properties used in conditional statements', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -936,12 +896,12 @@ describe('Program', () => {
                     end if
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
             expect(completions.filter(x => x.label === 'isAlive')).to.be.lengthOf(1);
         });
 
-        it('does not filter text results for object properties used in assignments', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('does not filter text results for object properties used in assignments', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -950,12 +910,12 @@ describe('Program', () => {
                    localVar = person.name
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
             expect(completions.filter(x => x.label === 'name')).to.be.lengthOf(1);
         });
 
-        it('does not filter text results for object properties', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('does not filter text results for object properties', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -964,12 +924,12 @@ describe('Program', () => {
                    person.name = "bob"
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 22));
             expect(completions.filter(x => x.label === 'name')).to.be.lengthOf(1);
         });
 
-        it('filters out text results for local vars used in conditional statements', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('filters out text results for local vars used in conditional statements', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -980,12 +940,12 @@ describe('Program', () => {
                     end if
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             expect(completions.filter(x => x.label === 'isTrue')).to.be.lengthOf(0);
         });
 
-        it('filters out text results for local variable assignments', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('filters out text results for local variable assignments', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -993,12 +953,12 @@ describe('Program', () => {
                     message = "Hello"
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             expect(completions.filter(x => x.label === 'message')).to.be.lengthOf(0);
         });
 
-        it('filters out text results for local variables used in assignments', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('filters out text results for local variables used in assignments', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -1007,32 +967,32 @@ describe('Program', () => {
                     otherVar = message
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             expect(completions.filter(x => x.label === 'message')).to.be.lengthOf(0);
         });
 
-        it('does not suggest local variables when initiated to the right of a period', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('does not suggest local variables when initiated to the right of a period', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main()
                     helloMessage = "jack"
                     person.hello
                 end function
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 32));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 32));
             expect(completions.filter(x => x.kind === CompletionItemKind.Variable).map(x => x.label)).not.to.contain('helloMessage');
         });
 
-        it('finds all file paths when initiated on xml uri', async () => {
+        it('finds all file paths when initiated on xml uri', () => {
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            await program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="" />
                 </component>
             `);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            await program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
-            let completions = await program.getCompletions(xmlPath, Position.create(2, 42));
+            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            let completions = program.getCompletions(xmlPath, Position.create(2, 42));
             expect(completions[0]).to.include({
                 kind: CompletionItemKind.File,
                 label: 'component1.brs'
@@ -1045,8 +1005,8 @@ describe('Program', () => {
             expect(completions).to.be.lengthOf(2);
         });
 
-        it('get all functions and properties in scope when doing any dotted get on non m ', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        it('get all functions and properties in scope when doing any dotted get on non m ', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     thing.anonPropA = "foo"
                     thing.anonPropB = "bar"
@@ -1085,12 +1045,12 @@ describe('Program', () => {
             `);
             //note - we let the vscode extension do the filtering, so we still return everything; otherwise it exhibits strange behaviour in the IDE
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 32))).map(x => x.label).sort()
+                (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(4, 32))).map(x => x.label).sort()
             ).to.eql(['anonPropA', 'anonPropB', 'person', 'personAMethodA', 'personAMethodB', 'personAMethodC', 'personAName', 'personBMethodA', 'personBMethodB', 'personBName', 'personName']);
         });
 
-        it('get all functions and properties relevant for m ', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        it('get all functions and properties relevant for m ', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 class MyClassA
                     function new()
                         m.
@@ -1128,17 +1088,17 @@ describe('Program', () => {
                 end sub
             `);
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 26))).map(x => x.label).sort()
+                (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 26))).map(x => x.label).sort()
             ).to.eql(['personAMethodA', 'personAMethodB', 'personAName', 'personName']);
             expect(
-                (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(24, 26))).map(x => x.label).sort()
+                (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(24, 26))).map(x => x.label).sort()
             ).to.eql(['personAMethodA', 'personAMethodB', 'personAName', 'personCMethodA', 'personCMethodB', 'personCMethodC', 'personCName', 'personName']);
         });
 
     });
 
-    it('include non-namespaced classes in the list of general output', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+    it('include non-namespaced classes in the list of general output', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 function regularFunc()
                     MyClass
                 end function
@@ -1152,12 +1112,12 @@ describe('Program', () => {
                 end class
             `);
         expect(
-            (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 26))).map(x => x.label).sort()
+            (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 26))).map(x => x.label).sort()
         ).to.include.members(['MyClassA', 'MyClassB', 'MyClassC']);
     });
 
-    it('only include classes when using new keyword', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+    it('only include classes when using new keyword', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 class MyClassA
                 end class
                 class MyClassB
@@ -1171,21 +1131,21 @@ describe('Program', () => {
                 end sub
             `);
         expect(
-            (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(8, 29))).map(x => x.label).sort()
+            (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(8, 29))).map(x => x.label).sort()
         ).to.eql(['MyClassA', 'MyClassB', 'MyClassC']);
     });
 
-    it('gets completions when using callfunc inovation', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('gets completions when using callfunc inovation', () => {
+        program.addOrReplaceFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        await program.addOrReplaceFile('components/MyNode.bs', `
+        program.addOrReplaceFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
         `);
-        await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1193,26 +1153,26 @@ describe('Program', () => {
                     <function name="sayHello"/>
                 </interface>
             </component>`);
-        await program.validate();
+        program.validate();
 
         expect(
-            (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
+            (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
         ).to.eql(['sayHello']);
     });
 
-    it('gets completions for callfunc invocation with multiple nodes', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('gets completions for callfunc invocation with multiple nodes', () => {
+        program.addOrReplaceFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        await program.addOrReplaceFile('components/MyNode.bs', `
+        program.addOrReplaceFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
             function sayHello2(text, text2)
             end function
         `);
-        await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1221,13 +1181,13 @@ describe('Program', () => {
                     <function name="sayHello2"/>
                 </interface>
             </component>`);
-        await program.addOrReplaceFile('components/MyNode2.bs', `
+        program.addOrReplaceFile('components/MyNode2.bs', `
             function sayHello3(text, text2)
             end function
             function sayHello4(text, text2)
             end function
         `);
-        await program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
+        program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component2" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode2.bs" />
@@ -1236,26 +1196,26 @@ describe('Program', () => {
                     <function name="sayHello4"/>
                 </interface>
             </component>`);
-        await program.validate();
+        program.validate();
 
         expect(
-            (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
+            (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
         ).to.eql(['sayHello', 'sayHello2', 'sayHello3', 'sayHello4']);
     });
 
-    it('gets completions for extended nodes with callfunc invocation - ensure overridden methods included', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('gets completions for extended nodes with callfunc invocation - ensure overridden methods included', () => {
+        program.addOrReplaceFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        await program.addOrReplaceFile('components/MyNode.bs', `
+        program.addOrReplaceFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
             function sayHello2(text, text2)
             end function
         `);
-        await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1264,7 +1224,7 @@ describe('Program', () => {
                     <function name="sayHello2"/>
                 </interface>
             </component>`);
-        await program.addOrReplaceFile('components/MyNode2.bs', `
+        program.addOrReplaceFile('components/MyNode2.bs', `
             function sayHello3(text, text2)
             end function
             function sayHello2(text, text2)
@@ -1272,7 +1232,7 @@ describe('Program', () => {
             function sayHello4(text, text2)
             end function
         `);
-        await program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
+        program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component2" extends="Component1">
                 <script type="text/brightscript" uri="pkg:/components/MyNode2.bs" />
@@ -1281,24 +1241,24 @@ describe('Program', () => {
                     <function name="sayHello4"/>
                 </interface>
             </component>`);
-        await program.validate();
+        program.validate();
 
         expect(
-            (await program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
+            (program.getCompletions(`${rootDir}/source/main.bs`, Position.create(2, 30))).map(x => x.label).sort()
         ).to.eql(['sayHello', 'sayHello2', 'sayHello2', 'sayHello3', 'sayHello4']);
     });
 
     describe('xml inheritance', () => {
-        it('handles parent-child attach and detach', async () => {
+        it('handles parent-child attach and detach', () => {
             //create parent component
-            let parentFile = await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            let parentFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            let childFile = await program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            let childFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                 </component>
@@ -1308,7 +1268,7 @@ describe('Program', () => {
             expect((childFile as XmlFile).parentComponent).to.equal(parentFile);
 
             //change the name of the parent
-            parentFile = await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            parentFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="NotParentScene" extends="Scene">
                 </component>
@@ -1318,28 +1278,28 @@ describe('Program', () => {
             expect((childFile as XmlFile).parentComponent).not.to.exist;
         });
 
-        it('provides child components with parent functions', async () => {
+        it('provides child components with parent functions', () => {
             //create parent component
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
                 </component>
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/components/ChildScene.brs`, dest: 'components/ChildScene.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/ChildScene.brs`, dest: 'components/ChildScene.brs' }, `
                 sub Init()
                     DoParentThing()
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
 
             //there should be an error when calling DoParentThing, since it doesn't exist on child or parent
             expect(program.getDiagnostics()).to.be.lengthOf(1);
@@ -1348,34 +1308,34 @@ describe('Program', () => {
             });
 
             //add the script into the parent
-            await program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="ParentScene.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/ParentScene.brs`, dest: 'components/ParentScene.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/ParentScene.brs`, dest: 'components/ParentScene.brs' }, `
                 sub DoParentThing()
 
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
             //the error should be gone because the child now has access to the parent script
             expect(program.getDiagnostics()).to.be.empty;
         });
     });
 
     describe('xml scope', () => {
-        it('does not fail on base components with many children', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+        it('does not fail on base components with many children', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub DoSomething()
                 end sub
             `);
 
             //add a brs file with invalid syntax
-            await program.addOrReplaceFile({ src: `${rootDir}/components/base.xml`, dest: 'components/base.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/base.xml`, dest: 'components/base.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="BaseScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -1384,14 +1344,14 @@ describe('Program', () => {
             let childCount = 20;
             //add many children, we should never encounter an error
             for (let i = 0; i < childCount; i++) {
-                await program.addOrReplaceFile({ src: `${rootDir}/components/child${i}.xml`, dest: `components/child${i}.xml` }, trim`
+                program.addOrReplaceFile({ src: `${rootDir}/components/child${i}.xml`, dest: `components/child${i}.xml` }, trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="Child${i}" extends="BaseScene">
                         <script type="text/brightscript" uri="pkg:/source/lib.brs" />
                     </component>
                 `);
             }
-            await program.validate();
+            program.validate();
             let diagnostics = program.getDiagnostics();
 
             //the children shouldn't have diagnostics about shadowing their parent lib.brs file.
@@ -1403,9 +1363,9 @@ describe('Program', () => {
             expect(importDiagnositcs).to.be.lengthOf(childCount);
         });
 
-        it('detects script import changes', async () => {
+        it('detects script import changes', () => {
             //create the xml file without script imports
-            let xmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            let xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                 </component>
@@ -1415,10 +1375,10 @@ describe('Program', () => {
             expect(program.getScopeByName(xmlFile.pkgPath).getOwnFiles().length).to.equal(1);
 
             //create the lib file
-            let libFile = await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `'comment`);
+            let libFile = program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `'comment`);
 
             //change the xml file to have a script import
-            xmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -1431,7 +1391,7 @@ describe('Program', () => {
             expect(ctx.getFile(libFile.pathAbsolute)).to.exist;
 
             //reload the xml file again, removing the script import.
-            xmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                 </component>
@@ -1444,49 +1404,29 @@ describe('Program', () => {
     });
 
     describe('getFileByPkgPath', () => {
-        it('finds file in source folder', async () => {
+        it('finds file in source folder', () => {
             expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
             expect(program.getFileByPkgPath(s`source/main2.brs`)).not.to.exist;
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main2.brs`, dest: 'source/main2.brs' }, '');
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/source/main2.brs`, dest: 'source/main2.brs' }, '');
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
             expect(program.getFileByPkgPath(s`source/main2.brs`)).to.exist;
         });
     });
 
     describe('removeFiles', () => {
-        it('removes files by absolute paths', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+        it('removes files by absolute paths', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
             program.removeFiles([`${rootDir}/source/main.brs`]);
             expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
         });
     });
 
-    describe('addOrReplaceFiles', () => {
-        it('adds multiple files', async () => {
-            expect(Object.keys(program.files).length).to.equal(0);
-            let brsFilePath = s`${rootDir}/components/comp1.brs`.toLowerCase();
-            let xmlFilePath = s`${rootDir}/components/comp1.xml`.toLowerCase();
-            program.fileResolvers.push((filePath) => {
-                if (filePath.toLowerCase() === s`${brsFilePath}`) {
-                    return `'${filePath}`;
-                } else if (filePath.toLowerCase() === s`${xmlFilePath}`) {
-                    return `<!--${filePath}`;
-                }
-            });
-            await program.addOrReplaceFiles([
-                { src: brsFilePath, dest: 'components/comp1.brs' },
-                { src: xmlFilePath, dest: 'components/comp1.xml' }
-            ]);
-            expect(Object.keys(program.files).length).to.equal(2);
-        });
-    });
-
     describe('getDiagnostics', () => {
-        it('includes diagnostics from files not included in any scope', async () => {
+        it('includes diagnostics from files not included in any scope', () => {
             let pathAbsolute = s`${rootDir}/components/a/b/c/main.brs`;
-            await program.addOrReplaceFile({ src: pathAbsolute, dest: 'components/a/b/c/main.brs' }, `
+            program.addOrReplaceFile({ src: pathAbsolute, dest: 'components/a/b/c/main.brs' }, `
                 sub A()
                     "this string is not terminated
                 end sub
@@ -1499,9 +1439,9 @@ describe('Program', () => {
             expect(parseError).to.exist;
         });
 
-        it('it excludes specified error codes', async () => {
+        it('it excludes specified error codes', () => {
             //declare file with two different syntax errors
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub A()
                     'call with wrong param count
                     B(1,2,3)
@@ -1514,7 +1454,7 @@ describe('Program', () => {
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.lengthOf(2);
 
             program.options.diagnosticFilters = [
@@ -1527,8 +1467,8 @@ describe('Program', () => {
     });
 
     describe('getCompletions', () => {
-        it('returns all functions in scope', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('returns all functions in scope', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -1536,16 +1476,16 @@ describe('Program', () => {
                 sub ActionA()
                 end sub
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub ActionB()
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
 
-            let completions = (await program
+            let completions = program
                 //get completions
-                .getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10)))
+                .getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10))
                 //only keep the label property for this test
                 .map(x => pick(x, 'label'));
 
@@ -1554,8 +1494,8 @@ describe('Program', () => {
             expect(completions).to.deep.include({ label: 'ActionB' });
         });
 
-        it('returns all variables in scope', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('returns all variables in scope', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "bob"
                     age = 20
@@ -1564,14 +1504,14 @@ describe('Program', () => {
                 sub ActionA()
                 end sub
             `);
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub ActionB()
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
 
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             let labels = completions.map(x => pick(x, 'label'));
 
             expect(labels).to.deep.include({ label: 'Main' });
@@ -1582,20 +1522,26 @@ describe('Program', () => {
             expect(labels).to.deep.include({ label: 'shoeSize' });
         });
 
-        it('returns empty set when out of range', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
-            expect(program.getCompletions(`${rootDir}/source/main.brs`, Position.create(99, 99))).to.be.empty;
+        it('returns empty set when out of range', () => {
+            const position = util.createPosition(99, 99);
+            program.addOrReplaceFile('source/main.brs', '');
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, position);
+            //get the name of all global completions
+            const globalCompletions = program.globalScope.getAllFiles().flatMap(x => x.getCompletions(position)).map(x => x.label);
+            //filter out completions from global scope
+            completions = completions.filter(x => !globalCompletions.includes(x.label));
+            expect(completions).to.be.empty;
         });
 
-        it('finds parameters', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('finds parameters', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(count = 1)
                     firstName = "bob"
                     age = 21
                     shoeSize = 10
                 end sub
             `);
-            let completions = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 10));
             let labels = completions.map(x => pick(x, 'label'));
 
             expect(labels).to.deep.include({ label: 'count' });
@@ -1604,11 +1550,11 @@ describe('Program', () => {
 
     it('does not create map by default', async () => {
         fsExtra.ensureDirSync(program.options.stagingFolderPath);
-        await program.addOrReplaceFile('source/main.brs', `
+        program.addOrReplaceFile('source/main.brs', `
             sub main()
             end sub
         `);
-        await program.validate();
+        program.validate();
         await program.transpile([], program.options.stagingFolderPath);
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/main.brs`)).is.true;
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/main.brs.map`)).is.false;
@@ -1616,16 +1562,16 @@ describe('Program', () => {
 
     it('creates sourcemap for brs and xml files', async () => {
         fsExtra.ensureDirSync(program.options.stagingFolderPath);
-        await program.addOrReplaceFile('source/main.brs', `
+        program.addOrReplaceFile('source/main.brs', `
             sub main()
             end sub
         `);
-        await program.addOrReplaceFile('components/comp1.xml', trim`
+        program.addOrReplaceFile('components/comp1.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="SimpleScene" extends="Scene">
             </component>
         `);
-        await program.validate();
+        program.validate();
 
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/main.brs.map`)).is.false;
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/components/comp1.xml.map`)).is.false;
@@ -1646,7 +1592,7 @@ describe('Program', () => {
 
     it('copies the bslib.brs file', async () => {
         fsExtra.ensureDirSync(program.options.stagingFolderPath);
-        await program.validate();
+        program.validate();
 
         await program.transpile([], program.options.stagingFolderPath);
 
@@ -1655,7 +1601,7 @@ describe('Program', () => {
 
     describe('transpile', () => {
         it('transpiles in-memory-only files', async () => {
-            await program.addOrReplaceFile('source/logger.bs', trim`
+            program.addOrReplaceFile('source/logger.bs', trim`
                 sub logInfo()
                     print SOURCE_LINE_NUM
                 end sub
@@ -1671,7 +1617,7 @@ describe('Program', () => {
         });
 
         it('copies in-memory-only .brs files to stagingDir', async () => {
-            await program.addOrReplaceFile('source/logger.brs', trim`
+            program.addOrReplaceFile('source/logger.brs', trim`
                 sub logInfo()
                     print "logInfo"
                 end sub
@@ -1687,7 +1633,7 @@ describe('Program', () => {
         });
 
         it('copies in-memory .xml file', async () => {
-            await program.addOrReplaceFile('components/Component1.xml', trim`
+            program.addOrReplaceFile('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
@@ -1711,7 +1657,7 @@ describe('Program', () => {
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });
-            await program.addOrReplaceFile('source/main.brs', `
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -1737,7 +1683,7 @@ describe('Program', () => {
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });
-            await program.addOrReplaceFile('source/main.bs', `
+            program.addOrReplaceFile('source/main.bs', `
                 sub main()
                 end sub
             `);
@@ -1759,12 +1705,12 @@ describe('Program', () => {
     describe('typedef', () => {
         describe('emitDefinitions', () => {
             it('generates typedef for .bs files', async () => {
-                await program.addOrReplaceFile<BrsFile>('source/Duck.bs', `
+                program.addOrReplaceFile<BrsFile>('source/Duck.bs', `
                     class Duck
                     end class
                 `);
                 program.options.emitDefinitions = true;
-                await program.validate();
+                program.validate();
                 await program.transpile([], stagingFolderPath);
 
                 expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.brs`)).to.be.true;
@@ -1773,12 +1719,12 @@ describe('Program', () => {
             });
 
             it('does not generate typedef for typedef file', async () => {
-                await program.addOrReplaceFile<BrsFile>('source/Duck.d.bs', `
+                program.addOrReplaceFile<BrsFile>('source/Duck.d.bs', `
                     class Duck
                     end class
                 `);
                 program.options.emitDefinitions = true;
-                await program.validate();
+                program.validate();
                 await program.transpile([], stagingFolderPath);
 
                 expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/Duck.d.brs`)).to.be.false;
@@ -1786,8 +1732,8 @@ describe('Program', () => {
             });
         });
 
-        it('ignores bs1018 for d.bs files', async () => {
-            await program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
+        it('ignores bs1018 for d.bs files', () => {
+            program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
                 class Duck
                     sub new(name as string)
                     end sub
@@ -1800,14 +1746,14 @@ describe('Program', () => {
                     age as integer
                 end class
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()).to.be.empty;
         });
     });
 
     describe('getSignatureHelp', () => {
-        it('gets signature help for constructor with no args', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for constructor with no args', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p = new Person()
                 end function
@@ -1825,8 +1771,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('Person()');
         });
 
-        it('gets signature help for class function on dotted get with params', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for class function on dotted get with params', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p.sayHello("there")
                 end function
@@ -1856,8 +1802,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
         });
 
-        it('gets signature help for namespaced class function', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for namespaced class function', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     person.sayHello("there")
                 end function
@@ -1880,8 +1826,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
         });
 
-        it('gets signature help for namespace function', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for namespace function', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     person.sayHello("hey", "you")
                 end function
@@ -1896,8 +1842,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
-        it('gets signature help for nested namespace function', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for nested namespace function', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     person.roger.sayHello("hi", "there")
                 end function
@@ -1917,17 +1863,17 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
-        it('gets signature help for callfunc method', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for callfunc method', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     myNode@.sayHello(arg1)
                 end function
             `);
-            await program.addOrReplaceFile('components/MyNode.bs', `
+            program.addOrReplaceFile('components/MyNode.bs', `
                 function sayHello(text, text2)
                 end function
             `);
-            await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1935,24 +1881,24 @@ describe('Program', () => {
                         <function name="sayHello"/>
                     </interface>
                 </component>`);
-            await program.validate();
+            program.validate();
 
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
             expect(program.getDiagnostics()).to.be.empty;
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
-        it('does not get signature help for callfunc method, referenced by dot', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('does not get signature help for callfunc method, referenced by dot', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     myNode.sayHello(arg1)
                 end function
             `);
-            await program.addOrReplaceFile('components/MyNode.bs', `
+            program.addOrReplaceFile('components/MyNode.bs', `
                 function sayHello(text, text2)
                 end function
             `);
-            await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1960,7 +1906,7 @@ describe('Program', () => {
                         <function name="sayHello"/>
                     </interface>
                 </component>`);
-            await program.validate();
+            program.validate();
 
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
             expect(program.getDiagnostics()).to.be.empty;
@@ -1968,8 +1914,8 @@ describe('Program', () => {
             expect(signatureHelp).to.be.empty;
         });
 
-        it('gets signature help for constructor with args', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for constructor with args', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p = new Person(arg1, arg2)
                 end function
@@ -1984,8 +1930,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('Person(arg1, arg2)');
         });
 
-        it('gets signature help for constructor with args, defined in super class', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for constructor with args, defined in super class', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p = new Roger(arg1, arg2)
                 end function
@@ -2002,8 +1948,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('Roger(arg1, arg2)');
         });
 
-        it('identifies arg index', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('identifies arg index', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p = new Person(arg1, arg2)
                 end function
@@ -2022,8 +1968,8 @@ describe('Program', () => {
             expect(signatureHelp[0].index).to.equal(1);
         });
 
-        it('gets signature help for namespaced constructor with args', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for namespaced constructor with args', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p = new people.coders.Person(arg1, arg2)
                 end function
@@ -2040,8 +1986,8 @@ describe('Program', () => {
             expect(signatureHelp[0].index).to.equal(0);
         });
 
-        it('gets signature help for regular method call', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for regular method call', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     test(arg1, a2)
                 end function
@@ -2058,8 +2004,8 @@ describe('Program', () => {
             expect(signatureHelp[0].index).to.equal(1);
         });
 
-        it('gets signature help for dotted method call, with method in in-scope class', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for dotted method call, with method in in-scope class', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     p.test(arg1)
                 end function
@@ -2075,8 +2021,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 
-        it('gets signature help for namespaced method call', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for namespaced method call', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     Person.test(arg1)
                 end function
@@ -2090,8 +2036,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 
-        it('gets signature help for namespaced method call', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for namespaced method call', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     Person.roger.test(arg1)
                 end function
@@ -2105,8 +2051,8 @@ describe('Program', () => {
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 
-        it('gets signature help for regular method call on various index points', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for regular method call on various index points', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     test(a1, a2, a3)
                 end function
@@ -2130,18 +2076,18 @@ describe('Program', () => {
             }
         });
 
-        it('gets signature help for callfunc method call on various index points', async () => {
-            await program.addOrReplaceFile('components/MyNode.bs', `
+        it('gets signature help for callfunc method call on various index points', () => {
+            program.addOrReplaceFile('components/MyNode.bs', `
                 function test(arg1, arg2, arg3)
                 end function
             `);
-            await program.addOrReplaceFile('source/main.bs', `
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     thing@.test(a1, a2, a3)
                 end function
             `);
 
-            await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2149,7 +2095,7 @@ describe('Program', () => {
                         <function name="test"/>
                     </interface>
                 </component>`);
-            await program.validate();
+            program.validate();
 
             for (let col = 29; col < 34; col++) {
                 let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, col)));
@@ -2168,8 +2114,8 @@ describe('Program', () => {
             }
         });
 
-        it('gets signature help for constructor method call on various index points', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for constructor method call on various index points', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     a = new Person(a1, a2, a3)
                 end function
@@ -2195,19 +2141,19 @@ describe('Program', () => {
             }
         });
 
-        it('gets signature help for partially typed line', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('gets signature help for partially typed line', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 function main()
                     thing@.test(a1, a2,
                 end function
                 function test(arg1, arg2, arg3)
                 end function
                 `);
-            await program.addOrReplaceFile('components/MyNode.bs', `
+            program.addOrReplaceFile('components/MyNode.bs', `
                 function test(arg1, arg2, arg3)
                 end function
                 `);
-            await program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2215,7 +2161,7 @@ describe('Program', () => {
                     <function name="test"/>
                 </interface>
             </component>`);
-            await program.validate();
+            program.validate();
 
             for (let col = 28; col < 34; col++) {
                 let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, col)));

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1130,9 +1130,3 @@ export class Program {
         this.dependencyGraph.dispose();
     }
 }
-
-export interface FileResolver {
-    readFile(pathAbsolute: string): string | undefined | Thenable<string | undefined> | void;
-    readFileSync(pathAbsolute: string): string | undefined;
-}
-

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -73,12 +73,6 @@ export class Program {
         this.options.rootDir = util.getRootDir(this.options);
 
         this.createGlobalScope();
-
-        //add the default file resolver (used by this program to load source file contents).
-        this.fileResolvers.push(async (pathAbsolute) => {
-            let contents = await this.util.getFileContents(pathAbsolute);
-            return contents;
-        });
     }
 
     public logger: Logger;
@@ -105,16 +99,6 @@ export class Program {
     public dependencyGraph = new DependencyGraph();
 
     private diagnosticFilterer = new DiagnosticFilterer();
-
-    private util = util;
-
-    /**
-     * A list of functions that will be used to load file contents.
-     * In most cases, there will only be the "read from filesystem" resolver.
-     * However, when running inside the LanguageServer, a second resolver will be added
-     * to resolve the opened file contents from memory instead of going to disk.
-     */
-    public fileResolvers = [] as FileResolver[];
 
     /**
      * A scope that contains all built-in global functions.
@@ -181,23 +165,6 @@ export class Program {
     }
 
     /**
-     * Get the contents of the specified file as a string.
-     * This walks backwards through the file resolvers until we get a value.
-     * This allow the language server to provide file contents directly from memory.
-     */
-    public async getFileContents(pathAbsolute: string) {
-        pathAbsolute = s`${pathAbsolute}`;
-        let reversedResolvers = [...this.fileResolvers].reverse();
-        for (let fileResolver of reversedResolvers) {
-            let result = await fileResolver(pathAbsolute);
-            if (typeof result === 'string') {
-                return result;
-            }
-        }
-        throw new Error(`Could not load file "${pathAbsolute}"`);
-    }
-
-    /**
      * Get a list of all files that are included in the project but are not referenced
      * by any scope in the program.
      */
@@ -257,22 +224,6 @@ export class Program {
         return this.files[filePath] !== undefined;
     }
 
-    /**
-     * Add and parse all of the provided files.
-     * Files that are already loaded will be replaced by the latest
-     * contents from the file system.
-     * @param filePaths
-     */
-    public async addOrReplaceFiles<T extends BscFile[]>(fileObjects: Array<FileObj>) {
-        let promises = [];
-        for (let fileObject of fileObjects) {
-            promises.push(
-                this.addOrReplaceFile(fileObject)
-            );
-        }
-        return Promise.all(promises) as Promise<T>;
-    }
-
     public getPkgPath(...args: any[]): any { //eslint-disable-line
         throw new Error('Not implemented');
     }
@@ -310,17 +261,16 @@ export class Program {
      * Load a file into the program. If that file already exists, it is replaced.
      * If file contents are provided, those are used, Otherwise, the file is loaded from the file system
      * @param relativePath the file path relative to the root dir
-     * @param fileContents the file contents. If not provided, the file will be loaded from disk
+     * @param fileContents the file contents
      */
-    public async addOrReplaceFile<T extends BscFile>(relativePath: string, fileContents?: string): Promise<T>;
+    public addOrReplaceFile<T extends BscFile>(relativePath: string, fileContents: string): T;
     /**
      * Load a file into the program. If that file already exists, it is replaced.
-     * If file contents are provided, those are used, Otherwise, the file is loaded from the file system
      * @param fileEntry an object that specifies src and dest for the file.
      * @param fileContents the file contents. If not provided, the file will be loaded from disk
      */
-    public async addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents?: string): Promise<T>;
-    public async addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents?: string): Promise<T> {
+    public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
+    public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
         assert.ok(fileParam, 'fileEntry is required');
         let srcPath: string;
         let pkgPath: string;
@@ -331,7 +281,7 @@ export class Program {
             srcPath = s`${fileParam.src}`;
             pkgPath = s`${fileParam.dest}`;
         }
-        let file = await this.logger.time(LogLevel.debug, ['Program.addOrReplaceFile()', chalk.green(srcPath)], async () => {
+        let file = this.logger.time(LogLevel.debug, ['Program.addOrReplaceFile()', chalk.green(srcPath)], () => {
 
             assert.ok(srcPath, 'fileEntry.src is required');
             assert.ok(pkgPath, 'fileEntry.dest is required');
@@ -342,15 +292,6 @@ export class Program {
             }
             let fileExtension = path.extname(srcPath).toLowerCase();
             let file: BscFile | undefined;
-
-            //load the file contents by file path if not provided
-            let getFileContents = async () => {
-                if (fileContents === undefined) {
-                    return this.getFileContents(srcPath);
-                } else {
-                    return fileContents;
-                }
-            };
 
             if (fileExtension === '.brs' || fileExtension === '.bs') {
                 let brsFile = new BrsFile(srcPath, pkgPath, this);
@@ -365,14 +306,14 @@ export class Program {
                 //add the file to the program
                 this.files[srcPath] = brsFile;
                 this.pkgMap[brsFile.pkgPath.toLowerCase()] = brsFile;
-                let fileContents: SourceObj = {
+                let sourceObj: SourceObj = {
                     pathAbsolute: srcPath,
-                    source: await getFileContents()
+                    source: fileContents
                 };
-                this.plugins.emit('beforeFileParse', fileContents);
+                this.plugins.emit('beforeFileParse', sourceObj);
 
                 this.logger.time(LogLevel.info, ['parse', chalk.green(srcPath)], () => {
-                    brsFile.parse(fileContents.source);
+                    brsFile.parse(sourceObj.source);
                 });
                 file = brsFile;
 
@@ -389,12 +330,12 @@ export class Program {
                 //add the file to the program
                 this.files[srcPath] = xmlFile;
                 this.pkgMap[xmlFile.pkgPath.toLowerCase()] = xmlFile;
-                let fileContents: SourceObj = {
+                let sourceObj: SourceObj = {
                     pathAbsolute: srcPath,
-                    source: await getFileContents()
+                    source: fileContents
                 };
-                this.plugins.emit('beforeFileParse', fileContents);
-                xmlFile.parse(fileContents.source);
+                this.plugins.emit('beforeFileParse', sourceObj);
+                xmlFile.parse(sourceObj.source);
 
                 file = xmlFile;
 
@@ -525,8 +466,8 @@ export class Program {
      * Traverse the entire project, and validate all scopes
      * @param force - if true, then all scopes are force to validate, even if they aren't marked as dirty
      */
-    public async validate() {
-        await this.logger.time(LogLevel.debug, ['Program.validate()'], async () => {
+    public validate() {
+        this.logger.time(LogLevel.debug, ['Program.validate()'], () => {
             this.diagnostics = [];
             this.plugins.emit('beforeProgramValidate', this);
 
@@ -553,7 +494,6 @@ export class Program {
             this.detectDuplicateComponentNames();
 
             this.plugins.emit('afterProgramValidate', this);
-            await Promise.resolve();
         });
     }
 
@@ -703,7 +643,7 @@ export class Program {
      * @param lineIndex
      * @param columnIndex
      */
-    public async getCompletions(pathAbsolute: string, position: Position) {
+    public getCompletions(pathAbsolute: string, position: Position) {
         let file = this.getFile(pathAbsolute);
         if (!file) {
             return [];
@@ -737,7 +677,6 @@ export class Program {
             c => c
         );
 
-
         //only keep completions common to every scope for this file
         let keyCounts = {} as Record<string, number>;
         for (let completion of allCompletions) {
@@ -747,7 +686,7 @@ export class Program {
                 result.push(completion);
             }
         }
-        return Promise.resolve(result);
+        return result;
     }
 
     /**
@@ -1192,4 +1131,8 @@ export class Program {
     }
 }
 
-export type FileResolver = (pathAbsolute: string) => string | undefined | Thenable<string | undefined> | void;
+export interface FileResolver {
+    readFile(pathAbsolute: string): string | undefined | Thenable<string | undefined> | void;
+    readFileSync(pathAbsolute: string): string | undefined;
+}
+

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -63,14 +63,9 @@ describe('ProgramBuilder', () => {
 
         it('loads all type definitions first', async () => {
             const requestedFiles = [] as string[];
-            builder['fileResolvers'].push({
-                readFile: (filePath) => {
-                    requestedFiles.push(s(filePath));
-                },
-                readFileSync: (filePath) => {
-                    requestedFiles.push(s(filePath));
-                }
-            } as any);
+            builder['fileResolvers'].push((filePath) => {
+                requestedFiles.push(s(filePath));
+            });
             fsExtra.outputFileSync(s`${rootDir}/source/main.brs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/main.d.bs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/lib.d.bs`, '');
@@ -88,15 +83,14 @@ describe('ProgramBuilder', () => {
 
         it('does not load non-existent type definition file', async () => {
             const requestedFiles = [] as string[];
-            builder['fileResolvers'].push({
-                readFile: (filePath) => {
-                    requestedFiles.push(s(filePath));
-                }
-            } as any);
+            builder['fileResolvers'].push((filePath) => {
+                requestedFiles.push(s(filePath));
+            });
             fsExtra.outputFileSync(s`${rootDir}/source/main.brs`, '');
             await builder['loadAllFilesAST']();
             //the d file should not be requested because `loadAllFilesAST` knows it doesn't exist
             expect(requestedFiles).not.to.include(s`${rootDir}/source/main.d.bs`);
+            expect(requestedFiles).to.include(s`${rootDir}/source/main.brs`);
         });
     });
 

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -11,10 +11,16 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import { Logger, LogLevel } from './Logger';
 import PluginInterface from './PluginInterface';
 import * as diagnosticUtils from './diagnosticUtils';
+
 /**
  * A runner class that handles
  */
 export class ProgramBuilder {
+
+    public constructor() {
+        //add the default file resolver (used to load source file contents).
+        this.addFileResolver(util.fileResolver);
+    }
     /**
      * Determines whether the console should be cleared after a run (true for cli, false for languageserver)
      */
@@ -30,9 +36,40 @@ export class ProgramBuilder {
 
     public addFileResolver(fileResolver: FileResolver) {
         this.fileResolvers.push(fileResolver);
-        if (this.program) {
-            this.program.fileResolvers.push(fileResolver);
+    }
+
+    /**
+     * Get the contents of the specified file as a string.
+     * This walks backwards through the file resolvers until we get a value.
+     * This allow the language server to provide file contents directly from memory.
+     */
+    public async getFileContents(pathAbsolute: string) {
+        pathAbsolute = s`${pathAbsolute}`;
+        let reversedResolvers = [...this.fileResolvers].reverse();
+        for (let fileResolver of reversedResolvers) {
+            let result = await fileResolver.readFile(pathAbsolute);
+            if (typeof result === 'string') {
+                return result;
+            }
         }
+        throw new Error(`Could not load file "${pathAbsolute}"`);
+    }
+
+    /**
+     * Get the contents of the specified file as a string.
+     * This walks backwards through the file resolvers until we get a value.
+     * This allow the language server to provide file contents directly from memory.
+     */
+    public getFileContentsSync(pathAbsolute: string) {
+        pathAbsolute = s`${pathAbsolute}`;
+        let reversedResolvers = [...this.fileResolvers].reverse();
+        for (let fileResolver of reversedResolvers) {
+            let result = fileResolver.readFileSync(pathAbsolute);
+            if (typeof result === 'string') {
+                return result;
+            }
+        }
+        throw new Error(`Could not load file "${pathAbsolute}"`);
     }
 
     /**
@@ -106,9 +143,6 @@ export class ProgramBuilder {
     protected createProgram() {
         const program = new Program(this.options, undefined, this.plugins);
 
-        //add the initial FileResolvers
-        program.fileResolvers.push(...this.fileResolvers);
-
         this.plugins.emit('afterProgramCreate', program);
         return program;
     }
@@ -163,10 +197,15 @@ export class ProgramBuilder {
         this.watcher.on('all', async (event: string, thePath: string) => { //eslint-disable-line @typescript-eslint/no-misused-promises
             thePath = s`${path.resolve(this.rootDir, thePath)}`;
             if (event === 'add' || event === 'change') {
-                await this.program.addOrReplaceFile({
+                const fileObj = {
                     src: thePath,
                     dest: rokuDeploy.getDestPath(thePath, this.program.options.files, this.rootDir)
-                });
+                };
+                this.program.addOrReplaceFile(
+                    fileObj,
+                    //load the file synchronously because that's faster than async for a small number of filies
+                    await this.getFileContents(fileObj.src)
+                );
             } else if (event === 'unlink') {
                 this.program.removeFile(thePath);
             }
@@ -273,7 +312,7 @@ export class ProgramBuilder {
             }
             this.logger.log('Validating project');
             //validate program
-            await this.validateProject();
+            this.validateProject();
 
             //maybe cancel?
             if (cancellationToken.isCanceled === true) {
@@ -408,9 +447,12 @@ export class ProgramBuilder {
 
         //preload every type definition file first, which eliminates duplicate file loading
         await Promise.all(
-            typedefFiles.map(async (file) => {
+            typedefFiles.map(async (fileObj) => {
                 try {
-                    await this.program.addOrReplaceFile(file);
+                    this.program.addOrReplaceFile(
+                        fileObj,
+                        await this.getFileContents(fileObj.src)
+                    );
                 } catch (e) {
                     //log the error, but don't fail this process because the file might be fixable later
                     this.logger.log(e);
@@ -418,15 +460,19 @@ export class ProgramBuilder {
             })
         );
 
+        const acceptableExtensions = ['.bs', '.brs', '.xml'];
         //parse every file other than the type definitions
         await Promise.all(
-            nonTypedefFiles.map(async (file) => {
+            nonTypedefFiles.map(async (fileObj) => {
                 try {
-                    let fileExtension = path.extname(file.src).toLowerCase();
+                    let fileExtension = path.extname(fileObj.src).toLowerCase();
 
                     //only process certain file types
-                    if (['.bs', '.brs', '.xml'].includes(fileExtension)) {
-                        await this.program.addOrReplaceFile(file);
+                    if (acceptableExtensions.includes(fileExtension)) {
+                        this.program.addOrReplaceFile(
+                            fileObj,
+                            await this.getFileContents(fileObj.src)
+                        );
                     }
                 } catch (e) {
                     //log the error, but don't fail this process because the file might be fixable later
@@ -454,8 +500,8 @@ export class ProgramBuilder {
      * Scan every file and resolve all variable references.
      * If no errors were encountered, return true. Otherwise return false.
      */
-    private async validateProject() {
-        await this.program.validate();
+    private validateProject() {
+        this.program.validate();
     }
 
     public dispose() {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -23,8 +23,8 @@ describe('Scope', () => {
         program.dispose();
     });
 
-    it('does not mark namespace functions as collisions with stdlib', async () => {
-        await program.addOrReplaceFile({
+    it('does not mark namespace functions as collisions with stdlib', () => {
+        program.addOrReplaceFile({
             src: `${rootDir}/source/main.bs`,
             dest: `source/main.bs`
         }, `
@@ -34,18 +34,18 @@ describe('Scope', () => {
             end namespace
         `);
 
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
 
-    it('flags parameter with same name as namespace', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('flags parameter with same name as namespace', () => {
+        program.addOrReplaceFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main(nameA)
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.eql(
@@ -53,8 +53,8 @@ describe('Scope', () => {
         );
     });
 
-    it('flags assignments with same name as namespace', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('flags assignments with same name as namespace', () => {
+        program.addOrReplaceFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main()
@@ -62,7 +62,7 @@ describe('Scope', () => {
                 NAMEA += 1
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics().map(x => x.message)
         ).to.eql([
@@ -89,10 +89,10 @@ describe('Scope', () => {
     });
 
     describe('addFile', () => {
-        it('detects callables from all loaded files', async () => {
+        it('detects callables from all loaded files', () => {
             const sourceScope = program.getScopeByName('source');
 
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub Main()
 
                 end sub
@@ -100,12 +100,12 @@ describe('Scope', () => {
                 sub ActionA()
                 end sub
             `);
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
+            program.addOrReplaceFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
                 sub ActionB()
                 end sub
             `);
 
-            await program.validate();
+            program.validate();
 
             expect(sourceScope.getOwnFiles().map(x => x.pathAbsolute).sort()).eql([
                 s`${rootDir}/source/lib.brs`,
@@ -116,12 +116,12 @@ describe('Scope', () => {
             expect(sourceScope.getAllCallables()).is.length.greaterThan(3);
         });
 
-        it('picks up new callables', async () => {
-            await program.addOrReplaceFile('source/file.brs', '');
+        it('picks up new callables', () => {
+            program.addOrReplaceFile('source/file.brs', '');
             //we have global callables, so get that initial number
             let originalLength = program.getScopeByName('source').getAllCallables().length;
 
-            await program.addOrReplaceFile('source/file.brs', `
+            program.addOrReplaceFile('source/file.brs', `
             function DoA()
                 print "A"
             end function
@@ -135,9 +135,9 @@ describe('Scope', () => {
     });
 
     describe('removeFile', () => {
-        it('removes callables from list', async () => {
+        it('removes callables from list', () => {
             //add the file
-            let file = await program.addOrReplaceFile(`source/file.brs`, `
+            let file = program.addOrReplaceFile(`source/file.brs`, `
                 function DoA()
                     print "A"
                 end function
@@ -151,19 +151,19 @@ describe('Scope', () => {
     });
 
     describe('validate', () => {
-        it('marks the scope as validated after validation has occurred', async () => {
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+        it('marks the scope as validated after validation has occurred', () => {
+            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                sub main()
                end sub
             `);
-            let lib = await program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            let lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                sub libFunc()
                end sub
             `);
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.false;
-            await program.validate();
+            program.validate();
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.true;
-            lib = await program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                 sub libFunc()
                 end sub
             `);
@@ -173,8 +173,8 @@ describe('Scope', () => {
 
         });
 
-        it('does not mark same-named-functions in different namespaces as an error', async () => {
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+        it('does not mark same-named-functions in different namespaces as an error', () => {
+            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                 namespace NameA
                     sub alert()
                     end sub
@@ -184,12 +184,12 @@ describe('Scope', () => {
                     end sub
                 end namespace
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
             expect(program.getDiagnostics()).to.be.lengthOf(0);
         });
-        it('resolves local-variable function calls', async () => {
-            await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+        it('resolves local-variable function calls', () => {
+            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub DoSomething()
                     sayMyName = function(name as string)
                     end function
@@ -197,14 +197,14 @@ describe('Scope', () => {
                     sayMyName()
                 end sub`
             );
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
             expect(program.getDiagnostics()).to.be.lengthOf(0);
         });
 
         describe('function shadowing', () => {
-            it('warns when local var function has same name as stdlib function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('warns when local var function has same name as stdlib function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = function(p)
                             return "override"
@@ -212,7 +212,7 @@ describe('Scope', () => {
                         print str(12345) 'prints "12345" (i.e. our local function is never used)
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics().map(x => {
                     return {
                         message: x.message,
@@ -225,32 +225,32 @@ describe('Scope', () => {
                 });
             });
 
-            it('warns when local var has same name as built-in function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('warns when local var has same name as built-in function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 12345
                         print str ' prints "12345" (i.e. our local variable is allowed to shadow the built-in function name)
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics();
                 expect(diagnostics[0]?.message).not.to.exist;
             });
 
-            it('warns when local var has same name as built-in function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('warns when local var has same name as built-in function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 6789
                         print str(12345) ' prints "12345" (i.e. our local variable did not override the callable global function)
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics();
                 expect(diagnostics[0]?.message).not.to.exist;
             });
 
-            it('detects local function with same name as scope function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('detects local function with same name as scope function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = function()
                             return "override"
@@ -262,7 +262,7 @@ describe('Scope', () => {
                         return "hello"
                     end function
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics().map(x => {
                     return {
                         message: x.message,
@@ -275,8 +275,8 @@ describe('Scope', () => {
                 });
             });
 
-            it('detects local function with same name as scope function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('detects local function with same name as scope function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = "override"
                         print getHello ' prints <Function: gethello> (i.e. local variable override does NOT work for same-scope-defined methods)
@@ -285,7 +285,7 @@ describe('Scope', () => {
                         return "hello"
                     end function
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics().map(x => {
                     return {
                         message: x.message,
@@ -298,8 +298,8 @@ describe('Scope', () => {
                 });
             });
 
-            it('flags scope function with same name (but different case) as built-in function', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            it('flags scope function with same name (but different case) as built-in function', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         print str(12345) ' prints 12345 (i.e. our str() function below is ignored)
                     end sub
@@ -307,7 +307,7 @@ describe('Scope', () => {
                         return "override"
                     end function
                 `);
-                await program.validate();
+                program.validate();
                 let diagnostics = program.getDiagnostics().map(x => {
                     return {
                         message: x.message,
@@ -321,8 +321,8 @@ describe('Scope', () => {
             });
         });
 
-        it('detects duplicate callables', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('detects duplicate callables', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 function DoA()
                     print "A"
                 end function
@@ -335,7 +335,7 @@ describe('Scope', () => {
                 program.getDiagnostics().length
             ).to.equal(0);
             //validate the scope
-            await program.validate();
+            program.validate();
             //we should have the "DoA declared more than once" error twice (one for each function named "DoA")
             expect(program.getDiagnostics().map(x => x.message).sort()).to.eql([
                 DiagnosticMessages.duplicateFunctionImplementation('DoA', 'source').message,
@@ -343,22 +343,22 @@ describe('Scope', () => {
             ]);
         });
 
-        it('detects calls to unknown callables', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('detects calls to unknown callables', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
             `);
             expect(program.getDiagnostics().length).to.equal(0);
             //validate the scope
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]).to.deep.include({
                 code: DiagnosticMessages.callToUnknownFunction('DoB', '').code
             });
         });
 
-        it('recognizes known callables', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('recognizes known callables', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
@@ -367,111 +367,111 @@ describe('Scope', () => {
                 end function
             `);
             //validate the scope
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().map(x => x.message)).to.eql([
                 DiagnosticMessages.callToUnknownFunction('DoC', 'source').message
             ]);
         });
 
         //We don't currently support someObj.callSomething() format, so don't throw errors on those
-        it('does not fail on object callables', async () => {
+        it('does not fail on object callables', () => {
             expect(program.getDiagnostics().length).to.equal(0);
-            await program.addOrReplaceFile('source/file.brs', `
+            program.addOrReplaceFile('source/file.brs', `
                function DoB()
                     m.doSomething()
                 end function
             `);
             //validate the scope
-            await program.validate();
+            program.validate();
             //shouldn't have any errors
             expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
         });
 
-        it('detects calling functions with too many parameters', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('detects calling functions with too many parameters', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a()
                 end sub
                 sub b()
                     a(1)
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().map(x => x.message)).includes(
                 DiagnosticMessages.mismatchArgumentCount(0, 1).message
             );
         });
 
-        it('detects calling functions with too many parameters', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('detects calling functions with too many parameters', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a(name)
                 end sub
                 sub b()
                     a()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().map(x => x.message)).to.includes(
                 DiagnosticMessages.mismatchArgumentCount(1, 0).message
             );
         });
 
-        it('allows skipping optional parameter', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('allows skipping optional parameter', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a(name="Bob")
                 end sub
                 sub b()
                     a()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             //should have an error
             expect(program.getDiagnostics().length).to.equal(0);
         });
 
-        it('shows expected parameter range in error message', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('shows expected parameter range in error message', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
                     a()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             //should have an error
             expect(program.getDiagnostics().map(x => x.message)).includes(
                 DiagnosticMessages.mismatchArgumentCount('1-2', 0).message
             );
         });
 
-        it('handles expressions as arguments to a function', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('handles expressions as arguments to a function', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
                     a("cat" + "dog" + "mouse")
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics().length).to.equal(0);
         });
 
-        it('Catches extra arguments for expressions as arguments to a function', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('Catches extra arguments for expressions as arguments to a function', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub a(age)
                 end sub
                 sub b()
                     a(m.lib.movies[0], 1)
                 end sub
             `);
-            await program.validate();
+            program.validate();
             //should have an error
             expect(program.getDiagnostics().map(x => x.message)).to.include(
                 DiagnosticMessages.mismatchArgumentCount(1, 2).message
             );
         });
 
-        it('handles JavaScript reserved names', async () => {
-            await program.addOrReplaceFile('source/file.brs', `
+        it('handles JavaScript reserved names', () => {
+            program.addOrReplaceFile('source/file.brs', `
                 sub constructor()
                 end sub
                 sub toString()
@@ -481,21 +481,21 @@ describe('Scope', () => {
                 sub getPrototypeOf()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
 
-        it('Emits validation events', async () => {
+        it('Emits validation events', () => {
             const validateStartScope = sinon.spy();
             const validateEndScope = sinon.spy();
-            await program.addOrReplaceFile('source/file.brs', ``);
-            await program.addOrReplaceFile('components/comp.xml', trim`
+            program.addOrReplaceFile('source/file.brs', ``);
+            program.addOrReplaceFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp" extends="Scene">
                     <script uri="comp.brs"/>
                 </component>
             `);
-            await program.addOrReplaceFile(s`components/comp.brs`, ``);
+            program.addOrReplaceFile(s`components/comp.brs`, ``);
             const sourceScope = program.getScopeByName('source');
             const compScope = program.getScopeByName('components/comp.xml');
             program.plugins = new PluginInterface([{
@@ -503,7 +503,7 @@ describe('Scope', () => {
                 beforeScopeValidate: validateStartScope,
                 afterScopeValidate: validateEndScope
             }], undefined);
-            await program.validate();
+            program.validate();
             expect(validateStartScope.callCount).to.equal(2);
             expect(validateStartScope.calledWith(sourceScope)).to.be.true;
             expect(validateStartScope.calledWith(compScope)).to.be.true;
@@ -513,8 +513,8 @@ describe('Scope', () => {
         });
 
         describe('custom types', () => {
-            it('detects an unknown function return type', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('detects an unknown function return type', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function a()
                         return invalid
                     end function
@@ -537,15 +537,15 @@ describe('Scope', () => {
                         return new myClass()
                     end function
                 `);
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.invalidFunctionReturnType('unknownType').message,
                     DiagnosticMessages.invalidFunctionReturnType('unknownType').message
                 ]);
             });
 
-            it('detects an unknown function parameter type', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('detects an unknown function parameter type', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     sub a(num as integer)
                     end sub
 
@@ -560,15 +560,15 @@ describe('Scope', () => {
                     sub d(obj as myClass)
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message,
                     DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message
                 ]);
             });
 
-            it('detects an unknown field parameter type', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('detects an unknown field parameter type', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     class myClass
                         foo as unknownType 'error
                     end class
@@ -579,15 +579,15 @@ describe('Scope', () => {
                         buz as myOtherClass
                     end class
                 `);
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.expectedValidTypeToFollowAsKeyword().message,
                     DiagnosticMessages.expectedValidTypeToFollowAsKeyword().message
                 ]);
             });
 
-            it('finds custom types inside namespaces', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('finds custom types inside namespaces', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -601,13 +601,13 @@ describe('Scope', () => {
                     end namespace
 
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('finds custom types from other namespaces', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('finds custom types from other namespaces', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -616,13 +616,13 @@ describe('Scope', () => {
                     function foo(param as MyNamespace.MyClass) as MyNamespace.MyClass
                     end function
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('detects missing custom types from current namespaces', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('detects missing custom types from current namespaces', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -631,45 +631,45 @@ describe('Scope', () => {
                         end function
                     end namespace
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.invalidFunctionReturnType('UnknownType').message
                 ]);
             });
 
-            it('finds custom types from other other files', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('finds custom types from other other files', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyClass) as MyClass
                     end function
                 `);
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
+                program.addOrReplaceFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
                     class MyClass
                     end class
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('finds custom types from other other files', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('finds custom types from other other files', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyNameSpace.MyClass) as MyNameSpace.MyClass
                     end function
                 `);
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
+                program.addOrReplaceFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
                     namespace MyNameSpace
                       class MyClass
                       end class
                     end namespace
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('detects missing custom types from another namespaces', async () => {
-                await program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            it('detects missing custom types from another namespaces', () => {
+                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -678,72 +678,72 @@ describe('Scope', () => {
                     function foo() as MyNamespace.UnknownType
                     end function
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.invalidFunctionReturnType('MyNamespace.UnknownType').message
                 ]);
             });
 
-            it('scopes types to correct scope', async () => {
+            it('scopes types to correct scope', () => {
                 program = new Program({ rootDir: rootDir });
 
-                await program.addOrReplaceFile('components/foo.xml', trim`
+                program.addOrReplaceFile('components/foo.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="foo" extends="Scene">
                         <script uri="foo.bs"/>
                     </component>
                 `);
-                await program.addOrReplaceFile(s`components/foo.bs`, `
+                program.addOrReplaceFile(s`components/foo.bs`, `
                     class MyClass
                     end class
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
 
-                await program.addOrReplaceFile('components/bar.xml', trim`
+                program.addOrReplaceFile('components/bar.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="bar" extends="Scene">
                         <script uri="bar.bs"/>
                     </component>
                 `);
-                await program.addOrReplaceFile(s`components/bar.bs`, `
+                program.addOrReplaceFile(s`components/bar.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
                     DiagnosticMessages.invalidFunctionReturnType('MyClass').message
                 ]);
             });
 
-            it('can reference types from parent component', async () => {
+            it('can reference types from parent component', () => {
                 program = new Program({ rootDir: rootDir });
 
-                await program.addOrReplaceFile('components/parent.xml', trim`
+                program.addOrReplaceFile('components/parent.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="parent" extends="Scene">
                         <script uri="parent.bs"/>
                     </component>
                 `);
-                await program.addOrReplaceFile(s`components/parent.bs`, `
+                program.addOrReplaceFile(s`components/parent.bs`, `
                     class MyClass
                     end class
                 `);
-                await program.addOrReplaceFile('components/child.xml', trim`
+                program.addOrReplaceFile('components/child.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="child" extends="parent">
                         <script uri="child.bs"/>
                     </component>
                 `);
-                await program.addOrReplaceFile(s`components/child.bs`, `
+                program.addOrReplaceFile(s`components/child.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
 
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
 
@@ -752,31 +752,31 @@ describe('Scope', () => {
     });
 
     describe('inheritance', () => {
-        it('inherits callables from parent', async () => {
+        it('inherits callables from parent', () => {
             program = new Program({ rootDir: rootDir });
 
-            await program.addOrReplaceFile('components/child.xml', trim`
+            program.addOrReplaceFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <script uri="child.brs"/>
                 </component>
             `);
-            await program.addOrReplaceFile(s`components/child.brs`, ``);
-            await program.validate();
+            program.addOrReplaceFile(s`components/child.brs`, ``);
+            program.validate();
             let childScope = program.getComponentScope('child');
             expect(childScope.getAllCallables().map(x => x.callable.name)).not.to.include('parentSub');
 
-            await program.addOrReplaceFile('components/parent.xml', trim`
+            program.addOrReplaceFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="parent" extends="Scene">
                     <script uri="parent.brs"/>
                 </component>
             `);
-            await program.addOrReplaceFile(s`components/parent.brs`, `
+            program.addOrReplaceFile(s`components/parent.brs`, `
                 sub parentSub()
                 end sub
             `);
-            await program.validate();
+            program.validate();
 
             expect(childScope.getAllCallables().map(x => x.callable.name)).to.include('parentSub');
         });
@@ -789,8 +789,8 @@ describe('Scope', () => {
     });
 
     describe('getDefinition', () => {
-        it('returns empty list when there are no files', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+        it('returns empty list when there are no files', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             let scope = program.getScopeByName('source');
             expect(scope.getDefinition(file, Position.create(0, 0))).to.be.lengthOf(0);
         });

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -20,8 +20,8 @@ describe('XmlScope', () => {
     });
 
     describe('constructor', () => {
-        it('listens for attach/detach parent events', async () => {
-            let parentXmlFile = await program.addOrReplaceFile<XmlFile>('components/parent.xml', trim`
+        it('listens for attach/detach parent events', () => {
+            let parentXmlFile = program.addOrReplaceFile<XmlFile>('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                 </component>
@@ -31,14 +31,14 @@ describe('XmlScope', () => {
             //should default to global scope
             expect(scope.getParentScope()).to.equal(program.globalScope);
 
-            let childXmlFile = await program.addOrReplaceFile<XmlFile>('components/child.xml', trim`
+            let childXmlFile = program.addOrReplaceFile<XmlFile>('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
             `);
             let childScope = program.getComponentScope('Child');
 
-            await program.validate();
+            program.validate();
 
             // child should have found its parent
             expect(childXmlFile.parentComponent).to.equal(parentXmlFile);
@@ -47,7 +47,7 @@ describe('XmlScope', () => {
 
             //remove the parent component
             program.removeFile(`${rootDir}/components/parent.xml`);
-            await program.validate();
+            program.validate();
             //the child should know the parent no longer exists
             expect(childXmlFile.parentComponent).not.to.exist;
             //child's parent scope should be the global scope
@@ -56,13 +56,13 @@ describe('XmlScope', () => {
     });
 
     describe('getDefinition', () => {
-        it('finds parent file', async () => {
-            let parentXmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+        it('finds parent file', () => {
+            let parentXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent">
                 </component>
             `);
-            let childXmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            let childXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                 </component>
@@ -75,22 +75,22 @@ describe('XmlScope', () => {
     });
 
     describe('getFiles', () => {
-        it('includes the xml file', async () => {
-            let xmlFile = await program.addOrReplaceFile('components/child.xml', trim`
+        it('includes the xml file', () => {
+            let xmlFile = program.addOrReplaceFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child">
                 </component>
             `);
-            await program.validate();
+            program.validate();
             expect(program.getComponentScope('Child').getOwnFiles()[0]).to.equal(xmlFile);
         });
     });
 
     describe('validate', () => {
-        it('adds an error when an interface function cannot be found', async () => {
+        it('adds an error when an interface function cannot be found', () => {
             program = new Program({ rootDir: rootDir });
 
-            await program.addOrReplaceFile('components/child.xml', trim`
+            program.addOrReplaceFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -103,11 +103,11 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            await program.addOrReplaceFile(s`components/child.brs`, `
+            program.addOrReplaceFile(s`components/child.brs`, `
                 sub func1()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             let childScope = program.getComponentScope('child');
             let diagnostics = childScope.getDiagnostics();
             expect(diagnostics.length).to.equal(5);
@@ -132,10 +132,10 @@ describe('XmlScope', () => {
             });
         });
 
-        it('adds an error when an interface field is invalid', async () => {
+        it('adds an error when an interface field is invalid', () => {
             program = new Program({ rootDir: rootDir });
 
-            await program.addOrReplaceFile('components/child.xml', trim`
+            program.addOrReplaceFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -150,11 +150,11 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            await program.addOrReplaceFile(s`components/child.brs`, `
+            program.addOrReplaceFile(s`components/child.brs`, `
                 sub init()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             let childScope = program.getComponentScope('child');
             let diagnostics = childScope.getDiagnostics();
             expect(diagnostics.length).to.equal(7);

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -313,8 +313,8 @@ describe('astUtils visitors', () => {
     });
 
     describe('walk', () => {
-        async function testWalk(text: string, expectedConstructors: string[], walkMode = WalkMode.visitAllRecursive) {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', text);
+        function testWalk(text: string, expectedConstructors: string[], walkMode = WalkMode.visitAllRecursive) {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', text);
             const items = [];
             let index = 1;
             file.ast.walk((element: any) => {
@@ -327,8 +327,8 @@ describe('astUtils visitors', () => {
             expect(items.map(x => `${x.constructor.name}:${x._testId}`)).to.eql(expectedConstructors.map(x => `${x}:${index++}`));
         }
 
-        it('Walks through all expressions until cancelled', async () => {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', `
+        it('Walks through all expressions until cancelled', () => {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
                 sub logger(message = "nil" as string)
                     innerLog = sub(message = "nil" as string)
                         print message
@@ -354,8 +354,8 @@ describe('astUtils visitors', () => {
             expect(count).to.equal(stopIndex);
         });
 
-        it('walks if statement', async () => {
-            await testWalk(`
+        it('walks if statement', () => {
+            testWalk(`
                 sub main()
                     if true then
                         print "true"
@@ -388,8 +388,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks if statement without else', async () => {
-            await testWalk(`
+        it('walks if statement without else', () => {
+            testWalk(`
                 sub main()
                     if true then
                         print "true"
@@ -407,8 +407,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks increment statement', async () => {
-            await testWalk(`
+        it('walks increment statement', () => {
+            testWalk(`
                 sub main()
                     age = 12
                     age++
@@ -424,8 +424,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks ForStatement', async () => {
-            await testWalk(`
+        it('walks ForStatement', () => {
+            testWalk(`
                 sub main()
                     for i = 0 to 10 step 1
                         print i
@@ -446,8 +446,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks ForEachStatement', async () => {
-            await testWalk(`
+        it('walks ForEachStatement', () => {
+            testWalk(`
                 sub main()
                     for each item in [1,2,3]
                         print item
@@ -468,8 +468,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks dotted and indexed set statements', async () => {
-            await testWalk(`
+        it('walks dotted and indexed set statements', () => {
+            testWalk(`
                 sub main()
                     person = {}
                     person.name = "person"
@@ -491,8 +491,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks while loop', async () => {
-            await testWalk(`
+        it('walks while loop', () => {
+            testWalk(`
                 sub main()
                     while 1 + 1 = 2
                         print "infinite"
@@ -514,8 +514,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks namespace', async () => {
-            await testWalk(`
+        it('walks namespace', () => {
+            testWalk(`
                namespace NameA.NameB
                end namespace
             `, [
@@ -526,8 +526,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks nested functions', async () => {
-            await testWalk(`
+        it('walks nested functions', () => {
+            testWalk(`
                 sub main()
                     print "main"
                     inner1 = sub()
@@ -571,8 +571,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks CallExpression', async () => {
-            await testWalk(`
+        it('walks CallExpression', () => {
+            testWalk(`
                 sub main()
                     Sleep(123)
                 end sub
@@ -587,8 +587,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks function parameters', async () => {
-            await testWalk(`
+        it('walks function parameters', () => {
+            testWalk(`
                 sub main(arg1)
                     speak = sub(arg1, arg2)
                     end sub
@@ -606,8 +606,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks DottedGetExpression', async () => {
-            await testWalk(`
+        it('walks DottedGetExpression', () => {
+            testWalk(`
                 sub main()
                     print person.name
                 end sub
@@ -621,8 +621,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks XmlAttributeGetExpression', async () => {
-            await testWalk(`
+        it('walks XmlAttributeGetExpression', () => {
+            testWalk(`
                 sub main()
                     print person@name
                 end sub
@@ -636,8 +636,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks IndexedGetExpression', async () => {
-            await testWalk(`
+        it('walks IndexedGetExpression', () => {
+            testWalk(`
                 sub main()
                     print person["name"]
                 end sub
@@ -652,8 +652,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks GroupingExpression', async () => {
-            await testWalk(`
+        it('walks GroupingExpression', () => {
+            testWalk(`
                 sub main()
                     print 1 + ( 1 + 2 )
                 end sub
@@ -671,8 +671,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks AALiteralExpression', async () => {
-            await testWalk(`
+        it('walks AALiteralExpression', () => {
+            testWalk(`
                 sub main()
                     person = {
                         'comment
@@ -691,8 +691,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks UnaryExpression', async () => {
-            await testWalk(`
+        it('walks UnaryExpression', () => {
+            testWalk(`
                 sub main()
                    isAlive = not isDead
                 end sub
@@ -706,8 +706,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks TemplateStringExpression', async () => {
-            await testWalk(`
+        it('walks TemplateStringExpression', () => {
+            testWalk(`
                 sub main()
                    print \`Hello \${worldVar}\`
                 end sub
@@ -725,8 +725,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks ReturnStatement with or without value', async () => {
-            await testWalk(`
+        it('walks ReturnStatement with or without value', () => {
+            testWalk(`
                 sub main()
                     a = 0
                     if a = 0 then
@@ -765,8 +765,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks TaggedTemplateStringExpression', async () => {
-            await testWalk(`
+        it('walks TaggedTemplateStringExpression', () => {
+            testWalk(`
                 sub main()
                    print tag\`Hello \${worldVar}\`
                 end sub
@@ -784,8 +784,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks CharCodeLiteral expression within TemplateLiteralExpression', async () => {
-            await testWalk(`
+        it('walks CharCodeLiteral expression within TemplateLiteralExpression', () => {
+            testWalk(`
                 sub main()
                    print \`\\n\`
                 end sub
@@ -802,8 +802,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks NewExpression', async () => {
-            await testWalk(`
+        it('walks NewExpression', () => {
+            testWalk(`
                 sub main()
                   person = new Person()
                 end sub
@@ -819,8 +819,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks CallfuncExpression', async () => {
-            await testWalk(`
+        it('walks CallfuncExpression', () => {
+            testWalk(`
                 sub main()
                   person@.doSomething("arg1")
                 end sub
@@ -835,8 +835,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('walks ClassStatement', async () => {
-            await testWalk(`
+        it('walks ClassStatement', () => {
+            testWalk(`
                 class Person
                     name as string
                     age as integer = 1
@@ -858,8 +858,8 @@ describe('astUtils visitors', () => {
             ]);
         });
 
-        it('visits all statements and no expressions', async () => {
-            await testWalk(`
+        it('visits all statements and no expressions', () => {
+            testWalk(`
                 sub main()
                     log = sub(message)
                         print "hello " + message
@@ -876,8 +876,8 @@ describe('astUtils visitors', () => {
             ], WalkMode.visitStatementsRecursive);
         });
 
-        it('visits all expressions and no statement', async () => {
-            await testWalk(`
+        it('visits all expressions and no statement', () => {
+            testWalk(`
                 sub main()
                     log = sub(message)
                         print "hello " + message

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -25,12 +25,12 @@ describe('BrsFile BrighterScript classes', () => {
         program.dispose();
     });
 
-    async function addFile(relativePath: string, text: string) {
+    function addFile(relativePath: string, text: string) {
         return program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
     }
 
-    it('detects all classes after parse', async () => {
-        let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it('detects all classes after parse', () => {
+        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
             end class
             class Duck
@@ -41,16 +41,16 @@ describe('BrsFile BrighterScript classes', () => {
         expect(file.parser.references.classStatements.map(x => x.getName(ParseMode.BrighterScript)).sort()).to.eql(['Animal', 'Duck']);
     });
 
-    it('does not cause errors with incomplete class statement', async () => {
-        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('does not cause errors with incomplete class statement', () => {
+        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class
         `);
-        await program.validate();
+        program.validate();
         //if no exception was thrown, this test passes
     });
 
-    it('catches child class missing super call in constructor', async () => {
-        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('catches child class missing super call in constructor', () => {
+        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Person
                 sub new()
                 end sub
@@ -60,7 +60,7 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.equal(
@@ -68,8 +68,8 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it('access modifier is option for override', async () => {
-        let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('access modifier is option for override', () => {
+        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub move()
                 end sub
@@ -80,15 +80,15 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
         let duckClass = file.parser.references.classStatements.find(x => x.name.text.toLowerCase() === 'duck');
         expect(duckClass).to.exist;
         expect(duckClass.memberMap['move']).to.exist;
     });
 
-    it('supports various namespace configurations', async () => {
-        await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('supports various namespace configurations', () => {
+        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub new()
                     bigBird = new Birds.Bird()
@@ -107,12 +107,12 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
     describe('super', () => {
-        it('always requires super call in child constructor', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('always requires super call in child constructor', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 class Bird
                 end class
                 class Duck extends Bird
@@ -120,12 +120,12 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).to.eql(DiagnosticMessages.classConstructorMissingSuperCall().message);
         });
 
-        it('requires super call in child when parent has own `new` method', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('requires super call in child when parent has own `new` method', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 class Bird
                     sub new()
                     end sub
@@ -135,12 +135,12 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).to.eql(DiagnosticMessages.classConstructorMissingSuperCall().message);
         });
 
-        it('allows non-`m` expressions and statements before the super call', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('allows non-`m` expressions and statements before the super call', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -154,12 +154,12 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).to.be.undefined;
         });
 
-        it('allows non-`m` expressions and statements before the super call', async () => {
-            await program.addOrReplaceFile('source/main.bs', `
+        it('allows non-`m` expressions and statements before the super call', () => {
+            program.addOrReplaceFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -171,7 +171,7 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `);
-            await program.validate();
+            program.validate();
             expect(
                 program.getDiagnostics().map(x => ({ message: x.message, range: x.range }))
             ).to.eql([{
@@ -186,8 +186,8 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     describe('transpile', () => {
-        it('follows correct sequence for property initializers', async () => {
-            await testTranspile(`
+        it('follows correct sequence for property initializers', () => {
+            testTranspile(`
                 class Animal
                     species = "Animal"
                     sub new()
@@ -233,8 +233,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('handles class inheritance inferred constructor calls', async () => {
-            await testTranspile(`
+        it('handles class inheritance inferred constructor calls', () => {
+            testTranspile(`
                 class Animal
                     className = "Animal"
                 end class
@@ -289,8 +289,8 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
 
-        it('works with namespaces', async () => {
-            await testTranspile(`
+        it('works with namespaces', () => {
+            testTranspile(`
                 namespace Birds.WaterFowl
                     class Duck
                     end class
@@ -325,8 +325,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('works for simple  class', async () => {
-            await testTranspile(`
+        it('works for simple  class', () => {
+            testTranspile(`
                 class Duck
                 end class
             `, `
@@ -344,8 +344,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('registers the constructor and properly handles its parameters', async () => {
-            await testTranspile(`
+        it('registers the constructor and properly handles its parameters', () => {
+            testTranspile(`
                 class Duck
                     sub new(name as string, age as integer)
                     end sub
@@ -365,8 +365,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('properly handles child class constructor override and super calls', async () => {
-            await testTranspile(`
+        it('properly handles child class constructor override and super calls', () => {
+            testTranspile(`
                 class Animal
                     sub new(name as string)
                     end sub
@@ -407,8 +407,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('properly transpiles classes from outside current namespace', async () => {
-            await addFile('source/Animals.bs', `
+        it('properly transpiles classes from outside current namespace', () => {
+            addFile('source/Animals.bs', `
                 namespace Animals
                     class Duck
                     end class
@@ -416,7 +416,7 @@ describe('BrsFile BrighterScript classes', () => {
                 class Bird
                 end class
             `);
-            await testTranspile(`
+            testTranspile(`
                 namespace Animals
                     sub init()
                         donaldDuck = new Duck()
@@ -433,8 +433,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('properly transpiles new statement for missing class ', async () => {
-            await testTranspile(`
+        it('properly transpiles new statement for missing class ', () => {
+            testTranspile(`
             sub main()
                 bob = new Human()
             end sub
@@ -445,14 +445,14 @@ describe('BrsFile BrighterScript classes', () => {
         `, undefined, 'source/main.bs');
         });
 
-        it('new keyword transpiles correctly', async () => {
-            await addFile('source/Animal.bs', `
+        it('new keyword transpiles correctly', () => {
+            addFile('source/Animal.bs', `
                 class Animal
                     sub new(name as string)
                     end sub
                 end class
             `);
-            await testTranspile(`
+            testTranspile(`
                 sub main()
                     a = new Animal("donald")
                 end sub
@@ -463,8 +463,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('does not screw up local variable references', async () => {
-            await testTranspile(`
+        it('does not screw up local variable references', () => {
+            testTranspile(`
                 class Animal
                     sub new(name as string)
                         m.name = name
@@ -572,8 +572,8 @@ describe('BrsFile BrighterScript classes', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('calculates the proper super index', async () => {
-            await testTranspile(`
+        it('calculates the proper super index', () => {
+            testTranspile(`
                 class Duck
                     public sub walk(meters as integer)
                         print "Walked " + meters.ToStr() + " meters"
@@ -623,15 +623,15 @@ describe('BrsFile BrighterScript classes', () => {
         });
     });
 
-    it('detects using `new` keyword on non-classes', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it('detects using `new` keyword on non-classes', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             sub quack()
             end sub
             sub main()
                 duck = new quack()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.equal(
@@ -639,8 +639,8 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it('detects missing call to super', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it('detects missing call to super', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                 end sub
@@ -650,7 +650,7 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.equal(
@@ -658,15 +658,15 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it.skip('detects calls to unknown m methods', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it.skip('detects calls to unknown m methods', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                     m.methodThatDoesNotExist()
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.equal(
@@ -674,8 +674,8 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it('detects duplicate member names', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('detects duplicate member names', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
                 public name
@@ -688,7 +688,7 @@ describe('BrsFile BrighterScript classes', () => {
                 public age
             end class
         `);
-        await program.validate();
+        program.validate();
         let diagnostics = program.getDiagnostics().map(x => {
             return {
                 code: x.code,
@@ -712,8 +712,8 @@ describe('BrsFile BrighterScript classes', () => {
         }]);
     });
 
-    it('detects mismatched member type in child class', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('detects mismatched member type in child class', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -723,7 +723,7 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics().map(x => x.message).sort()[0]
         ).to.eql(
@@ -731,8 +731,8 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it('detects overridden property name in child class', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('detects overridden property name in child class', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -740,15 +740,15 @@ describe('BrsFile BrighterScript classes', () => {
                 public name
             end class
         `);
-        await program.validate();
+        program.validate();
         let diagnostics = program.getDiagnostics().map(x => x.message);
         expect(diagnostics).to.eql([
             DiagnosticMessages.memberAlreadyExistsInParentClass('field', 'Animal').message
         ]);
     });
 
-    it('detects overridden methods without override keyword', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it('detects overridden methods without override keyword', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub speak()
                 end sub
@@ -758,28 +758,28 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]).to.exist.and.to.include({
             ...DiagnosticMessages.missingOverrideKeyword('Animal')
         });
     });
 
-    it('detects extending unknown parent class', async () => {
-        await program.addOrReplaceFile('source/main.brs', `
+    it('detects extending unknown parent class', () => {
+        program.addOrReplaceFile('source/main.brs', `
             class Duck extends Animal
                 sub speak()
                 end sub
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]).to.exist.and.to.deep.include({
             ...DiagnosticMessages.classCouldNotBeFound('Animal', 'source'),
             range: Range.create(1, 31, 1, 37)
         });
     });
 
-    it('catches newable class without namespace name', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('catches newable class without namespace name', () => {
+        program.addOrReplaceFile('source/main.bs', `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -789,14 +789,14 @@ describe('BrsFile BrighterScript classes', () => {
                 d = new Duck()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.classCouldNotBeFound('Duck', 'source').message
         );
     });
 
-    it('supports newable class namespace inference', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('supports newable class namespace inference', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -805,12 +805,12 @@ describe('BrsFile BrighterScript classes', () => {
                 end sub
             end namespace
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
 
-    it('catches extending unknown namespaced class', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('catches extending unknown namespaced class', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -818,14 +818,14 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.classCouldNotBeFound('NameA.NameB.Animal1', 'source').message
         );
     });
 
-    it('supports omitting namespace prefix for items in same namespace', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('supports omitting namespace prefix for items in same namespace', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -833,38 +833,38 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).not.to.exist;
     });
 
-    it('catches duplicate root-level class declarations', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('catches duplicate root-level class declarations', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
             end class
             class Animal
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.duplicateClassDeclaration('source', 'Animal').message
         );
     });
 
-    it('catches duplicate namespace-level class declarations', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('catches duplicate namespace-level class declarations', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
                 class Animal
             end namespace
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.duplicateClassDeclaration('source', 'NameA.NameB.Animal').message
         );
     });
 
-    it('catches namespaced class name which is the same as a global class', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+    it('catches namespaced class name which is the same as a global class', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -872,54 +872,54 @@ describe('BrsFile BrighterScript classes', () => {
             class Animal
             end class
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.namespacedClassCannotShareNamewithNonNamespacedClass('Animal').message
         );
     });
 
-    it('catches class with same name as function', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('catches class with same name as function', () => {
+        program.addOrReplaceFile('source/main.bs', `
             class Animal
             end class
             sub Animal()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.functionCannotHaveSameNameAsClass('Animal').message
         );
     });
 
-    it('catches class with same name (but different case) as function', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('catches class with same name (but different case) as function', () => {
+        program.addOrReplaceFile('source/main.bs', `
             class ANIMAL
             end class
             sub animal()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.functionCannotHaveSameNameAsClass('animal').message
         );
     });
 
-    it('catches variable with same name as class', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('catches variable with same name as class', () => {
+        program.addOrReplaceFile('source/main.bs', `
             class Animal
             end class
             sub main()
                 animal = new Animal()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.equal(
             DiagnosticMessages.localVarSameNameAsClass('Animal').message
         );
     });
 
-    it('allows extending classes with more than one dot in the filename', async () => {
-        await program.addOrReplaceFile('source/testclass.bs', `
+    it('allows extending classes with more than one dot in the filename', () => {
+        program.addOrReplaceFile('source/testclass.bs', `
             class Foo
             end class
 
@@ -930,7 +930,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        await program.addOrReplaceFile('source/testclass_no_testdot.bs', `
+        program.addOrReplaceFile('source/testclass_no_testdot.bs', `
             class BarNoDot extends Foo
                 sub new()
                     super()
@@ -938,7 +938,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        await program.addOrReplaceFile('source/testclass.dot.bs', `
+        program.addOrReplaceFile('source/testclass.dot.bs', `
             class BarDot extends Foo
                 sub new()
                 super()
@@ -946,12 +946,12 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        await program.validate();
+        program.validate();
         expectZeroDiagnostics(program);
     });
 
-    it('computes correct super index for grandchild class', async () => {
-        await program.addOrReplaceFile('source/main.bs', `
+    it('computes correct super index for grandchild class', () => {
+        program.addOrReplaceFile('source/main.bs', `
             sub Main()
                 c = new App.ClassC()
             end sub
@@ -965,7 +965,7 @@ describe('BrsFile BrighterScript classes', () => {
             end namespace
         `);
 
-        await testTranspile(`
+        testTranspile(`
             namespace App
                 class ClassC extends ClassB
                     sub new()

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -38,13 +38,13 @@ describe('BrsFile', () => {
         program.dispose();
     });
 
-    it('supports the third parameter in CreateObject', async () => {
-        await program.addOrReplaceFile('source/main.brs', `
+    it('supports the third parameter in CreateObject', () => {
+        program.addOrReplaceFile('source/main.brs', `
             sub main()
                 regexp = CreateObject("roRegex", "[a-z]+", "i")
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics()[0]?.message).to.not.exist;
     });
 
@@ -72,8 +72,8 @@ describe('BrsFile', () => {
             dest: `source/lib.brs`
         } as StandardizedFileEntry;
 
-        it('creates proper tokens', async () => {
-            file = await program.addOrReplaceFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
+        it('creates proper tokens', () => {
+            file = program.addOrReplaceFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
             expect(file['getPartialVariableName'](file.parser.tokens[7])).to.equal('ModuleA.ModuleB.ModuleC.');
             expect(file['getPartialVariableName'](file.parser.tokens[6])).to.equal('ModuleA.ModuleB.ModuleC');
             expect(file['getPartialVariableName'](file.parser.tokens[5])).to.equal('ModuleA.ModuleB.');
@@ -84,16 +84,16 @@ describe('BrsFile', () => {
     });
 
     describe('getScopesForFile', () => {
-        it('finds the scope for the file', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', ``);
+        it('finds the scope for the file', () => {
+            let file = program.addOrReplaceFile('source/main.brs', ``);
             expect(program.getScopesForFile(file)[0]?.name).to.equal('source');
         });
     });
 
     describe('getCompletions', () => {
-        it('waits for the file to be processed before collecting completions', async () => {
+        it('waits for the file to be processed before collecting completions', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile('source/main.brs', `
+            program.addOrReplaceFile('source/main.brs', `
                 sub Main()
                     print "hello"
                     Say
@@ -103,28 +103,28 @@ describe('BrsFile', () => {
                 end sub
             `);
 
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 23));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 23));
             let names = result.map(x => x.label);
             expect(names).to.includes('Main');
             expect(names).to.includes('SayHello');
         });
 
-        it('always includes `m`', async () => {
+        it('always includes `m`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
             `);
 
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
             let names = result.map(x => x.label);
             expect(names).to.contain('m');
         });
 
-        it('includes all keywordsm`', async () => {
+        it('includes all keywordsm`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -133,36 +133,36 @@ describe('BrsFile', () => {
             let keywords = Object.keys(Keywords).filter(x => !x.includes(' '));
 
             //inside the function
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
             let names = result.map(x => x.label);
             for (let keyword of keywords) {
                 expect(names).to.include(keyword);
             }
 
             //outside the function
-            result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(4, 8));
+            result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(4, 8));
             names = result.map(x => x.label);
             for (let keyword of keywords) {
                 expect(names).to.include(keyword);
             }
         });
 
-        it('does not provide completions within a comment', async () => {
+        it('does not provide completions within a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'some comment
                 end sub
             `);
 
             //inside the function
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 33));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 33));
             expect(result).to.be.lengthOf(0);
         });
 
-        it('does not provide duplicate entries for variables', async () => {
+        it('does not provide duplicate entries for variables', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "bob"
                     age = 12
@@ -170,7 +170,7 @@ describe('BrsFile', () => {
                 end sub
             `);
 
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 23));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 23));
 
             let count = result.reduce((total, x) => {
                 return x.label === 'name' ? total + 1 : total;
@@ -178,28 +178,28 @@ describe('BrsFile', () => {
             expect(count).to.equal(1);
         });
 
-        it('does not include `as` and `string` text options when used in function params', async () => {
+        it('does not include `as` and `string` text options when used in function params', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
 
                 end sub
             `);
 
-            let result = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
+            let result = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 23));
             expect(result.filter(x => x.kind === CompletionItemKind.Text)).not.to.contain('as');
             expect(result.filter(x => x.kind === CompletionItemKind.Text)).not.to.contain('string');
         });
 
-        it('does not provide intellisense results when inside a comment', async () => {
+        it('does not provide intellisense results when inside a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                     'this is a comment
                 end sub
             `);
 
-            let results = await program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 30));
+            let results = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 30));
             expect(results).to.be.empty;
         });
 
@@ -207,41 +207,41 @@ describe('BrsFile', () => {
 
     describe('comment flags', () => {
         describe('bs:disable-next-line', () => {
-            it('disables critical diagnostic issues', async () => {
-                await program.addOrReplaceFile('source/main.brs', `
+            it('disables critical diagnostic issues', () => {
+                program.addOrReplaceFile('source/main.brs', `
                     sub main()
                         Dim requestData[requestList.count()]
                     end sub
                 `);
                 //should have an error
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics()[0]?.message).to.exist;
 
-                await program.addOrReplaceFile('source/main.brs', `
+                program.addOrReplaceFile('source/main.brs', `
                     sub main()
                         'bs:disable-next-line
                         Dim requestData[requestList.count()]
                     end sub
                 `);
                 //should have an error
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('works with leading whitespace', async () => {
-                await program.addOrReplaceFile('source/main.brs', `
+            it('works with leading whitespace', () => {
+                program.addOrReplaceFile('source/main.brs', `
                     sub main()
                         ' bs:disable-next-line
                         =asdf=sadf=
                     end sub
                 `);
                 //should have an error
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('works for all', async () => {
-                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('works for all', () => {
+                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line
                         name = "bob
@@ -253,13 +253,13 @@ describe('BrsFile', () => {
                     range: Range.create(2, 24, 2, 45),
                     affectedRange: util.createRange(3, 0, 3, Number.MAX_SAFE_INTEGER)
                 } as CommentFlag);
-                await program.validate();
+                program.validate();
                 //the "unterminated string" error should be filtered out
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('works for specific codes', async () => {
-                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('works for specific codes', () => {
+                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: 1083, 1001
                         name = "bob
@@ -275,8 +275,8 @@ describe('BrsFile', () => {
                 expect(program.getDiagnostics()[0]?.message).to.not.exist;
             });
 
-            it('ignores non-numeric codes', async () => {
-                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('ignores non-numeric codes', () => {
+                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: LINT9999
                         name = "bob
@@ -286,14 +286,14 @@ describe('BrsFile', () => {
                 expect(program.getDiagnostics()[0]?.message).to.exist;
             });
 
-            it('adds diagnostics for unknown numeric diagnostic codes', async () => {
-                await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('adds diagnostics for unknown numeric diagnostic codes', () => {
+                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         print "hi" 'bs:disable-line: 123456 999999   aaaab
                     end sub
                 `);
 
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()).to.be.lengthOf(2);
                 expect(program.getDiagnostics()[0]).to.deep.include({
@@ -307,8 +307,8 @@ describe('BrsFile', () => {
         });
 
         describe('bs:disable-line', () => {
-            it('works for all', async () => {
-                let file = await program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('works for all', () => {
+                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         z::;;%%%%%% 'bs:disable-line
                     end sub
@@ -319,13 +319,13 @@ describe('BrsFile', () => {
                     range: Range.create(2, 36, 2, 52),
                     affectedRange: Range.create(2, 0, 2, 36)
                 } as CommentFlag);
-                await program.validate();
+                program.validate();
                 //the "unterminated string" error should be filtered out
                 expect(program.getDiagnostics()).to.be.lengthOf(0);
             });
 
-            it('works for specific codes', async () => {
-                await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('works for specific codes', () => {
+                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         'should not have any errors
                         DoSomething(1) 'bs:disable-line:1002
@@ -336,7 +336,7 @@ describe('BrsFile', () => {
                     end sub
                 `);
 
-                await program.validate();
+                program.validate();
 
                 expect(program.getDiagnostics()).to.be.lengthOf(1);
                 expect(program.getDiagnostics()[0]).to.deep.include({
@@ -344,40 +344,40 @@ describe('BrsFile', () => {
                 } as BsDiagnostic);
             });
 
-            it('handles the erraneous `stop` keyword', async () => {
+            it('handles the erraneous `stop` keyword', () => {
                 //the current version of BRS causes parse errors after the `parse` keyword, showing error in comments
                 //the program should ignore all diagnostics found in brs:* comment lines EXCEPT
                 //for the diagnostics about using unknown error codes
-                await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         stop 'bs:disable-line
                         print "need a valid line to fix stop error"
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics()).to.be.lengthOf(0);
             });
         });
     });
 
     describe('parse', () => {
-        it('uses the proper parse mode based on file extension', async () => {
-            async function testParseMode(destPath: string, expectedParseMode: ParseMode) {
-                const file = await program.addOrReplaceFile<BrsFile>(destPath, '');
+        it('uses the proper parse mode based on file extension', () => {
+            function testParseMode(destPath: string, expectedParseMode: ParseMode) {
+                const file = program.addOrReplaceFile<BrsFile>(destPath, '');
                 expect(file.parseMode).to.equal(expectedParseMode);
             }
 
-            await testParseMode('source/main.brs', ParseMode.BrightScript);
-            await testParseMode('source/main.spec.brs', ParseMode.BrightScript);
-            await testParseMode('source/main.d.brs', ParseMode.BrightScript);
+            testParseMode('source/main.brs', ParseMode.BrightScript);
+            testParseMode('source/main.spec.brs', ParseMode.BrightScript);
+            testParseMode('source/main.d.brs', ParseMode.BrightScript);
 
-            await testParseMode('source/main.bs', ParseMode.BrighterScript);
-            await testParseMode('source/main.d.bs', ParseMode.BrighterScript);
-            await testParseMode('source/main.spec.bs', ParseMode.BrighterScript);
+            testParseMode('source/main.bs', ParseMode.BrighterScript);
+            testParseMode('source/main.d.bs', ParseMode.BrighterScript);
+            testParseMode('source/main.spec.bs', ParseMode.BrighterScript);
         });
 
-        it('supports labels and goto statements', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('supports labels and goto statements', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'multiple goto statements on one line
                     goto myLabel : goto myLabel
@@ -387,8 +387,8 @@ describe('BrsFile', () => {
             expect(file.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('supports empty print statements', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('supports empty print statements', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    print
                 end sub
@@ -398,8 +398,8 @@ describe('BrsFile', () => {
 
         describe('conditional compile', () => {
 
-            it('works for upper case keywords', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('works for upper case keywords', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #CONST someFlag = true
                         #IF someFlag
@@ -414,8 +414,8 @@ describe('BrsFile', () => {
                 expect(file.getDiagnostics()).to.be.lengthOf(0);
             });
 
-            it('supports single-word #elseif and #endif', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('supports single-word #elseif and #endif', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -428,8 +428,8 @@ describe('BrsFile', () => {
                 expect(file.getDiagnostics()).to.be.lengthOf(0);
             });
 
-            it('supports multi-word #else if and #end if', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('supports multi-word #else if and #end if', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -442,8 +442,8 @@ describe('BrsFile', () => {
                 expect(file.getDiagnostics()).to.be.lengthOf(0);
             });
 
-            it('does not choke on invalid code inside a false conditional compile', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('does not choke on invalid code inside a false conditional compile', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if false
                             non-commented code here should not cause parse errors
@@ -453,8 +453,8 @@ describe('BrsFile', () => {
                 expect(file.getDiagnostics()).to.be.lengthOf(0);
             });
 
-            it('detects syntax error in #if', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('detects syntax error in #if', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if true1
                             print "true"
@@ -466,8 +466,8 @@ describe('BrsFile', () => {
                 });
             });
 
-            it('detects syntax error in #const', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('detects syntax error in #const', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if %
                             print "true"
@@ -479,8 +479,8 @@ describe('BrsFile', () => {
                 });
             });
 
-            it('detects #const name using reserved word', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('detects #const name using reserved word', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const function = true
                     end sub
@@ -490,8 +490,8 @@ describe('BrsFile', () => {
                 });
             });
 
-            it('detects syntax error in #const', async () => {
-                let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            it('detects syntax error in #const', () => {
+                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someConst = 123
                     end sub
@@ -502,8 +502,8 @@ describe('BrsFile', () => {
             });
         });
 
-        it('supports stop statement', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('supports stop statement', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    stop
                 end sub
@@ -511,8 +511,8 @@ describe('BrsFile', () => {
             expect(file.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('supports single-line if statements', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('supports single-line if statements', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                     if 1 < 2: return true: end if
                     if 1 < 2: return true
@@ -886,8 +886,8 @@ describe('BrsFile', () => {
             expect(file.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('adds error for library statements NOT at top of file', async () => {
-            let file = await program.addOrReplaceFile('source/main.bs', `
+        it('adds error for library statements NOT at top of file', () => {
+            let file = program.addOrReplaceFile('source/main.bs', `
                 sub main()
                 end sub
                 import "file.brs"
@@ -906,8 +906,8 @@ describe('BrsFile', () => {
             expect(file.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('adds error for library statements NOT at top of file', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', `
+        it('adds error for library statements NOT at top of file', () => {
+            let file = program.addOrReplaceFile('source/main.brs', `
                 sub main()
                 end sub
                 Library "v30/bslCore.brs"
@@ -919,8 +919,8 @@ describe('BrsFile', () => {
             ]);
         });
 
-        it('adds error for library statements inside of function body', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', `
+        it('adds error for library statements inside of function body', () => {
+            let file = program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     Library "v30/bslCore.brs"
                 end sub
@@ -941,8 +941,8 @@ describe('BrsFile', () => {
             expect(file.getDiagnostics()).to.be.lengthOf(0);
         });
 
-        it('succeeds when finding variables with "sub" in them', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', `
+        it('succeeds when finding variables with "sub" in them', () => {
+            let file = program.addOrReplaceFile('source/main.brs', `
                 function DoSomething()
                     return value.subType()
                 end function
@@ -1196,15 +1196,15 @@ describe('BrsFile', () => {
             }]);
         });
 
-        it('finds function calls nested inside statements', async () => {
-            await program.addOrReplaceFile(`source/main.brs`, `
+        it('finds function calls nested inside statements', () => {
+            program.addOrReplaceFile(`source/main.brs`, `
                 sub main()
                     if true then
                         DoesNotExist(1, 2)
                     end if
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(
                 program.getDiagnostics()[0]?.message
             ).to.equal(
@@ -1246,8 +1246,8 @@ describe('BrsFile', () => {
             expect(file.callables.length).to.equal(0);
         });
 
-        it('finds return type', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', `
+        it('finds return type', () => {
+            let file = program.addOrReplaceFile('source/main.brs', `
                 function DoSomething() as string
                 end function
             `);
@@ -1349,8 +1349,8 @@ describe('BrsFile', () => {
             expect(scope.variableDeclarations[0].name).to.equal('theLength');
         });
 
-        it('finds value from global return', async () => {
-            let file = await program.addOrReplaceFile('source/main.brs', `
+        it('finds value from global return', () => {
+            let file = program.addOrReplaceFile('source/main.brs', `
                 sub Main()
                    myName = GetName()
                 end sub
@@ -1400,8 +1400,8 @@ describe('BrsFile', () => {
     });
 
     describe('getHover', () => {
-        it('works for param types', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('works for param types', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething(name as string)
                     name = 1
                     sayMyName = function(name as string)
@@ -1421,8 +1421,8 @@ describe('BrsFile', () => {
         });
 
         //ignore this for now...it's not a huge deal
-        it('does not match on keywords or data types', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('does not match on keywords or data types', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                 end sub
                 sub as()
@@ -1434,8 +1434,8 @@ describe('BrsFile', () => {
             expect(file.getHover(Position.create(1, 36))).not.to.exist;
         });
 
-        it('finds declared function', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('finds declared function', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -1450,8 +1450,8 @@ describe('BrsFile', () => {
             expect(hover.contents).to.equal('function Main(count? as dynamic) as dynamic');
         });
 
-        it('finds variable function hover in same scope', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('finds variable function hover in same scope', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName = sub(name as string)
                     end sub
@@ -1466,8 +1466,8 @@ describe('BrsFile', () => {
             expect(hover.contents).to.equal('sub sayMyName(name as string) as void');
         });
 
-        it('finds function hover in file scope', async () => {
-            let file = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('finds function hover in file scope', () => {
+            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
@@ -1483,19 +1483,19 @@ describe('BrsFile', () => {
             expect(hover.contents).to.equal('sub sayMyName() as void');
         });
 
-        it('finds function hover in scope', async () => {
+        it('finds function hover in scope', () => {
             let rootDir = process.cwd();
             program = new Program({
                 rootDir: rootDir
             });
 
-            let mainFile = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub sayMyName(name as string)
 
                 end sub
@@ -1508,8 +1508,8 @@ describe('BrsFile', () => {
             expect(hover.contents).to.equal('sub sayMyName(name as string) as void');
         });
 
-        it('handles mixed case `then` partions of conditionals', async () => {
-            let mainFile = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        it('handles mixed case `then` partions of conditionals', () => {
+            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true then
                         print "works"
@@ -1518,7 +1518,7 @@ describe('BrsFile', () => {
             `);
 
             expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
-            mainFile = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true Then
                         print "works"
@@ -1527,7 +1527,7 @@ describe('BrsFile', () => {
             `);
             expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
 
-            mainFile = await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true THEN
                         print "works"
@@ -1538,20 +1538,20 @@ describe('BrsFile', () => {
         });
     });
 
-    it('does not throw when encountering incomplete import statement', async () => {
-        await program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+    it('does not throw when encountering incomplete import statement', () => {
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             import
             sub main()
             end sub
         `);
-        await program.validate();
+        program.validate();
         //this test will throw an exception if something went wrong
     });
 
     describe('transpile', () => {
         describe('throwStatement', () => {
-            it('transpiles properly', async () => {
-                await testTranspile(`
+            it('transpiles properly', () => {
+                testTranspile(`
                     sub main()
                         try
                             throw "some message"
@@ -1563,8 +1563,8 @@ describe('BrsFile', () => {
         });
 
         describe('try/catch', () => {
-            it('transpiles properly', async () => {
-                await testTranspile(`
+            it('transpiles properly', () => {
+                testTranspile(`
                     sub main()
                         try
                             print a.b.c
@@ -1577,8 +1577,8 @@ describe('BrsFile', () => {
         });
 
         describe('namespaces', () => {
-            it('properly transpiles namespace functions for assignments', async () => {
-                await testTranspile(`
+            it('properly transpiles namespace functions for assignments', () => {
+                testTranspile(`
                     namespace NameA.NameB
                         sub Speak()
                         end sub
@@ -1600,8 +1600,8 @@ describe('BrsFile', () => {
                 `);
             });
 
-            it('properly transpiles inferred namespace function for assignment', async () => {
-                await testTranspile(`
+            it('properly transpiles inferred namespace function for assignment', () => {
+                testTranspile(`
                     namespace NameA.NameB
                         sub Speak()
                         end sub
@@ -1621,8 +1621,8 @@ describe('BrsFile', () => {
                 `);
             });
         });
-        it('includes all text to end of line for a non-terminated string', async () => {
-            await testTranspile(
+        it('includes all text to end of line for a non-terminated string', () => {
+            testTranspile(
                 'sub main()\n    name = "john \nend sub',
                 'sub main()\n    name = "john "\nend sub',
                 null,
@@ -1630,22 +1630,22 @@ describe('BrsFile', () => {
                 false
             );
         });
-        it('escapes quotes in string literals', async () => {
-            await testTranspile(`
+        it('escapes quotes in string literals', () => {
+            testTranspile(`
                 sub main()
                     expected += chr(10) + " version=""2.0"""
                 end sub
             `);
         });
-        it('keeps function parameter types in proper order', async () => {
-            await testTranspile(`
+        it('keeps function parameter types in proper order', () => {
+            testTranspile(`
                 function CreateTestStatistic(name as string, result = "Success" as string, time = 0 as integer, errorCode = 0 as integer, errorMessage = "" as string) as object
                 end function
             `);
         });
 
-        it('transpiles local var assignment operators', async () => {
-            await testTranspile(`
+        it('transpiles local var assignment operators', () => {
+            testTranspile(`
                 sub main()
                     count = 0
                     count += 1
@@ -1659,8 +1659,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('transpiles AA property assignment operators', async () => {
-            await testTranspile(`
+        it('transpiles AA property assignment operators', () => {
+            testTranspile(`
                 sub main()
                     person = {
                         count: 0
@@ -1670,8 +1670,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('transpiles AA indexed assignment operators', async () => {
-            await testTranspile(`
+        it('transpiles AA indexed assignment operators', () => {
+            testTranspile(`
                 sub main()
                     person = {
                         count: 0
@@ -1681,8 +1681,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('relative-referenced namespaced functions get prefixed', async () => {
-            await testTranspile(`
+        it('relative-referenced namespaced functions get prefixed', () => {
+            testTranspile(`
                 namespace Vertibrates.Birds
                     function GetAllBirds()
                         return [
@@ -1713,8 +1713,8 @@ describe('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('transpiles namespaced functions', async () => {
-            await testTranspile(`
+        it('transpiles namespaced functions', () => {
+            testTranspile(`
                 namespace NameA
                     sub alert()
                     end sub
@@ -1731,8 +1731,8 @@ describe('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('transpiles calls to fully-qualified namespaced functions', async () => {
-            await testTranspile(`
+        it('transpiles calls to fully-qualified namespaced functions', () => {
+            testTranspile(`
                 namespace NameA
                     sub alert()
                     end sub
@@ -1758,16 +1758,16 @@ describe('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('keeps end-of-line comments with their line', async () => {
-            await testTranspile(`
+        it('keeps end-of-line comments with their line', () => {
+            testTranspile(`
                 function DoSomething() 'comment 1
                     name = "bob" 'comment 2
                 end function 'comment 3
             `);
         });
 
-        it('works for functions', async () => {
-            await testTranspile(`
+        it('works for functions', () => {
+            testTranspile(`
                 function DoSomething()
                     'lots of empty white space
                     'that will be removed during transpile
@@ -1783,8 +1783,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('keeps empty AAs and arrays on same line', async () => {
-            await testTranspile(`
+        it('keeps empty AAs and arrays on same line', () => {
+            testTranspile(`
                 sub a()
                     person = {}
                     stuff = []
@@ -1792,8 +1792,8 @@ describe('BrsFile', () => {
         `, null, 'trim');
         });
 
-        it('adds `then` when missing', async () => {
-            await testTranspile(`
+        it('adds `then` when missing', () => {
+            testTranspile(`
                 sub a()
                     if true
                         print "true"
@@ -1816,8 +1816,8 @@ describe('BrsFile', () => {
             `, 'trim');
         });
 
-        it('does not add leading or trailing newlines', async () => {
-            await testTranspile(`function log()\nend function`, undefined, 'none');
+        it('does not add leading or trailing newlines', () => {
+            testTranspile(`function log()\nend function`, undefined, 'none');
         });
 
         it('handles sourcemap edge case', async () => {
@@ -1828,7 +1828,7 @@ describe('BrsFile', () => {
                 '\n' +
                 'end sub';
             program.options.sourceMap = true;
-            let result = await testTranspile(source, `sub main()\n    print 1\nend sub`, 'none', 'source/main.bs');
+            let result = testTranspile(source, `sub main()\n    print 1\nend sub`, 'none', 'source/main.bs');
             //load the source map
             let location = await SourceMapConsumer.with(result.map.toJSON(), null, (consumer) => {
                 return consumer.generatedPositionFor({
@@ -1849,7 +1849,7 @@ describe('BrsFile', () => {
                 .filter(x => x.kind !== TokenKind.Eof && x.kind !== TokenKind.Newline);
 
             program.options.sourceMap = true;
-            let result = await testTranspile(source, source, 'none');
+            let result = testTranspile(source, source, 'none');
             //load the source map
             await SourceMapConsumer.with(result.map.toString(), null, (consumer) => {
                 let tokenResult = tokens.map(token => ({
@@ -1875,8 +1875,8 @@ describe('BrsFile', () => {
             });
         });
 
-        it('handles empty if block', async () => {
-            await testTranspile(`
+        it('handles empty if block', () => {
+            testTranspile(`
                 if true then
                 end if
                 if true then
@@ -1896,8 +1896,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('handles empty elseif block', async () => {
-            await testTranspile(`
+        it('handles empty elseif block', () => {
+            testTranspile(`
                 if true then
                     print "if"
                 else if true then
@@ -1910,8 +1910,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('handles empty else block', async () => {
-            await testTranspile(`
+        it('handles empty else block', () => {
+            testTranspile(`
                 if true then
                     print "if"
                 else
@@ -1925,8 +1925,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('works for function parameters', async () => {
-            await testTranspile(`
+        it('works for function parameters', () => {
+            testTranspile(`
                 function DoSomething(name, age as integer, text as string)
                 end function
             `, `
@@ -1935,8 +1935,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('adds newlines between top-level statements', async () => {
-            await testTranspile(`
+        it('adds newlines between top-level statements', () => {
+            testTranspile(`
                 function a()
                 end function
 
@@ -1945,8 +1945,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('properly indents nested AA literals', async () => {
-            await testTranspile(`
+        it('properly indents nested AA literals', () => {
+            testTranspile(`
                 sub doSomething()
                     grandparent = {
                         parent: {
@@ -1961,8 +1961,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('does not add comma after final object property even when comments are present', async () => {
-            await testTranspile(`
+        it('does not add comma after final object property even when comments are present', () => {
+            testTranspile(`
                 sub doSomething()
                     person = {
                         age: 12, 'comment
@@ -1986,8 +1986,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('works for a complex function with comments all over the place', async () => {
-            await testTranspile(`
+        it('works for a complex function with comments all over the place', () => {
+            testTranspile(`
                 'import some library
                 library "v30/bslCore.brs" 'comment
 
@@ -2073,8 +2073,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('simple mapped files include a reference to the source map', async () => {
-            let file = await program.addOrReplaceFile('source/logger.brs', trim`
+        it('simple mapped files include a reference to the source map', () => {
+            let file = program.addOrReplaceFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2083,8 +2083,8 @@ describe('BrsFile', () => {
             expect(code.endsWith(`'//# sourceMappingURL=./logger.brs.map`)).to.be.true;
         });
 
-        it('AST generated files include a reference to the source map', async () => {
-            let file = await program.addOrReplaceFile('source/logger.brs', trim`
+        it('AST generated files include a reference to the source map', () => {
+            let file = program.addOrReplaceFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2096,18 +2096,18 @@ describe('BrsFile', () => {
 
     describe('callfunc operator', () => {
         describe('transpile', () => {
-            it('does not produce diagnostics', async () => {
-                await program.addOrReplaceFile('source/main.bs', `
+            it('does not produce diagnostics', () => {
+                program.addOrReplaceFile('source/main.bs', `
                     sub main()
                         someObject@.someFunction(paramObject.value)
                     end sub
                 `);
-                await program.validate();
+                program.validate();
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
             });
 
-            it('sets invalid on empty callfunc', async () => {
-                await testTranspile(`
+            it('sets invalid on empty callfunc', () => {
+                testTranspile(`
                     sub main()
                         node@.doSomething()
                         m.top.node@.doSomething()
@@ -2122,8 +2122,8 @@ describe('BrsFile', () => {
                 `);
             });
 
-            it('includes original arguments', async () => {
-                await testTranspile(`
+            it('includes original arguments', () => {
+                testTranspile(`
                     sub main()
                         node@.doSomething(1, true, m.top.someVal)
                     end sub
@@ -2170,35 +2170,35 @@ describe('BrsFile', () => {
     });
 
     describe('typedefKey', () => {
-        it('works for .brs files', async () => {
+        it('works for .brs files', () => {
             expect(
-                s((await program.addOrReplaceFile<BrsFile>('source/main.brs', '')).typedefKey)
+                s((program.addOrReplaceFile<BrsFile>('source/main.brs', '')).typedefKey)
             ).to.equal(
                 s`${rootDir.toLowerCase()}/source/main.d.bs`
             );
         });
-        it('returns undefined for files that should not have a typedef', async () => {
-            expect((await program.addOrReplaceFile<BrsFile>('source/main.bs', '')).typedefKey).to.be.undefined;
+        it('returns undefined for files that should not have a typedef', () => {
+            expect((program.addOrReplaceFile<BrsFile>('source/main.bs', '')).typedefKey).to.be.undefined;
 
-            expect((await program.addOrReplaceFile<BrsFile>('source/main.d.bs', '')).typedefKey).to.be.undefined;
+            expect((program.addOrReplaceFile<BrsFile>('source/main.d.bs', '')).typedefKey).to.be.undefined;
 
-            const xmlFile = await program.addOrReplaceFile<BrsFile>('components/comp.xml', '');
+            const xmlFile = program.addOrReplaceFile<BrsFile>('components/comp.xml', '');
             expect(xmlFile.typedefKey).to.be.undefined;
         });
     });
 
 
     describe('type definitions', () => {
-        it('only exposes defined functions even if source has more', async () => {
+        it('only exposes defined functions even if source has more', () => {
             //parse the .brs file first so it doesn't know about the typedef
-            await program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            program.addOrReplaceFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
                 end sub
             `);
 
-            await program.addOrReplaceFile('source/main.d.bs', `
+            program.addOrReplaceFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2209,8 +2209,8 @@ describe('BrsFile', () => {
             expect(functionNames).not.to.include('speak');
         });
 
-        it('reacts to typedef file changes', async () => {
-            let file = await program.addOrReplaceFile<BrsFile>('source/main.brs', `
+        it('reacts to typedef file changes', () => {
+            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2219,7 +2219,7 @@ describe('BrsFile', () => {
             expect(file.hasTypedef).to.be.false;
             expect(file.typedefFile).not.to.exist;
 
-            await program.addOrReplaceFile('source/main.d.bs', `
+            program.addOrReplaceFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2227,7 +2227,7 @@ describe('BrsFile', () => {
             expect(file.typedefFile).to.exist;
 
             //add replace file, does it still find the typedef
-            file = await program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2244,47 +2244,47 @@ describe('BrsFile', () => {
     });
 
     describe('typedef', () => {
-        it('sets typedef path properly', async () => {
-            expect((await program.addOrReplaceFile<BrsFile>('source/main1.brs', '')).typedefKey).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
-            expect((await program.addOrReplaceFile<BrsFile>('source/main2.d.bs', '')).typedefKey).to.equal(undefined);
-            expect((await program.addOrReplaceFile<BrsFile>('source/main3.bs', '')).typedefKey).to.equal(undefined);
+        it('sets typedef path properly', () => {
+            expect((program.addOrReplaceFile<BrsFile>('source/main1.brs', '')).typedefKey).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
+            expect((program.addOrReplaceFile<BrsFile>('source/main2.d.bs', '')).typedefKey).to.equal(undefined);
+            expect((program.addOrReplaceFile<BrsFile>('source/main3.bs', '')).typedefKey).to.equal(undefined);
             //works for dest with `.brs` extension
-            expect((await program.addOrReplaceFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefKey).to.equal(undefined);
+            expect((program.addOrReplaceFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefKey).to.equal(undefined);
         });
 
-        it('does not link when missing from program', async () => {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+        it('does not link when missing from program', () => {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).not.to.exist;
         });
 
-        it('links typedef when added BEFORE .brs file', async () => {
-            const typedef = await program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+        it('links typedef when added BEFORE .brs file', () => {
+            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).to.equal(typedef);
         });
 
-        it('links typedef when added AFTER .brs file', async () => {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
-            const typedef = await program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
+        it('links typedef when added AFTER .brs file', () => {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
             expect(file.typedefFile).to.eql(typedef);
         });
 
-        it('removes typedef link when typedef is removed', async () => {
-            const typedef = await program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+        it('removes typedef link when typedef is removed', () => {
+            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
             program.removeFile(typedef.pathAbsolute);
             expect(file.typedefFile).to.be.undefined;
         });
     });
 
     describe('getTypedef', () => {
-        async function testTypedef(original: string, expected: string) {
-            let file = await program.addOrReplaceFile<BrsFile>('source/main.brs', original);
+        function testTypedef(original: string, expected: string) {
+            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', original);
             expect(file.getTypedef()).to.eql(expected);
         }
 
-        it('strips function body', async () => {
-            await testTypedef(`
+        it('strips function body', () => {
+            testTypedef(`
                 sub main(param1 as string)
                     print "main"
                 end sub
@@ -2294,16 +2294,16 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes import statements', async () => {
-            await testTypedef(`
+        it('includes import statements', () => {
+            testTypedef(`
                import "pkg:/source/lib.brs"
             `, trim`
                 import "pkg:/source/lib.brs"
             `);
         });
 
-        it('includes namespace statements', async () => {
-            await testTypedef(`
+        it('includes namespace statements', () => {
+            testTypedef(`
                 namespace Name
                     sub logInfo()
                     end sub
@@ -2324,8 +2324,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes classes', async () => {
-            await testTypedef(`
+        it('includes classes', () => {
+            testTypedef(`
                 class Person
                     public name as string
                     public age = 12
@@ -2360,8 +2360,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('sets properties to dynamic when initialized to invalid', async () => {
-            await testTypedef(`
+        it('sets properties to dynamic when initialized to invalid', () => {
+            testTypedef(`
                 class Human
                     public firstName = invalid
                     public lastName as string = invalid
@@ -2374,8 +2374,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes class inheritance', async () => {
-            await testTypedef(`
+        it('includes class inheritance', () => {
+            testTypedef(`
                 class Human
                     sub new(name as string)
                         m.name = name
@@ -2398,8 +2398,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes access modifier keyword', async () => {
-            await testTypedef(`
+        it('includes access modifier keyword', () => {
+            testTypedef(`
                 class Human
                     public firstName as string
                     protected middleName as string
@@ -2429,8 +2429,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes overrides keyword if present in source', async () => {
-            await testTypedef(`
+        it('includes overrides keyword if present in source', () => {
+            testTypedef(`
                 class Animal
                     public sub speak()
                         print "Hello Animal"
@@ -2453,8 +2453,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('includes class inheritance cross-namespace', async () => {
-            await testTypedef(`
+        it('includes class inheritance cross-namespace', () => {
+            testTypedef(`
                 namespace NameA
                     class Human
                         sub new(name as string)
@@ -2487,8 +2487,8 @@ describe('BrsFile', () => {
     });
 
     describe('parser getter', () => {
-        it('recreates the parser when missing', async () => {
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', `
+        it('recreates the parser when missing', () => {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -2505,12 +2505,12 @@ describe('BrsFile', () => {
             expect(file.parser).to.equal(newParser);
         });
 
-        it('call parse when previously skipped', async () => {
-            await program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
+        it('call parse when previously skipped', () => {
+            program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
                 sub main()
                 end sub
             `);
-            const file = await program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -2527,8 +2527,8 @@ describe('BrsFile', () => {
     });
 
     describe('Plugins', () => {
-        async function testPluginTranspile() {
-            await testTranspile(`
+        function testPluginTranspile() {
+            testTranspile(`
                 sub main()
                     sayHello(sub()
                         print "sub hello"
@@ -2552,44 +2552,44 @@ describe('BrsFile', () => {
             `);
         }
 
-        it('can use a plugin object which transforms the AST', async () => {
+        it('can use a plugin object which transforms the AST', () => {
             program.plugins = new PluginInterface(
                 util.loadPlugins('', [
                     require.resolve('../examples/plugins/removePrint')
                 ]),
                 undefined
             );
-            await testPluginTranspile();
+            testPluginTranspile();
         });
 
-        it('can load an absolute plugin which transforms the AST', async () => {
+        it('can load an absolute plugin which transforms the AST', () => {
             program.plugins = new PluginInterface(
                 util.loadPlugins('', [
                     path.resolve(process.cwd(), './dist/examples/plugins/removePrint.js')
                 ]),
                 undefined
             );
-            await testPluginTranspile();
+            testPluginTranspile();
         });
 
-        it('can load a relative plugin which transforms the AST', async () => {
+        it('can load a relative plugin which transforms the AST', () => {
             program.plugins = new PluginInterface(
                 util.loadPlugins(process.cwd(), [
                     './dist/examples/plugins/removePrint.js'
                 ]),
                 undefined
             );
-            await testPluginTranspile();
+            testPluginTranspile();
         });
     });
 });
 
 export function getTestTranspile(scopeGetter: () => [Program, string]) {
-    return async (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
+    return (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
         let [program, rootDir] = scopeGetter();
         expected = expected ? expected : source;
-        let file = await program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
-        await program.validate();
+        let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
+        program.validate();
         let diagnostics = file.getDiagnostics();
         if (diagnostics.length > 0 && failOnDiagnostic !== false) {
             throw new Error(

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -48,8 +48,8 @@ describe('XmlFile', () => {
             expect(file.componentName.text).to.equal(expected);
         });
 
-        it('supports importing BrighterScript files', async () => {
-            file = await program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+        it('supports importing BrighterScript files', () => {
+            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.bs" />
@@ -59,8 +59,8 @@ describe('XmlFile', () => {
                 s`components/ChildScene.bs`
             );
         });
-        it('does not include commented-out script imports', async () => {
-            file = await program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+        it('does not include commented-out script imports', () => {
+            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -223,8 +223,8 @@ describe('XmlFile', () => {
             }
         });
 
-        it('resolves relative paths', async () => {
-            file = await program.addOrReplaceFile({
+        it('resolves relative paths', () => {
+            file = program.addOrReplaceFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -240,8 +240,8 @@ describe('XmlFile', () => {
             });
         });
 
-        it('finds correct position for empty uri in script tag', async () => {
-            file = await program.addOrReplaceFile({
+        it('finds correct position for empty uri in script tag', () => {
+            file = program.addOrReplaceFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -258,8 +258,8 @@ describe('XmlFile', () => {
     });
 
     describe('doesReferenceFile', () => {
-        it('compares case insensitive', async () => {
-            let xmlFile = await program.addOrReplaceFile({
+        it('compares case insensitive', () => {
+            let xmlFile = program.addOrReplaceFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -268,7 +268,7 @@ describe('XmlFile', () => {
                     <script type="text/brightscript" uri="HeroGrid.brs" />
                 </component>
             `);
-            let brsFile = await program.addOrReplaceFile({
+            let brsFile = program.addOrReplaceFile({
                 src: `${rootDir}/components/HEROGRID.brs`,
                 dest: `components/HEROGRID.brs`
             }, ``);
@@ -277,26 +277,26 @@ describe('XmlFile', () => {
     });
 
     describe('autoImportComponentScript', () => {
-        it('is not enabled by default', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+        it('is not enabled by default', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
             `);
 
-            await program.validate();
+            program.validate();
 
             expect(
                 program.getDiagnostics().map(x => x.message)
@@ -305,30 +305,30 @@ describe('XmlFile', () => {
             );
         });
 
-        it('is not enabled by default', async () => {
+        it('is not enabled by default', () => {
             program = new Program({
                 rootDir: rootDir,
                 autoImportComponentScript: true
             });
-            await program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            await program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
             `);
 
-            await program.validate();
+            program.validate();
 
             //there should be no errors
             expect(
@@ -360,16 +360,16 @@ describe('XmlFile', () => {
             });
         });
 
-        it('returns empty set when out of range', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+        it('returns empty set when out of range', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
             expect(file.getCompletions(Position.create(99, 99))).to.be.empty;
         });
 
         //TODO - refine this test once cdata scripts are supported
-        it('prevents scope completions entirely', async () => {
-            await program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+        it('prevents scope completions entirely', () => {
+            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
 
-            let xmlFile = await program.addOrReplaceFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./Component1.brs" />
@@ -381,13 +381,13 @@ describe('XmlFile', () => {
     });
 
     describe('getAllDependencies', () => {
-        it('returns own imports', async () => {
-            file = await program.addOrReplaceFile('components/comp1.xml', trim`
+        it('returns own imports', () => {
+            file = program.addOrReplaceFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="BaseScene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
                 </component>
-            `) as any;
+            `);
             expect(file.getOwnDependencies().sort()).to.eql([
                 s`source/lib.brs`,
                 s`source/lib.d.bs`
@@ -395,8 +395,8 @@ describe('XmlFile', () => {
         });
     });
 
-    it('invalidates dependent scopes on change', async () => {
-        let xmlFile = await program.addOrReplaceFile<XmlFile>({
+    it('invalidates dependent scopes on change', () => {
+        let xmlFile = program.addOrReplaceFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -405,23 +405,23 @@ describe('XmlFile', () => {
                 <script type="text/brightscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        await program.validate();
+        program.validate();
         let scope = program.getScopesForFile(xmlFile)[0];
         //scope should be validated
         expect(scope.isValidated);
 
         //add lib1
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, ``);
         //adding a dependent file should have invalidated the scope
         expect(scope.isValidated).to.be.false;
-        await program.validate();
+        program.validate();
         expect(scope.isValidated).to.be.true;
 
         //update lib1 to include an import
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, `
@@ -430,26 +430,26 @@ describe('XmlFile', () => {
 
         //scope should have been invalidated again
         expect(scope.isValidated).to.be.false;
-        await program.validate();
+        program.validate();
         expect(scope.isValidated).to.be.true;
 
         //add the lib2 imported from lib
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/source/lib2.bs`,
             dest: `source/lib2.bs`
         }, ``);
 
         //scope should have been invalidated again because of chained dependency
         expect(scope.isValidated).to.be.false;
-        await program.validate();
+        program.validate();
         expect(scope.isValidated).to.be.true;
 
         program.removeFile(`${rootDir}/source/lib.bs`);
         expect(scope.isValidated).to.be.false;
     });
 
-    it('does not invalidate unrelated scopes on change', async () => {
-        let xmlFile1 = await program.addOrReplaceFile<XmlFile>({
+    it('does not invalidate unrelated scopes on change', () => {
+        let xmlFile1 = program.addOrReplaceFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -459,7 +459,7 @@ describe('XmlFile', () => {
             </component>
         `);
 
-        let xmlFile2 = await program.addOrReplaceFile<XmlFile>({
+        let xmlFile2 = program.addOrReplaceFile<XmlFile>({
             src: `${rootDir}/components/comp2.xml`,
             dest: `components/comp2.xml`
         }, trim`
@@ -468,13 +468,13 @@ describe('XmlFile', () => {
             </component>
         `);
 
-        await program.validate();
+        program.validate();
         //scope should be validated
         expect(program.getScopesForFile(xmlFile1)[0].isValidated).to.be.true;
         expect(program.getScopesForFile(xmlFile2)[0].isValidated).to.be.true;
 
         //add the lib file
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/source/lib.brs`,
             dest: `source/lib.brs`
         }, ``);
@@ -494,8 +494,8 @@ describe('XmlFile', () => {
     });
 
     describe('component extends', () => {
-        it('works for single-line', async () => {
-            file = await program.addOrReplaceFile(
+        it('works for single-line', () => {
+            file = program.addOrReplaceFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -505,12 +505,12 @@ describe('XmlFile', () => {
                     <component name="ChildScene" extends="BaseScene">
                     </component>
                 `
-            ) as any;
+            );
             expect(file.parentComponentName.range).to.eql(Range.create(1, 38, 1, 47));
         });
 
-        it('works for multi-line', async () => {
-            file = await program.addOrReplaceFile(
+        it('works for multi-line', () => {
+            file = program.addOrReplaceFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -521,12 +521,12 @@ describe('XmlFile', () => {
                         extends="BaseScene">
                     </component>
                 `
-            ) as any;
+            );
             expect(file.parentComponentName.range).to.eql(Range.create(2, 13, 2, 22));
         });
 
-        it('does not throw when unable to find extends', async () => {
-            file = await program.addOrReplaceFile(
+        it('does not throw when unable to find extends', () => {
+            file = program.addOrReplaceFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -536,12 +536,12 @@ describe('XmlFile', () => {
                     <component name="ChildScene">
                     </component>
                 `
-            ) as any;
+            );
             expect(file.parentComponentName).to.not.exist;
         });
 
-        it('adds warning when no "extends" attribute is found', async () => {
-            file = await program.addOrReplaceFile<XmlFile>(
+        it('adds warning when no "extends" attribute is found', () => {
+            file = program.addOrReplaceFile<XmlFile>(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -560,16 +560,16 @@ describe('XmlFile', () => {
         });
     });
 
-    it('detects when importing the codebehind file unnecessarily', async () => {
+    it('detects when importing the codebehind file unnecessarily', () => {
         program = new Program({
             autoImportComponentScript: true,
             rootDir: rootDir
         });
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/components/SimpleScene.bs`,
             dest: `components/SimpleScene.bs`
         }, '');
-        await program.addOrReplaceFile({
+        program.addOrReplaceFile({
             src: `${rootDir}/components/SimpleScene.xml`,
             dest: `components/SimpleScene.xml`
         }, trim`
@@ -579,7 +579,7 @@ describe('XmlFile', () => {
             </component>
         `);
 
-        await program.validate();
+        program.validate();
         expect(
             program.getDiagnostics()[0]?.message
         ).to.equal(
@@ -588,13 +588,13 @@ describe('XmlFile', () => {
     });
 
     describe('transpile', () => {
-        it('keeps all content of the XML', async () => {
-            await program.addOrReplaceFile(`components/SimpleScene.bs`, `
+        it('keeps all content of the XML', () => {
+            program.addOrReplaceFile(`components/SimpleScene.bs`, `
                 sub init()
                 end sub
             `);
 
-            await testTranspile(trim`
+            testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component
                     name="SimpleScene" extends="Scene"
@@ -630,13 +630,13 @@ describe('XmlFile', () => {
             `, 'none', 'components/SimpleScene.xml');
         });
 
-        it('changes file extensions to brs from bs', async () => {
-            await program.addOrReplaceFile(`components/SimpleScene.bs`, `
+        it('changes file extensions to brs from bs', () => {
+            program.addOrReplaceFile(`components/SimpleScene.bs`, `
                 import "pkg:/source/lib.bs"
             `);
-            await program.addOrReplaceFile('source/lib.bs', ``);
+            program.addOrReplaceFile('source/lib.bs', ``);
 
-            await testTranspile(trim`
+            testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
                     <script type="text/brighterscript" uri="SimpleScene.bs"/>
@@ -651,8 +651,8 @@ describe('XmlFile', () => {
             `, 'none', 'components/SimpleScene.xml');
         });
 
-        it('returns the XML unmodified if needsTranspiled is false', async () => {
-            let file = await program.addOrReplaceFile(
+        it('returns the XML unmodified if needsTranspiled is false', () => {
+            let file = program.addOrReplaceFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -672,8 +672,8 @@ describe('XmlFile', () => {
             `);
         });
 
-        it('needsTranspiled is false by default', async () => {
-            let file = await program.addOrReplaceFile(
+        it('needsTranspiled is false by default', () => {
+            let file = program.addOrReplaceFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -683,8 +683,8 @@ describe('XmlFile', () => {
             expect(file.needsTranspiled).to.be.false;
         });
 
-        it('needsTranspiled is true if an import is brighterscript', async () => {
-            let file = await program.addOrReplaceFile(
+        it('needsTranspiled is true if an import is brighterscript', () => {
+            let file = program.addOrReplaceFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -695,8 +695,8 @@ describe('XmlFile', () => {
             expect(file.needsTranspiled).to.be.true;
         });
 
-        it('simple source mapping includes sourcemap reference', async () => {
-            let file = await program.addOrReplaceFile(
+        it('simple source mapping includes sourcemap reference', () => {
+            let file = program.addOrReplaceFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -709,8 +709,8 @@ describe('XmlFile', () => {
             expect(code.endsWith(`<!--//# sourceMappingURL=./SimpleScene.xml.map -->`)).to.be.true;
         });
 
-        it('AST-based source mapping includes sourcemap reference', async () => {
-            let file = await program.addOrReplaceFile(
+        it('AST-based source mapping includes sourcemap reference', () => {
+            let file = program.addOrReplaceFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -750,7 +750,7 @@ describe('XmlFile', () => {
         });
     });
 
-    it('plugin diagnostics work for xml files', async () => {
+    it('plugin diagnostics work for xml files', () => {
         program.plugins.add({
             name: 'Xml diagnostic test',
             afterFileParse: (file) => {
@@ -765,12 +765,12 @@ describe('XmlFile', () => {
             }
         });
 
-        await program.addOrReplaceFile('components/comp.xml', trim`
+        program.addOrReplaceFile('components/comp.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
             </component>
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics().map(x => ({ message: x.message, code: x.code }))).to.eql([{
             message: 'Test diagnostic',
             code: 9999
@@ -778,50 +778,50 @@ describe('XmlFile', () => {
     });
 
     describe('typedef', () => {
-        it('loads d.bs files from parent scope', async () => {
-            await program.addOrReplaceFile<XmlFile>('components/ParentComponent.xml', trim`
+        it('loads d.bs files from parent scope', () => {
+            program.addOrReplaceFile<XmlFile>('components/ParentComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent" extends="Scene">
                     <script uri="ParentComponent.brs" />
                 </component>
             `);
 
-            await program.addOrReplaceFile('components/ParentComponent.d.bs', `
+            program.addOrReplaceFile('components/ParentComponent.d.bs', `
                 import "Lib.brs"
                 namespace Parent
                     sub log()
                     end sub
                 end namespace
             `);
-            await program.addOrReplaceFile('components/ParentComponent.brs', `
+            program.addOrReplaceFile('components/ParentComponent.brs', `
                 sub Parent_log()
                 end sub
             `);
 
-            await program.addOrReplaceFile('components/Lib.d.bs', `
+            program.addOrReplaceFile('components/Lib.d.bs', `
                 namespace Lib
                     sub log()
                     end sub
                 end namespace
             `);
-            await program.addOrReplaceFile('components/Lib.brs', `
+            program.addOrReplaceFile('components/Lib.brs', `
                 sub Lib_log()
                 end sub
             `);
 
-            await program.addOrReplaceFile<XmlFile>('components/ChildComponent.xml', trim`
+            program.addOrReplaceFile<XmlFile>('components/ChildComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                     <script uri="ChildComponent.bs" />
                 </component>
             `);
-            await program.addOrReplaceFile('components/ChildComponent.bs', `
+            program.addOrReplaceFile('components/ChildComponent.bs', `
                 sub init()
                     Parent.log()
                     Lib.log()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
             const scope = program.getComponentScope('ChildComponent');
             expect(Object.keys(scope.namespaceLookup).sort()).to.eql([
@@ -830,14 +830,14 @@ describe('XmlFile', () => {
             ]);
         });
 
-        it('loads `d.bs` files into scope', async () => {
-            const xmlFile = await program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+        it('loads `d.bs` files into scope', () => {
+            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
                 </component>
             `);
-            await program.addOrReplaceFile('components/Component1.d.bs', `
+            program.addOrReplaceFile('components/Component1.d.bs', `
                 sub logInfo()
                 end sub
             `);
@@ -845,21 +845,21 @@ describe('XmlFile', () => {
             expect(program.getScopesForFile(xmlFile)[0].getAllCallables().map(x => x.callable.name)).to.include('logInfo');
         });
 
-        it('does not include `d.bs` script during transpile', async () => {
-            await program.addOrReplaceFile('source/logger.d.bs', `
+        it('does not include `d.bs` script during transpile', () => {
+            program.addOrReplaceFile('source/logger.d.bs', `
                 sub logInfo()
                 end sub
             `);
-            await program.addOrReplaceFile('source/logger.brs', `
+            program.addOrReplaceFile('source/logger.brs', `
                 sub logInfo()
                 end sub
             `);
-            await program.addOrReplaceFile('components/Component1.bs', `
+            program.addOrReplaceFile('components/Component1.bs', `
                 import "pkg:/source/logger.brs"
                 sub logInfo()
                 end sub
             `);
-            await testTranspile(trim`
+            testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brighterscript" uri="Component1.bs" />
@@ -874,8 +874,8 @@ describe('XmlFile', () => {
             `, 'none', 'components/Component1.xml');
         });
 
-        it('does not load .brs information into scope if related d.bs is in scope', async () => {
-            const xmlFile = await program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+        it('does not load .brs information into scope if related d.bs is in scope', () => {
+            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -884,7 +884,7 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            await program.addOrReplaceFile('components/Component1.brs', `
+            program.addOrReplaceFile('components/Component1.brs', `
                 sub logInfo()
                 end sub
                 sub logWarning()
@@ -896,7 +896,7 @@ describe('XmlFile', () => {
             expect(functionNames).to.include('logWarning');
 
             //load d.bs file, which should shadow out the .brs file
-            await program.addOrReplaceFile('components/Component1.d.bs', `
+            program.addOrReplaceFile('components/Component1.d.bs', `
                 sub logError()
                 end sub
             `);
@@ -907,8 +907,8 @@ describe('XmlFile', () => {
             expect(functionNames).not.to.include('logWarning');
         });
 
-        it('updates xml scope when typedef disappears', async () => {
-            const xmlFile = await program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+        it('updates xml scope when typedef disappears', () => {
+            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -917,16 +917,16 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            await program.addOrReplaceFile('components/Component1.brs', `
+            program.addOrReplaceFile('components/Component1.brs', `
                 sub logBrs()
                 end sub
             `);
             //load d.bs file, which should shadow out the .brs file
-            const typedef = await program.addOrReplaceFile('components/Component1.d.bs', `
+            const typedef = program.addOrReplaceFile('components/Component1.d.bs', `
                 sub logTypedef()
                 end sub
             `);
-            await program.validate();
+            program.validate();
             let functionNames = scope.getOwnCallables().map(x => x.callable.name);
             expect(functionNames).to.include('logTypedef');
             expect(functionNames).not.to.include('logBrs');
@@ -934,15 +934,15 @@ describe('XmlFile', () => {
             //remove the typdef file
             program.removeFile(typedef.pathAbsolute);
 
-            await program.validate();
+            program.validate();
             functionNames = scope.getOwnCallables().map(x => x.callable.name);
             expect(functionNames).not.to.include('logTypedef');
             expect(functionNames).to.include('logBrs');
         });
     });
 
-    it('finds script imports for single-quoted script tags', async () => {
-        const file = await program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+    it('finds script imports for single-quoted script tags', () => {
+        const file = program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
                 <script uri='SingleQuotedFile.brs' />

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -34,14 +34,14 @@ describe('import statements', () => {
     });
 
     it('still transpiles import statements if found at bottom of file', async () => {
-        await program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.addOrReplaceFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="Scene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
 
-        await program.addOrReplaceFile('source/lib.bs', `
+        program.addOrReplaceFile('source/lib.bs', `
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
@@ -49,7 +49,7 @@ describe('import statements', () => {
             import "stringOps.bs"
         `);
 
-        await program.addOrReplaceFile('source/stringOps.bs', `
+        program.addOrReplaceFile('source/stringOps.bs', `
             function StringToLower(strVal as string)
                 return true
             end function
@@ -73,32 +73,32 @@ describe('import statements', () => {
         `);
     });
 
-    it('finds function loaded in by import multiple levels deep', async () => {
+    it('finds function loaded in by import multiple levels deep', () => {
         //create child component
-        let component = await program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        await program.addOrReplaceFile('source/lib.bs', `
+        program.addOrReplaceFile('source/lib.bs', `
             import "stringOps.bs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        await program.addOrReplaceFile('source/stringOps.bs', `
+        program.addOrReplaceFile('source/stringOps.bs', `
             import "intOps.bs"
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
         `);
-        await program.addOrReplaceFile('source/intOps.bs', `
+        program.addOrReplaceFile('source/intOps.bs', `
             function isInt(strVal as dynamic)
                 return true
             end function
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics().map(x => x.message)[0]).to.not.exist;
         expect(
             (component as XmlFile).getAvailableScriptImports().sort()
@@ -109,26 +109,26 @@ describe('import statements', () => {
         ]);
     });
 
-    it('supports importing brs files', async () => {
+    it('supports importing brs files', () => {
         //create child component
-        let component = await program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        await program.addOrReplaceFile('source/lib.bs', `
+        program.addOrReplaceFile('source/lib.bs', `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        await program.addOrReplaceFile('source/stringOps.brs', `
+        program.addOrReplaceFile('source/stringOps.brs', `
             function StringToLower(strVal as string)
                 return lcase(strVal)
             end function
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics().map(x => x.message)[0]).to.not.exist;
         expect(
             (component as XmlFile).getAvailableScriptImports()
@@ -138,65 +138,65 @@ describe('import statements', () => {
         ]);
     });
 
-    it('detects when dependency contents have changed', async () => {
+    it('detects when dependency contents have changed', () => {
         //create child component
-        await program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.addOrReplaceFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="lib.bs" />
             </component>
         `);
-        await program.addOrReplaceFile('components/lib.bs', `
+        program.addOrReplaceFile('components/lib.bs', `
             import "animalActions.bs"
             function init1(strVal as string)
                 Waddle()
             end function
         `);
         //add the empty dependency
-        await program.addOrReplaceFile('components/animalActions.bs', ``);
+        program.addOrReplaceFile('components/animalActions.bs', ``);
 
         //there should be an error because that function doesn't exist
-        await program.validate();
+        program.validate();
 
         expect(program.getDiagnostics().map(x => x.message)).to.eql([
             DiagnosticMessages.callToUnknownFunction('Waddle', s`components/ChildScene.xml`).message
         ]);
 
         //change the dependency to now contain the file. the scope should re-validate
-        await program.addOrReplaceFile('components/animalActions.bs', `
+        program.addOrReplaceFile('components/animalActions.bs', `
             sub Waddle()
                 print "Waddling"
             end sub
         `);
 
         //validate again
-        await program.validate();
+        program.validate();
 
         //the error should be gone
         expect(program.getDiagnostics()).to.be.empty;
 
     });
 
-    it('adds brs imports to xml file during transpile', async () => {
+    it('adds brs imports to xml file during transpile', () => {
         //create child component
-        let component = await program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+        let component = program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        await program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
+        program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        await program.addOrReplaceFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
+        program.addOrReplaceFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
         `);
-        await program.validate();
+        program.validate();
         expect(trimMap(component.transpile().code)).to.equal(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
@@ -207,36 +207,36 @@ describe('import statements', () => {
         `);
     });
 
-    it('shows diagnostic for missing file in import', async () => {
+    it('shows diagnostic for missing file in import', () => {
         //create child component
-        await program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.addOrReplaceFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="ChildScene.bs" />
             </component>
         `);
-        await program.addOrReplaceFile('components/ChildScene.bs', `
+        program.addOrReplaceFile('components/ChildScene.bs', `
             import "stringOps.bs"
             sub init()
             end sub
         `);
-        await program.validate();
+        program.validate();
         expect(program.getDiagnostics().map(x => x.message)[0]).to.eql(DiagnosticMessages.referencedFileDoesNotExist().message);
     });
 
-    it('complicated import graph adds correct script tags', async () => {
-        await program.addOrReplaceFile('source/maestro/ioc/IOCMixin.bs', `
+    it('complicated import graph adds correct script tags', () => {
+        program.addOrReplaceFile('source/maestro/ioc/IOCMixin.bs', `
             sub DoIocThings()
             end sub
         `);
-        await program.addOrReplaceFile('source/BaseClass.bs', `
+        program.addOrReplaceFile('source/BaseClass.bs', `
             import "pkg:/source/maestro/ioc/IOCMixin.bs"
         `);
 
-        await program.addOrReplaceFile('components/AuthManager.bs', `
+        program.addOrReplaceFile('components/AuthManager.bs', `
             import "pkg:/source/BaseClass.bs"
         `);
-        await testTranspile(trim`
+        testTranspile(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="AuthManager.bs" />
@@ -252,9 +252,9 @@ describe('import statements', () => {
         `, null, 'components/AuthenticationService.xml');
     });
 
-    it('handles malformed imports', async () => {
+    it('handles malformed imports', () => {
         //shouldn't crash
-        const brsFile = await program.addOrReplaceFile<BrsFile>('source/SomeFile.bs', `
+        const brsFile = program.addOrReplaceFile<BrsFile>('source/SomeFile.bs', `
             import ""
             import ":"
             import ":/"

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -19,45 +19,45 @@ describe('globalCallables', () => {
     });
 
     describe('val', () => {
-        it('allows single parameter', async () => {
-            await program.addOrReplaceFile('source/main.brs', `
+        it('allows single parameter', () => {
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     print val("1001")
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
 
-        it('allows both parameters', async () => {
-            await program.addOrReplaceFile('source/main.brs', `
+        it('allows both parameters', () => {
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     print val("1001", 10)
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
     });
 
     describe('StrI', () => {
-        it('allows single parameter', async () => {
-            await program.addOrReplaceFile('source/main.brs', `
+        it('allows single parameter', () => {
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     print StrI(2)
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
 
-        it('allows both parameters', async () => {
-            await program.addOrReplaceFile('source/main.brs', `
+        it('allows both parameters', () => {
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     print StrI(2, 10)
                 end sub
             `);
-            await program.validate();
+            program.validate();
             expect(program.getDiagnostics()[0]?.message).not.to.exist;
         });
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -194,3 +194,5 @@ export interface TypedefProvider {
 }
 
 export type TranspileResult = Array<(string | SourceNode)>;
+
+export type FileResolver = (pathAbsolute: string) => string | undefined | Thenable<string | undefined> | void;

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -92,8 +92,8 @@ describe('Statement', () => {
 
     describe('ImportStatement', () => {
         describe('getTypedef', () => {
-            it('changes .bs file extensions to .brs', async () => {
-                const file = await program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            it('changes .bs file extensions to .brs', () => {
+                const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
                     import "lib1.bs"
                     import "pkg:/source/lib2.bs"
                 `);

--- a/src/parser/tests/expression/SourceLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/SourceLiteralExpression.spec.ts
@@ -17,8 +17,8 @@ describe('SourceLiteralExpression', () => {
 
     describe('transpile', () => {
 
-        it('allows bs source literals local vars in brs mode', async () => {
-            await testTranspile(`
+        it('allows bs source literals local vars in brs mode', () => {
+            testTranspile(`
                 sub main()
                     source_file_path = true
                     source_line_num = true
@@ -40,8 +40,8 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'none', 'main.brs');
         });
 
-        it('computes SOURCE_FILE_PATH', async () => {
-            await testTranspile(`
+        it('computes SOURCE_FILE_PATH', () => {
+            testTranspile(`
                 sub main()
                     print SOURCE_FILE_PATH
                 end sub
@@ -52,8 +52,8 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('computes SOURCE_LINE_NUM', async () => {
-            await testTranspile(`
+        it('computes SOURCE_LINE_NUM', () => {
+            testTranspile(`
                 sub main()
                     print SOURCE_LINE_NUM
                     print "hello world"
@@ -68,8 +68,8 @@ describe('SourceLiteralExpression', () => {
             `);
         });
 
-        it('computes FUNCTION_NAME', async () => {
-            await testTranspile(`
+        it('computes FUNCTION_NAME', () => {
+            testTranspile(`
                 sub main1()
                     print FUNCTION_NAME
                 end sub
@@ -88,8 +88,8 @@ describe('SourceLiteralExpression', () => {
             `);
         });
 
-        it('computes SOURCE_FUNCTION_NAME', async () => {
-            await testTranspile(`
+        it('computes SOURCE_FUNCTION_NAME', () => {
+            testTranspile(`
                 sub main1()
                     print SOURCE_FUNCTION_NAME
                 end sub
@@ -108,8 +108,8 @@ describe('SourceLiteralExpression', () => {
             `);
         });
 
-        it('SOURCE_FUNCTION_NAME computes nested anon', async () => {
-            await testTranspile(`
+        it('SOURCE_FUNCTION_NAME computes nested anon', () => {
+            testTranspile(`
                 namespace NameA
                     sub main()
                         speak = sub()
@@ -132,8 +132,8 @@ describe('SourceLiteralExpression', () => {
             `);
         });
 
-        it('computes SOURCE_LOCATION', async () => {
-            await testTranspile(`
+        it('computes SOURCE_LOCATION', () => {
+            testTranspile(`
                 sub main()
                     print SOURCE_LOCATION
                 end sub
@@ -144,8 +144,8 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('computes PKG_PATH', async () => {
-            await testTranspile(`
+        it('computes PKG_PATH', () => {
+            testTranspile(`
                 sub main()
                     print PKG_PATH
                 end sub
@@ -156,8 +156,8 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('computes PKG_LOCATION', async () => {
-            await testTranspile(`
+        it('computes PKG_LOCATION', () => {
+            testTranspile(`
                 sub main()
                     print PKG_LOCATION
                 end sub
@@ -168,21 +168,21 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('retains LINE_NUM', async () => {
-            await testTranspile(`
+        it('retains LINE_NUM', () => {
+            testTranspile(`
                 sub main()
                     print LINE_NUM
                 end sub
             `);
         });
 
-        it('accounts for sourceRoot in SOURCE_FILE_PATH', async () => {
+        it('accounts for sourceRoot in SOURCE_FILE_PATH', () => {
             let sourceRoot = s`${process.cwd()} / sourceRoot`;
             program = new Program({
                 rootDir: rootDir,
                 sourceRoot: sourceRoot
             });
-            await testTranspile(`
+            testTranspile(`
                 sub main()
                     print SOURCE_FILE_PATH
                 end sub
@@ -193,13 +193,13 @@ describe('SourceLiteralExpression', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('accounts for sourceRoot in SOURCE_LOCATION', async () => {
+        it('accounts for sourceRoot in SOURCE_LOCATION', () => {
             let sourceRoot = s`${process.cwd()} / sourceRoot`;
             program = new Program({
                 rootDir: rootDir,
                 sourceRoot: sourceRoot
             });
-            await testTranspile(`
+            testTranspile(`
                 sub main()
                     print SOURCE_LOCATION
                 end sub

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -74,64 +74,64 @@ describe('TemplateStringExpression', () => {
             program.dispose();
         });
 
-        it('properly transpiles simple template string', async () => {
-            await testTranspile(
+        it('properly transpiles simple template string', () => {
+            testTranspile(
                 'a = `hello world`',
                 'a = "hello world"'
             );
         });
 
-        it('properly transpiles one line template string with expressions', async () => {
-            await testTranspile(
+        it('properly transpiles one line template string with expressions', () => {
+            testTranspile(
                 'a = `hello ${a.text} world ${"template" + m.getChars()} test`',
                 `a = "hello " + bslib_toString(a.text) + " world " + bslib_toString("template" + m.getChars()) + " test"`
             );
         });
 
-        it('handles escaped characters', async () => {
-            await testTranspile(
+        it('handles escaped characters', () => {
+            testTranspile(
                 'a = `\\r\\n\\`\\$`',
                 `a = chr(13) + chr(10) + chr(96) + chr(36)`
             );
         });
 
-        it('handles escaped unicode char codes', async () => {
-            await testTranspile(
+        it('handles escaped unicode char codes', () => {
+            testTranspile(
                 'a = `\\c2\\c987`',
                 `a = chr(2) + chr(987)`
             );
         });
 
-        it('properly transpiles simple multiline template string', async () => {
-            await testTranspile(
+        it('properly transpiles simple multiline template string', () => {
+            testTranspile(
                 'a = `hello world\nI am multiline`',
                 'a = "hello world" + chr(10) + "I am multiline"'
             );
         });
 
-        it('properly handles newlines', async () => {
-            await testTranspile(
+        it('properly handles newlines', () => {
+            testTranspile(
                 'a = `\n`',
                 'a = chr(10)'
             );
         });
 
-        it('properly handles clrf', async () => {
-            await testTranspile(
+        it('properly handles clrf', () => {
+            testTranspile(
                 'a = `\r\n`',
                 'a = chr(13) + chr(10)'
             );
         });
 
-        it('properly transpiles more complex multiline template string', async () => {
-            await testTranspile(
+        it('properly transpiles more complex multiline template string', () => {
+            testTranspile(
                 'a = `I am multiline\n${a.isRunning()}\nmore`',
                 'a = "I am multiline" + chr(10) + bslib_toString(a.isRunning()) + chr(10) + "more"'
             );
         });
 
-        it('properly transpiles complex multiline template string in array def', async () => {
-            await testTranspile(
+        it('properly transpiles complex multiline template string in array def', () => {
+            testTranspile(
                 `a = [
                     "one",
                     "two",
@@ -150,8 +150,8 @@ describe('TemplateStringExpression', () => {
             `);
         });
 
-        it('properly transpiles complex multiline template string in array def, with nested template', async () => {
-            await testTranspile(`
+        it('properly transpiles complex multiline template string in array def, with nested template', () => {
+            testTranspile(`
                 a = [
                     "one",
                     "two",
@@ -176,8 +176,8 @@ describe('TemplateStringExpression', () => {
             `);
         });
 
-        it('skips calling toString on strings', async () => {
-            await testTranspile(`
+        it('skips calling toString on strings', () => {
+            testTranspile(`
                 text = \`Hello \${"world"}\`
             `, `
                 text = "Hello " + "world"
@@ -185,8 +185,8 @@ describe('TemplateStringExpression', () => {
         });
 
         describe('tagged template strings', () => {
-            it('properly transpiles with escaped characters and quasis', async () => {
-                await testTranspile(`
+            it('properly transpiles with escaped characters and quasis', () => {
+                testTranspile(`
                     function zombify(strings, values)
                     end function
                     sub main()
@@ -202,8 +202,8 @@ describe('TemplateStringExpression', () => {
                 `);
             });
 
-            it('handles multiple embedded expressions', async () => {
-                await testTranspile(`
+            it('handles multiple embedded expressions', () => {
+                testTranspile(`
                     function zombify(strings, values)
                     end function
                     sub main()

--- a/src/preprocessor/Manifest.spec.ts
+++ b/src/preprocessor/Manifest.spec.ts
@@ -13,7 +13,7 @@
 //     });
 
 //     describe('manifest parser', () => {
-//         it.only('returns an empty map if manifest not found', async () => {
+//         it('returns an empty map if manifest not found', async () => {
 //             // sinon.stub(fsExtra, 'readFile').returns(<any>
 //             //     Promise.reject(
 //             //         new Error('File not found')

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -26,7 +26,7 @@ describe('util', () => {
 
     describe('fileExists', () => {
         it('returns false when no value is passed', async () => {
-            expect(await util.fileExists(undefined)).to.be.false;
+            expect(await util.pathExists(undefined)).to.be.false;
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,21 +28,8 @@ import type { Token } from './lexer';
 import { TokenKind } from './lexer';
 import { isBrsFile, isDottedGetExpression, isVariableExpression } from './astUtils';
 import { CustomType } from './types/CustomType';
-import type { FileResolver } from './Program';
 
 export class Util {
-
-    public fileResolver = {
-        readFile: (filePath) => {
-            return fsExtra.readFile(filePath).then((value) => {
-                return value.toString();
-            });
-        },
-        readFileSync: (filePath) => {
-            return fsExtra.readFileSync(filePath).toString();
-        }
-    } as FileResolver;
-
     public clearConsole() {
         // process.stdout.write('\x1Bc');
     }


### PR DESCRIPTION
Since the xml parser change removed the need for any async parsing, there's no benefit to having async file adding logic at all in the Program and downstream. Notable changes:
 - remove all unnecessary async functionality from `Program`, `BrsFile`, `XmlFile`. 
 - The `ProgramBuilder` still uses async logic when loading files because it yields a lot of performance benefits.
 - Moved `fileResolver` logic out of `Program` and into `ProgramBuilder` so the language server can continue to use the in-memory `Document` stores
 - Changed `fileResolver` into an object with `readFile` and `readFileSync` functions so we can use the proper function when needed.
 - renamed `fileExists` to `pathExists` and `pathExistsSync` to line up with the ones from `fs-extra`

I broke the commits up so you can see just the raw api changes in [this commit](https://github.com/rokucommunity/brighterscript/commit/5ef936f95e75c9c309dde193945ae779884cef32), and then all the unit tests in [this commit](https://github.com/rokucommunity/brighterscript/commit/92776895fe1e5cf4751816e6a690e1e3c4f080e0). 