### PR TITLE
ForEach item completions

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -685,6 +685,34 @@ describe('Program', () => {
     });
 
     describe('getCompletions', () => {
+        it('includes `for each` variable', () => {
+            program.addOrReplaceFile('source/main.brs', `
+                sub main()
+                    items = [1, 2, 3]
+                    for each thing in items
+                        t =
+                    end for
+                    end for
+                end sub
+            `);
+            program.validate();
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(4, 28)).map(x => x.label);
+            expect(completions).to.include('thing');
+        });
+
+        it('includes `for` variable', () => {
+            program.addOrReplaceFile('source/main.brs', `
+                sub main()
+                    for i = 0 to 10
+                        t =
+                    end for
+                end sub
+            `);
+            program.validate();
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 28)).map(x => x.label);
+            expect(completions).to.include('i');
+        });
+
         it('should include first-level namespace names for brighterscript files', () => {
             program.addOrReplaceFile('source/main.bs', `
                 namespace NameA.NameB.NameC

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -669,8 +669,6 @@ export class Program {
         //if there are no scopes, include the global scope so we at least get the built-in functions
         scopes = scopes.length > 0 ? scopes : [this.globalScope];
 
-        //get the completions for this file for every scope
-
         //get the completions from all scopes for this file
         let allCompletions = util.flatMap(
             scopes.map(ctx => file.getCompletions(position, ctx)),

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -501,6 +501,20 @@ export class BrsFile {
                 });
             }
 
+            //add all of ForEachStatement loop varibales
+            func.body.walk(createVisitor({
+                ForEachStatement: (stmt) => {
+                    scope.variableDeclarations.push({
+                        nameRange: stmt.item.range,
+                        lineIndex: stmt.item.range.start.line,
+                        name: stmt.item.text,
+                        type: new DynamicType()
+                    });
+                }
+            }), {
+                walkMode: WalkMode.visitStatements
+            });
+
             this.scopesByFunc.set(func, scope);
 
             //find every statement in the scope


### PR DESCRIPTION
The loop item in `for each` statements is not currently showing up in completions. [this pr](https://github.com/rokucommunity/brighterscript/pull/258) attempted to fix that, but it quickly morphed into an entirely different type of PR. 

This PR fixes the original issue. I did use the `walk` function, but only for `WalkMode.VisitStatements`. The local benchmarks show that the walk doesn't have any significant impact on performance (and remember these numbers are ops/sec for parsing the [Roku-GooglePhotos](https://github.com/chtaylo2/Roku-GooglePhotos) project) :
![image](https://user-images.githubusercontent.com/2544493/105483951-9a549f00-5c78-11eb-99cb-b5b77262999b.png)

Once #258 lands, the code in this PR will be obsolete, but this helps bridge the gap in the short-term. 
