### PR TITLE
catch errors when getting signatures

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -963,21 +963,25 @@ export class LanguageServer {
         const filepath = util.uriToPath(params.textDocument.uri);
         await this.keyedThrottler.onIdleOnce(filepath, true);
 
-        const signatures = util.flatMap(
-            await Promise.all(this.getWorkspaces().map(workspace => workspace.builder.program.getSignatureHelp(filepath, params.position)
-            )),
-            c => c
-        );
+        try {
+            let signatures = util.flatMap(
+                await Promise.all(this.getWorkspaces().map(workspace => workspace.builder.program.getSignatureHelp(filepath, params.position)
+                )),
+                c => c
+            );
 
-        const activeSignature = signatures.length > 0 ? 0 : null;
-        const activeParameter = activeSignature >= 0 ? signatures[activeSignature].index : null;
-        let results: SignatureHelp = {
-            signatures: signatures.map((s) => s.signature),
-            activeSignature: activeSignature,
-            activeParameter: activeParameter
-        };
+            const activeSignature = signatures.length > 0 ? 0 : null;
+            const activeParameter = activeSignature >= 0 ? signatures[activeSignature].index : null;
+            let results: SignatureHelp = {
+                signatures: signatures.map((s) => s.signature),
+                activeSignature: activeSignature,
+                activeParameter: activeParameter
+            };
 
-        return results;
+            return results;
+        } catch (e) {
+            return undefined;
+        }
     }
 
     private async onReferences(params: ReferenceParams) {

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -964,14 +964,14 @@ export class LanguageServer {
         await this.keyedThrottler.onIdleOnce(filepath, true);
 
         try {
-            let signatures = util.flatMap(
+            const signatures = util.flatMap(
                 await Promise.all(this.getWorkspaces().map(workspace => workspace.builder.program.getSignatureHelp(filepath, params.position)
                 )),
                 c => c
             );
 
             const activeSignature = signatures.length > 0 ? 0 : null;
-            const activeParameter = activeSignature >= 0 ? signatures[activeSignature].index : null;
+            const activeParameter = (activeSignature >= 0 && signatures[activeSignature]) ? signatures[activeSignature].index : null;
             let results: SignatureHelp = {
                 signatures: signatures.map((s) => s.signature),
                 activeSignature: activeSignature,
@@ -980,7 +980,12 @@ export class LanguageServer {
 
             return results;
         } catch (e) {
-            return undefined;
+            console.error('error in onSigHelp', e);
+            return {
+                signatures: [],
+                activeSignature: 0,
+                activeParameter: 0
+            };
         }
     }
 


### PR DESCRIPTION
Ive seen a few times where I've had errors on getting signature completions. I dont' have time to work out what they are now (they're related to typing fast, with @. afaict); so this is a stop gap.