### PR TITLE
Annotation fixes

### DIFF
--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -644,7 +644,19 @@ describe('parser', () => {
                 sub main()
                 end sub
             `, ParseMode.BrighterScript);
-            expect(diagnostics[0]?.code).to.equal(1081); //unexpected token '@'
+            expect(diagnostics[0]?.message).to.equal(DiagnosticMessages.foundUnexpectedToken('@').message);
+        });
+
+        it('properly handles empty annotation above class method', () => {
+            //this code used to cause an infinite loop, so the fact that the test passes/fails on its own is a success!
+            let { diagnostics } = parse(`
+                class Person
+                    @
+                    sub new()
+                    end sub
+                end class
+            `, ParseMode.BrighterScript);
+            expect(diagnostics[0]?.message).to.equal(DiagnosticMessages.expectedIdentifier().message);
         });
 
         it('parses with error if annotation is not followed by a statement', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -382,7 +382,7 @@ export class Parser {
                 let decl: Statement;
                 let accessModifier: Token;
 
-                if (this.check(TokenKind.At) && this.checkNext(TokenKind.Identifier)) {
+                if (this.check(TokenKind.At)) {
                     this.annotationExpression();
                 }
 
@@ -1174,10 +1174,12 @@ export class Parser {
     }
 
     private annotationExpression() {
-        let annotation = new AnnotationExpression(
-            this.advance(),
-            this.advance()
-        );
+        const atToken = this.advance();
+        const identifier = this.tryConsume(DiagnosticMessages.expectedIdentifier(), TokenKind.Identifier, ...AllowedProperties);
+        if (identifier) {
+            identifier.kind = TokenKind.Identifier;
+        }
+        let annotation = new AnnotationExpression(atToken, identifier);
         this.pendingAnnotations.push(annotation);
 
         //optional arguments


### PR DESCRIPTION
Currently an empty annotation symbol `@` above class methods will cause an infinite loop in the parser. This fixes that issue.