### PR TITLE
Better handling for `createStringLiteral`

### DIFF
--- a/src/astUtils/creators.spec.ts
+++ b/src/astUtils/creators.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { createStringLiteral } from './creators';
+
+describe('creators', () => {
+
+    describe('createStringLiteral', () => {
+        it('wraps the value in quotes', () => {
+            expect(createStringLiteral('hello world').token.text).to.equal('"hello world"');
+        });
+        it('does not wrap already-quoted value in extra quotes', () => {
+            expect(createStringLiteral('"hello world"').token.text).to.equal('"hello world"');
+        });
+
+        it('does not wrap badly quoted value in additional quotes', () => {
+            //leading
+            expect(createStringLiteral('"hello world').token.text).to.equal('"hello world');
+            //trailing
+            expect(createStringLiteral('hello world"').token.text).to.equal('hello world"');
+        });
+    });
+});

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -46,7 +46,7 @@ export function createDottedIdentifier(path: string[], range?: Range, namespaceN
  */
 export function createStringLiteral(value: string, range?: Range) {
     //wrap the value in double quotes
-    if (value.startsWith('"') === false && value.endsWith('"') === false) {
+    if (!value.startsWith('"') && !value.endsWith('"')) {
         value = '"' + value + '"';
     }
     return new LiteralExpression(createToken(TokenKind.StringLiteral, value, range));

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -39,7 +39,16 @@ export function createDottedIdentifier(path: string[], range?: Range, namespaceN
     return new DottedGetExpression(obj, createToken(TokenKind.Identifier, ident, range), createToken(TokenKind.Dot, '.', range));
 }
 
+/**
+ * Create a StringLiteralExpression. The TokenKind.StringLiteral token value includes the leading and trailing doublequote during lexing.
+ * Since brightscript doesn't support strings with quotes in them, we can safely auto-detect and wrap the value in quotes in this function.
+ * @param value - the string value. (value will be wrapped in quotes if they are missing)
+ */
 export function createStringLiteral(value: string, range?: Range) {
+    //wrap the value in double quotes
+    if (value.startsWith('"') === false && value.endsWith('"') === false) {
+        value = '"' + value + '"';
+    }
     return new LiteralExpression(createToken(TokenKind.StringLiteral, value, range));
 }
 export function createIntegerLiteral(value: string, range?: Range) {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -17,7 +17,9 @@ import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
 import { trim, trimMap } from '../testHelpers.spec';
-import { ParseMode } from '../parser/Parser';
+import { ParseMode, Parser } from '../parser/Parser';
+import { createStringLiteral, createToken } from '../astUtils/creators';
+import { ClassFieldStatement } from '../parser/Statement';
 
 let sinon = sinonImport.createSandbox();
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -17,9 +17,7 @@ import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
 import { trim, trimMap } from '../testHelpers.spec';
-import { ParseMode, Parser } from '../parser/Parser';
-import { createStringLiteral, createToken } from '../astUtils/creators';
-import { ClassFieldStatement } from '../parser/Statement';
+import { ParseMode } from '../parser/Parser';
 
 let sinon = sinonImport.createSandbox();
 


### PR DESCRIPTION
the `createStringLiteral` function was not wrapping the value in quotes, which was unintuitive since it's not obvious that TokenKind.StringLiteral's value should be wrapped in quotes. This PR wraps the value if the quotes are missing, or leaves the value alone if at least one quotemark is found.