### PR TITLE
Fix xml parse error

### DIFF
--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -75,6 +75,20 @@ describe('SGParser', () => {
         `);
     });
 
+    it('does not crash when missing tag name', () => {
+        const parser = new SGParser();
+        parser.parse(
+            'pkg:/components/ParentScene.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="ChildScene" extends="ParentScene">
+            <!-- a standalone less-than symbol used to cause issues -->
+            <
+            </component>
+        `);
+        //the test passes if the parser doesn't throw a runtime exception.
+    });
+
+
     it('Adds error when an unexpected tag is found in xml', () => {
         const parser = new SGParser();
         parser.parse(

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -250,14 +250,18 @@ function mapElements(content: ContentCstNode, allow: string[], diagnostics: Diag
     if (element) {
         for (const entry of element) {
             const name = entry.children.Name?.[0];
-            if (name && allow.includes(name.image)) {
-                tags.push(mapElement(entry, diagnostics));
+            if (name?.image) {
+                if (allow.includes(name.image)) {
+                    tags.push(mapElement(entry, diagnostics));
+                } else {
+                    //unexpected tag
+                    diagnostics.push({
+                        ...DiagnosticMessages.xmlUnexpectedTag(name.image),
+                        range: rangeFromTokens(name)
+                    });
+                }
             } else {
-                //unexpected tag
-                diagnostics.push({
-                    ...DiagnosticMessages.xmlUnexpectedTag(name.image),
-                    range: rangeFromTokens(name)
-                });
+                //bad xml syntax...
             }
         }
     }


### PR DESCRIPTION
Fix issue where parser throws a nodejs runtime error anytime it encounters a standalone `<` token. 