### PR TITLE
Improve transpilation performance by indexing fileEntries beforehand

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1029,8 +1029,14 @@ export class Program {
     }
 
     public async transpile(fileEntries: FileObj[], stagingFolderPath: string) {
+        // map fileEntries using their path as key, to avoid excessive "find()" operations
+        const mappedFileEntries = fileEntries.reduce((collection, entry) => {
+            collection[s`${entry.src}`] = entry;
+            return collection;
+        }, {} as Record<string, FileObj>);
+
         const entries = Object.values(this.files).map(file => {
-            let filePathObj = fileEntries.find(x => s`${x.src}` === s`${file.pathAbsolute}`);
+            let filePathObj = mappedFileEntries[s`${file.pathAbsolute}`];
             if (!filePathObj) {
                 //this file has been added in-memory, from a plugin, for example
                 filePathObj = {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1030,10 +1030,10 @@ export class Program {
 
     public async transpile(fileEntries: FileObj[], stagingFolderPath: string) {
         // map fileEntries using their path as key, to avoid excessive "find()" operations
-        const mappedFileEntries = fileEntries.reduce((collection, entry) => {
+        const mappedFileEntries = fileEntries.reduce<Record<string, FileObj>>((collection, entry) => {
             collection[s`${entry.src}`] = entry;
             return collection;
-        }, {} as Record<string, FileObj>);
+        }, {});
 
         const entries = Object.values(this.files).map(file => {
             let filePathObj = mappedFileEntries[s`${file.pathAbsolute}`];


### PR DESCRIPTION
While integrating the brighterscript compiler into a fairly-large project (1 `.bs` file, >900 `.brs` files, >150 `.xml` files), I noticed fairly high times while building, taking ~16s in the transpilation step alone.

Narrowed it down to a loop within `Program.transpile` which was iterating `fileEntries` (2113 items) trying to find a specific entry for every item in `Program.files` (1223 items), resulting in over a million iterations. The solution, while not very pleasant memory-wise, reduces the number of iterations to 3336, and transpilation of the same project now takes ~435ms.