### PR TITLE
Completion and code navigation for labels

### DIFF
--- a/src/FunctionScope.ts
+++ b/src/FunctionScope.ts
@@ -1,4 +1,4 @@
-import type { VariableDeclaration } from './interfaces';
+import type { LabelDeclaration, VariableDeclaration } from './interfaces';
 import type { FunctionExpression } from './parser/Expression';
 
 //TODO I think this class can be eliminated in favor of moving some of these onto the FunctionExpression AST node
@@ -24,6 +24,7 @@ export class FunctionScope {
      */
     public parentScope: FunctionScope;
     public variableDeclarations = [] as VariableDeclaration[];
+    public labelStatements = [] as LabelDeclaration[];
 
     /**
      * Find all variable declarations above the given line index

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -203,6 +203,19 @@ describe('BrsFile', () => {
             expect(results).to.be.empty;
         });
 
+        it('does provide intellisence for labels only after a goto keyword', () => {
+            //eslint-disable-next-line @typescript-eslint/no-floating-promises
+            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                sub Main(name as string)
+                    something:
+                    goto \nend sub
+            `);
+
+            let results = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(3, 25));
+            expect(results.length).to.equal(1);
+            expect(results[0]?.label).to.equal('something');
+        });
+
     });
 
     describe('comment flags', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1467,7 +1467,7 @@ export class BrsFile {
             let functionScope = this.getFunctionScopeAtPosition(position);
             if (functionScope) {
                 //find any variable with this name
-                for (let varDeclaration of functionScope.variableDeclarations) {
+                for (const varDeclaration of functionScope.variableDeclarations) {
                     //we found a variable declaration with this token text!
                     if (varDeclaration.name.toLowerCase() === lowerTokenText) {
                         let typeText: string;
@@ -1483,11 +1483,11 @@ export class BrsFile {
                         };
                     }
                 }
-                for (let labelStatement of functionScope.labelStatements) {
+                for (const labelStatement of functionScope.labelStatements) {
                     if (labelStatement.name.toLocaleLowerCase() === lowerTokenText) {
                         return {
                             range: token.range,
-                            contents: 'Label'
+                            contents: `${labelStatement.name}: label`
                         };
                     }
                 }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -510,6 +510,14 @@ export class BrsFile {
                         name: stmt.item.text,
                         type: new DynamicType()
                     });
+                },
+                LabelStatement: (stmt) => {
+                    const { identifier } = stmt.tokens;
+                    scope.labelStatements.push({
+                        nameRange: identifier.range,
+                        lineIndex: identifier.range.start.line,
+                        name: identifier.text
+                    });
                 }
             }), {
                 walkMode: WalkMode.visitStatements
@@ -789,6 +797,10 @@ export class BrsFile {
             return result;
         }
 
+        if (this.tokenFollows(currentToken, TokenKind.Goto)) {
+            return this.getLabelCompletion(functionScope);
+        }
+
         if (this.isPositionNextToTokenKind(position, TokenKind.Dot)) {
             if (namespaceCompletions.length > 0) {
                 //if we matched a namespace, after a dot, it can't be anything else but something from our namespace completions
@@ -830,7 +842,6 @@ export class BrsFile {
 
             //include local variables
             let variables = functionScope.variableDeclarations;
-
             for (let variable of variables) {
                 //skip duplicate variable names
                 if (names[variable.name.toLowerCase()]) {
@@ -861,6 +872,13 @@ export class BrsFile {
             }
         }
         return result;
+    }
+
+    private getLabelCompletion(functionScope: FunctionScope) {
+        return functionScope.labelStatements.map(label => ({
+            label: label.name,
+            kind: CompletionItemKind.Reference
+        }));
     }
 
     private getClassMemberCompletions(position: Position, currentToken: Token, functionScope: FunctionScope, scope: Scope) {
@@ -1072,8 +1090,9 @@ export class BrsFile {
         }
     }
 
-    private getTokenBefore(currentToken: Token, tokenKind: TokenKind) {
-        for (let i = this.parser.tokens.indexOf(currentToken); i >= 0; i--) {
+    private getTokenBefore(currentToken: Token, tokenKind: TokenKind): Token {
+        const index = this.parser.tokens.indexOf(currentToken);
+        for (let i = index - 1; i >= 0; i--) {
             currentToken = this.parser.tokens[i];
             if (currentToken.kind === TokenKind.Newline) {
                 break;
@@ -1082,6 +1101,14 @@ export class BrsFile {
             }
         }
         return undefined;
+    }
+
+    private tokenFollows(currentToken: Token, tokenKind: TokenKind): boolean {
+        const index = this.parser.tokens.indexOf(currentToken);
+        if (index > 0) {
+            return this.parser.tokens[index - 1].kind === tokenKind;
+        }
+        return false;
     }
 
     public getTokensUntil(currentToken: Token, tokenKind: TokenKind, direction: -1 | 1 = -1) {
@@ -1341,12 +1368,20 @@ export class BrsFile {
         //look through local variables first, get the function scope for this position (if it exists)
         const functionScope = this.getFunctionScopeAtPosition(position);
         if (functionScope) {
-            //find any variable with this name
+            //find any variable or label with this name
             for (const varDeclaration of functionScope.variableDeclarations) {
                 //we found a variable declaration with this token text!
                 if (varDeclaration.name.toLowerCase() === textToSearchFor) {
                     const uri = util.pathToUri(this.pathAbsolute);
                     results.push(Location.create(uri, varDeclaration.nameRange));
+                }
+            }
+            if (this.tokenFollows(token, TokenKind.Goto)) {
+                for (const label of functionScope.labelStatements) {
+                    if (label.name.toLocaleLowerCase() === textToSearchFor) {
+                        const uri = util.pathToUri(this.pathAbsolute);
+                        results.push(Location.create(uri, label.nameRange));
+                    }
                 }
             }
         }
@@ -1445,6 +1480,14 @@ export class BrsFile {
                             range: token.range,
                             //append the variable name to the front for scope
                             contents: typeText
+                        };
+                    }
+                }
+                for (let labelStatement of functionScope.labelStatements) {
+                    if (labelStatement.name.toLocaleLowerCase() === lowerTokenText) {
+                        return {
+                            range: token.range,
+                            contents: 'Label'
                         };
                     }
                 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -136,6 +136,18 @@ export interface VariableDeclaration {
     lineIndex: number;
 }
 
+export interface LabelDeclaration {
+    name: string;
+    /**
+     * The range for the label name
+     */
+    nameRange: Range;
+    /**
+     * The line of the label
+     */
+    lineIndex: number;
+}
+
 /**
  * A wrapper around a callable to provide more information about where it came from
  */


### PR DESCRIPTION
- shows labels in scope after `goto` keyword
  <img width="288" alt="image" src="https://user-images.githubusercontent.com/297963/106755616-39d54280-6626-11eb-9930-4dccbaba37a4.png">

- hovering a label name (after `goto` or at declaration location) says it's a label
  <img width="189" alt="image" src="https://user-images.githubusercontent.com/297963/106755524-232eeb80-6626-11eb-9d39-f3678f6e8ab0.png">

- ctrl+click label (after `goto`) goes to the line of the label declaration

