### PR TITLE
Don't mangle xml scripts during transpile

### DIFF
--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as sinonImport from 'sinon';
 import type { CompletionItem } from 'vscode-languageserver';
 import { CompletionItemKind, Position, Range, DiagnosticSeverity } from 'vscode-languageserver';
-
+import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { BsDiagnostic, FileReference } from '../interfaces';
 import { Program } from '../Program';
@@ -14,13 +14,20 @@ import { getTestTranspile } from './BrsFile.spec';
 import { trim, trimMap } from '../testHelpers.spec';
 
 describe('XmlFile', () => {
-    let rootDir = process.cwd();
+    const tempDir = s`${process.cwd()}/.tmp`;
+    const rootDir = s`${tempDir}/rootDir`;
+    const stagingDir = s`${tempDir}/stagingDir`;
+
     let program: Program;
     let sinon = sinonImport.createSandbox();
     let file: XmlFile;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
+        fsExtra.ensureDirSync(rootDir);
+        fsExtra.ensureDirSync(stagingDir);
         program = new Program({ rootDir: rootDir });
         file = new XmlFile(`${rootDir}/components/MainComponent.xml`, 'components/MainComponent.xml', program);
     });
@@ -618,6 +625,36 @@ describe('XmlFile', () => {
     });
 
     describe('transpile', () => {
+        /**
+         * There was a bug that would incorrectly replace one of the script paths on the second or third transpile, so this test verifies it doesn't do that anymore
+         */
+        it('does not mangle scripts on multiple transpile', async () => {
+            program.addOrReplaceFile('components/SimpleScene.bs', ``);
+
+            program.addOrReplaceFile(`components/SimpleScene.xml`, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="SimpleScene" extends="Scene">
+                    <script type="text/brightscript" uri="SimpleScene.bs" />
+                </component>
+            `);
+
+            const expected = trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="SimpleScene" extends="Scene">
+                    <script type="text/brightscript" uri="SimpleScene.brs" />
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `;
+
+            await program.transpile([], stagingDir);
+            expect(fsExtra.readFileSync(`${stagingDir}/components/SimpleScene.xml`).toString()).to.eql(expected);
+
+            //clear the output folder
+            fsExtra.emptyDirSync(stagingDir);
+            await program.transpile([], stagingDir);
+            expect(fsExtra.readFileSync(`${stagingDir}/components/SimpleScene.xml`).toString()).to.eql(expected);
+        });
+
         it('keeps all content of the XML', () => {
             program.addOrReplaceFile(`components/SimpleScene.bs`, `
                 sub init()

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -454,16 +454,20 @@ export class XmlFile {
             return script;
         });
 
-        const extraImportIdx = this.ast.component.scripts.length - 1;
-        //temporarily add the missing imports as script tags
-        this.ast.component.scripts.push(...extraImportScripts);
         let transpileResult: SourceNode | undefined;
 
         if (this.needsTranspiled || extraImportScripts.length > 0) {
+            //temporarily add the missing imports as script tags
+            const originalScripts = this.ast.component.scripts;
+            this.ast.component.scripts = [
+                ...originalScripts,
+                ...extraImportScripts
+            ];
+
             transpileResult = new SourceNode(null, null, state.source, this.parser.ast.transpile(state));
 
-            //remove the extra import scripts added pre-transpile
-            this.ast.component.scripts.splice(extraImportIdx, extraImportScripts.length);
+            //restore the original scripts array
+            this.ast.component.scripts = originalScripts;
 
         } else if (this.program.options.sourceMap) {
             //emit code as-is with a simple map to the original file location


### PR DESCRIPTION
Fix bug with multiple-in-a-row transpiles for xml files that hadn't changed, would cause scripts to get mangled.