### PR TITLE
Intermediary fix for Roku_Ads error

### DIFF
--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -1,6 +1,7 @@
 import { standardizePath as s } from './util';
 import { Program } from './Program';
 import { expect } from 'chai';
+import { expectZeroDiagnostics } from './testHelpers.spec';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let rootDir = s`${tmpPath}/rootDir`;
@@ -16,6 +17,18 @@ describe('globalCallables', () => {
     });
     afterEach(() => {
         program.dispose();
+    });
+
+    describe('Roku_ads', () => {
+        it('exists', () => {
+            program.addOrReplaceFile('source/main.brs', `
+                sub main()
+                    adIface = Roku_Ads()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('val', () => {

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -722,6 +722,13 @@ let programStatementFunctions = [
             name: 'x',
             type: new IntegerType()
         }]
+        //TODO this is a temporary fix for library imported files. Eventually this should be moved into `Roku_Ads.brs` and handled by the `Library` statement
+    }, {
+        name: 'Roku_Ads',
+        shortDescription: 'The main entry point for instantiating the ad interface. This object manages ad server requests, parses ad structure, schedules and renders ads, and triggers tracking beacons.\n\nThe Roku ad parser/renderer object returned has global scope because it is meant to represent interaction with external resources (the ad server and any tracking services) that have persistence and state independent of the ad rendering within a client application.',
+        type: new FunctionType(new ObjectType()),
+        file: globalFile,
+        params: []
     }
 ] as Callable[];
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -57,10 +57,10 @@ export function expectZeroDiagnostics(arg: { getDiagnostics(): Array<Diagnostic>
     let diagnostics: BsDiagnostic[];
     if (Array.isArray(arg)) {
         diagnostics = arg as BsDiagnostic[];
-    } else if ((arg as any).diagnostics) {
-        diagnostics = (arg as any).diagnostics;
     } else if ((arg as any).getDiagnostics) {
         diagnostics = (arg as any).getDiagnostics();
+    } else if ((arg as any).diagnostics) {
+        diagnostics = (arg as any).diagnostics;
     } else {
         throw new Error('Cannot derive a list of diagnostics from ' + JSON.stringify(arg));
     }


### PR DESCRIPTION
This is a temporary fix for the fact that `Roku_Ads` is _sometimes_ available globally (dependent on a `Library` import. 

Long-term we want to add formal `Library` handling. However, There's a lot of other more important things to work on right now, so this will hold us over until then.

Provides temporary relief for #179 