### PR TITLE
Standardize sourcenode

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -441,7 +441,7 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new = sub(name as string)
                     end sub
                     instance.sayHello = function(text)
-                        print text
+                        ? text
                     end function
                     return instance
                 end function

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1745,25 +1745,25 @@ describe('BrsFile', () => {
         });
 
         it('transpiles dim', () => {
-            testTranspile(`Dim c[5]`, `dim c[5]`);
-            testTranspile(`Dim c[5, 4]`, `dim c[5, 4]`);
-            testTranspile(`Dim c[5, 4, 6]`, `dim c[5, 4, 6]`);
-            testTranspile(`Dim requestData[requestList.count()]`, `dim requestData[requestList.count()]`);
-            testTranspile(`Dim requestData[1, requestList.count()]`, `dim requestData[1, requestList.count()]`);
-            testTranspile(`Dim requestData[1, requestList.count(), 2]`, `dim requestData[1, requestList.count(), 2]`);
-            testTranspile(`Dim requestData[requestList[2]]`, `dim requestData[requestList[2]]`);
-            testTranspile(`Dim requestData[1, requestList[2]]`, `dim requestData[1, requestList[2]]`);
-            testTranspile(`Dim requestData[1, requestList[2], 2]`, `dim requestData[1, requestList[2], 2]`);
-            testTranspile(`Dim requestData[requestList["2"]]`, `dim requestData[requestList["2"]]`);
-            testTranspile(`Dim requestData[1, requestList["2"]]`, `dim requestData[1, requestList["2"]]`);
-            testTranspile(`Dim requestData[1, requestList["2"], 2]`, `dim requestData[1, requestList["2"], 2]`);
-            testTranspile(`Dim requestData[1, getValue(), 2]`, `dim requestData[1, getValue(), 2]`);
+            testTranspile(`Dim c[5]`, `Dim c[5]`);
+            testTranspile(`Dim c[5, 4]`, `Dim c[5, 4]`);
+            testTranspile(`Dim c[5, 4, 6]`, `Dim c[5, 4, 6]`);
+            testTranspile(`Dim requestData[requestList.count()]`, `Dim requestData[requestList.count()]`);
+            testTranspile(`Dim requestData[1, requestList.count()]`, `Dim requestData[1, requestList.count()]`);
+            testTranspile(`Dim requestData[1, requestList.count(), 2]`, `Dim requestData[1, requestList.count(), 2]`);
+            testTranspile(`Dim requestData[requestList[2]]`, `Dim requestData[requestList[2]]`);
+            testTranspile(`Dim requestData[1, requestList[2]]`, `Dim requestData[1, requestList[2]]`);
+            testTranspile(`Dim requestData[1, requestList[2], 2]`, `Dim requestData[1, requestList[2], 2]`);
+            testTranspile(`Dim requestData[requestList["2"]]`, `Dim requestData[requestList["2"]]`);
+            testTranspile(`Dim requestData[1, requestList["2"]]`, `Dim requestData[1, requestList["2"]]`);
+            testTranspile(`Dim requestData[1, requestList["2"], 2]`, `Dim requestData[1, requestList["2"], 2]`);
+            testTranspile(`Dim requestData[1, getValue(), 2]`, `Dim requestData[1, getValue(), 2]`);
             testTranspile(`
                 Dim requestData[1, getValue({
                     key: "value"
                 }), 2]
             `, `
-                dim requestData[1, getValue({
+                Dim requestData[1, getValue({
                     key: "value"
                 }), 2]
             `);

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -49,7 +49,7 @@ export class BinaryExpression extends Expression {
         return [
             state.sourceNode(this.left, this.left.transpile(state)),
             ' ',
-            state.sourceNode(this.operator, this.operator.text),
+            state.tokenToSourceNode(this.operator),
             ' ',
             state.sourceNode(this.right, this.right.transpile(state))
         ];
@@ -93,7 +93,7 @@ export class CallExpression extends Expression {
         }
 
         result.push(
-            state.sourceNode(this.openingParen, '(')
+            state.tokenToSourceNode(this.openingParen)
         );
         for (let i = 0; i < this.args.length; i++) {
             //add comma between args
@@ -104,7 +104,7 @@ export class CallExpression extends Expression {
             result.push(...arg.transpile(state));
         }
         result.push(
-            state.sourceNode(this.closingParen, ')')
+            state.tokenToSourceNode(this.closingParen)
         );
         return result;
     }
@@ -181,18 +181,18 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         let results = [];
         //'function'|'sub'
         results.push(
-            state.sourceNode(this.functionType, this.functionType.text.toLowerCase())
+            state.tokenToSourceNode(this.functionType)
         );
         //functionName?
         if (name) {
             results.push(
                 ' ',
-                state.sourceNode(name, name.text)
+                state.tokenToSourceNode(name)
             );
         }
         //leftParen
         results.push(
-            state.sourceNode(this.leftParen, '(')
+            state.tokenToSourceNode(this.leftParen)
         );
         //parameters
         for (let i = 0; i < this.parameters.length; i++) {
@@ -206,17 +206,17 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         //right paren
         results.push(
-            state.sourceNode(this.rightParen, ')')
+            state.tokenToSourceNode(this.rightParen)
         );
         //as [Type]
         if (this.asToken) {
             results.push(
                 ' ',
                 //as
-                state.sourceNode(this.asToken, 'as'),
+                state.tokenToSourceNode(this.asToken),
                 ' ',
                 //return type
-                state.sourceNode(this.returnTypeToken, this.returnType.toTypeString())
+                state.tokenToSourceNode(this.returnTypeToken)
             );
         }
         if (includeBody) {
@@ -229,7 +229,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         //'end sub'|'end function'
         results.push(
             state.indent(),
-            state.sourceNode(this.end, this.end.text)
+            state.tokenToSourceNode(this.end)
         );
         return results;
     }
@@ -280,7 +280,7 @@ export class FunctionParameterExpression extends Expression {
     public transpile(state: TranspileState) {
         let result = [
             //name
-            state.sourceNode(this.name, this.name.text)
+            state.tokenToSourceNode(this.name)
         ] as any[];
         //default value
         if (this.defaultValue) {
@@ -290,7 +290,7 @@ export class FunctionParameterExpression extends Expression {
         //type declaration
         if (this.asToken) {
             result.push(' ');
-            result.push(state.sourceNode(this.asToken, 'as'));
+            result.push(state.tokenToSourceNode(this.asToken));
             result.push(' ');
             result.push(state.sourceNode(this.typeToken, this.type.toTypeString()));
         }
@@ -374,7 +374,7 @@ export class DottedGetExpression extends Expression {
             return [
                 ...this.obj.transpile(state),
                 '.',
-                state.sourceNode(this.name, this.name.text)
+                state.tokenToSourceNode(this.name)
             ];
         }
     }
@@ -402,7 +402,7 @@ export class XmlAttributeGetExpression extends Expression {
         return [
             ...this.obj.transpile(state),
             '@',
-            state.sourceNode(this.name, this.name.text)
+            state.tokenToSourceNode(this.name)
         ];
     }
 
@@ -429,9 +429,9 @@ export class IndexedGetExpression extends Expression {
     transpile(state: TranspileState) {
         return [
             ...this.obj.transpile(state),
-            state.sourceNode(this.openingSquare, '['),
+            state.tokenToSourceNode(this.openingSquare),
             ...this.index.transpile(state),
-            state.sourceNode(this.closingSquare, ']')
+            state.tokenToSourceNode(this.closingSquare)
         ];
     }
 
@@ -459,9 +459,9 @@ export class GroupingExpression extends Expression {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.left, '('),
+            state.tokenToSourceNode(this.tokens.left),
             ...this.expression.transpile(state),
-            state.sourceNode(this.tokens.right, ')')
+            state.tokenToSourceNode(this.tokens.right)
         ];
     }
 
@@ -554,7 +554,7 @@ export class ArrayLiteralExpression extends Expression {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            state.sourceNode(this.open, '[')
+            state.tokenToSourceNode(this.open)
         );
         let hasChildren = this.elements.length > 0;
         state.blockDepth++;
@@ -602,7 +602,7 @@ export class ArrayLiteralExpression extends Expression {
         }
 
         result.push(
-            state.sourceNode(this.close, ']')
+            state.tokenToSourceNode(this.close)
         );
         return result;
     }
@@ -656,7 +656,7 @@ export class AALiteralExpression extends Expression {
         let result = [];
         //open curly
         result.push(
-            state.sourceNode(this.open, this.open.text)
+            state.tokenToSourceNode(this.open)
         );
         let hasChildren = this.elements.length > 0;
         //add newline if the object has children and the first child isn't a comment starting on the same line as opening curly
@@ -686,11 +686,11 @@ export class AALiteralExpression extends Expression {
             } else {
                 //key
                 result.push(
-                    state.sourceNode(element.keyToken, element.keyToken.text)
+                    state.tokenToSourceNode(element.keyToken)
                 );
                 //colon
                 result.push(
-                    state.sourceNode(element.colonToken, ':'),
+                    state.tokenToSourceNode(element.colonToken),
                     ' '
                 );
 
@@ -728,7 +728,7 @@ export class AALiteralExpression extends Expression {
         }
         //close curly
         result.push(
-            state.sourceNode(this.close, this.close.text)
+            state.tokenToSourceNode(this.close)
         );
         return result;
     }
@@ -759,7 +759,7 @@ export class UnaryExpression extends Expression {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.operator, this.operator.text),
+            state.tokenToSourceNode(this.operator),
             ' ',
             ...this.right.transpile(state)
         ];
@@ -803,7 +803,7 @@ export class VariableExpression extends Expression {
             //transpile  normally
         } else {
             result.push(
-                state.sourceNode(this.name, this.name.text)
+                state.tokenToSourceNode(this.name)
             );
         }
         return result;
@@ -957,7 +957,7 @@ export class CallfuncExpression extends Expression {
         result.push(
             ...this.callee.transpile(state),
             state.sourceNode(this.operator, '.callfunc'),
-            state.sourceNode(this.openingParen, '('),
+            state.tokenToSourceNode(this.openingParen),
             //the name of the function
             state.sourceNode(this.methodName, ['"', this.methodName.text, '"']),
             ', '
@@ -977,7 +977,7 @@ export class CallfuncExpression extends Expression {
             }
         }
         result.push(
-            state.sourceNode(this.closingParen, ')')
+            state.tokenToSourceNode(this.closingParen)
         );
         return result;
     }
@@ -1056,15 +1056,6 @@ export class TemplateStringExpression extends Expression {
             return this.quasis[0].transpile(state);
         }
         let result = [];
-        //wrap the expression in parens to readability
-        // result.push(
-        //     state.sourceNode(
-        //         this.openingBacktick.range.start.line + 1,
-        //         this.openingBacktick.range.start.character,
-        //         state.pathAbsolute,
-        //         '('
-        //     )
-        // );
         let plus = '';
         //helper function to figure out when to include the plus
         function add(...items) {
@@ -1105,15 +1096,6 @@ export class TemplateStringExpression extends Expression {
             }
         }
 
-        //wrap the expression in parens to readability
-        // result.push(
-        //     state.sourceNode(
-        //         this.openingBacktick.range.end.line + 1,
-        //         this.openingBacktick.range.end.character,
-        //         state.pathAbsolute,
-        //         ')'
-        //     )
-        // );
         return result;
     }
 
@@ -1152,7 +1134,7 @@ export class TaggedTemplateStringExpression extends Expression {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            state.sourceNode(this.tagName, this.tagName.text),
+            state.tokenToSourceNode(this.tagName),
             '(['
         );
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -150,9 +150,9 @@ export class AssignmentStatement extends Statement {
             return this.value.transpile(state);
         } else {
             return [
-                state.sourceNode(this.name, this.name.text),
+                state.tokenToSourceNode(this.name),
                 ' ',
-                state.sourceNode(this.equals, '='),
+                state.tokenToSourceNode(this.equals),
                 ' ',
                 ...this.value.transpile(state)
             ];
@@ -274,7 +274,7 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
                 result.push(state.indent());
             }
             result.push(
-                state.sourceNode(comment, comment.text)
+                state.tokenToSourceNode(comment)
             );
             //add newline for all except final comment
             if (i < this.comments.length - 1) {
@@ -307,7 +307,7 @@ export class ExitForStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.exitFor, 'exit for')
+            state.tokenToSourceNode(this.tokens.exitFor)
         ];
     }
 
@@ -331,7 +331,7 @@ export class ExitWhileStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.exitWhile, 'exit while')
+            state.tokenToSourceNode(this.tokens.exitWhile)
         ];
     }
 
@@ -411,7 +411,7 @@ export class IfStatement extends Statement {
     transpile(state: TranspileState) {
         let results = [];
         //if   (already indented by block)
-        results.push(state.sourceNode(this.tokens.if, 'if'));
+        results.push(state.tokenToSourceNode(this.tokens.if));
         results.push(' ');
         //conditions
         results.push(...this.condition.transpile(state));
@@ -419,7 +419,7 @@ export class IfStatement extends Statement {
         //then
         if (this.tokens.then) {
             results.push(
-                state.sourceNode(this.tokens.then, 'then')
+                state.tokenToSourceNode(this.tokens.then)
             );
         } else {
             results.push('then');
@@ -439,7 +439,7 @@ export class IfStatement extends Statement {
             //else
             results.push(
                 state.indent(),
-                state.sourceNode(this.tokens.else, 'else')
+                state.tokenToSourceNode(this.tokens.else)
             );
         }
 
@@ -477,7 +477,7 @@ export class IfStatement extends Statement {
         results.push(state.indent());
         if (this.tokens.endIf) {
             results.push(
-                state.sourceNode(this.tokens.endIf, 'end if')
+                state.tokenToSourceNode(this.tokens.endIf)
             );
         } else {
             results.push('end if');
@@ -512,7 +512,7 @@ export class IncrementStatement extends Statement {
     transpile(state: TranspileState) {
         return [
             ...this.value.transpile(state),
-            state.sourceNode(this.operator, this.operator.text)
+            state.tokenToSourceNode(this.operator)
         ];
     }
 
@@ -561,7 +561,7 @@ export class PrintStatement extends Statement {
 
     transpile(state: TranspileState) {
         let result = [
-            state.sourceNode(this.tokens.print, 'print'),
+            state.tokenToSourceNode(this.tokens.print),
             ' '
         ];
         for (let i = 0; i < this.expressions.length; i++) {
@@ -608,10 +608,10 @@ export class DimStatement extends Statement {
 
     public transpile(state: TranspileState) {
         let result = [
-            state.sourceNode(this.dimToken, 'dim'),
+            state.tokenToSourceNode(this.dimToken),
             ' ',
-            state.sourceNode(this.identifier, this.identifier.text),
-            state.sourceNode(this.openingSquare, '[')
+            state.tokenToSourceNode(this.identifier),
+            state.tokenToSourceNode(this.openingSquare)
         ];
         for (let i = 0; i < this.dimensions.length; i++) {
             if (i > 0) {
@@ -621,7 +621,7 @@ export class DimStatement extends Statement {
                 ...this.dimensions[i].transpile(state)
             );
         }
-        result.push(state.sourceNode(this.closingSquare, ']'));
+        result.push(state.tokenToSourceNode(this.closingSquare));
         return result;
     }
 
@@ -649,9 +649,9 @@ export class GotoStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.goto, 'goto'),
+            state.tokenToSourceNode(this.tokens.goto),
             ' ',
-            state.sourceNode(this.tokens.label, this.tokens.label.text)
+            state.tokenToSourceNode(this.tokens.label)
         ];
     }
 
@@ -675,8 +675,8 @@ export class LabelStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.identifier, this.tokens.identifier.text),
-            state.sourceNode(this.tokens.colon, ':')
+            state.tokenToSourceNode(this.tokens.identifier),
+            state.tokenToSourceNode(this.tokens.colon)
 
         ];
     }
@@ -705,7 +705,7 @@ export class ReturnStatement extends Statement {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            state.sourceNode(this.tokens.return, 'return')
+            state.tokenToSourceNode(this.tokens.return)
         );
         if (this.value) {
             result.push(' ');
@@ -735,7 +735,7 @@ export class EndStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.end, 'end')
+            state.tokenToSourceNode(this.tokens.end)
         ];
     }
 
@@ -758,7 +758,7 @@ export class StopStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            state.sourceNode(this.tokens.stop, 'stop')
+            state.tokenToSourceNode(this.tokens.stop)
         ];
     }
 
@@ -789,7 +789,7 @@ export class ForStatement extends Statement {
         let result = [];
         //for
         result.push(
-            state.sourceNode(this.forToken, 'for'),
+            state.tokenToSourceNode(this.forToken),
             ' '
         );
         //i=1
@@ -799,7 +799,7 @@ export class ForStatement extends Statement {
         );
         //to
         result.push(
-            state.sourceNode(this.toToken, 'to'),
+            state.tokenToSourceNode(this.toToken),
             ' '
         );
         //final value
@@ -808,7 +808,7 @@ export class ForStatement extends Statement {
         if (this.stepToken) {
             result.push(
                 ' ',
-                state.sourceNode(this.stepToken, 'step'),
+                state.tokenToSourceNode(this.stepToken),
                 ' ',
                 this.increment.transpile(state)
             );
@@ -823,7 +823,7 @@ export class ForStatement extends Statement {
         //end for
         result.push(
             state.indent(),
-            state.sourceNode(this.endForToken, 'end for')
+            state.tokenToSourceNode(this.endForToken)
         );
 
         return result;
@@ -865,17 +865,17 @@ export class ForEachStatement extends Statement {
         let result = [];
         //for each
         result.push(
-            state.sourceNode(this.tokens.forEach, 'for each'),
+            state.tokenToSourceNode(this.tokens.forEach),
             ' '
         );
         //item
         result.push(
-            state.sourceNode(this.tokens.forEach, this.item.text),
+            state.tokenToSourceNode(this.item),
             ' '
         );
         //in
         result.push(
-            state.sourceNode(this.tokens.in, 'in'),
+            state.tokenToSourceNode(this.tokens.in),
             ' '
         );
         //target
@@ -890,7 +890,7 @@ export class ForEachStatement extends Statement {
         //end for
         result.push(
             state.indent(),
-            state.sourceNode(this.tokens.endFor, 'end for')
+            state.tokenToSourceNode(this.tokens.endFor)
         );
         return result;
     }
@@ -925,7 +925,7 @@ export class WhileStatement extends Statement {
         let result = [];
         //while
         result.push(
-            state.sourceNode(this.tokens.while, 'while'),
+            state.tokenToSourceNode(this.tokens.while),
             ' '
         );
         //condition
@@ -943,7 +943,7 @@ export class WhileStatement extends Statement {
         //end while
         result.push(
             state.indent(),
-            state.sourceNode(this.tokens.endWhile, 'end while')
+            state.tokenToSourceNode(this.tokens.endWhile)
         );
 
         return result;
@@ -981,7 +981,7 @@ export class DottedSetStatement extends Statement {
                 ...this.obj.transpile(state),
                 '.',
                 //name
-                state.sourceNode(this.name, this.name.text),
+                state.tokenToSourceNode(this.name),
                 ' = ',
                 //right-hand-side of assignment
                 ...this.value.transpile(state)
@@ -1020,11 +1020,11 @@ export class IndexedSetStatement extends Statement {
                 //obj
                 ...this.obj.transpile(state),
                 //   [
-                state.sourceNode(this.openingSquare, '['),
+                state.tokenToSourceNode(this.openingSquare),
                 //    index
                 ...this.index.transpile(state),
                 //         ]
-                state.sourceNode(this.closingSquare, ']'),
+                state.tokenToSourceNode(this.closingSquare),
                 //           =
                 ' = ',
                 //             value
@@ -1061,13 +1061,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            state.sourceNode(this.tokens.library, 'library')
+            state.tokenToSourceNode(this.tokens.library)
         );
         //there will be a parse error if file path is missing, but let's prevent a runtime error just in case
         if (this.tokens.filePath) {
             result.push(
                 ' ',
-                state.sourceNode(this.tokens.filePath, this.tokens.filePath.text)
+                state.tokenToSourceNode(this.tokens.filePath)
             );
         }
         return result;
@@ -1173,7 +1173,10 @@ export class ImportStatement extends Statement implements TypedefProvider {
         //The xml files are responsible for adding the additional script imports, but
         //add the import statement as a comment just for debugging purposes
         return [
-            state.sourceNode(this, [`'`, this.importToken.text, '', this.filePathToken.text])
+            `'`,
+            state.tokenToSourceNode(this.importToken),
+            ' ',
+            state.tokenToSourceNode(this.filePathToken)
         ];
     }
 
@@ -1447,7 +1450,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 state.classStatement = this;
                 result.push(
                     'instance.',
-                    state.sourceNode(statement.name, statement.name.text),
+                    state.tokenToSourceNode(statement.name),
                     ' = ',
                     ...statement.transpile(state),
                     state.newline(),
@@ -1516,7 +1519,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 result.push(', ');
             }
             result.push(
-                state.sourceNode(param, param.name.text)
+                state.tokenToSourceNode(param.name)
             );
             i++;
         }
@@ -1786,17 +1789,17 @@ export class TryCatchStatement extends Statement {
 
     public transpile(state: TranspileState): TranspileResult {
         return [
-            state.sourceNode(this.tryToken, 'try'),
+            state.tokenToSourceNode(this.tryToken),
             ...this.tryBranch.transpile(state),
             state.newline(),
             state.indent(),
-            state.sourceNode(this.catchToken, 'catch'),
+            state.tokenToSourceNode(this.catchToken),
             ' ',
-            state.sourceNode(this.exceptionVariable, this.exceptionVariable.text),
+            state.tokenToSourceNode(this.exceptionVariable),
             ...this.catchBranch.transpile(state),
             state.newline(),
             state.indent(),
-            state.sourceNode(this.endTryToken, 'end try')
+            state.tokenToSourceNode(this.endTryToken)
         ];
     }
 
@@ -1823,7 +1826,7 @@ export class ThrowStatement extends Statement {
 
     public transpile(state: TranspileState) {
         const result = [
-            state.sourceNode(this.throwToken, 'throw'),
+            state.tokenToSourceNode(this.throwToken),
             ' '
         ];
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer';
-import { SourceNode } from 'source-map';
 import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression, AnnotationExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
@@ -151,9 +150,9 @@ export class AssignmentStatement extends Statement {
             return this.value.transpile(state);
         } else {
             return [
-                new SourceNode(this.name.range.start.line + 1, this.name.range.start.character, state.pathAbsolute, this.name.text),
+                state.sourceNode(this.name, this.name.text),
                 ' ',
-                new SourceNode(this.equals.range.start.line + 1, this.equals.range.start.character, state.pathAbsolute, '='),
+                state.sourceNode(this.equals, '='),
                 ' ',
                 ...this.value.transpile(state)
             ];
@@ -267,7 +266,7 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
         return this.comments.map(x => x.text).join('\n');
     }
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         let result = [];
         for (let i = 0; i < this.comments.length; i++) {
             let comment = this.comments[i];
@@ -275,7 +274,7 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
                 result.push(state.indent());
             }
             result.push(
-                new SourceNode(comment.range.start.line + 1, comment.range.start.character, state.pathAbsolute, comment.text)
+                state.sourceNode(comment, comment.text)
             );
             //add newline for all except final comment
             if (i < this.comments.length - 1) {
@@ -306,9 +305,9 @@ export class ExitForStatement extends Statement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.exitFor.range.start.line + 1, this.tokens.exitFor.range.start.character, state.pathAbsolute, 'exit for')
+            state.sourceNode(this.tokens.exitFor, 'exit for')
         ];
     }
 
@@ -330,9 +329,9 @@ export class ExitWhileStatement extends Statement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.exitWhile.range.start.line + 1, this.tokens.exitWhile.range.start.character, state.pathAbsolute, 'exit while')
+            state.sourceNode(this.tokens.exitWhile, 'exit while')
         ];
     }
 
@@ -412,7 +411,7 @@ export class IfStatement extends Statement {
     transpile(state: TranspileState) {
         let results = [];
         //if   (already indented by block)
-        results.push(new SourceNode(this.tokens.if.range.start.line + 1, this.tokens.if.range.start.character, state.pathAbsolute, 'if'));
+        results.push(state.sourceNode(this.tokens.if, 'if'));
         results.push(' ');
         //conditions
         results.push(...this.condition.transpile(state));
@@ -420,7 +419,7 @@ export class IfStatement extends Statement {
         //then
         if (this.tokens.then) {
             results.push(
-                new SourceNode(this.tokens.then.range.start.line + 1, this.tokens.then.range.start.character, state.pathAbsolute, 'then')
+                state.sourceNode(this.tokens.then, 'then')
             );
         } else {
             results.push('then');
@@ -440,7 +439,7 @@ export class IfStatement extends Statement {
             //else
             results.push(
                 state.indent(),
-                new SourceNode(this.tokens.else.range.start.line + 1, this.tokens.else.range.start.character, state.pathAbsolute, 'else')
+                state.sourceNode(this.tokens.else, 'else')
             );
         }
 
@@ -478,7 +477,7 @@ export class IfStatement extends Statement {
         results.push(state.indent());
         if (this.tokens.endIf) {
             results.push(
-                new SourceNode(this.tokens.endIf.range.start.line + 1, this.tokens.endIf.range.start.character, state.pathAbsolute, 'end if')
+                state.sourceNode(this.tokens.endIf, 'end if')
             );
         } else {
             results.push('end if');
@@ -510,10 +509,10 @@ export class IncrementStatement extends Statement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         return [
             ...this.value.transpile(state),
-            new SourceNode(this.operator.range.start.line + 1, this.operator.range.start.character, state.pathAbsolute, this.operator.text)
+            state.sourceNode(this.operator, this.operator.text)
         ];
     }
 
@@ -562,7 +561,7 @@ export class PrintStatement extends Statement {
 
     transpile(state: TranspileState) {
         let result = [
-            new SourceNode(this.tokens.print.range.start.line + 1, this.tokens.print.range.start.character, state.pathAbsolute, 'print'),
+            state.sourceNode(this.tokens.print, 'print'),
             ' '
         ];
         for (let i = 0; i < this.expressions.length; i++) {
@@ -648,11 +647,11 @@ export class GotoStatement extends Statement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.goto.range.start.line + 1, this.tokens.goto.range.start.character, state.pathAbsolute, 'goto'),
+            state.sourceNode(this.tokens.goto, 'goto'),
             ' ',
-            new SourceNode(this.tokens.label.range.start.line + 1, this.tokens.label.range.start.character, state.pathAbsolute, this.tokens.label.text)
+            state.sourceNode(this.tokens.label, this.tokens.label.text)
         ];
     }
 
@@ -674,10 +673,10 @@ export class LabelStatement extends Statement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.identifier.range.start.line + 1, this.tokens.identifier.range.start.character, state.pathAbsolute, this.tokens.identifier.text),
-            new SourceNode(this.tokens.colon.range.start.line + 1, this.tokens.colon.range.start.character, state.pathAbsolute, ':')
+            state.sourceNode(this.tokens.identifier, this.tokens.identifier.text),
+            state.sourceNode(this.tokens.colon, ':')
 
         ];
     }
@@ -706,7 +705,7 @@ export class ReturnStatement extends Statement {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            new SourceNode(this.tokens.return.range.start.line + 1, this.tokens.return.range.start.character, state.pathAbsolute, 'return')
+            state.sourceNode(this.tokens.return, 'return')
         );
         if (this.value) {
             result.push(' ');
@@ -736,7 +735,7 @@ export class EndStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.end.range.start.line + 1, this.tokens.end.range.start.character, state.pathAbsolute, 'end')
+            state.sourceNode(this.tokens.end, 'end')
         ];
     }
 
@@ -759,7 +758,7 @@ export class StopStatement extends Statement {
 
     transpile(state: TranspileState) {
         return [
-            new SourceNode(this.tokens.stop.range.start.line + 1, this.tokens.stop.range.start.character, state.pathAbsolute, 'stop')
+            state.sourceNode(this.tokens.stop, 'stop')
         ];
     }
 
@@ -790,7 +789,7 @@ export class ForStatement extends Statement {
         let result = [];
         //for
         result.push(
-            new SourceNode(this.forToken.range.start.line + 1, this.forToken.range.start.character, state.pathAbsolute, 'for'),
+            state.sourceNode(this.forToken, 'for'),
             ' '
         );
         //i=1
@@ -800,7 +799,7 @@ export class ForStatement extends Statement {
         );
         //to
         result.push(
-            new SourceNode(this.toToken.range.start.line + 1, this.toToken.range.start.character, state.pathAbsolute, 'to'),
+            state.sourceNode(this.toToken, 'to'),
             ' '
         );
         //final value
@@ -809,7 +808,7 @@ export class ForStatement extends Statement {
         if (this.stepToken) {
             result.push(
                 ' ',
-                new SourceNode(this.stepToken.range.start.line + 1, this.stepToken.range.start.character, state.pathAbsolute, 'step'),
+                state.sourceNode(this.stepToken, 'step'),
                 ' ',
                 this.increment.transpile(state)
             );
@@ -824,7 +823,7 @@ export class ForStatement extends Statement {
         //end for
         result.push(
             state.indent(),
-            new SourceNode(this.endForToken.range.start.line + 1, this.endForToken.range.start.character, state.pathAbsolute, 'end for')
+            state.sourceNode(this.endForToken, 'end for')
         );
 
         return result;
@@ -866,17 +865,17 @@ export class ForEachStatement extends Statement {
         let result = [];
         //for each
         result.push(
-            new SourceNode(this.tokens.forEach.range.start.line + 1, this.tokens.forEach.range.start.character, state.pathAbsolute, 'for each'),
+            state.sourceNode(this.tokens.forEach, 'for each'),
             ' '
         );
         //item
         result.push(
-            new SourceNode(this.tokens.forEach.range.start.line + 1, this.tokens.forEach.range.start.character, state.pathAbsolute, this.item.text),
+            state.sourceNode(this.tokens.forEach, this.item.text),
             ' '
         );
         //in
         result.push(
-            new SourceNode(this.tokens.in.range.start.line + 1, this.tokens.in.range.start.character, state.pathAbsolute, 'in'),
+            state.sourceNode(this.tokens.in, 'in'),
             ' '
         );
         //target
@@ -891,7 +890,7 @@ export class ForEachStatement extends Statement {
         //end for
         result.push(
             state.indent(),
-            new SourceNode(this.tokens.endFor.range.start.line + 1, this.tokens.endFor.range.start.character, state.pathAbsolute, 'end for')
+            state.sourceNode(this.tokens.endFor, 'end for')
         );
         return result;
     }
@@ -926,7 +925,7 @@ export class WhileStatement extends Statement {
         let result = [];
         //while
         result.push(
-            new SourceNode(this.tokens.while.range.start.line + 1, this.tokens.while.range.start.character, state.pathAbsolute, 'while'),
+            state.sourceNode(this.tokens.while, 'while'),
             ' '
         );
         //condition
@@ -944,7 +943,7 @@ export class WhileStatement extends Statement {
         //end while
         result.push(
             state.indent(),
-            new SourceNode(this.tokens.endWhile.range.start.line + 1, this.tokens.endWhile.range.start.character, state.pathAbsolute, 'end while')
+            state.sourceNode(this.tokens.endWhile, 'end while')
         );
 
         return result;
@@ -982,7 +981,7 @@ export class DottedSetStatement extends Statement {
                 ...this.obj.transpile(state),
                 '.',
                 //name
-                new SourceNode(this.name.range.start.line + 1, this.name.range.start.character, state.pathAbsolute, this.name.text),
+                state.sourceNode(this.name, this.name.text),
                 ' = ',
                 //right-hand-side of assignment
                 ...this.value.transpile(state)
@@ -1021,11 +1020,11 @@ export class IndexedSetStatement extends Statement {
                 //obj
                 ...this.obj.transpile(state),
                 //   [
-                new SourceNode(this.openingSquare.range.start.line + 1, this.openingSquare.range.start.character, state.pathAbsolute, '['),
+                state.sourceNode(this.openingSquare, '['),
                 //    index
                 ...this.index.transpile(state),
                 //         ]
-                new SourceNode(this.closingSquare.range.start.line + 1, this.closingSquare.range.start.character, state.pathAbsolute, ']'),
+                state.sourceNode(this.closingSquare, ']'),
                 //           =
                 ' = ',
                 //             value
@@ -1062,13 +1061,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     transpile(state: TranspileState) {
         let result = [];
         result.push(
-            new SourceNode(this.tokens.library.range.start.line + 1, this.tokens.library.range.start.character, state.pathAbsolute, 'library')
+            state.sourceNode(this.tokens.library, 'library')
         );
         //there will be a parse error if file path is missing, but let's prevent a runtime error just in case
         if (this.tokens.filePath) {
             result.push(
                 ' ',
-                new SourceNode(this.tokens.filePath.range.start.line + 1, this.tokens.filePath.range.start.character, state.pathAbsolute, this.tokens.filePath.text)
+                state.sourceNode(this.tokens.filePath, this.tokens.filePath.text)
             );
         }
         return result;
@@ -1174,12 +1173,7 @@ export class ImportStatement extends Statement implements TypedefProvider {
         //The xml files are responsible for adding the additional script imports, but
         //add the import statement as a comment just for debugging purposes
         return [
-            new SourceNode(
-                this.range.start.line + 1,
-                this.range.start.character,
-                state.file.pathAbsolute,
-                `'${this.importToken.text} ${this.filePathToken.text}`
-            )
+            state.sourceNode(this, [`'`, this.importToken.text, '', this.filePathToken.text])
         ];
     }
 
@@ -1252,7 +1246,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         let result = [];
         //make the builder
         result.push(...this.getTranspiledBuilder(state));
@@ -1266,7 +1260,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
     }
 
     getTypedef(state: TranspileState) {
-        const result = [] as Array<string | SourceNode>;
+        const result = [] as TranspileResult;
         result.push(
             'class ',
             this.name.text
@@ -1488,24 +1482,9 @@ export class ClassStatement extends Statement implements TypedefProvider {
         const constructorParams = constructorFunction ? constructorFunction.func.parameters : [];
 
         result.push(
-            new SourceNode(
-                this.classKeyword.range.start.line + 1,
-                this.classKeyword.range.start.character,
-                state.pathAbsolute,
-                'function'
-            ),
-            new SourceNode(
-                this.classKeyword.range.end.line + 1,
-                this.classKeyword.range.end.character,
-                state.pathAbsolute,
-                ' '
-            ),
-            new SourceNode(
-                this.name.range.start.line + 1,
-                this.name.range.start.character,
-                state.pathAbsolute,
-                this.getName(ParseMode.BrightScript)
-            ),
+            state.sourceNode(this.classKeyword, 'function'),
+            state.sourceNode(this.classKeyword, ' '),
+            state.sourceNode(this.name, this.getName(ParseMode.BrightScript)),
             `(`
         );
         let i = 0;
@@ -1580,7 +1559,7 @@ export class ClassMethodStatement extends FunctionStatement {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState) {
         if (this.name.text.toLowerCase() === 'new') {
             this.ensureSuperConstructorCall(state);
             //TODO we need to undo this at the bottom of this method
@@ -1755,7 +1734,7 @@ export class ClassFieldStatement extends Statement implements TypedefProvider {
 
     public readonly range: Range;
 
-    transpile(state: TranspileState): Array<SourceNode | string> {
+    transpile(state: TranspileState): TranspileResult {
         throw new Error('transpile not implemented for ' + Object.getPrototypeOf(this).constructor.name);
     }
 

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -1,6 +1,7 @@
 import { SourceNode } from 'source-map';
 import type { Range } from 'vscode-languageserver';
 import type { BrsFile } from '../files/BrsFile';
+import type { Token } from '../lexer/Token';
 import type { ClassStatement } from './Statement';
 
 /**
@@ -69,18 +70,25 @@ export class TranspileState {
      * Shorthand for creating a new source node
      */
     public sourceNode(locatable: { range: Range }, code: string | SourceNode | Array<string | SourceNode>): SourceNode | undefined {
-        const node = new SourceNode(
-            null,
-            null,
+        return new SourceNode(
+            locatable.range.start.line + 1,
+            locatable.range.start.character,
             this.pathAbsolute,
-            code ?? ''
+            code
         );
-        if (locatable?.range) {
-            //convert 0-based Range line to 1-based SourceNode line
-            node.line = locatable.range.start.line + 1;
-            //SourceNode columns are 0-based so no conversion necessary
-            node.column = locatable.range.start.character;
-        }
-        return node;
+    }
+
+    /**
+     * Create a SourceNode from a token. This is more efficient than the above `sourceNode` function
+     * because the entire token is passed by reference, instead of the raw string being copied to the parameter,
+     * only to then be copied again for the SourceNode constructor
+     */
+    public tokenToSourceNode(token: Token) {
+        return new SourceNode(
+            token.range.start.line + 1,
+            token.range.start.character,
+            this.pathAbsolute,
+            token.text
+        );
     }
 }

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -68,13 +68,19 @@ export class TranspileState {
     /**
      * Shorthand for creating a new source node
      */
-    public sourceNode(locatable: { range: Range }, code: string) {
-        let result = new SourceNode(
-            locatable.range.start.line,
-            locatable.range.start.character,
+    public sourceNode(locatable: { range: Range }, code: string | SourceNode | Array<string | SourceNode>): SourceNode | undefined {
+        const node = new SourceNode(
+            null,
+            null,
             this.pathAbsolute,
-            code
+            code ?? ''
         );
-        return code || result;
+        if (locatable?.range) {
+            //convert 0-based Range line to 1-based SourceNode line
+            node.line = locatable.range.start.line + 1;
+            //SourceNode columns are 0-based so no conversion necessary
+            node.column = locatable.range.start.character;
+        }
+        return node;
     }
 }

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -71,7 +71,9 @@ export class TranspileState {
      */
     public sourceNode(locatable: { range: Range }, code: string | SourceNode | Array<string | SourceNode>): SourceNode | undefined {
         return new SourceNode(
+            //convert 0-based range line to 1-based SourceNode line
             locatable.range.start.line + 1,
+            //range and SourceNode character are both 0-based, so no conversion necessary
             locatable.range.start.character,
             this.pathAbsolute,
             code
@@ -85,7 +87,9 @@ export class TranspileState {
      */
     public tokenToSourceNode(token: Token) {
         return new SourceNode(
+            //convert 0-based range line to 1-based SourceNode line
             token.range.start.line + 1,
+            //range and SourceNode character are both 0-based, so no conversion necessary
             token.range.start.character,
             this.pathAbsolute,
             token.text


### PR DESCRIPTION
Centralizes all of the brs transpiling SourceNode line and column tracking into a single function.
 - the previous `state.sourceNode` implementation did not convert 0-based Range line to 1-based SourceNode line. This fixes that problem and should improve debug precision
 - remove use of `new SourceNode` from `Expressions.ts` and `Statements.ts`
 - for token transpiling, use `state.tokenToSourceNode` which should have a slight performance bump since the token text is passed in by reference on the `token` reference rather than by value as the second parameter to `state.sourceNode`
 - fixed a few small bugs in transpile