### PR TITLE
codeaction don't fail on missing file

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -561,6 +561,8 @@ export class LanguageServer {
 
         let codeActions = this
             .getWorkspaces()
+            //skip programs that don't have this file
+            .filter(x => x.builder.program.hasFile(filePath))
             .flatMap(workspace => workspace.builder.program.getCodeActions(filePath, params.range));
 
         return codeActions;

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -14,6 +14,7 @@ import PluginInterface from './PluginInterface';
 import type { FunctionStatement } from './parser/Statement';
 import { EmptyStatement } from './parser/Statement';
 import { expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
+import { doesNotThrow } from 'assert';
 
 let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;
@@ -681,6 +682,14 @@ describe('Program', () => {
 
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).to.exist;
 
+        });
+    });
+
+    describe('getCodeActions', () => {
+        it('does not fail when file is missing from program', () => {
+            doesNotThrow(() => {
+                program.getCodeActions('not/real/file', util.createRange(1, 2, 3, 4));
+            });
         });
     });
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -744,23 +744,25 @@ export class Program {
     public getCodeActions(pathAbsolute: string, range: Range) {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(pathAbsolute);
+        if (file) {
 
-        this.plugins.emit('beforeProgramGetCodeActions', this, file, range, codeActions);
+            this.plugins.emit('beforeProgramGetCodeActions', this, file, range, codeActions);
 
-        //get code actions from the file
-        file.getCodeActions(range, codeActions);
+            //get code actions from the file
+            file.getCodeActions(range, codeActions);
 
-        //get code actions from every scope this file is a member of
-        for (let key in this.scopes) {
-            let scope = this.scopes[key];
+            //get code actions from every scope this file is a member of
+            for (let key in this.scopes) {
+                let scope = this.scopes[key];
 
-            if (scope.hasFile(file)) {
-                //get code actions from each scope this file is a member of
-                scope.getCodeActions(file, range, codeActions);
+                if (scope.hasFile(file)) {
+                    //get code actions from each scope this file is a member of
+                    scope.getCodeActions(file, range, codeActions);
+                }
             }
-        }
 
-        this.plugins.emit('afterProgramGetCodeActions', this, file, range, codeActions);
+            this.plugins.emit('afterProgramGetCodeActions', this, file, range, codeActions);
+        }
         return codeActions;
     }
 


### PR DESCRIPTION
Resolves an oversight in codeAction functionality where we weren't accounting for missing files or programs that didn't have the file.
Fixes #322 