### PR TITLE
include namespace for class extends in typedef

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2321,6 +2321,23 @@ describe('BrsFile', () => {
             expect(file.getTypedef()).to.eql(expected);
         }
 
+        it('includes namespace on extend class names', () => {
+            testTypedef(`
+                namespace AnimalKingdom
+                    class Bird
+                    end class
+                    class Duck extends Bird
+                    end class
+                end namespace`, trim`
+                namespace AnimalKingdom
+                    class Bird
+                    end class
+                    class Duck extends AnimalKingdom.Bird
+                    end class
+                end namespace
+            `);
+        });
+
         it('strips function body', () => {
             testTypedef(`
                 sub main(param1 as string)

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1289,8 +1289,12 @@ export class ClassStatement extends Statement implements TypedefProvider {
             this.name.text
         );
         if (this.extendsKeyword && this.parentClassName) {
+            const fqName = util.getFullyQualifiedClassName(
+                this.parentClassName.getName(ParseMode.BrighterScript),
+                this.namespaceName?.getName(ParseMode.BrighterScript)
+            );
             result.push(
-                ` extends ${this.parentClassName.getName(ParseMode.BrighterScript)}`
+                ` extends ${fqName}`
             );
         }
         result.push(state.newline());


### PR DESCRIPTION
When generating type definition files, include the namespace for every `extends` statement, just for clarity. 