### PR TITLE
Prevent completion error for first token in file

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -123,7 +123,15 @@ describe('BrsFile', () => {
             expect(names).to.contain('m');
         });
 
-        it('includes all keywordsm`', () => {
+        it('does not fail for missing previousToken', () => {
+            //add a single character to the file, and get completions after it
+            program.addOrReplaceFile('source/main.brs', `i`);
+            expect(() => {
+                program.getCompletions(`${rootDir}/source/main.brs`, Position.create(0, 1)).map(x => x.label);
+            }).not.to.throw;
+        });
+
+        it('includes all keywords`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
             program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1073,17 +1073,18 @@ export class BrsFile {
     }
 
     public isPositionNextToTokenKind(position: Position, tokenKind: TokenKind) {
-        let closestToken = this.getClosestToken(position);
-        let previousToken = this.getPreviousToken(closestToken);
+        const closestToken = this.getClosestToken(position);
+        const previousToken = this.getPreviousToken(closestToken);
+        const previousTokenKind = previousToken?.kind;
         //next to matched token
         if (!closestToken || closestToken.kind === TokenKind.Eof) {
             return false;
         } else if (closestToken.kind === tokenKind) {
             return true;
-        } else if (closestToken.kind === TokenKind.Newline || previousToken.kind === TokenKind.Newline) {
+        } else if (closestToken.kind === TokenKind.Newline || previousTokenKind === TokenKind.Newline) {
             return false;
             //next to an identifier, which is next to token kind
-        } else if (closestToken.kind === TokenKind.Identifier && previousToken.kind === tokenKind) {
+        } else if (closestToken.kind === TokenKind.Identifier && previousTokenKind === tokenKind) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Fixes null reference exception caused by activating completions on the first token in a file