### PR TITLE
Fix - print statement parsing

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1782,7 +1782,7 @@ export class Parser {
             return new ReturnStatement(tokens);
         }
 
-        let toReturn = this.expression();
+        let toReturn = this.check(TokenKind.Else) ? undefined : this.expression();
         return new ReturnStatement(tokens, toReturn);
     }
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1750,6 +1750,8 @@ export class Parser {
                 values.push(this.advance() as PrintSeparatorSpace);
             } else if (this.check(TokenKind.Comma)) {
                 values.push(this.advance() as PrintSeparatorTab);
+            } else if (this.check(TokenKind.Else)) {
+                break; // inline branch
             } else {
                 values.push(this.expression());
             }

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -220,6 +220,19 @@ describe('parser if statements', () => {
             expect(diagnostics).to.be.lengthOf(0);
             expect(statements).to.be.length.greaterThan(0);
         });
+
+        it('parses print statement in inline block', () => {
+            const { statements, diagnostics } = Parser.parse(`
+                if true print 1 else print 1
+                if true then print 1 else print 1
+                if true print "x=" ; 1 else print 1
+                if true then print "x=", 1 else print 1
+                if true print "x=" 1 else print 1
+            `);
+
+            expect(diagnostics).to.be.lengthOf(0);
+            expect(statements).to.be.length.greaterThan(0);
+        });
     });
 
     describe('block if', () => {

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -221,13 +221,15 @@ describe('parser if statements', () => {
             expect(statements).to.be.length.greaterThan(0);
         });
 
-        it('parses print statement in inline block', () => {
+        it('parses special statements in inline block', () => {
             const { statements, diagnostics } = Parser.parse(`
                 if true print 1 else print 1
                 if true then print 1 else print 1
                 if true print "x=" ; 1 else print 1
                 if true then print "x=", 1 else print 1
                 if true print "x=" 1 else print 1
+                if true return else print 1
+                if true then return else print 1
             `);
 
             expect(diagnostics).to.be.lengthOf(0);


### PR DESCRIPTION
Print statement parsing needs to stop when it reaches an `else`

Fixes #344 
