### PR TITLE
Bslib fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ bslib is actually published to npm under the name [@rokucommunity/bslib](https:/
 ropm install bslib@npm:@rokucommunity/bslib
 ```
 
-If you're using a version of NodeJS that doesn't support aliases, then you can also simply install @rokucommunity/bslib directly without the alias, and BrighterScript will recognize this as well.
+If you're using a version of NodeJS that doesn't support npm aliases, then you can also simply install @rokucommunity/bslib directly without the alias, and BrighterScript will recognize this as well.
 ```bash
 ropm install @rokucommunity/bslib
 ```

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ bslib is actually published to npm under the name [@rokucommunity/bslib](https:/
 ropm install bslib@npm:@rokucommunity/bslib
 ```
 
+If you're using a version of NodeJS that doesn't support aliases, then you can also simply install @rokucommunity/bslib directly without the alias, and BrighterScript will recognize this as well.
+```bash
+ropm install @rokucommunity/bslib
+```
 ## Language Server Protocol
 
 This project also contributes a class that aligns with Microsoft's [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), which makes it easy to integrate `BrightScript` and `BrighterScript` with any IDE that supports the protocol. We won't go into more detail here, but you can use the `LanguageServer` class from this project to integrate into your IDE. The [vscode-BrightScript-language](https://github.com/rokucommunity/vscode-BrightScript-language) extension uses this LanguageServer class to bring `BrightScript` and `BrighterScript` language support to Visual Studio Code.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ To encourage reducing code duplication, BrighterScript has built-in support for 
 
 
 ### Installing bslib in your ropm-enabled project
-bslib is actually published to npm under the name [@rokucommunity/bslib](https://npmjs.com/package/@rokucommunity/bslib). If you are using NodeJS version 12 or above, we recommend installing `@rokucommunity/bslib` with the `bslib` alias, as it keeps the transpiled code size smaller since the bslib function names shorter (i.e. `bslib_` instead of `rokucommunity_bslib_`). Here's the command to install bslib under the `bslib` alias using the ropm CLI.
+bslib is published to npm under the name [@rokucommunity/bslib](https://npmjs.com/package/@rokucommunity/bslib). If you use NodeJS version 12 or above, we recommend installing `@rokucommunity/bslib` with the `bslib` alias, as it produces smaller transpiled code (i.e. emits `bslib_` prefix instead of `rokucommunity_bslib_`). Here's the command to install bslib under the `bslib` alias using the ropm CLI.
 
 ```bash
 ropm install bslib@npm:@rokucommunity/bslib

--- a/README.md
+++ b/README.md
@@ -264,17 +264,19 @@ To encourage reducing code duplication, BrighterScript has built-in support for 
 2. if your program uses ropm and has installed `bslib` as a dependency, then the BrighterScript compiler will _not_ emit a copy of bslib at `pkg:/source/bslib.brs`, and will instead use the path to the version from ropm `pkg:/source/roku_modules/bslib/bslib.brs`.
 
 
-
 ### Installing bslib in your ropm-enabled project
-bslib is actually published to npm under the name [@rokucommunity/bslib](https://npmjs.com/package/@rokucommunity/bslib). However, to keep the bslib function names short, BrighterScript requires that you install @rokucommunity/bslib with the `bslib` alias. Here's the command to do that using the ropm CLI.
+bslib is actually published to npm under the name [@rokucommunity/bslib](https://npmjs.com/package/@rokucommunity/bslib). If you are using NodeJS version 12 or above, we recommend installing `@rokucommunity/bslib` with the `bslib` alias, as it keeps the transpiled code size smaller since the bslib function names shorter (i.e. `bslib_` instead of `rokucommunity_bslib_`). Here's the command to install bslib under the `bslib` alias using the ropm CLI.
+
 ```bash
 ropm install bslib@npm:@rokucommunity/bslib
 ```
 
-If you're using a version of NodeJS that doesn't support npm aliases, then you can also simply install @rokucommunity/bslib directly without the alias, and BrighterScript will recognize this as well.
+#### bslib support on NodeJS versions less than 12
+npm aliases only work in NodeJS version 12 and above. If you're using a NodeJS version less than 12, you will need to install @rokucommunity/bslib directly without the alias. BrighterScript recognizes this pattern as well, it's just not preferred (for the reasons mentioned previously). Here's the command for that:
 ```bash
 ropm install @rokucommunity/bslib
 ```
+
 ## Language Server Protocol
 
 This project also contributes a class that aligns with Microsoft's [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), which makes it easy to integrate `BrightScript` and `BrighterScript` with any IDE that supports the protocol. We won't go into more detail here, but you can use the `LanguageServer` class from this project to integrate into your IDE. The [vscode-BrightScript-language](https://github.com/rokucommunity/vscode-BrightScript-language) extension uses this LanguageServer class to bring `BrightScript` and `BrighterScript` language support to Visual Studio Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,6 +324,11 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@rokucommunity/bslib": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
+            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
+        },
         "@sinonjs/commons": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1028,11 +1033,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "bslib": {
-            "version": "npm:@rokucommunity/bslib@0.1.1",
-            "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
-            "integrity": "sha512-2ox6EUL+UTtccTbD4dbVjZK3QHa0PHCqpoKMF8lZz9ayzzEP3iVPF8KZR6hOi6bxsIcbGXVjqmtCVkpC4P9SrA=="
         },
         "buffer": {
             "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
         "vscode-jsonrpc": "^5.0.1"
     },
     "dependencies": {
+        "@rokucommunity/bslib": "^0.1.1",
         "@xml-tools/parser": "^1.0.7",
         "array-flat-polyfill": "^1.0.1",
-        "bslib": "npm:@rokucommunity/bslib@^0.1.1",
         "chalk": "^2.4.2",
         "chokidar": "^3.0.2",
         "clear": "^0.1.0",

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -26,7 +26,8 @@ import { ParseMode } from './parser';
 import { TokenKind } from './lexer';
 import { BscPlugin } from './bscPlugin/BscPlugin';
 const startOfSourcePkgPath = `source${path.sep}`;
-const bslibRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
+const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
+const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
 
 export interface SourceObj {
     pathAbsolute: string;
@@ -126,13 +127,28 @@ export class Program {
      * The path to bslib.brs (the BrightScript runtime for certain BrighterScript features)
      */
     public get bslibPkgPath() {
-        //if there's a version of bslib from roku_modules loaded into the program, use that
-        if (this.getFileByPkgPath(bslibRokuModulesPkgPath)) {
-            return bslibRokuModulesPkgPath;
+        //if there's an aliased (preferred) version of bslib from roku_modules loaded into the program, use that
+        if (this.getFileByPkgPath(bslibAliasedRokuModulesPkgPath)) {
+            return bslibAliasedRokuModulesPkgPath;
+
+            //if there's a non-aliased version of bslib from roku_modules, use that
+        } else if (this.getFileByPkgPath(bslibNonAliasedRokuModulesPkgPath)) {
+            return bslibNonAliasedRokuModulesPkgPath;
+
+            //default to the embedded version
         } else {
             return `source${path.sep}bslib.brs`;
         }
     }
+
+    public get bslibPrefix() {
+        if (this.bslibPkgPath === bslibNonAliasedRokuModulesPkgPath) {
+            return 'rokucommunity_bslib';
+        } else {
+            return 'bslib';
+        }
+    }
+
 
     /**
      * A map of every file loaded into this program, indexed by its original file location
@@ -1155,7 +1171,7 @@ export class Program {
         });
 
         //if there's no bslib file already loaded into the program, copy it to the staging directory
-        if (!this.getFileByPkgPath(bslibRokuModulesPkgPath) && !this.getFileByPkgPath(s`source/bslib.brs`)) {
+        if (!this.getFileByPkgPath(bslibAliasedRokuModulesPkgPath) && !this.getFileByPkgPath(s`source/bslib.brs`)) {
             promises.push(util.copyBslibToStaging(stagingFolderPath));
         }
         await Promise.all(promises);

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1088,7 +1088,7 @@ export class TemplateStringExpression extends Expression {
                     //wrap all other expressions with a bslib_toString call to prevent runtime type mismatch errors
                 } else {
                     add(
-                        'bslib_toString(',
+                        state.bslibPrefix + '_toString(',
                         ...expression.transpile(state),
                         ')'
                     );
@@ -1296,7 +1296,7 @@ export class TernaryExpression extends Expression {
             state.blockDepth--;
         } else {
             result.push(
-                state.sourceNode(this.test, `bslib_ternary(`),
+                state.sourceNode(this.test, state.bslibPrefix + `_ternary(`),
                 ...this.test.transpile(state),
                 state.sourceNode(this.test, `, `),
                 ...this.consequent?.transpile(state) ?? ['invalid'],
@@ -1381,7 +1381,7 @@ export class NullCoalescingExpression extends Expression {
             state.blockDepth--;
         } else {
             result.push(
-                `bslib_coalesce(`,
+                state.bslibPrefix + `_coalesce(`,
                 ...this.consequent.transpile(state),
                 ', ',
                 ...this.alternate.transpile(state),

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -25,6 +25,7 @@ export class TranspileState {
         } else {
             this.pathAbsolute = this.file.pathAbsolute;
         }
+        this.bslibPrefix = this.file.program.bslibPrefix;
     }
 
     /**
@@ -33,6 +34,11 @@ export class TranspileState {
      * If the file resides outside of rootDir, then no changes will be made to this path.
      */
     public pathAbsolute: string;
+
+    /**
+     * The prefix to use in front of all bslib functions
+     */
+    public bslibPrefix: string;
 
     /**
      * The number of active parent blocks for the current location of the state.

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -190,6 +190,14 @@ describe('NullCoalescingExpression', () => {
             program.dispose();
         });
 
+        it('uses the proper prefix when aliased package is installed', () => {
+            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            testTranspile(
+                'a = user ?? false',
+                `a = rokucommunity_bslib_coalesce(user, false)`
+            );
+        });
+
         it('properly transpiles null coalesence assignments - simple', () => {
             testTranspile(`a = user ?? {"id": "default"}`, 'a = bslib_coalesce(user, {\n    "id": "default"\n})', 'none');
         });

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -74,6 +74,14 @@ describe('TemplateStringExpression', () => {
             program.dispose();
         });
 
+        it('uses the proper prefix when aliased package is installed', () => {
+            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            testTranspile(
+                'a = `${one},${two}`',
+                `a = rokucommunity_bslib_toString(one) + "," + rokucommunity_bslib_toString(two)`
+            );
+        });
+
         it('properly transpiles simple template string with no leading text', () => {
             testTranspile(
                 'a = `${one},${two}`',

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -266,6 +266,14 @@ describe('ternary expressions', () => {
             program.dispose();
         });
 
+        it('uses the proper prefix when aliased package is installed', () => {
+            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            testTranspile(
+                `a = user = invalid ? "no user" : "logged in"`,
+                `a = rokucommunity_bslib_ternary(user = invalid, "no user", "logged in")`
+            );
+        });
+
         it('simple consequents', () => {
             testTranspile(
                 `a = user = invalid ? "no user" : "logged in"`,

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -635,6 +635,11 @@ describe('util', () => {
         it('copies from local bslib dependency', async () => {
             await util.copyBslibToStaging(tempDir);
             expect(fsExtra.pathExistsSync(`${tempDir}/source/bslib.brs`)).to.be.true;
+            expect(
+                /^function bslib_toString\(/mg.exec(
+                    fsExtra.readFileSync(`${tempDir}/source/bslib.brs`).toString()
+                )
+            ).not.to.be.null;
         });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1189,8 +1189,9 @@ export class Util {
         //apply the `bslib_` prefix to the functions
         let match: RegExpExecArray;
         const positions = [] as number[];
+        const regexp = /^(\s*(?:function|sub)\s+)([a-z0-9_]+)/mg;
         // eslint-disable-next-line no-cond-assign
-        while (match = /^(\s*(?:function|sub)\s+)([a-z0-9_]+)/.exec(source)) {
+        while (match = regexp.exec(source)) {
             positions.push(match.index + match[1].length);
         }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1183,7 +1183,7 @@ export class Util {
         //copy bslib to the output directory
         await fsExtra.ensureDir(standardizePath(`${stagingDir}/source`));
         // eslint-disable-next-line
-        const bslib = require('bslib');
+        const bslib = require('@rokucommunity/bslib');
         let source = bslib.source as string;
 
         //apply the `bslib_` prefix to the functions


### PR DESCRIPTION
Adds:
 - support for both npm aliased bslib AND non-aliased:
     - `ropm install bslib@npm:@rokucommunity/bslib`
     - `ropm install @rokucommunity/bslib`

Fixes:
 - bug with npm alias of bslib for node version 10
 - infinite loop when rewriting the bslib file during transpile.
 