### PR TITLE
Fixes #348 - Use 'toTypeString' method on transpilation of function return types

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1750,7 +1750,6 @@ describe('Program', () => {
                 s`${sourceRoot}/source/main.bs`
             );
         });
-
     });
 
     describe('typedef', () => {

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1750,6 +1750,36 @@ describe('Program', () => {
                 s`${sourceRoot}/source/main.bs`
             );
         });
+
+        it('replaces custom types in bs files', async () => {
+            let sourceRoot = s`${tmpPath}/sourceRootFolder`;
+            program = new Program({
+                rootDir: rootDir,
+                stagingFolderPath: stagingFolderPath,
+                sourceRoot: sourceRoot,
+                sourceMap: true
+            });
+            program.addOrReplaceFile('source/customType.bs', `
+                class SomeKlass
+                end class
+
+                function foo() as SomeKlass
+                    return new SomeKlass()
+                end function
+
+                sub bar(obj as SomeKlass)
+                end function
+            `);
+            await program.transpile([{
+                src: s`${rootDir}/source/main.bs`,
+                dest: s`source/main.bs`
+            }], stagingFolderPath);
+
+            const transpiledSource =
+                fsExtra.readFileSync(s`${stagingFolderPath}/source/customType.brs`).toString();
+            expect(transpiledSource.indexOf("as SomeKlass")).to.eq(-1);
+        });
+
     });
 
     describe('typedef', () => {

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1751,35 +1751,6 @@ describe('Program', () => {
             );
         });
 
-        it('replaces custom types in bs files', async () => {
-            let sourceRoot = s`${tmpPath}/sourceRootFolder`;
-            program = new Program({
-                rootDir: rootDir,
-                stagingFolderPath: stagingFolderPath,
-                sourceRoot: sourceRoot,
-                sourceMap: true
-            });
-            program.addOrReplaceFile('source/customType.bs', `
-                class SomeKlass
-                end class
-
-                function foo() as SomeKlass
-                    return new SomeKlass()
-                end function
-
-                sub bar(obj as SomeKlass)
-                end function
-            `);
-            await program.transpile([{
-                src: s`${rootDir}/source/main.bs`,
-                dest: s`source/main.bs`
-            }], stagingFolderPath);
-
-            const transpiledSource =
-                fsExtra.readFileSync(s`${stagingFolderPath}/source/customType.brs`).toString();
-            expect(transpiledSource.indexOf("as SomeKlass")).to.eq(-1);
-        });
-
     });
 
     describe('typedef', () => {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2191,7 +2191,7 @@ describe('BrsFile', () => {
             expect(code.endsWith(`'//# sourceMappingURL=./logger.brs.map`)).to.be.true;
         });
 
-        it('replaces custom types in parameter types and return types', async () => {
+        it('replaces custom types in parameter types and return types', () => {
             testTranspile(`
                 function foo() as SomeKlass
                     return new SomeKlass()

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2190,6 +2190,25 @@ describe('BrsFile', () => {
             const { code } = file.transpile();
             expect(code.endsWith(`'//# sourceMappingURL=./logger.brs.map`)).to.be.true;
         });
+
+        it('replaces custom types in parameter types and return types', async () => {
+            testTranspile(`
+                function foo() as SomeKlass
+                    return new SomeKlass()
+                end function
+
+                sub bar(obj as SomeKlass)
+                end sub
+            `, `
+                function foo() as object
+                    return SomeKlass()
+                end function
+
+                sub bar(obj as object)
+                end sub
+            `);
+        });
+
     });
 
     describe('callfunc operator', () => {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -216,7 +216,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
                 state.tokenToSourceNode(this.asToken),
                 ' ',
                 //return type
-                state.tokenToSourceNode(this.returnTypeToken)
+                state.sourceNode(this.returnTypeToken, this.returnType.toTypeString())
             );
         }
         if (includeBody) {


### PR DESCRIPTION
Also added a test with transpiling with custom types.