### PR TITLE
onSignatureHelp stability fix

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -16,6 +16,8 @@ import { EmptyStatement } from './parser/Statement';
 import { expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
 import { doesNotThrow } from 'assert';
 import { Logger } from './Logger';
+import { createToken } from './astUtils';
+import { TokenKind } from './lexer';
 
 let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;
@@ -1802,6 +1804,15 @@ describe('Program', () => {
     });
 
     describe('getSignatureHelp', () => {
+        it('does not crash when second previousToken is undefined', () => {
+            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ` `);
+            sinon.stub(file, 'getPreviousToken').returns(undefined);
+            //should not crash
+            expect(
+                file['getClassFromMReference'](util.createPosition(2, 3), createToken(TokenKind.Dot, '.'), null)
+            ).to.be.undefined;
+        });
+
         it('works with no leading whitespace when the cursor is after the open paren', () => {
             program.addOrReplaceFile('source/main.brs', `sub main()\nsayHello()\nend sub\nsub sayHello(name)\nend sub`);
             let signatureHelp = program.getSignatureHelp(

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -934,7 +934,7 @@ export class BrsFile {
         if (previousToken?.kind === TokenKind.Dot) {
             previousToken = this.getPreviousToken(previousToken);
         }
-        if (previousToken.kind === TokenKind.Identifier && previousToken.text.toLowerCase() === 'm' && isClassMethodStatement(functionScope.func.functionStatement)) {
+        if (previousToken?.kind === TokenKind.Identifier && previousToken?.text.toLowerCase() === 'm' && isClassMethodStatement(functionScope.func.functionStatement)) {
             return { item: this.parser.references.classStatements.find((cs) => util.rangeContains(cs.range, position)), file: this };
         }
         return undefined;


### PR DESCRIPTION
Fixes a crash when `getClassFromMReference` would throw an exception when previousToken was null. 

#357 shows a stack trace where the code is crashing. I couldn't figure out the brightscript code to reproduce it, but I was able to write a unit test that causes the crash to occur, so I fixed it that way. 
Fixes #357