### PR TITLE
Move `getTestTranspile` into test helpers

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1,14 +1,13 @@
 import * as sinonImport from 'sinon';
 
 import { Program } from '../Program';
-import { getTestTranspile } from './BrsFile.spec';
 import type { BrsFile } from './BrsFile';
 import { expect } from 'chai';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { Diagnostic } from 'vscode-languageserver';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { ParseMode } from '../parser/Parser';
-import { expectZeroDiagnostics } from '../testHelpers.spec';
+import { expectZeroDiagnostics, getTestTranspile } from '../testHelpers.spec';
 import { standardizePath as s } from '../util';
 import * as fsExtra from 'fs-extra';
 import { TranspileState } from '../parser/TranspileState';

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -16,7 +16,7 @@ import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
-import { expectZeroDiagnostics, trim, trimMap } from '../testHelpers.spec';
+import { expectZeroDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
 import { ParseMode } from '../parser/Parser';
 import { Logger } from '../Logger';
 
@@ -2754,53 +2754,3 @@ describe('BrsFile', () => {
         });
     });
 });
-
-export function getTestTranspile(scopeGetter: () => [Program, string]) {
-    return (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
-        let [program, rootDir] = scopeGetter();
-        expected = expected ? expected : source;
-        let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
-        program.validate();
-        let diagnostics = file.getDiagnostics();
-        if (diagnostics.length > 0 && failOnDiagnostic !== false) {
-            throw new Error(
-                diagnostics[0].range.start.line +
-                ':' +
-                diagnostics[0].range.start.character +
-                ' ' +
-                diagnostics[0]?.message
-            );
-        }
-        let transpiled = file.transpile();
-
-        let sources = [transpiled.code, expected];
-        for (let i = 0; i < sources.length; i++) {
-            if (formatType === 'trim') {
-                let lines = sources[i].split('\n');
-                //throw out leading newlines
-                while (lines[0].length === 0) {
-                    lines.splice(0, 1);
-                }
-                let trimStartIndex = null;
-                for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-                    //if we don't have a starting trim count, compute it
-                    if (!trimStartIndex) {
-                        trimStartIndex = lines[lineIndex].length - lines[lineIndex].trim().length;
-                    }
-                    //only trim the expected file (since that's what we passed in from the test)
-                    if (lines[lineIndex].length > 0 && i === 1) {
-                        lines[lineIndex] = lines[lineIndex].substring(trimStartIndex);
-                    }
-                }
-                //trim trailing newlines
-                while (lines[lines.length - 1]?.length === 0) {
-                    lines.splice(lines.length - 1);
-                }
-                sources[i] = lines.join('\n');
-
-            }
-        }
-        expect(trimMap(sources[0])).to.equal(sources[1]);
-        return transpiled;
-    };
-}

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -10,8 +10,7 @@ import { Program } from '../Program';
 import { BrsFile } from './BrsFile';
 import { XmlFile } from './XmlFile';
 import { standardizePath as s } from '../util';
-import { getTestTranspile } from './BrsFile.spec';
-import { expectZeroDiagnostics, trim, trimMap } from '../testHelpers.spec';
+import { expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 
 describe('XmlFile', () => {
     const tempDir = s`${process.cwd()}/.tmp`;

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -6,8 +6,7 @@ import { Program } from '../../Program';
 import { standardizePath as s } from '../../util';
 import type { XmlFile } from '../XmlFile';
 import type { BrsFile } from '../BrsFile';
-import { getTestTranspile } from '../BrsFile.spec';
-import { trim, trimMap } from '../../testHelpers.spec';
+import { getTestTranspile, trim, trimMap } from '../../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -15,8 +15,7 @@ import {
     NullCoalescingExpression
 } from '../../Expression';
 import { Program } from '../../..';
-import { getTestTranspile } from '../../../files/BrsFile.spec';
-import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import { expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 
 describe('NullCoalescingExpression', () => {
     it('throws exception when used in brightscript scope', () => {

--- a/src/parser/tests/expression/SourceLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/SourceLiteralExpression.spec.ts
@@ -1,7 +1,7 @@
-import { getTestTranspile } from '../../../files/BrsFile.spec';
 import { Program } from '../../../Program';
 import { standardizePath as s } from '../../../util';
 import * as fileUrl from 'file-url';
+import { getTestTranspile } from '../../../testHelpers.spec';
 
 describe('SourceLiteralExpression', () => {
     let rootDir = s`${process.cwd()}/rootDir`;

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -6,8 +6,8 @@ import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Lexer } from '../../../lexer';
 import { Parser, ParseMode } from '../../Parser';
 import { AssignmentStatement } from '../../Statement';
-import { getTestTranspile } from '../../../files/BrsFile.spec';
 import { Program } from '../../../Program';
+import { getTestTranspile } from '../../../testHelpers.spec';
 
 describe('TemplateStringExpression', () => {
     describe('parser template String', () => {

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -17,8 +17,7 @@ import {
     LiteralExpression
 } from '../../Expression';
 import { Program } from '../../../Program';
-import { getTestTranspile } from '../../../files/BrsFile.spec';
-import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import { expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 
 describe('ternary expressions', () => {
     it('throws exception when used in brightscript scope', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -5,6 +5,11 @@ import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import type { CodeActionShorthand } from './CodeActionUtil';
 import { codeActionUtil } from './CodeActionUtil';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { BrsFile } from './files/BrsFile';
+import type { Program } from './Program';
+import { standardizePath as s } from './util';
+
 /**
  * Trim leading whitespace for every line (to make test writing cleaner
  */
@@ -100,4 +105,54 @@ export function expectCodeActions(test: () => any, expected: CodeActionShorthand
         delete arg.diagnostics;
     }
     expect(args).to.eql(expected);
+}
+
+export function getTestTranspile(scopeGetter: () => [Program, string]) {
+    return (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
+        let [program, rootDir] = scopeGetter();
+        expected = expected ? expected : source;
+        let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
+        program.validate();
+        let diagnostics = file.getDiagnostics();
+        if (diagnostics.length > 0 && failOnDiagnostic !== false) {
+            throw new Error(
+                diagnostics[0].range.start.line +
+                ':' +
+                diagnostics[0].range.start.character +
+                ' ' +
+                diagnostics[0]?.message
+            );
+        }
+        let transpiled = file.transpile();
+
+        let sources = [transpiled.code, expected];
+        for (let i = 0; i < sources.length; i++) {
+            if (formatType === 'trim') {
+                let lines = sources[i].split('\n');
+                //throw out leading newlines
+                while (lines[0].length === 0) {
+                    lines.splice(0, 1);
+                }
+                let trimStartIndex = null;
+                for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+                    //if we don't have a starting trim count, compute it
+                    if (!trimStartIndex) {
+                        trimStartIndex = lines[lineIndex].length - lines[lineIndex].trim().length;
+                    }
+                    //only trim the expected file (since that's what we passed in from the test)
+                    if (lines[lineIndex].length > 0 && i === 1) {
+                        lines[lineIndex] = lines[lineIndex].substring(trimStartIndex);
+                    }
+                }
+                //trim trailing newlines
+                while (lines[lines.length - 1]?.length === 0) {
+                    lines.splice(lines.length - 1);
+                }
+                sources[i] = lines.join('\n');
+
+            }
+        }
+        expect(trimMap(sources[0])).to.equal(sources[1]);
+        return transpiled;
+    };
 }


### PR DESCRIPTION
Just some housecleaning. Moved the `getTestTranspile()` function into `testHelpers.spec.ts` so it's more easily discoverable.