### PR TITLE
Fix needsTranspiled xml issue.

### DIFF
--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -624,6 +624,22 @@ describe('XmlFile', () => {
     });
 
     describe('transpile', () => {
+        it(`honors the 'needsTranspiled' flag when set in 'afterFileParse'`, () => {
+            program.plugins.add({
+                name: 'test',
+                afterFileParse: (file) => {
+                    //enable transpile for every file
+                    file.needsTranspiled = true;
+                }
+            });
+            const file = program.addOrReplaceFile('components/file.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                </component>
+            `);
+            expect(file.needsTranspiled).to.be.true;
+        });
+
         it('includes bslib script', () => {
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -254,7 +254,7 @@ export class XmlFile {
         }
 
         //needsTranspiled should be true if an import is brighterscript
-        this.needsTranspiled = component.scripts.some(
+        this.needsTranspiled = this.needsTranspiled || component.scripts.some(
             script => script.type?.indexOf('brighterscript') > 0 || script.uri?.endsWith('.bs')
         );
 


### PR DESCRIPTION
Fixes issue where `file.needsTranspiled = true` would be reset during certain stages of the plugin lifecycle.