### PR TITLE
Code action callfunc operator refactor

### DIFF
--- a/src/CodeActionUtil.ts
+++ b/src/CodeActionUtil.ts
@@ -20,7 +20,11 @@ export class CodeActionUtil {
                     TextEdit.insert(change.position, change.newText)
                 );
             } else if (change.type === 'replace') {
-                TextEdit.replace(change.range, change.newText);
+                edit.changes[uri].push(
+                    TextEdit.replace(change.range, change.newText)
+                );
+            } else if (change.type === 'delete') {
+                TextEdit.del(change.range);
             }
         }
         return CodeAction.create(obj.title, edit);
@@ -32,7 +36,7 @@ export interface CodeActionShorthand {
     diagnostics?: Diagnostic[];
     kind?: CodeActionKind;
     isPreferred?: boolean;
-    changes: Array<InsertChange | ReplaceChange>;
+    changes: Array<InsertChange | ReplaceChange | DeleteChange>;
 }
 
 export interface InsertChange {
@@ -46,6 +50,12 @@ export interface ReplaceChange {
     filePath: string;
     newText: string;
     type: 'replace';
+    range: Range;
+}
+
+export interface DeleteChange {
+    filePath: string;
+    type: 'delete';
     range: Range;
 }
 

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -225,6 +225,51 @@ describe('CodeActionsProcessor', () => {
                 `import "pkg:/source/Animals.bs"`
             ]);
         });
+
+        it('suggests callfunc operator refactor', () => {
+            //define the function in two files
+            const file = program.addOrReplaceFile('components/main.bs', `
+                sub doSomething()
+                    someComponent.callfunc("doThing")
+                    someComponent.callfunc("doOtherThing", 1, 2)
+                end sub
+            `);
+            program.validate();
+
+            expectCodeActions(() => {
+                program.getCodeActions(
+                    file.pathAbsolute,
+                    util.createRange(2, 39, 2, 39)
+                );
+            }, [{
+                title: `Refactor to use callfunc operator`,
+                isPreferred: false,
+                kind: 'quickfix',
+                changes: [{
+                    filePath: file.pathAbsolute,
+                    newText: '@.doThing(',
+                    type: 'replace',
+                    range: util.createRange(2, 33, 2, 52)
+                }]
+            }]);
+
+            expectCodeActions(() => {
+                program.getCodeActions(
+                    file.pathAbsolute,
+                    util.createRange(3, 39, 3, 39)
+                );
+            }, [{
+                title: `Refactor to use callfunc operator`,
+                isPreferred: false,
+                kind: 'quickfix',
+                changes: [{
+                    filePath: file.pathAbsolute,
+                    newText: '@.doOtherThing(',
+                    type: 'replace',
+                    range: util.createRange(3, 33, 3, 59)
+                }]
+            }]);
+        });
     });
 
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -1,11 +1,14 @@
-import type { Diagnostic } from 'vscode-languageserver';
+import type { Diagnostic, Position } from 'vscode-languageserver';
 import { CodeActionKind } from 'vscode-languageserver';
+import { isBrsFile } from '../../astUtils';
 import { codeActionUtil } from '../../CodeActionUtil';
 import type { DiagnosticMessageType } from '../../DiagnosticMessages';
 import { DiagnosticCodeMap } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { BscFile, OnGetCodeActionsEvent } from '../../interfaces';
+import type { Token } from '../../lexer/Token';
+import { TokenKind } from '../../lexer/TokenKind';
 import { ParseMode } from '../../parser';
 import { util } from '../../util';
 
@@ -25,6 +28,58 @@ export class CodeActionsProcessor {
             } else if (diagnostic.code === DiagnosticCodeMap.xmlComponentMissingExtendsAttribute) {
                 this.addMissingExtends(diagnostic as any);
             }
+        }
+
+        if (isBrsFile(this.event.file)) {
+            const token = this.event.file.getTokenAt(this.event.range.start);
+            const previousToken = this.event.file.getPreviousToken(token);
+            const lowerText = token?.text?.toLowerCase();
+
+            //brighterscript-specific code actions
+            if (this.event.file.extension === '.bs') {
+                if (lowerText === 'callfunc' && previousToken.kind === TokenKind.Dot) {
+                    this.suggestCallfuncOperator(token, previousToken);
+                }
+            }
+        }
+    }
+
+    /**
+     * Suggest refactoring callfunc calls to use the callfunc operator instead
+     */
+    private suggestCallfuncOperator(token: Token, previousToken: Token) {
+        const file = this.event.file as BrsFile;
+        const openParenToken = file.getNextToken(token);
+        const functionNameToken = file.getNextToken(openParenToken);
+
+        const comma = file.getNextToken(functionNameToken, TokenKind.Comma);
+        let endPosition: Position;
+        //consume the comma and any space up until the next token
+        if (comma) {
+            const tokenAfterComma = file.getNextToken(comma);
+            endPosition = tokenAfterComma?.range.start ?? comma?.range.end;
+        } else {
+            endPosition = functionNameToken.range.end;
+        }
+
+
+        //if we have the necessary tokens
+        if (openParenToken?.kind === TokenKind.LeftParen && functionNameToken?.kind === TokenKind.StringLiteral) {
+            //replace leading and trailing quotes
+            const functionName = functionNameToken.text.replace(/^"/, '').replace(/"$/, '');
+            this.event.codeActions.push(
+                codeActionUtil.createCodeAction({
+                    title: `Refactor to use callfunc operator`,
+                    isPreferred: false,
+                    kind: CodeActionKind.QuickFix,
+                    changes: [{
+                        type: 'replace',
+                        filePath: this.event.file.pathAbsolute,
+                        newText: `@.${functionName}(`,
+                        range: util.createRangeFromPositions(previousToken.range.start, endPosition)
+                    }]
+                })
+            );
         }
     }
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1093,6 +1093,21 @@ export class BrsFile {
     }
 
     /**
+     * Get the token after the given token.
+     * If `requiredTokenKind` is specified, then the next token's type is checked, and if no match, undefined is returned.
+     */
+    public getNextToken(token: Token, requiredTokenKind?: TokenKind) {
+        const parser = this.parser;
+        let idx = parser.tokens.indexOf(token);
+        const result = parser.tokens[idx + 1];
+        if (!requiredTokenKind) {
+            return result;
+        } else if (result?.kind === requiredTokenKind) {
+            return result;
+        }
+    }
+
+    /**
      * Find the first scope that has a namespace with this name.
      * Returns false if no namespace was found with that name
      */


### PR DESCRIPTION
Adds code action in brighterscript files to suggest refactoring a normal callfunc call into using a callfunc operator. 

I don't produce any diagnostics for this, as it's not the compiler's job to suggest such a preference-based thing. However, since it's easy enough to provide hints when you click on it, i think that's a fair compromise. 

Resolves #240 

**Notable changes:**
 - add codeAction to refactor callfunc statement to use the callfunc operator.
 - fixed bug in code action utils that wasn't supporting update. Also added delete support.