### PR TITLE
Upgrade chokidar to support M1 macs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -536,13 +536,12 @@
             "dev": true
         },
         "@types/chokidar": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.5.tgz",
-            "integrity": "sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+            "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/node": "*"
+                "chokidar": "*"
             }
         },
         "@types/command-line-args": {
@@ -570,12 +569,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.3.tgz",
             "integrity": "sha512-mjcCf//DAUQ6YLQMhqYJAv/+a4BsE1GQFmy1el5K62wLJJmQwGi3TsnshhOFynPpuBF9Gh2Vvb+5ImPi47KaZw==",
-            "dev": true
-        },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
             "dev": true
         },
         "@types/form-data": {
@@ -1326,13 +1319,13 @@
             }
         },
         "chokidar": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
+                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -2740,9 +2733,9 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "optional": true
         },
         "function-bind": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "devDependencies": {
         "@types/benchmark": "^1.0.31",
         "@types/chai": "^4.1.2",
-        "@types/chokidar": "^1.7.5",
+        "@types/chokidar": "^2.1.3",
         "@types/command-line-args": "^5.0.0",
         "@types/command-line-usage": "^5.0.1",
         "@types/debounce-promise": "^3.1.1",
@@ -113,7 +113,7 @@
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^2.4.2",
         "chevrotain": "^7.0.1",
-        "chokidar": "^3.0.2",
+        "chokidar": "^3.5.1",
         "clear": "^0.1.0",
         "cross-platform-clear-console": "^2.3.0",
         "debounce-promise": "^3.1.0",


### PR DESCRIPTION
I heard that the bsc watch mode doesn't work with M1 macs. I don't have a mac, but I did find [this GitHub issue](https://github.com/paulmillr/chokidar/issues/1048) stating that a recent chokidar release supports mac M1, so i'm upgrading BSc to use that version. It shouldn't cause any issues? I'll need someone with an M1 mac to test this build out.