### PR TITLE
validate transpile code

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -198,13 +198,13 @@ describe('BrsFile BrighterScript classes', () => {
         it('follows correct sequence for property initializers', () => {
             testTranspile(`
                 class Animal
-                    species = "Animal"
+                    species1 = "Animal"
                     sub new()
                         print "From Animal: " + m.species
                     end sub
                 end class
                 class Duck extends Animal
-                    species = "Duck"
+                    species2 = "Duck"
                     sub new()
                         super()
                         print "From Duck: " + m.species
@@ -214,7 +214,7 @@ describe('BrsFile BrighterScript classes', () => {
                 function __Animal_builder()
                     instance = {}
                     instance.new = sub()
-                        m.species = "Animal"
+                        m.species1 = "Animal"
                         print "From Animal: " + m.species
                     end sub
                     return instance
@@ -229,7 +229,7 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.super0_new = instance.new
                     instance.new = sub()
                         m.super0_new()
-                        m.species = "Duck"
+                        m.species2 = "Duck"
                         print "From Duck: " + m.species
                     end sub
                     return instance
@@ -245,19 +245,19 @@ describe('BrsFile BrighterScript classes', () => {
         it('handles class inheritance inferred constructor calls', () => {
             testTranspile(`
                 class Animal
-                    className = "Animal"
+                    className1 = "Animal"
                 end class
                 class Duck extends Animal
-                    className = "Duck"
+                    className2 = "Duck"
                 end class
                 class BabyDuck extends Duck
-                    className = "BabyDuck"
+                    className3 = "BabyDuck"
                 end class
             `, `
                 function __Animal_builder()
                     instance = {}
                     instance.new = sub()
-                        m.className = "Animal"
+                        m.className1 = "Animal"
                     end sub
                     return instance
                 end function
@@ -271,7 +271,7 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.super0_new = instance.new
                     instance.new = sub()
                         m.super0_new()
-                        m.className = "Duck"
+                        m.className2 = "Duck"
                     end sub
                     return instance
                 end function
@@ -285,7 +285,7 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.super1_new = instance.new
                     instance.new = sub()
                         m.super1_new()
-                        m.className = "BabyDuck"
+                        m.className3 = "BabyDuck"
                     end sub
                     return instance
                 end function
@@ -508,7 +508,7 @@ describe('BrsFile BrighterScript classes', () => {
                 sub main()
                     bob = Human()
                 end sub
-            `, undefined, 'source/main.bs');
+            `, undefined, 'source/main.bs', false);
         });
 
         it('new keyword transpiles correctly', () => {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1926,7 +1926,7 @@ describe('BrsFile', () => {
         });
 
         it('does not add leading or trailing newlines', () => {
-            testTranspile(`function log()\nend function`, undefined, 'none');
+            testTranspile(`function abc()\nend function`, undefined, 'none');
         });
 
         it('handles sourcemap edge case', async () => {
@@ -1952,7 +1952,7 @@ describe('BrsFile', () => {
         });
 
         it('computes correct locations for sourcemap', async () => {
-            let source = `function log(name)\n    firstName = name\nend function`;
+            let source = `function abc(name)\n    firstName = name\nend function`;
             let tokens = Lexer.scan(source).tokens
                 //remove newlines and EOF
                 .filter(x => x.kind !== TokenKind.Eof && x.kind !== TokenKind.Newline);
@@ -2203,6 +2203,10 @@ describe('BrsFile', () => {
         });
 
         it('replaces custom types in parameter types and return types', () => {
+            program.addOrReplaceFile('source/SomeKlass.bs', `
+                class SomeKlass
+                end class
+            `);
             testTranspile(`
                 function foo() as SomeKlass
                     return new SomeKlass()

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -731,7 +731,7 @@ describe('XmlFile', () => {
 
         it('keeps all content of the XML', () => {
             program.addOrReplaceFile(`components/SimpleScene.bs`, `
-                sub init()
+                sub b()
                 end sub
             `);
 
@@ -743,10 +743,10 @@ describe('XmlFile', () => {
                     xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd"
                 >
                     <interface>
-                        <field id="a" />
+                        <field id="a" type="string" />
                         <function name="b" />
                     </interface>
-                    <script type="text/brightscript" uri="SimpleScene.brs"/>
+                    <script type="text/brightscript" uri="SimpleScene.bs"/>
                     <children>
                         <aa id="aa">
                             <bb id="bb" />
@@ -757,7 +757,7 @@ describe('XmlFile', () => {
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
                     <interface>
-                        <field id="a" />
+                        <field id="a" type="string" />
                         <function name="b" />
                     </interface>
                     <script type="text/brightscript" uri="SimpleScene.brs" />
@@ -792,7 +792,8 @@ describe('XmlFile', () => {
             `, 'none', 'components/SimpleScene.xml');
         });
 
-        it('does not fail on msissing script type', () => {
+        it('does not fail on missing script type', () => {
+            program.addOrReplaceFile('components/SimpleScene.brs', '');
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
@@ -1014,7 +1015,7 @@ describe('XmlFile', () => {
             `);
             program.addOrReplaceFile('components/Component1.bs', `
                 import "pkg:/source/logger.brs"
-                sub logInfo()
+                sub init()
                 end sub
             `);
             testTranspile(trim`

--- a/src/parser/tests/expression/SourceLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/SourceLiteralExpression.spec.ts
@@ -37,7 +37,7 @@ describe('SourceLiteralExpression', () => {
                     print pkg_path
                     print pkg_location
                 end sub
-            `, undefined, 'none', 'main.brs');
+            `, undefined, 'none', 'source/main.brs');
         });
 
         it('computes SOURCE_FILE_PATH', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -113,15 +113,8 @@ export function getTestTranspile(scopeGetter: () => [Program, string]) {
         expected = expected ? expected : source;
         let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
         program.validate();
-        let diagnostics = file.getDiagnostics();
-        if (diagnostics.length > 0 && failOnDiagnostic !== false) {
-            throw new Error(
-                diagnostics[0].range.start.line +
-                ':' +
-                diagnostics[0].range.start.character +
-                ' ' +
-                diagnostics[0]?.message
-            );
+        if (failOnDiagnostic !== false) {
+            expectZeroDiagnostics(program);
         }
         let transpiled = file.transpile();
 


### PR DESCRIPTION
Updates `testTranspile` to check the program for diagnostics instead of just the file, and to use `expectZeroDiagnostics` for better diagnostic printing.
