### PR TITLE
Allow class field overrides, disallow type changes

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -511,8 +511,8 @@ export let DiagnosticMessages = {
         code: 1097,
         severity: DiagnosticSeverity.Error
     }),
-    memberAlreadyExistsInParentClass: (memberType: string, parentClassName: string) => ({
-        message: `A ${memberType} with this name already exists in inherited class '${parentClassName}'`,
+    childFieldTypeNotAssignableToBaseProperty: (childTypeName: string, baseTypeName: string, fieldName: string, childFieldType: string, parentFieldType: string) => ({
+        message: `Field '${fieldName}' in class '${childTypeName}' is not assignable to the same field in base class '${baseTypeName}'. Type '${childFieldType}' is not assignable to type '${parentFieldType}'.`,
         code: 1098,
         severity: DiagnosticSeverity.Error
     }),
@@ -624,6 +624,11 @@ export let DiagnosticMessages = {
     missingExpressionsInDimStatement: () => ({
         message: `Missing expression(s) in 'dim' statement`,
         code: 1121,
+        severity: DiagnosticSeverity.Error
+    }),
+    cannotFindType: (typeName: string) => ({
+        message: `Cannot find type with name '${typeName}'`,
+        code: 1122,
         severity: DiagnosticSeverity.Error
     })
 };

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -599,8 +599,8 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expect(program.getDiagnostics().map(x => x.message)).to.eql([
-                    DiagnosticMessages.expectedValidTypeToFollowAsKeyword().message,
-                    DiagnosticMessages.expectedValidTypeToFollowAsKeyword().message
+                    DiagnosticMessages.cannotFindType('unknownType').message,
+                    DiagnosticMessages.cannotFindType('unknownType').message
                 ]);
             });
 

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -16,6 +16,7 @@ import { DoubleType } from '../types/DoubleType';
 import { CustomType } from '../types/CustomType';
 import type { Scope } from '../Scope';
 import type { XmlScope } from '../XmlScope';
+import { DynamicType } from '../types/DynamicType';
 
 // File reflection
 
@@ -237,6 +238,9 @@ export function isVoidType(e: any): e is VoidType {
 }
 export function isCustomType(e: any): e is CustomType {
     return e?.constructor.name === CustomType.name;
+}
+export function isDynamicType(e: any): e is DynamicType {
+    return e?.constructor.name === DynamicType.name;
 }
 
 const numberConstructorNames = [

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -797,7 +797,7 @@ describe('BrsFile BrighterScript classes', () => {
         );
     });
 
-    it('detects overridden property name in child class', () => {
+    it('allows untyped overridden field in child class', () => {
         program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
@@ -807,9 +807,41 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        let diagnostics = program.getDiagnostics().map(x => x.message);
-        expect(diagnostics).to.eql([
-            DiagnosticMessages.memberAlreadyExistsInParentClass('field', 'Animal').message
+        expectZeroDiagnostics(program);
+    });
+
+    it('allows overridden property name in child class', () => {
+        program.addOrReplaceFile('source/main.bs', `
+            class Bird
+                public name = "bird"
+            end class
+            class Duck extends Bird
+                public name = "duck"
+            end class
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
+    it('flags incompatible child field type changes', () => {
+        program.addOrReplaceFile('source/main.bs', `
+            class Bird
+                public age = 12
+                public name = "bird"
+                public owner as Person
+            end class
+            class Duck extends Bird
+                public age = 12.2 'should be integer but is float
+                public name = 12 'should be string but is integer
+                public owner as string
+            end class
+        `);
+        program.validate();
+        expect(program.getDiagnostics().map(x => x.message).sort()).to.eql([
+            DiagnosticMessages.cannotFindType('Person').message,
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer').message,
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string').message,
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person').message
         ]);
     });
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -492,7 +492,7 @@ export class Parser {
             fieldType = this.typeToken();
 
             //no field type specified
-            if (!util.tokenToBscType(fieldType) && !this.check(TokenKind.Identifier)) {
+            if (!util.tokenToBscType(fieldType)) {
                 this.diagnostics.push({
                     ...DiagnosticMessages.expectedValidTypeToFollowAsKeyword(),
                     range: this.peek().range

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1757,7 +1757,7 @@ export class ClassFieldStatement extends Statement implements TypedefProvider {
 
     /**
      * Derive a ValueKind from the type token, or the initial value.
-     * Defaults to `ValueKind.Dynamic`
+     * Defaults to `DynamicType`
      */
     getType() {
         if (this.type) {

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -1,9 +1,31 @@
+import { isCustomType, isDynamicType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
-import { ObjectType } from './ObjectType';
 
-export class CustomType extends ObjectType implements BscType {
+export class CustomType implements BscType {
 
     constructor(public name: string) {
-        super();
+    }
+
+    public toString() {
+        return this.name;
+    }
+
+    public toTypeString(): string {
+        return 'object';
+    }
+
+    public isAssignableTo(targetType: BscType) {
+        //TODO for now, if the custom types have the same name, assume they're the same thing
+        if (isCustomType(targetType) && targetType.name === this.name) {
+            return true;
+        } else if (isDynamicType(targetType)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public isConvertibleTo(targetType: BscType) {
+        return this.isAssignableTo(targetType);
     }
 }

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -2,7 +2,7 @@ import type { Scope } from '../Scope';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { CallExpression } from '../parser/Expression';
 import { ParseMode } from '../parser/Parser';
-import type { ClassMethodStatement, ClassStatement } from '../parser/Statement';
+import type { ClassFieldStatement, ClassMethodStatement, ClassStatement } from '../parser/Statement';
 import { CancellationTokenSource, Location } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import util from '../util';
@@ -179,14 +179,14 @@ export class BsClassValidator {
                     let memberType = isClassFieldStatement(member) ? 'field' : 'method';
                     let ancestorAndMember = this.getAncestorMember(classStatement, lowerMemberName);
                     if (ancestorAndMember) {
-                        let ancestorMemberType = isClassFieldStatement(ancestorAndMember.member) ? 'field' : 'method';
+                        let ancestorMemberKind = isClassFieldStatement(ancestorAndMember.member) ? 'field' : 'method';
 
-                        //mismatched member type (field/method in child, opposite in parent)
-                        if (memberType !== ancestorMemberType) {
+                        //mismatched member type (field/method in child, opposite in ancestor)
+                        if (memberType !== ancestorMemberKind) {
                             this.diagnostics.push({
                                 ...DiagnosticMessages.classChildMemberDifferentMemberTypeThanAncestor(
                                     memberType,
-                                    ancestorMemberType,
+                                    ancestorMemberKind,
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
                                 file: classStatement.file,
@@ -196,14 +196,22 @@ export class BsClassValidator {
 
                         //child field has same name as parent
                         if (isClassFieldStatement(member)) {
-                            this.diagnostics.push({
-                                ...DiagnosticMessages.memberAlreadyExistsInParentClass(
-                                    memberType,
-                                    ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
-                                ),
-                                file: classStatement.file,
-                                range: member.range
-                            });
+                            const ancestorFieldType = (ancestorAndMember.member as ClassFieldStatement).getType();
+                            const childFieldType = member.getType();
+                            if (!childFieldType.isAssignableTo(ancestorFieldType)) {
+                                //flag incompatible child field type to ancestor field type
+                                this.diagnostics.push({
+                                    ...DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty(
+                                        classStatement.getName(ParseMode.BrighterScript),
+                                        ancestorAndMember.classStatement.getName(ParseMode.BrighterScript),
+                                        member.name.text,
+                                        childFieldType.toString(),
+                                        ancestorFieldType.toString()
+                                    ),
+                                    file: classStatement.file,
+                                    range: member.range
+                                });
+                            }
                         }
 
                         //child method missing the override keyword
@@ -255,7 +263,7 @@ export class BsClassValidator {
                             //check if this custom type is in our class map
                             if (!this.getClassByName(lowerFieldTypeName, currentNamespaceName)) {
                                 this.diagnostics.push({
-                                    ...DiagnosticMessages.expectedValidTypeToFollowAsKeyword(),
+                                    ...DiagnosticMessages.cannotFindType(fieldTypeName),
                                     range: statement.type.range,
                                     file: classStatement.file
                                 });


### PR DESCRIPTION
Fixes #391.

**Notable changes:**
- allow class fields to be redeclared in child classes as long as the types are the same
- flag type differences between parent and child class fields with same name
- allow custom types for class field types