### PR TITLE
Rename `Program` `addOrReplaceFile` to `setFile`

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -113,12 +113,12 @@ describe('LanguageServer', () => {
             ${additionalXmlContents}
             <script type="text/brightscript" uri="${name}.brs" />
         </component>`;
-        program.addOrReplaceFile(filePath, contents);
+        program.setFile(filePath, contents);
     }
 
     function addScriptFile(name: string, contents: string, extension = 'brs') {
         const pkgPath = `pkg:/components/${name}.${extension}`;
-        const file = program.addOrReplaceFile<XmlFile>(pkgPath, contents);
+        const file = program.setFile<XmlFile>(pkgPath, contents);
         const document = TextDocument.create(util.pathToUri(file.srcPath), 'brightscript', 1, contents);
         svr.documents._documents[document.uri] = document;
         return document;
@@ -281,7 +281,7 @@ describe('LanguageServer', () => {
                     getFileContents: sinon.stub().callsFake(() => Promise.resolve('')) as any,
                     rootDir: rootDir,
                     program: {
-                        addOrReplaceFile: <any>addOrReplaceFileStub
+                        setFile: <any>addOrReplaceFileStub
                     }
                 }
             } as Workspace;

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -838,7 +838,7 @@ export class LanguageServer {
 
             //if we got a dest path, then the program wants this file
             if (destPath) {
-                program.addOrReplaceFile(
+                program.setFile(
                     {
                         src: change.srcPath,
                         dest: rokuDeploy.getDestPath(change.srcPath, options.files, rootDir)
@@ -856,7 +856,7 @@ export class LanguageServer {
             //sometimes "changed" events are emitted on files that were actually deleted,
             //so determine file existance and act accordingly
             if (await util.pathExists(change.srcPath)) {
-                program.addOrReplaceFile(
+                program.setFile(
                     {
                         src: change.srcPath,
                         dest: rokuDeploy.getDestPath(change.srcPath, options.files, rootDir)
@@ -932,7 +932,7 @@ export class LanguageServer {
                     if (workspace.builder.program.hasFile(filePath)) {
                         let rootDir = workspace.builder.program.options.rootDir ?? workspace.builder.program.options.cwd;
                         let dest = rokuDeploy.getDestPath(filePath, workspace.builder.program.options.files, rootDir);
-                        workspace.builder.program.addOrReplaceFile({
+                        workspace.builder.program.setFile({
                             src: filePath,
                             dest: dest
                         }, documentText);

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1813,7 +1813,7 @@ describe('Program', () => {
     describe('getSignatureHelp', () => {
         it('does not crash when second previousToken is undefined', () => {
             const file = program.setFile<BrsFile>('source/main.brs', ` `);
-            sinon.stub(file, 'getPreviousToken').returns(undefined);
+            sinon.stub(file.parser, 'getPreviousToken').returns(undefined);
             //should not crash
             expect(
                 file['getClassFromMReference'](util.createPosition(2, 3), createToken(TokenKind.Dot, '.'), null)

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -345,7 +345,7 @@ export class Program {
     /**
      * Update internal maps with this file reference
      */
-    private setFile(file: BscFile) {
+    private assignFile(file: BscFile) {
         this.files[file.srcPath.toLowerCase()] = file;
         this.pkgMap[file.pkgPath.toLowerCase()] = file;
     }
@@ -353,7 +353,7 @@ export class Program {
     /**
      * Remove this file from internal maps
      */
-    private unsetFile(file: BscFile) {
+    private unassignFile(file: BscFile) {
         delete this.files[file.srcPath.toLowerCase()];
         delete this.pkgMap[file.pkgPath.toLowerCase()];
     }
@@ -364,14 +364,14 @@ export class Program {
      * @param srcDestOrPkgPath the absolute path, or the pkg path (i.e. `pkg:/path/to/file.brs`) or the destPath (i.e. `path/to/file.brs` relative to `pkg:/`)
      * @param fileContents the file contents
      */
-    public addOrReplaceFile<T extends BscFile>(srcDestOrPkgPath: string, fileContents: string): T;
+    public setFile<T extends BscFile>(srcDestOrPkgPath: string, fileContents: string): T;
     /**
      * Load a file into the program. If that file already exists, it is replaced.
      * @param fileEntry an object that specifies src and dest for the file.
      * @param fileContents the file contents. If not provided, the file will be loaded from disk
      */
-    public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
-    public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
+    public setFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
+    public setFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
         assert.ok(fileParam, 'fileParam is required');
         let srcPath: string;
         let pkgPath: string;
@@ -434,7 +434,7 @@ export class Program {
                 }
 
                 //add the file to the program
-                this.setFile(brsFile);
+                this.assignFile(brsFile);
 
                 this.plugins.emit('beforeFileParse', beforeFileParseEvent);
 
@@ -457,7 +457,7 @@ export class Program {
             ) {
                 let xmlFile = new XmlFile(srcPath, pkgPath, this);
 
-                this.setFile(xmlFile);
+                this.assignFile(xmlFile);
 
                 //add the file to the program
                 this.plugins.emit('beforeFileParse', beforeFileParseEvent);
@@ -547,7 +547,7 @@ export class Program {
                 });
             }
             //remove the file from the program
-            this.unsetFile(file);
+            this.unassignFile(file);
 
             this.dependencyGraph.remove(file.dependencyGraphKey);
 

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -55,7 +55,7 @@ describe('ProgramBuilder', () => {
                 dest: 'file4.xml'
             }]));
 
-            let stub = sinon.stub(builder.program, 'addOrReplaceFile');
+            let stub = sinon.stub(builder.program, 'setFile');
             sinon.stub(builder, 'getFileContents').returns(Promise.resolve(''));
             await builder['loadAllFilesAST']();
             expect(stub.getCalls()).to.be.lengthOf(3);
@@ -70,7 +70,7 @@ describe('ProgramBuilder', () => {
             fsExtra.outputFileSync(s`${rootDir}/source/main.d.bs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/lib.d.bs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/lib.brs`, '');
-            const stub = sinon.stub(builder.program, 'addOrReplaceFile');
+            const stub = sinon.stub(builder.program, 'setFile');
             await builder['loadAllFilesAST']();
             const srcPaths = stub.getCalls().map(x => x.args[0].src);
             //the d files should be first

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -204,7 +204,7 @@ export class ProgramBuilder {
                         util.driveLetterToLower(this.rootDir)
                     )
                 };
-                this.program.addOrReplaceFile(
+                this.program.setFile(
                     fileObj,
                     await this.getFileContents(fileObj.src, false)
                 );
@@ -470,7 +470,7 @@ export class ProgramBuilder {
             await Promise.all(
                 typedefFiles.map(async (fileObj) => {
                     try {
-                        this.program.addOrReplaceFile(
+                        this.program.setFile(
                             fileObj,
                             await this.getFileContents(fileObj.src)
                         );
@@ -490,7 +490,7 @@ export class ProgramBuilder {
 
                         //only process certain file types
                         if (acceptableExtensions.includes(fileExtension)) {
-                            this.program.addOrReplaceFile(
+                            this.program.setFile(
                                 fileObj,
                                 await this.getFileContents(fileObj.src)
                             );

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -27,7 +27,7 @@ describe('Scope', () => {
     });
 
     it('does not mark namespace functions as collisions with stdlib', () => {
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/main.bs`,
             dest: `source/main.bs`
         }, `
@@ -42,7 +42,7 @@ describe('Scope', () => {
     });
 
     it('flags parameter with same name as namespace', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main(nameA)
@@ -57,7 +57,7 @@ describe('Scope', () => {
     });
 
     it('flags assignments with same name as namespace', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main()
@@ -95,7 +95,7 @@ describe('Scope', () => {
         it('detects callables from all loaded files', () => {
             const sourceScope = program.getScopeByName('source');
 
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub Main()
 
                 end sub
@@ -103,7 +103,7 @@ describe('Scope', () => {
                 sub ActionA()
                 end sub
             `);
-            program.addOrReplaceFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
                 sub ActionB()
                 end sub
             `);
@@ -120,11 +120,11 @@ describe('Scope', () => {
         });
 
         it('picks up new callables', () => {
-            program.addOrReplaceFile('source/file.brs', '');
+            program.setFile('source/file.brs', '');
             //we have global callables, so get that initial number
             let originalLength = program.getScopeByName('source').getAllCallables().length;
 
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
             function DoA()
                 print "A"
             end function
@@ -140,7 +140,7 @@ describe('Scope', () => {
     describe('removeFile', () => {
         it('removes callables from list', () => {
             //add the file
-            let file = program.addOrReplaceFile(`source/file.brs`, `
+            let file = program.setFile(`source/file.brs`, `
                 function DoA()
                     print "A"
                 end function
@@ -155,18 +155,18 @@ describe('Scope', () => {
 
     describe('validate', () => {
         it('marks the scope as validated after validation has occurred', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                sub main()
                end sub
             `);
-            let lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            let lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                sub libFunc()
                end sub
             `);
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.false;
             program.validate();
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.true;
-            lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                 sub libFunc()
                 end sub
             `);
@@ -177,7 +177,7 @@ describe('Scope', () => {
         });
 
         it('does not mark same-named-functions in different namespaces as an error', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                 namespace NameA
                     sub alert()
                     end sub
@@ -192,7 +192,7 @@ describe('Scope', () => {
             expect(program.getDiagnostics()).to.be.lengthOf(0);
         });
         it('resolves local-variable function calls', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub DoSomething()
                     sayMyName = function(name as string)
                     end function
@@ -207,7 +207,7 @@ describe('Scope', () => {
 
         describe('function shadowing', () => {
             it('warns when local var function has same name as stdlib function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = function(p)
                             return "override"
@@ -229,7 +229,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 12345
                         print str ' prints "12345" (i.e. our local variable is allowed to shadow the built-in function name)
@@ -241,7 +241,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 6789
                         print str(12345) ' prints "12345" (i.e. our local variable did not override the callable global function)
@@ -253,7 +253,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = function()
                             return "override"
@@ -279,7 +279,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = "override"
                         print getHello ' prints <Function: gethello> (i.e. local variable override does NOT work for same-scope-defined methods)
@@ -302,7 +302,7 @@ describe('Scope', () => {
             });
 
             it('flags scope function with same name (but different case) as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         print str(12345) ' prints 12345 (i.e. our str() function below is ignored)
                     end sub
@@ -325,7 +325,7 @@ describe('Scope', () => {
         });
 
         it('detects duplicate callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     print "A"
                 end function
@@ -347,7 +347,7 @@ describe('Scope', () => {
         });
 
         it('detects calls to unknown callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
@@ -361,7 +361,7 @@ describe('Scope', () => {
         });
 
         it('does not error with calls to callables in same namespace', () => {
-            program.addOrReplaceFile('source/file.bs', `
+            program.setFile('source/file.bs', `
                 namespace Name.Space
                     sub a(param as string)
                         print param
@@ -378,7 +378,7 @@ describe('Scope', () => {
         });
 
         it('recognizes known callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
@@ -394,7 +394,7 @@ describe('Scope', () => {
         });
 
         it('does not error with calls to callables in same namespace', () => {
-            program.addOrReplaceFile('source/file.bs', `
+            program.setFile('source/file.bs', `
                 namespace Name.Space
                     sub a(param as string)
                         print param
@@ -413,7 +413,7 @@ describe('Scope', () => {
         //We don't currently support someObj.callSomething() format, so don't throw errors on those
         it('does not fail on object callables', () => {
             expect(program.getDiagnostics().length).to.equal(0);
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                function DoB()
                     m.doSomething()
                 end function
@@ -425,7 +425,7 @@ describe('Scope', () => {
         });
 
         it('detects calling functions with too many parameters', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a()
                 end sub
                 sub b()
@@ -439,7 +439,7 @@ describe('Scope', () => {
         });
 
         it('detects calling functions with too many parameters', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(name)
                 end sub
                 sub b()
@@ -453,7 +453,7 @@ describe('Scope', () => {
         });
 
         it('allows skipping optional parameter', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(name="Bob")
                 end sub
                 sub b()
@@ -466,7 +466,7 @@ describe('Scope', () => {
         });
 
         it('shows expected parameter range in error message', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
@@ -481,7 +481,7 @@ describe('Scope', () => {
         });
 
         it('handles expressions as arguments to a function', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
@@ -493,7 +493,7 @@ describe('Scope', () => {
         });
 
         it('Catches extra arguments for expressions as arguments to a function', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age)
                 end sub
                 sub b()
@@ -508,7 +508,7 @@ describe('Scope', () => {
         });
 
         it('Catches argument type mismatches on function calls', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age as integer)
                 end sub
                 sub b()
@@ -523,11 +523,11 @@ describe('Scope', () => {
         });
 
         it('Catches argument type mismatches on function calls for functions defined in another file', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age as integer)
                 end sub
             `);
-            program.addOrReplaceFile('source/file2.brs', `
+            program.setFile('source/file2.brs', `
                 sub b()
                     a("hello")
                     foo = "foo"
@@ -542,7 +542,7 @@ describe('Scope', () => {
         });
 
         it('catches argument type mismatches on function calls within namespaces', () => {
-            program.addOrReplaceFile('source/file.bs', `
+            program.setFile('source/file.bs', `
                 namespace Name.Space
                     sub a(param as integer)
                         print param
@@ -563,7 +563,7 @@ describe('Scope', () => {
         });
 
         it('catches argument type mismatches on function calls as arguments', () => {
-            program.addOrReplaceFile('source/file1.bs', `
+            program.setFile('source/file1.bs', `
                     sub a(param as string)
                         print param
                     end sub
@@ -585,7 +585,7 @@ describe('Scope', () => {
 
 
         it('catches argument type mismatches on function calls within namespaces across files', () => {
-            program.addOrReplaceFile('source/file1.bs', `
+            program.setFile('source/file1.bs', `
                 namespace Name.Space
                     function getNum() as integer
                         return 1
@@ -596,7 +596,7 @@ describe('Scope', () => {
                     end function
                 end namespace
                 `);
-            program.addOrReplaceFile('source/file2.bs', `
+            program.setFile('source/file2.bs', `
                 namespace Name.Space
                     sub needsInt(param as integer)
                         print param
@@ -618,7 +618,7 @@ describe('Scope', () => {
 
 
         it('handles JavaScript reserved names', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub constructor()
                 end sub
                 sub toString()
@@ -635,14 +635,14 @@ describe('Scope', () => {
         it('Emits validation events', () => {
             const validateStartScope = sinon.spy();
             const validateEndScope = sinon.spy();
-            program.addOrReplaceFile('source/file.brs', ``);
-            program.addOrReplaceFile('components/comp.xml', trim`
+            program.setFile('source/file.brs', ``);
+            program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp" extends="Scene">
                     <script uri="comp.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/comp.brs`, ``);
+            program.setFile(s`components/comp.brs`, ``);
             const sourceScope = program.getScopeByName('source');
             const compScope = program.getScopeByName('pkg:/components/comp.xml');
             program.plugins = new PluginInterface([{
@@ -661,7 +661,7 @@ describe('Scope', () => {
 
         describe('custom types', () => {
             it('detects an unknown function return type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function a()
                         return invalid
                     end function
@@ -692,7 +692,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown function parameter type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     sub a(num as integer)
                     end sub
 
@@ -715,7 +715,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown field parameter type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     class myClass
                         foo as unknownType 'error
                     end class
@@ -734,7 +734,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types inside namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -754,7 +754,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -769,7 +769,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from current namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -786,11 +786,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyClass) as MyClass
                     end function
                 `);
-                program.addOrReplaceFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
                     class MyClass
                     end class
                 `);
@@ -800,11 +800,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyNameSpace.MyClass) as MyNameSpace.MyClass
                     end function
                 `);
-                program.addOrReplaceFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
                     namespace MyNameSpace
                         class MyClass
                         end class
@@ -816,7 +816,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from another namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -835,13 +835,13 @@ describe('Scope', () => {
             it('scopes types to correct scope', () => {
                 program = new Program({ rootDir: rootDir });
 
-                program.addOrReplaceFile('components/foo.xml', trim`
+                program.setFile('components/foo.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="foo" extends="Scene">
                         <script uri="foo.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/foo.bs`, `
+                program.setFile(s`components/foo.bs`, `
                     class MyClass
                     end class
                 `);
@@ -849,13 +849,13 @@ describe('Scope', () => {
 
                 expect(program.getDiagnostics()[0]?.message).not.to.exist;
 
-                program.addOrReplaceFile('components/bar.xml', trim`
+                program.setFile('components/bar.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="bar" extends="Scene">
                         <script uri="bar.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/bar.bs`, `
+                program.setFile(s`components/bar.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
@@ -869,23 +869,23 @@ describe('Scope', () => {
             it('can reference types from parent component', () => {
                 program = new Program({ rootDir: rootDir });
 
-                program.addOrReplaceFile('components/parent.xml', trim`
+                program.setFile('components/parent.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="parent" extends="Scene">
                         <script uri="parent.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/parent.bs`, `
+                program.setFile(s`components/parent.bs`, `
                     class MyClass
                     end class
                 `);
-                program.addOrReplaceFile('components/child.xml', trim`
+                program.setFile('components/child.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="child" extends="parent">
                         <script uri="child.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/child.bs`, `
+                program.setFile(s`components/child.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
@@ -901,24 +901,24 @@ describe('Scope', () => {
         it('inherits callables from parent', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, ``);
+            program.setFile(s`components/child.brs`, ``);
             program.validate();
             let childScope = program.getComponentScope('child');
             expect(childScope.getAllCallables().map(x => x.callable.name)).not.to.include('parentSub');
 
-            program.addOrReplaceFile('components/parent.xml', trim`
+            program.setFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="parent" extends="Scene">
                     <script uri="parent.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/parent.brs`, `
+            program.setFile(s`components/parent.brs`, `
                 sub parentSub()
                 end sub
             `);
@@ -936,7 +936,7 @@ describe('Scope', () => {
 
     describe('getDefinition', () => {
         it('returns empty list when there are no files', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             let scope = program.getScopeByName('source');
             expect(scope.getDefinition(file, Position.create(0, 0))).to.be.lengthOf(0);
         });
@@ -954,7 +954,7 @@ describe('Scope', () => {
 
     describe('scope symbol tables', () => {
         it('adds symbols for the complete scope', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function funcInt() as integer
                     return 3
                 end function
@@ -963,7 +963,7 @@ describe('Scope', () => {
                     return "hello"
                 end function
             `);
-            program.addOrReplaceFile('source/file2.brs', `
+            program.setFile('source/file2.brs', `
                 function funcBool() as boolean
                     return true
                 end function
@@ -981,7 +981,7 @@ describe('Scope', () => {
         });
 
         it('adds updates symbol tables on invalidation', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function funcInt() as integer
                     return 3
                 end function
@@ -997,7 +997,7 @@ describe('Scope', () => {
             expect((sourceSymbols.getSymbolType('funcStr') as FunctionType).returnType.toString()).to.equal('string');
             program.getScopeByName('source').invalidate();
 
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function funcFloat() as float
                     return 3.14
                 end function
@@ -1011,12 +1011,12 @@ describe('Scope', () => {
 
 
         it('adds namespaced symbols tables to the scope', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function funcInt() as integer
                     return 1 + Name.Space.nsFunc2(1)
                 end function
             `);
-            program.addOrReplaceFile('source/namespace.brs', `
+            program.setFile('source/namespace.brs', `
                 namespace Name.Space
                     function nsFunc1() as integer
                         return 1
@@ -1037,7 +1037,7 @@ describe('Scope', () => {
         });
 
         it('merges namespace symbol tables in namespaceLookup', () => {
-            program.addOrReplaceFile('source/ns1.brs', `
+            program.setFile('source/ns1.brs', `
                 namespace Name.Space
                     function nsFunc1() as integer
                         return 1
@@ -1050,7 +1050,7 @@ describe('Scope', () => {
                     end function
                 end namespace
             `);
-            program.addOrReplaceFile('source/ns2.brs', `
+            program.setFile('source/ns2.brs', `
                 namespace Name.Space
                     function nsFunc2(num as integer) as integer
                         print Name.outerNsFunc()

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -21,7 +21,7 @@ describe('XmlScope', () => {
 
     describe('constructor', () => {
         it('listens for attach/detach parent events', () => {
-            let parentXmlFile = program.addOrReplaceFile<XmlFile>('components/parent.xml', trim`
+            let parentXmlFile = program.setFile<XmlFile>('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                 </component>
@@ -31,7 +31,7 @@ describe('XmlScope', () => {
             //should default to global scope
             expect(scope.getParentScope()).to.equal(program.globalScope);
 
-            let childXmlFile = program.addOrReplaceFile<XmlFile>('components/child.xml', trim`
+            let childXmlFile = program.setFile<XmlFile>('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
@@ -57,12 +57,12 @@ describe('XmlScope', () => {
 
     describe('getDefinition', () => {
         it('finds parent file', () => {
-            let parentXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+            let parentXmlFile = program.setFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent">
                 </component>
             `);
-            let childXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            let childXmlFile = program.setFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                 </component>
@@ -76,7 +76,7 @@ describe('XmlScope', () => {
 
     describe('getFiles', () => {
         it('includes the xml file', () => {
-            let xmlFile = program.addOrReplaceFile('components/child.xml', trim`
+            let xmlFile = program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child">
                 </component>
@@ -90,7 +90,7 @@ describe('XmlScope', () => {
         it('adds an error when an interface function cannot be found', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -103,7 +103,7 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, `
+            program.setFile(s`components/child.brs`, `
                 sub func1()
                 end sub
             `);
@@ -135,7 +135,7 @@ describe('XmlScope', () => {
         it('adds an error when an interface field is invalid', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -150,7 +150,7 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, `
+            program.setFile(s`components/child.brs`, `
                 sub init()
                 end sub
             `);

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -103,7 +103,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: (event) => walker(event.file as BrsFile)
             });
-            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.setFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block:0',                // Main sub body
                 'PrintStatement:1',       // print 1
@@ -140,7 +140,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: (event) => walker(event.file as BrsFile)
             });
-            program.addOrReplaceFile('source/file.brs', PRINTS_SRC);
+            program.setFile('source/file.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -187,7 +187,7 @@ describe('astUtils visitors', () => {
                     walker(event.file as BrsFile);
                 }
             });
-            program.addOrReplaceFile('source/file.brs', PRINTS_SRC);
+            program.setFile('source/file.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -267,7 +267,7 @@ describe('astUtils visitors', () => {
                 afterFileParse: (event) => walker(event.file as BrsFile)
             });
 
-            program.addOrReplaceFile('source/file.brs', EXPRESSIONS_SRC);
+            program.setFile('source/file.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 //The comment statement is weird because it can't be both a statement and expression, but is treated that way. Just ignore it for now until we refactor comments.
                 //'CommentStatement:1:CommentStatement',          // '<comment>
@@ -315,7 +315,7 @@ describe('astUtils visitors', () => {
 
     describe('walk', () => {
         function testWalk(text: string, expectedConstructors: string[], walkMode = WalkMode.visitAllRecursive) {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', text);
+            const file = program.setFile<BrsFile>('source/main.bs', text);
             const items = [];
             let index = 1;
             file.ast.walk((element: any) => {
@@ -329,7 +329,7 @@ describe('astUtils visitors', () => {
         }
 
         it('Walks through all expressions until cancelled', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            const file = program.setFile<BrsFile>('source/main.bs', `
                 sub logger(message = "nil" as string)
                     innerLog = sub(message = "nil" as string)
                         print message

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -18,7 +18,7 @@ describe('CodeActionsProcessor', () => {
 
     describe('getCodeActions', () => {
         it('suggests `extends=Group`', () => {
-            const file = program.addOrReplaceFile('components/comp1.xml', trim`
+            const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>
@@ -65,7 +65,7 @@ describe('CodeActionsProcessor', () => {
         });
 
         it('adds attribute at end of component with multiple attributes`', () => {
-            const file = program.addOrReplaceFile('components/comp1.xml', trim`
+            const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" attr2="attr3" attr3="attr3">
                 </component>
@@ -86,30 +86,30 @@ describe('CodeActionsProcessor', () => {
 
         it('does not produce duplicate code actions for bs imports', () => {
             //define the function in two files
-            program.addOrReplaceFile('components/lib1.brs', `
+            program.setFile('components/lib1.brs', `
                 sub doSomething()
                 end sub
             `);
-            program.addOrReplaceFile('components/lib2.brs', `
+            program.setFile('components/lib2.brs', `
                 sub doSomething()
                 end sub
             `);
 
             //use the function in this file
-            const componentCommonFile = program.addOrReplaceFile('components/ComponentCommon.bs', `
+            const componentCommonFile = program.setFile('components/ComponentCommon.bs', `
                 sub init()
                     doSomething()
                 end sub
             `);
 
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="ComponentCommon.bs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/comp2.xml', trim`
+            program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="ComponentCommon.bs" />
@@ -132,21 +132,21 @@ describe('CodeActionsProcessor', () => {
 
         it('does not suggest imports for brs files', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.brs" />
                 </component>
             `);
             //import the function here
-            const file = program.addOrReplaceFile('components/comp1.brs', `
+            const file = program.setFile('components/comp1.brs', `
                 sub init()
                     DoSomething()
                 end sub
             `);
 
             //define the function here
-            program.addOrReplaceFile('source/lib.brs', `
+            program.setFile('source/lib.brs', `
                 sub DoSomething()
                 end sub
             `);
@@ -164,19 +164,19 @@ describe('CodeActionsProcessor', () => {
 
         it('suggests class imports', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.bs" />
                 </component>
             `);
-            const file = program.addOrReplaceFile('components/comp1.bs', `
+            const file = program.setFile('components/comp1.bs', `
                 sub init()
                     dude = new Person()
                 end sub
             `);
 
-            program.addOrReplaceFile('source/Person.bs', `
+            program.setFile('source/Person.bs', `
                 class Person
                 end class
             `);
@@ -196,19 +196,19 @@ describe('CodeActionsProcessor', () => {
 
         it('suggests class imports', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.bs" />
                 </component>
             `);
             //import the function here
-            const file = program.addOrReplaceFile('components/comp1.bs', `
+            const file = program.setFile('components/comp1.bs', `
                 sub init()
                     kitty = new Animals.Cat()
                 end sub
             `);
-            program.addOrReplaceFile('source/Animals.bs', `
+            program.setFile('source/Animals.bs', `
                 namespace Animals
                     class Cat
                     end class

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -35,11 +35,11 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     function addFile(relativePath: string, text: string) {
-        return program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
+        return program.setFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
     }
 
     it('detects all classes after parse', () => {
-        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
             end class
             class Duck
@@ -51,7 +51,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not cause errors with incomplete class statement', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class
         `);
         program.validate();
@@ -59,7 +59,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches child class missing super call in constructor', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Person
                 sub new()
                 end sub
@@ -78,7 +78,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('access modifier is option for override', () => {
-        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub move()
                 end sub
@@ -97,7 +97,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports various namespace configurations', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub new()
                     bigBird = new Birds.Bird()
@@ -121,7 +121,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
     describe('super', () => {
         it('always requires super call in child constructor', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                 end class
                 class Duck extends Bird
@@ -134,7 +134,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('requires super call in child when parent has own `new` method', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new()
                     end sub
@@ -149,7 +149,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -168,7 +168,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -690,7 +690,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects using `new` keyword on non-classes', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             sub quack()
             end sub
             sub main()
@@ -706,7 +706,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects missing call to super', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                 end sub
@@ -725,7 +725,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it.skip('detects calls to unknown m methods', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                     m.methodThatDoesNotExist()
@@ -741,7 +741,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects duplicate member names', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
                 public name
@@ -779,7 +779,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects mismatched member type in child class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -798,7 +798,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows untyped overridden field in child class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -811,7 +811,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows overridden property name in child class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Bird
                 public name = "bird"
             end class
@@ -824,7 +824,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('flags incompatible child field type changes', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Bird
                 public age = 12
                 public name = "bird"
@@ -846,7 +846,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods without override keyword', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub speak()
                 end sub
@@ -863,7 +863,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods with different visibility', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -893,7 +893,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
     });
     it('allows overridden methods with matching visibility', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -916,7 +916,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects extending unknown parent class', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             class Duck extends Animal
                 sub speak()
                 end sub
@@ -930,7 +930,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches newable class without namespace name', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -947,7 +947,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports newable class namespace inference', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -961,7 +961,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches extending unknown namespaced class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -976,7 +976,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports omitting namespace prefix for items in same namespace', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -989,7 +989,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate root-level class declarations', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
             end class
             class Animal
@@ -1001,7 +1001,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate namespace-level class declarations', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1015,7 +1015,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches namespaced class name which is the same as a global class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1030,7 +1030,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches class with same name as function', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Animal
             end class
             sub Animal()
@@ -1043,7 +1043,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches class with same name (but different case) as function', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class ANIMAL
             end class
             sub animal()
@@ -1056,7 +1056,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches variable with same name as class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Animal
             end class
             sub main()
@@ -1070,7 +1070,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows extending classes with more than one dot in the filename', () => {
-        program.addOrReplaceFile('source/testclass.bs', `
+        program.setFile('source/testclass.bs', `
             class Foo
             end class
 
@@ -1081,7 +1081,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        program.addOrReplaceFile('source/testclass_no_testdot.bs', `
+        program.setFile('source/testclass_no_testdot.bs', `
             class BarNoDot extends Foo
                 sub new()
                     super()
@@ -1089,7 +1089,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        program.addOrReplaceFile('source/testclass.dot.bs', `
+        program.setFile('source/testclass.dot.bs', `
             class BarDot extends Foo
                 sub new()
                 super()
@@ -1102,7 +1102,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('computes correct super index for grandchild class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             sub Main()
                 c = new App.ClassC()
             end sub
@@ -1142,7 +1142,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('computes correct super index for namespaced child class and global parent class', () => {
-        program.addOrReplaceFile('source/ClassA.bs', `
+        program.setFile('source/ClassA.bs', `
             class ClassA
             end class
         `);
@@ -1170,7 +1170,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not crash when parent class is missing', () => {
-        const file = program.addOrReplaceFile<BrsFile>('source/ClassB.bs', `
+        const file = program.setFile<BrsFile>('source/ClassB.bs', `
             class ClassB extends ClassA
             end class
         `);

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -41,7 +41,7 @@ describe('BrsFile', () => {
     });
 
     it('supports the third parameter in CreateObject', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
                 regexp = CreateObject("roRegex", "[a-z]+", "i")
             end sub
@@ -75,7 +75,7 @@ describe('BrsFile', () => {
         } as StandardizedFileEntry;
 
         it('creates proper tokens', () => {
-            file = program.addOrReplaceFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
+            file = program.setFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
             expect(file['getPartialVariableName'](file.parser.tokens[7])).to.equal('ModuleA.ModuleB.ModuleC.');
             expect(file['getPartialVariableName'](file.parser.tokens[6])).to.equal('ModuleA.ModuleB.ModuleC');
             expect(file['getPartialVariableName'](file.parser.tokens[5])).to.equal('ModuleA.ModuleB.');
@@ -87,14 +87,14 @@ describe('BrsFile', () => {
 
     describe('getScopesForFile', () => {
         it('finds the scope for the file', () => {
-            let file = program.addOrReplaceFile('source/main.brs', ``);
+            let file = program.setFile('source/main.brs', ``);
             expect(program.getScopesForFile(file)[0]?.name).to.equal('source');
         });
     });
 
     describe('getCompletions', () => {
         it('does not crash for callfunc on a function call', () => {
-            const file = program.addOrReplaceFile('source/main.brs', `
+            const file = program.setFile('source/main.brs', `
                 sub main()
                     getManager()@.
                 end sub
@@ -105,7 +105,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests pkg paths in strings that match that criteria', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print "pkg:"
                 end sub
@@ -118,7 +118,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests libpkg paths in strings that match that criteria', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print "libpkg:"
                 end sub
@@ -131,7 +131,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests pkg paths in template strings', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print \`pkg:\`
                 end sub
@@ -145,7 +145,7 @@ describe('BrsFile', () => {
 
         it('waits for the file to be processed before collecting completions', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub Main()
                     print "hello"
                     Say
@@ -163,7 +163,7 @@ describe('BrsFile', () => {
 
         it('always includes `m`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -176,7 +176,7 @@ describe('BrsFile', () => {
 
         it('does not fail for missing previousToken', () => {
             //add a single character to the file, and get completions after it
-            program.addOrReplaceFile('source/main.brs', `i`);
+            program.setFile('source/main.brs', `i`);
             expect(() => {
                 program.getCompletions(`${rootDir}/source/main.brs`, Position.create(0, 1)).map(x => x.label);
             }).not.to.throw;
@@ -184,7 +184,7 @@ describe('BrsFile', () => {
 
         it('includes all keywords`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -209,7 +209,7 @@ describe('BrsFile', () => {
 
         it('does not provide completions within a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'some comment
                 end sub
@@ -222,7 +222,7 @@ describe('BrsFile', () => {
 
         it('does not provide duplicate entries for variables', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "bob"
                     age = 12
@@ -240,7 +240,7 @@ describe('BrsFile', () => {
 
         it('does not include `as` and `string` text options when used in function params', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
 
                 end sub
@@ -253,7 +253,7 @@ describe('BrsFile', () => {
 
         it('does not provide intellisense results when inside a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                     'this is a comment
                 end sub
@@ -265,7 +265,7 @@ describe('BrsFile', () => {
 
         it('does provide intellisence for labels only after a goto keyword', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                     something:
                     goto \nend sub
@@ -280,7 +280,7 @@ describe('BrsFile', () => {
     describe('comment flags', () => {
         describe('bs:disable-next-line', () => {
             it('disables critical diagnostic issues', () => {
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         Dim requestData
                     end sub
@@ -289,7 +289,7 @@ describe('BrsFile', () => {
                 program.validate();
                 expect(program.getDiagnostics()[0]?.message).to.exist;
 
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         'bs:disable-next-line
                         Dim requestData
@@ -301,7 +301,7 @@ describe('BrsFile', () => {
             });
 
             it('works with leading whitespace', () => {
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         ' bs:disable-next-line
                         =asdf=sadf=
@@ -313,7 +313,7 @@ describe('BrsFile', () => {
             });
 
             it('works for all', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line
                         name = "bob
@@ -331,7 +331,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: 1083, 1001
                         name = "bob
@@ -348,7 +348,7 @@ describe('BrsFile', () => {
             });
 
             it('ignores non-numeric codes', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: LINT9999
                         name = "bob
@@ -359,7 +359,7 @@ describe('BrsFile', () => {
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         print "hi" 'bs:disable-line: 123456 999999   aaaab
                     end sub
@@ -380,7 +380,7 @@ describe('BrsFile', () => {
 
         describe('bs:disable-line', () => {
             it('works for all', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         z::;;%%%%%% 'bs:disable-line
                     end sub
@@ -397,7 +397,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         'should not have any errors
                         DoSomething(1) 'bs:disable-line:1002
@@ -420,7 +420,7 @@ describe('BrsFile', () => {
                 //the current version of BRS causes parse errors after the `parse` keyword, showing error in comments
                 //the program should ignore all diagnostics found in brs:* comment lines EXCEPT
                 //for the diagnostics about using unknown error codes
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         stop 'bs:disable-line
                         print "need a valid line to fix stop error"
@@ -434,7 +434,7 @@ describe('BrsFile', () => {
 
     describe('parse', () => {
         it('supports iife in assignment', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     result = sub()
                     end sub()
@@ -447,7 +447,7 @@ describe('BrsFile', () => {
 
         it('uses the proper parse mode based on file extension', () => {
             function testParseMode(destPath: string, expectedParseMode: ParseMode) {
-                const file = program.addOrReplaceFile<BrsFile>(destPath, '');
+                const file = program.setFile<BrsFile>(destPath, '');
                 expect(file.parseMode).to.equal(expectedParseMode);
             }
 
@@ -461,7 +461,7 @@ describe('BrsFile', () => {
         });
 
         it('supports labels and goto statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'multiple goto statements on one line
                     goto myLabel : goto myLabel
@@ -472,7 +472,7 @@ describe('BrsFile', () => {
         });
 
         it('supports empty print statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    print
                 end sub
@@ -483,7 +483,7 @@ describe('BrsFile', () => {
         describe('conditional compile', () => {
 
             it('works for upper case keywords', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #CONST someFlag = true
                         #IF someFlag
@@ -499,7 +499,7 @@ describe('BrsFile', () => {
             });
 
             it('supports single-word #elseif and #endif', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -513,7 +513,7 @@ describe('BrsFile', () => {
             });
 
             it('supports multi-word #else if and #end if', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -527,7 +527,7 @@ describe('BrsFile', () => {
             });
 
             it('does not choke on invalid code inside a false conditional compile', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if false
                             non-commented code here should not cause parse errors
@@ -538,7 +538,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #if', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if true1
                             print "true"
@@ -551,7 +551,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if %
                             print "true"
@@ -564,7 +564,7 @@ describe('BrsFile', () => {
             });
 
             it('detects #const name using reserved word', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const function = true
                     end sub
@@ -575,7 +575,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someConst = 123
                     end sub
@@ -587,7 +587,7 @@ describe('BrsFile', () => {
         });
 
         it('supports stop statement', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    stop
                 end sub
@@ -596,7 +596,7 @@ describe('BrsFile', () => {
         });
 
         it('supports single-line if statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                     if 1 < 2: return true: end if
                     if 1 < 2: return true
@@ -971,7 +971,7 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            let file = program.addOrReplaceFile('source/main.bs', `
+            let file = program.setFile('source/main.bs', `
                 sub main()
                 end sub
                 import "file.brs"
@@ -991,7 +991,7 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                 end sub
                 Library "v30/bslCore.brs"
@@ -1004,7 +1004,7 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements inside of function body', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                     Library "v30/bslCore.brs"
                 end sub
@@ -1026,7 +1026,7 @@ describe('BrsFile', () => {
         });
 
         it('succeeds when finding variables with "sub" in them', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function DoSomething()
                     return value.subType()
                 end function
@@ -1281,7 +1281,7 @@ describe('BrsFile', () => {
         });
 
         it('finds function calls nested inside statements', () => {
-            program.addOrReplaceFile(`source/main.brs`, `
+            program.setFile(`source/main.brs`, `
                 sub main()
                     if true then
                         DoesNotExist(1, 2)
@@ -1331,7 +1331,7 @@ describe('BrsFile', () => {
         });
 
         it('finds return type', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function DoSomething() as string
                 end function
             `);
@@ -1410,7 +1410,7 @@ describe('BrsFile', () => {
         });
 
         it('finds value from global return', () => {
-            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            let file = program.setFile<BrsFile>('source/main.brs', `
                 sub Main()
                    myName = GetName()
                 end sub
@@ -1458,7 +1458,7 @@ describe('BrsFile', () => {
 
     describe('getHover', () => {
         it('works for param types', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething(name as string)
                     name = 1
                     sayMyName = function(name as string)
@@ -1479,7 +1479,7 @@ describe('BrsFile', () => {
 
         //ignore this for now...it's not a huge deal
         it('does not match on keywords or data types', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                 end sub
                 sub as()
@@ -1492,7 +1492,7 @@ describe('BrsFile', () => {
         });
 
         it('finds declared function', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -1508,7 +1508,7 @@ describe('BrsFile', () => {
         });
 
         it('finds variable function hover in same scope', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName = sub(name as string)
                     end sub
@@ -1524,7 +1524,7 @@ describe('BrsFile', () => {
         });
 
         it('finds function hover in file scope', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
@@ -1546,13 +1546,13 @@ describe('BrsFile', () => {
                 rootDir: rootDir
             });
 
-            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub sayMyName(name as string)
 
                 end sub
@@ -1566,7 +1566,7 @@ describe('BrsFile', () => {
         });
 
         it('handles mixed case `then` partions of conditionals', () => {
-            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true then
                         print "works"
@@ -1575,7 +1575,7 @@ describe('BrsFile', () => {
             `);
 
             expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
-            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true Then
                         print "works"
@@ -1584,7 +1584,7 @@ describe('BrsFile', () => {
             `);
             expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
 
-            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true THEN
                         print "works"
@@ -1597,20 +1597,20 @@ describe('BrsFile', () => {
 
         it('displays the context from multiple scopes', () => {
 
-            let commonFile = program.addOrReplaceFile('source/common.brs', `
+            let commonFile = program.setFile('source/common.brs', `
                 sub displayPi()
                     pi = getPi()
                     print pi
                 end sub
             `);
 
-            let scope1File = program.addOrReplaceFile('components/comp1/scope1.brs', `
+            let scope1File = program.setFile('components/comp1/scope1.brs', `
                 function getPi() as string
                     return "apple"
                 end function
             `);
             expect(scope1File.getDiagnostics()).to.be.lengthOf(0);
-            program.addOrReplaceFile('components/comp1/comp1.xml', trim`
+            program.setFile('components/comp1/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Group">
                     <script type="text/brightscript" uri="scope1.brs" />
@@ -1618,13 +1618,13 @@ describe('BrsFile', () => {
                 </component>
             `);
 
-            let scope2File = program.addOrReplaceFile('components/comp2/scope2.brs', `
+            let scope2File = program.setFile('components/comp2/scope2.brs', `
                 function getPi() as float
                     return 3.14
                 end function
             `);
             expect(scope2File.getDiagnostics()).to.be.lengthOf(0);
-            program.addOrReplaceFile('components/comp2/comp2.xml', trim`
+            program.setFile('components/comp2/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component2" extends="Group">
                     <script type="text/brightscript" uri="scope2.brs" />
@@ -1644,7 +1644,7 @@ describe('BrsFile', () => {
     });
 
     it('does not throw when encountering incomplete import statement', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             import
             sub main()
             end sub
@@ -2204,7 +2204,7 @@ describe('BrsFile', () => {
         });
 
         it('simple mapped files include a reference to the source map', () => {
-            let file = program.addOrReplaceFile('source/logger.brs', trim`
+            let file = program.setFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2214,7 +2214,7 @@ describe('BrsFile', () => {
         });
 
         it('AST generated files include a reference to the source map', () => {
-            let file = program.addOrReplaceFile('source/logger.brs', trim`
+            let file = program.setFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2224,7 +2224,7 @@ describe('BrsFile', () => {
         });
 
         it('replaces custom types in parameter types and return types', () => {
-            program.addOrReplaceFile('source/SomeKlass.bs', `
+            program.setFile('source/SomeKlass.bs', `
                 class SomeKlass
                 end class
             `);
@@ -2250,7 +2250,7 @@ describe('BrsFile', () => {
     describe('callfunc operator', () => {
         describe('transpile', () => {
             it('does not produce diagnostics', () => {
-                program.addOrReplaceFile('source/main.bs', `
+                program.setFile('source/main.bs', `
                     sub main()
                         someObject@.someFunction(paramObject.value)
                     end sub
@@ -2299,7 +2299,7 @@ describe('BrsFile', () => {
                 name: 'transform callback',
                 afterFileParse: onParsed
             });
-            file = program.addOrReplaceFile(`source/file.${ext}`, `
+            file = program.setFile(`source/file.${ext}`, `
                 sub Sum()
                 print "hello world"
                 end sub
@@ -2324,17 +2324,17 @@ describe('BrsFile', () => {
     describe('typedefKey', () => {
         it('works for .brs files', () => {
             expect(
-                s((program.addOrReplaceFile<BrsFile>('source/main.brs', '')).typedefSrcPath)
+                s((program.setFile<BrsFile>('source/main.brs', '')).typedefSrcPath)
             ).to.equal(
                 s`${rootDir.toLowerCase()}/source/main.d.bs`
             );
         });
         it('returns undefined for files that should not have a typedef', () => {
-            expect((program.addOrReplaceFile<BrsFile>('source/main.bs', '')).typedefSrcPath).to.be.undefined;
+            expect((program.setFile<BrsFile>('source/main.bs', '')).typedefSrcPath).to.be.undefined;
 
-            expect((program.addOrReplaceFile<BrsFile>('source/main.d.bs', '')).typedefSrcPath).to.be.undefined;
+            expect((program.setFile<BrsFile>('source/main.d.bs', '')).typedefSrcPath).to.be.undefined;
 
-            const xmlFile = program.addOrReplaceFile<BrsFile>('components/comp.xml', '');
+            const xmlFile = program.setFile<BrsFile>('components/comp.xml', '');
             expect(xmlFile.typedefSrcPath).to.be.undefined;
         });
     });
@@ -2343,14 +2343,14 @@ describe('BrsFile', () => {
     describe('type definitions', () => {
         it('only exposes defined functions even if source has more', () => {
             //parse the .brs file first so it doesn't know about the typedef
-            program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
                 end sub
             `);
 
-            program.addOrReplaceFile('source/main.d.bs', `
+            program.setFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2362,7 +2362,7 @@ describe('BrsFile', () => {
         });
 
         it('reacts to typedef file changes', () => {
-            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            let file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2371,7 +2371,7 @@ describe('BrsFile', () => {
             expect(file.hasTypedef).to.be.false;
             expect(file.typedefFile).not.to.exist;
 
-            program.addOrReplaceFile('source/main.d.bs', `
+            program.setFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2379,7 +2379,7 @@ describe('BrsFile', () => {
             expect(file.typedefFile).to.exist;
 
             //add replace file, does it still find the typedef
-            file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2397,33 +2397,33 @@ describe('BrsFile', () => {
 
     describe('typedef', () => {
         it('sets typedef path properly', () => {
-            expect((program.addOrReplaceFile<BrsFile>('source/main1.brs', '')).typedefSrcPath).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
-            expect((program.addOrReplaceFile<BrsFile>('source/main2.d.bs', '')).typedefSrcPath).to.equal(undefined);
-            expect((program.addOrReplaceFile<BrsFile>('source/main3.bs', '')).typedefSrcPath).to.equal(undefined);
+            expect((program.setFile<BrsFile>('source/main1.brs', '')).typedefSrcPath).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
+            expect((program.setFile<BrsFile>('source/main2.d.bs', '')).typedefSrcPath).to.equal(undefined);
+            expect((program.setFile<BrsFile>('source/main3.bs', '')).typedefSrcPath).to.equal(undefined);
             //works for dest with `.brs` extension
-            expect((program.addOrReplaceFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefSrcPath).to.equal(undefined);
+            expect((program.setFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefSrcPath).to.equal(undefined);
         });
 
         it('does not link when missing from program', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).not.to.exist;
         });
 
         it('links typedef when added BEFORE .brs file', () => {
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).to.equal(typedef);
         });
 
         it('links typedef when added AFTER .brs file', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
             expect(file.typedefFile).to.eql(typedef);
         });
 
         it('removes typedef link when typedef is removed', () => {
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             program.removeFile(typedef.srcPath);
             expect(file.typedefFile).to.be.undefined;
         });
@@ -2431,7 +2431,7 @@ describe('BrsFile', () => {
 
     describe('getTypedef', () => {
         function testTypedef(original: string, expected: string) {
-            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', original);
+            let file = program.setFile<BrsFile>('source/main.brs', original);
             expect(file.getTypedef()).to.eql(expected);
         }
 
@@ -2694,7 +2694,7 @@ describe('BrsFile', () => {
 
     describe('parser getter', () => {
         it('recreates the parser when missing', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            const file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -2712,11 +2712,11 @@ describe('BrsFile', () => {
         });
 
         it('call parse when previously skipped', () => {
-            program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
+            program.setFile<BrsFile>('source/main.d.bs', `
                 sub main()
                 end sub
             `);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            const file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
             `);

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -42,7 +42,7 @@ describe('XmlFile', () => {
                     (event.file as XmlFile).parser.ast.root.attributes[0].value.text = expected;
                 }
             });
-            file = program.addOrReplaceFile('components/ChildScene.xml', trim`
+            file = program.setFile('components/ChildScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene1.brs" /> <script type="text/brightscript" uri="ChildScene2.brs" /> <script type="text/brightscript" uri="ChildScene3.brs" />
@@ -82,7 +82,7 @@ describe('XmlFile', () => {
         });
 
         it('supports importing BrighterScript files', () => {
-            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.bs" />
@@ -93,7 +93,7 @@ describe('XmlFile', () => {
             );
         });
         it('does not include commented-out script imports', () => {
-            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -186,7 +186,7 @@ describe('XmlFile', () => {
         });
 
         it('Adds error when no component is declared in xml', () => {
-            file = program.addOrReplaceFile('components/file.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
+            file = program.setFile('components/file.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
             program.validate();
             expect(file.diagnostics).to.be.lengthOf(2);
             expect(file.diagnostics[0]).to.deep.include({
@@ -199,7 +199,7 @@ describe('XmlFile', () => {
         });
 
         it('adds error when component does not declare a name', () => {
-            file = program.addOrReplaceFile('components/ParentScene.xml', trim`
+            file = program.setFile('components/ParentScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component extends="ParentScene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -214,7 +214,7 @@ describe('XmlFile', () => {
         });
 
         it('catches xml parse errors', () => {
-            file = program.addOrReplaceFile('components/ParentScene.xml', trim`
+            file = program.setFile('components/ParentScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component 1extends="ParentScene">
                 </component>
@@ -257,7 +257,7 @@ describe('XmlFile', () => {
         });
 
         it('resolves relative paths', () => {
-            file = program.addOrReplaceFile({
+            file = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -274,7 +274,7 @@ describe('XmlFile', () => {
         });
 
         it('finds correct position for empty uri in script tag', () => {
-            file = program.addOrReplaceFile({
+            file = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -292,7 +292,7 @@ describe('XmlFile', () => {
 
     describe('doesReferenceFile', () => {
         it('compares case insensitive', () => {
-            let xmlFile = program.addOrReplaceFile({
+            let xmlFile = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -301,7 +301,7 @@ describe('XmlFile', () => {
                     <script type="text/brightscript" uri="HeroGrid.brs" />
                 </component>
             `);
-            let brsFile = program.addOrReplaceFile({
+            let brsFile = program.setFile({
                 src: `${rootDir}/components/HEROGRID.brs`,
                 dest: `components/HEROGRID.brs`
             }, ``);
@@ -311,19 +311,19 @@ describe('XmlFile', () => {
 
     describe('autoImportComponentScript', () => {
         it('is not enabled by default', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
@@ -343,19 +343,19 @@ describe('XmlFile', () => {
                 rootDir: rootDir,
                 autoImportComponentScript: true
             });
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
@@ -372,9 +372,9 @@ describe('XmlFile', () => {
 
     describe('getCompletions', () => {
         it('formats completion paths with proper slashes', () => {
-            program.addOrReplaceFile('pkg:/components/component1/component1.brs', '');
+            program.setFile('pkg:/components/component1/component1.brs', '');
 
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/component1/component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/component1/component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Group">
                 </component
@@ -397,15 +397,15 @@ describe('XmlFile', () => {
         });
 
         it('returns empty set when out of range', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
             expect(file.getCompletions(Position.create(99, 99))).to.be.empty;
         });
 
         //TODO - refine this test once cdata scripts are supported
         it('prevents scope completions entirely', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
 
-            let xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.setFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./Component1.brs" />
@@ -418,7 +418,7 @@ describe('XmlFile', () => {
 
     describe('getAllDependencies', () => {
         it('returns own imports', () => {
-            file = program.addOrReplaceFile('components/comp1.xml', trim`
+            file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="BaseScene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -432,7 +432,7 @@ describe('XmlFile', () => {
     });
 
     it('invalidates dependent scopes on change', () => {
-        let xmlFile = program.addOrReplaceFile<XmlFile>({
+        let xmlFile = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -447,7 +447,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated);
 
         //add lib1
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, ``);
@@ -457,7 +457,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated).to.be.true;
 
         //update lib1 to include an import
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, `
@@ -470,7 +470,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated).to.be.true;
 
         //add the lib2 imported from lib
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib2.bs`,
             dest: `source/lib2.bs`
         }, ``);
@@ -485,7 +485,7 @@ describe('XmlFile', () => {
     });
 
     it('does not invalidate unrelated scopes on change', () => {
-        let xmlFile1 = program.addOrReplaceFile<XmlFile>({
+        let xmlFile1 = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -495,7 +495,7 @@ describe('XmlFile', () => {
             </component>
         `);
 
-        let xmlFile2 = program.addOrReplaceFile<XmlFile>({
+        let xmlFile2 = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp2.xml`,
             dest: `components/comp2.xml`
         }, trim`
@@ -510,7 +510,7 @@ describe('XmlFile', () => {
         expect(program.getScopesForFile(xmlFile2)[0].isValidated).to.be.true;
 
         //add the lib file
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.brs`,
             dest: `source/lib.brs`
         }, ``);
@@ -531,7 +531,7 @@ describe('XmlFile', () => {
 
     describe('component extends', () => {
         it('works for single-line', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -546,7 +546,7 @@ describe('XmlFile', () => {
         });
 
         it('works for multi-line', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -562,7 +562,7 @@ describe('XmlFile', () => {
         });
 
         it('does not throw when unable to find extends', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -577,7 +577,7 @@ describe('XmlFile', () => {
         });
 
         it('adds warning when no "extends" attribute is found', () => {
-            file = program.addOrReplaceFile<XmlFile>(
+            file = program.setFile<XmlFile>(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -602,11 +602,11 @@ describe('XmlFile', () => {
             autoImportComponentScript: true,
             rootDir: rootDir
         });
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/components/SimpleScene.bs`,
             dest: `components/SimpleScene.bs`
         }, '');
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/components/SimpleScene.xml`,
             dest: `components/SimpleScene.xml`
         }, trim`
@@ -633,7 +633,7 @@ describe('XmlFile', () => {
                     event.file.needsTranspiled = true;
                 }
             });
-            const file = program.addOrReplaceFile('components/file.xml', trim`
+            const file = program.setFile('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Comp" extends="Group">
                 </component>
@@ -669,8 +669,8 @@ describe('XmlFile', () => {
         });
 
         it('does not include bslib script if already there from ropm', () => {
-            program.addOrReplaceFile('source/roku_modules/bslib/bslib.brs', ``);
-            program.addOrReplaceFile('source/lib.bs', ``);
+            program.setFile('source/roku_modules/bslib/bslib.brs', ``);
+            program.setFile('source/lib.bs', ``);
             //include a bs file to force transpile for the xml file
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -688,7 +688,7 @@ describe('XmlFile', () => {
         });
 
         it('does not transpile xml file when bslib script is already present', () => {
-            const file = program.addOrReplaceFile('components/comp.xml', trim`
+            const file = program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Comp" extends="Group">
                     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
@@ -704,9 +704,9 @@ describe('XmlFile', () => {
          * There was a bug that would incorrectly replace one of the script paths on the second or third transpile, so this test verifies it doesn't do that anymore
          */
         it('does not mangle scripts on multiple transpile', async () => {
-            program.addOrReplaceFile('components/SimpleScene.bs', ``);
+            program.setFile('components/SimpleScene.bs', ``);
 
-            program.addOrReplaceFile(`components/SimpleScene.xml`, trim`
+            program.setFile(`components/SimpleScene.xml`, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
                     <script type="text/brightscript" uri="SimpleScene.bs" />
@@ -731,7 +731,7 @@ describe('XmlFile', () => {
         });
 
         it('keeps all content of the XML', () => {
-            program.addOrReplaceFile(`components/SimpleScene.bs`, `
+            program.setFile(`components/SimpleScene.bs`, `
                 sub b()
                 end sub
             `);
@@ -773,10 +773,10 @@ describe('XmlFile', () => {
         });
 
         it('changes file extensions from bs to brs', () => {
-            program.addOrReplaceFile(`components/SimpleScene.bs`, `
+            program.setFile(`components/SimpleScene.bs`, `
                 import "pkg:/source/lib.bs"
             `);
-            program.addOrReplaceFile('source/lib.bs', ``);
+            program.setFile('source/lib.bs', ``);
 
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -794,7 +794,7 @@ describe('XmlFile', () => {
         });
 
         it('does not fail on missing script type', () => {
-            program.addOrReplaceFile('components/SimpleScene.brs', '');
+            program.setFile('components/SimpleScene.brs', '');
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
@@ -810,7 +810,7 @@ describe('XmlFile', () => {
         });
 
         it('returns the XML unmodified if needsTranspiled is false', () => {
-            let file = program.addOrReplaceFile('components/SimpleScene.xml', trim`
+            let file = program.setFile('components/SimpleScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!-- should stay as-is -->
                 <component name="SimpleScene" extends="Scene" >
@@ -829,7 +829,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is false by default', () => {
-            let file = program.addOrReplaceFile('components/SimpleScene.xml', trim`
+            let file = program.setFile('components/SimpleScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene" >
                 </component>
@@ -838,7 +838,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is true if an import is brighterscript', () => {
-            let file = program.addOrReplaceFile('components/SimpleScene.xml', trim`
+            let file = program.setFile('components/SimpleScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene" >
                     <script type="text/brightscript" uri="SimpleScene.bs"/>
@@ -850,7 +850,7 @@ describe('XmlFile', () => {
 
         it('simple source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.addOrReplaceFile('components/SimpleScene.xml', trim`
+            let file = program.setFile('components/SimpleScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
                 </component>
@@ -863,7 +863,7 @@ describe('XmlFile', () => {
 
         it('AST-based source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.addOrReplaceFile('components/SimpleScene.xml', trim`
+            let file = program.setFile('components/SimpleScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
                 </component>
@@ -884,7 +884,7 @@ describe('XmlFile', () => {
                 name: 'Transform plugins',
                 afterFileParse: (event: AfterFileParseEvent) => validateXml(event.file as XmlFile)
             });
-            return program.addOrReplaceFile('components/Cmp1.xml', trim`
+            return program.setFile('components/Cmp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Cmp1" extends="Scene">
                 </component>
@@ -914,7 +914,7 @@ describe('XmlFile', () => {
             }
         });
 
-        program.addOrReplaceFile('components/comp.xml', trim`
+        program.setFile('components/comp.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
             </component>
@@ -928,43 +928,43 @@ describe('XmlFile', () => {
 
     describe('typedef', () => {
         it('loads d.bs files from parent scope', () => {
-            program.addOrReplaceFile<XmlFile>('components/ParentComponent.xml', trim`
+            program.setFile<XmlFile>('components/ParentComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent" extends="Scene">
                     <script uri="ParentComponent.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile('components/ParentComponent.d.bs', `
+            program.setFile('components/ParentComponent.d.bs', `
                 import "Lib.brs"
                 namespace Parent
                     sub log()
                     end sub
                 end namespace
             `);
-            program.addOrReplaceFile('components/ParentComponent.brs', `
+            program.setFile('components/ParentComponent.brs', `
                 sub Parent_log()
                 end sub
             `);
 
-            program.addOrReplaceFile('components/Lib.d.bs', `
+            program.setFile('components/Lib.d.bs', `
                 namespace Lib
                     sub log()
                     end sub
                 end namespace
             `);
-            program.addOrReplaceFile('components/Lib.brs', `
+            program.setFile('components/Lib.brs', `
                 sub Lib_log()
                 end sub
             `);
 
-            program.addOrReplaceFile<XmlFile>('components/ChildComponent.xml', trim`
+            program.setFile<XmlFile>('components/ChildComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                     <script uri="ChildComponent.bs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/ChildComponent.bs', `
+            program.setFile('components/ChildComponent.bs', `
                 sub init()
                     Parent.log()
                     Lib.log()
@@ -980,13 +980,13 @@ describe('XmlFile', () => {
         });
 
         it('loads `d.bs` files into scope', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/Component1.d.bs', `
+            program.setFile('components/Component1.d.bs', `
                 sub logInfo()
                 end sub
             `);
@@ -995,15 +995,15 @@ describe('XmlFile', () => {
         });
 
         it('does not include `d.bs` script during transpile', () => {
-            program.addOrReplaceFile('source/logger.d.bs', `
+            program.setFile('source/logger.d.bs', `
                 sub logInfo()
                 end sub
             `);
-            program.addOrReplaceFile('source/logger.brs', `
+            program.setFile('source/logger.brs', `
                 sub logInfo()
                 end sub
             `);
-            program.addOrReplaceFile('components/Component1.bs', `
+            program.setFile('components/Component1.bs', `
                 import "pkg:/source/logger.brs"
                 sub init()
                 end sub
@@ -1024,7 +1024,7 @@ describe('XmlFile', () => {
         });
 
         it('does not load .brs information into scope if related d.bs is in scope', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -1033,7 +1033,7 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            program.addOrReplaceFile('components/Component1.brs', `
+            program.setFile('components/Component1.brs', `
                 sub logInfo()
                 end sub
                 sub logWarning()
@@ -1045,7 +1045,7 @@ describe('XmlFile', () => {
             expect(functionNames).to.include('logWarning');
 
             //load d.bs file, which should shadow out the .brs file
-            program.addOrReplaceFile('components/Component1.d.bs', `
+            program.setFile('components/Component1.d.bs', `
                 sub logError()
                 end sub
             `);
@@ -1057,7 +1057,7 @@ describe('XmlFile', () => {
         });
 
         it('updates xml scope when typedef disappears', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -1066,12 +1066,12 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            program.addOrReplaceFile('components/Component1.brs', `
+            program.setFile('components/Component1.brs', `
                 sub logBrs()
                 end sub
             `);
             //load d.bs file, which should shadow out the .brs file
-            const typedef = program.addOrReplaceFile('components/Component1.d.bs', `
+            const typedef = program.setFile('components/Component1.d.bs', `
                 sub logTypedef()
                 end sub
             `);
@@ -1091,7 +1091,7 @@ describe('XmlFile', () => {
     });
 
     it('finds script imports for single-quoted script tags', () => {
-        const file = program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+        const file = program.setFile<XmlFile>('components/file.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
                 <script uri='SingleQuotedFile.brs' />
@@ -1103,7 +1103,7 @@ describe('XmlFile', () => {
     describe('commentFlags', () => {
         it('ignores warning from previous line comment', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!--bs:disable-next-line-->
                 <component>
@@ -1115,7 +1115,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line just for the specified code', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!--bs:disable-next-line 1006-->
                 <component>
@@ -1129,7 +1129,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line comment', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component> <!--bs:disable-line-->
                 </component>
@@ -1140,7 +1140,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line just for the specified code', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component> <!--bs:disable-line 1006-->
                 </component>
@@ -1154,16 +1154,16 @@ describe('XmlFile', () => {
 
     describe('duplicate components', () => {
         it('more gracefully handles multiple components with the same name', () => {
-            program.addOrReplaceFile('components/comp1.brs', ``);
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.brs', ``);
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                     <script uri="comp1.brs" />
                 </component>
             `);
             //add another component with the same name
-            program.addOrReplaceFile('components/comp2.brs', ``);
-            program.addOrReplaceFile('components/comp2.xml', trim`
+            program.setFile('components/comp2.brs', ``);
+            program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                     <script uri="comp2.brs" />
@@ -1178,7 +1178,7 @@ describe('XmlFile', () => {
 
         it('maintains consistent component selection', () => {
             //add comp2 first
-            const comp2 = program.addOrReplaceFile('components/comp2.xml', trim`
+            const comp2 = program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>
@@ -1186,7 +1186,7 @@ describe('XmlFile', () => {
             expect(program.getComponent('comp1').file.pkgPath).to.equal(comp2.pkgPath);
 
             //add comp1. it should become the main component with this name
-            const comp1 = program.addOrReplaceFile('components/comp1.xml', trim`
+            const comp1 = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                 </component>
@@ -1198,7 +1198,7 @@ describe('XmlFile', () => {
             expect(program.getComponent('comp1').file.pkgPath).to.equal(comp2.pkgPath);
 
             //add comp3
-            program.addOrReplaceFile('components/comp3.xml', trim`
+            program.setFile('components/comp3.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -33,14 +33,14 @@ describe('import statements', () => {
     });
 
     it('still transpiles import statements if found at bottom of file', async () => {
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="Scene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
 
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
@@ -48,7 +48,7 @@ describe('import statements', () => {
             import "stringOps.bs"
         `);
 
-        program.addOrReplaceFile('source/stringOps.bs', `
+        program.setFile('source/stringOps.bs', `
             function StringToLower(strVal as string)
                 return true
             end function
@@ -74,25 +74,25 @@ describe('import statements', () => {
 
     it('finds function loaded in by import multiple levels deep', () => {
         //create child component
-        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             import "stringOps.bs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/stringOps.bs', `
+        program.setFile('source/stringOps.bs', `
             import "intOps.bs"
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/intOps.bs', `
+        program.setFile('source/intOps.bs', `
             function isInt(strVal as dynamic)
                 return true
             end function
@@ -110,19 +110,19 @@ describe('import statements', () => {
 
     it('supports importing brs files', () => {
         //create child component
-        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/stringOps.brs', `
+        program.setFile('source/stringOps.brs', `
             function StringToLower(strVal as string)
                 return lcase(strVal)
             end function
@@ -139,20 +139,20 @@ describe('import statements', () => {
 
     it('detects when dependency contents have changed', () => {
         //create child component
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('components/lib.bs', `
+        program.setFile('components/lib.bs', `
             import "animalActions.bs"
             function init1(strVal as string)
                 Waddle()
             end function
         `);
         //add the empty dependency
-        program.addOrReplaceFile('components/animalActions.bs', ``);
+        program.setFile('components/animalActions.bs', ``);
 
         //there should be an error because that function doesn't exist
         program.validate();
@@ -162,7 +162,7 @@ describe('import statements', () => {
         ]);
 
         //add the missing function
-        program.addOrReplaceFile('components/animalActions.bs', `
+        program.setFile('components/animalActions.bs', `
             sub Waddle()
                 print "Waddling"
             end sub
@@ -177,19 +177,19 @@ describe('import statements', () => {
 
     it('adds brs imports to xml file during transpile', () => {
         //create child component
-        let component = program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+        let component = program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
+        program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
+        program.setFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
@@ -207,13 +207,13 @@ describe('import statements', () => {
 
     it('shows diagnostic for missing file in import', () => {
         //create child component
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="ChildScene.bs" />
             </component>
         `);
-        program.addOrReplaceFile('components/ChildScene.bs', `
+        program.setFile('components/ChildScene.bs', `
             import "stringOps.bs"
             sub init()
             end sub
@@ -223,15 +223,15 @@ describe('import statements', () => {
     });
 
     it('complicated import graph adds correct script tags', () => {
-        program.addOrReplaceFile('source/maestro/ioc/IOCMixin.bs', `
+        program.setFile('source/maestro/ioc/IOCMixin.bs', `
             sub DoIocThings()
             end sub
         `);
-        program.addOrReplaceFile('source/BaseClass.bs', `
+        program.setFile('source/BaseClass.bs', `
             import "pkg:/source/maestro/ioc/IOCMixin.bs"
         `);
 
-        program.addOrReplaceFile('components/AuthManager.bs', `
+        program.setFile('components/AuthManager.bs', `
             import "pkg:/source/BaseClass.bs"
         `);
         testTranspile(trim`
@@ -252,7 +252,7 @@ describe('import statements', () => {
 
     it('handles malformed imports', () => {
         //shouldn't crash
-        const brsFile = program.addOrReplaceFile<BrsFile>('source/SomeFile.bs', `
+        const brsFile = program.setFile<BrsFile>('source/SomeFile.bs', `
             import ""
             import ":"
             import ":/"

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -53,7 +53,7 @@ describe('globalCallables', () => {
         });
 
         it('does not allows 3 parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print val("1001", 10, "extra")
                 end sub
@@ -85,7 +85,7 @@ describe('globalCallables', () => {
         });
 
         it('does not allows 3 parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print StrI(2, 10, "extra")
                 end sub

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -21,7 +21,7 @@ describe('globalCallables', () => {
 
     describe('Roku_ads', () => {
         it('exists', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     adIface = Roku_Ads()
                 end sub
@@ -33,7 +33,7 @@ describe('globalCallables', () => {
 
     describe('val', () => {
         it('allows single parameter', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print val("1001")
                 end sub
@@ -43,7 +43,7 @@ describe('globalCallables', () => {
         });
 
         it('allows both parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print val("1001", 10)
                 end sub
@@ -55,7 +55,7 @@ describe('globalCallables', () => {
 
     describe('StrI', () => {
         it('allows single parameter', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print StrI(2)
                 end sub
@@ -65,7 +65,7 @@ describe('globalCallables', () => {
         });
 
         it('allows both parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print StrI(2, 10)
                 end sub

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -23,7 +23,7 @@ describe('SGParser', () => {
     });
 
     it('Parses well formed SG component', () => {
-        const file = program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+        const file = program.setFile<XmlFile>('components/file.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ParentScene" extends="GrandparentScene">
                 <interface>

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -93,7 +93,7 @@ describe('Statement', () => {
     describe('ImportStatement', () => {
         describe('getTypedef', () => {
             it('changes .bs file extensions to .brs', () => {
-                const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+                const file = program.setFile<BrsFile>('source/main.bs', `
                     import "lib1.bs"
                     import "pkg:/source/lib2.bs"
                 `);

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -190,7 +190,7 @@ describe('NullCoalescingExpression', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 'a = user ?? false',
                 `a = rokucommunity_bslib_coalesce(user, false)`

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -75,7 +75,7 @@ describe('TemplateStringExpression', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 'a = `${one},${two}`',
                 `a = rokucommunity_bslib_toString(one) + "," + rokucommunity_bslib_toString(two)`

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -266,7 +266,7 @@ describe('ternary expressions', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 `a = user = invalid ? "no user" : "logged in"`,
                 `a = rokucommunity_bslib_ternary(user = invalid, "no user", "logged in")`

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -113,7 +113,7 @@ export function getTestTranspile(scopeGetter: () => [Program, string]) {
     return (source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) => {
         let [program, rootDir] = scopeGetter();
         expected = expected ? expected : source;
-        let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
+        let file = program.setFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
         program.validate();
         if (failOnDiagnostic !== false) {
             expectZeroDiagnostics(program);


### PR DESCRIPTION
`addOrReplaceFile` is needlessly verbose. Similar to the javascript `Set` object, calling `setFile` is much more concise and accurately describes the operation.