### PR TITLE
Add flag to remove parameter types on transpile

### DIFF
--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -91,7 +91,7 @@ export interface BsConfig {
     /**
      * A list of error codes the compiler should NOT emit, even if encountered.
      */
-    ignoreErrorCodes?: (number|string)[];
+    ignoreErrorCodes?: (number | string)[];
 
     /**
      * Emit full paths to files when printing diagnostics to the console. Defaults to false
@@ -107,7 +107,7 @@ export interface BsConfig {
     /**
      * A list of filters used to exclude diagnostics from the output
      */
-    diagnosticFilters?: Array<number | string | { src: string; codes: (number|string)[] } | { src: string } | { codes: (number|string)[] }>;
+    diagnosticFilters?: Array<number | string | { src: string; codes: (number | string)[] } | { src: string } | { codes: (number | string)[] }>;
 
     /**
      * Specify what diagnostic types should be printed to the console. Defaults to 'warn'
@@ -147,4 +147,14 @@ export interface BsConfig {
      * @default true
      */
     sourceMap?: boolean;
+    /**
+     * A set of options that only apply during transpile
+     */
+    transpileOptions?: {
+        /**
+         * Remove the types from function parameters during transpile. This can sometimes provide runtime performance improvements and reduce the risk of runtime crashes
+         * due to type mismatches on-device
+         */
+        removeParameterTypes?: boolean;
+    };
 }

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1633,6 +1633,27 @@ describe('BrsFile', () => {
     });
 
     describe('transpile', () => {
+        describe('options.transpileOptions.removeParameterTypes', () => {
+            it('omits function parameter types when true', () => {
+                program.options.transpileOptions.removeParameterTypes = true;
+                testTranspile(`
+                    function speak(message as string, options = {} as object, channel = invalid)
+                    end function
+                `, `
+                    function speak(message, options = {}, channel = invalid)
+                    end function
+                `);
+            });
+
+            it('does not omit function parameter types when false', () => {
+                program.options.transpileOptions.removeParameterTypes = false;
+                testTranspile(`
+                    function speak(message as string, options = {} as object, channel = invalid)
+                    end function
+                `);
+            });
+        });
+
         describe('throwStatement', () => {
             it('transpiles properly', () => {
                 testTranspile(`

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -288,7 +288,7 @@ export class FunctionParameterExpression extends Expression {
             result.push(this.defaultValue.transpile(state));
         }
         //type declaration
-        if (this.asToken) {
+        if (this.asToken && !state.options.transpileOptions.removeParameterTypes) {
             result.push(' ');
             result.push(state.transpileToken(this.asToken));
             result.push(' ');

--- a/src/util.ts
+++ b/src/util.ts
@@ -302,6 +302,8 @@ export class Util {
         config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
         config.cwd = config.cwd ?? process.cwd();
         config.emitDefinitions = config.emitDefinitions === true ? true : false;
+        config.transpileOptions = config.transpileOptions ?? {};
+        config.transpileOptions.removeParameterTypes = config.transpileOptions.removeParameterTypes === true;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];
         }


### PR DESCRIPTION
There are runtime performance implications for using function parameter types. This PR adds a compiler flag to remove param types during transpile. 

**Notable changes:**
 - add `options.transpileOptions.removeParameterTypes` bsc option that, when enabled, removes all function parameter types during transpile. (i.e. `param as object` becomes `param`). 