### PR TITLE
Extract AA comma when parsing

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -629,6 +629,7 @@ export class AAMemberExpression extends Expression {
     }
 
     public range: Range;
+    public commaToken?: Token;
 
     transpile(state: BrsTranspileState) {
         //TODO move the logic from AALiteralExpression loop into this function

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2334,14 +2334,16 @@ export class Parser {
                     }
 
                     while (this.matchAny(TokenKind.Comma, TokenKind.Newline, TokenKind.Colon, TokenKind.Comment)) {
+                        // collect comma at end of expression
+                        if (lastAAMember && this.checkPrevious(TokenKind.Comma)) {
+                            lastAAMember.commaToken = this.previous();
+                        }
+
                         //check for comment at the end of the current line
                         if (this.check(TokenKind.Comment) || this.checkPrevious(TokenKind.Comment)) {
                             let token = this.checkPrevious(TokenKind.Comment) ? this.previous() : this.advance();
                             members.push(new CommentStatement([token]));
                         } else {
-                            if (lastAAMember && this.checkPrevious(TokenKind.Comma)) {
-                                lastAAMember.commaToken = this.previous();
-                            }
                             this.consumeStatementSeparators(true);
 
                             //check for a comment on its own line

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -4,8 +4,8 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
-import { AssignmentStatement } from '../../Statement';
-import { AALiteralExpression } from '../../Expression';
+import type { AssignmentStatement } from '../../Statement';
+import type { AALiteralExpression } from '../../Expression';
 import { isCommentStatement } from '../../../astUtils';
 
 describe('parser associative array literals', () => {

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -4,6 +4,9 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { AssignmentStatement } from '../../Statement';
+import { AALiteralExpression } from '../../Expression';
+import { isCommentStatement } from '../../../astUtils';
 
 describe('parser associative array literals', () => {
     describe('empty associative arrays', () => {
@@ -176,6 +179,30 @@ describe('parser associative array literals', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.length.greaterThan(0);
+    });
+
+    it('captures commas', () => {
+        let { statements } = Parser.parse(`
+            _ = {
+                p1: 1,
+                p2: 2, 'comment
+                p3: 3
+                p4: 4
+                'comment
+                p5: 5,
+            }
+        `);
+        const commas = ((statements[0] as AssignmentStatement).value as AALiteralExpression).elements
+            .map(s => !isCommentStatement(s) && !!s.commaToken);
+        expect(commas).to.deep.equal([
+            true, // p1
+            true, // p2
+            false, // comment
+            false, // p3
+            false, // p4
+            false, // comment
+            true // p5
+        ]);
     });
 
     it('location tracking', () => {


### PR DESCRIPTION
For code-style validation we need to know whether a comma is present at the end of an AA member