### PR TITLE
Add regex literal support

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,6 +10,7 @@ See the following pages for more information
  - [Namespaces](namespaces.md)
  - [Null-coalescing operator](null-coalescing-operator.md)
  - [Plugins](plugins.md)
+ - [Regular Expression Literals](regex-literals.md)
  - [Source Literals](source-literals.md)
  - [Template Strings (Template Literals)](template-strings.md)
  - [Ternary (Conditional) Operator](ternary-operator.md)

--- a/docs/regex-literals.md
+++ b/docs/regex-literals.md
@@ -1,0 +1,13 @@
+# Regular Expression Literals
+You can create a regular expression literal in brighterscript. This simplifies pattern writing and improves readability.
+
+Example:
+```BrighterScript
+print /hello world/ig
+```
+
+transpiles to:
+
+```BrightScript
+print CreateObject("roRegex","hello world","ig")
+```

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1242,7 +1242,9 @@ describe('lexer', () => {
                 /with spaces/s,
                 /with(parens)and[squarebraces]/,
                 //lots of special characters
-                /.*()^$@/
+                /.*()^$@/,
+                //captures quote char
+                /"/
             );
         });
 

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1222,4 +1222,26 @@ describe('lexer', () => {
             TokenKind.Eof
         ]);
     });
+
+    describe('regular expression literals', () => {
+        function testRegex(...regexps) {
+            const results = [] as string[];
+            for (const regexp of regexps) {
+                const { tokens } = Lexer.scan(regexp);
+                results.push(tokens[0].text);
+            }
+            expect(results).to.eql(regexps);
+        }
+
+        it('recognizes regex literals', () => {
+            testRegex(
+                '/simple/',
+                '/SimpleWithValidFlags/imsx',
+                '/UnknownFlags/VUI',
+                '/with spaces/andflags',
+                '/with(parens)and[squarebraces]/',
+                '/*()^$@/'
+            );
+        });
+    });
 });

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1224,10 +1224,11 @@ describe('lexer', () => {
     });
 
     describe('regular expression literals', () => {
-        function testRegex(...regexps) {
+        function testRegex(...regexps: Array<string | RegExp>) {
+            regexps = regexps.map(x => x.toString());
             const results = [] as string[];
             for (const regexp of regexps) {
-                const { tokens } = Lexer.scan(regexp);
+                const { tokens } = Lexer.scan(regexp as string);
                 results.push(tokens[0].text);
             }
             expect(results).to.eql(regexps);
@@ -1235,12 +1236,25 @@ describe('lexer', () => {
 
         it('recognizes regex literals', () => {
             testRegex(
-                '/simple/',
-                '/SimpleWithValidFlags/imsx',
-                '/UnknownFlags/VUI',
-                '/with spaces/andflags',
-                '/with(parens)and[squarebraces]/',
-                '/*()^$@/'
+                /simple/,
+                /SimpleWithValidFlags/g,
+                /UnknownFlags/gi,
+                /with spaces/s,
+                /with(parens)and[squarebraces]/,
+                //lots of special characters
+                /.*()^$@/
+            );
+        });
+
+        it('handles escape characters properly', () => {
+            testRegex(
+                //an escaped forward slash right next to the end-regexp forwardslash
+                /\//,
+                /\r/,
+                /\n/,
+                /\r\n/,
+                //a literal backslash in front of an escape backslash
+                /\\\n/
             );
         });
     });

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -199,14 +199,17 @@ export class Lexer {
             }
         },
         '/': function (this: Lexer) {
-            switch (this.peek()) {
-                case '=':
-                    this.advance();
-                    this.addToken(TokenKind.ForwardslashEqual);
-                    break;
-                default:
-                    this.addToken(TokenKind.Forwardslash);
-                    break;
+            //try capturing a regex literal. If that doesn't work, fall back to normal handling
+            if (!this.regexLiteral()) {
+                switch (this.peek()) {
+                    case '=':
+                        this.advance();
+                        this.addToken(TokenKind.ForwardslashEqual);
+                        break;
+                    default:
+                        this.addToken(TokenKind.Forwardslash);
+                        break;
+                }
             }
         },
         '\\': function (this: Lexer) {
@@ -382,6 +385,19 @@ export class Lexer {
     private advance(): void {
         this.current++;
         this.columnEnd++;
+    }
+
+    private lookaheadStack = [] as Array<{ current: number; columnEnd: number }>;
+    private pushLookahead() {
+        this.lookaheadStack.push({
+            current: this.current,
+            columnEnd: this.columnEnd
+        });
+    }
+    private popLookahead() {
+        const { current, columnEnd } = this.lookaheadStack.pop();
+        this.current = current;
+        this.columnEnd = columnEnd;
     }
 
     /**
@@ -836,6 +852,17 @@ export class Lexer {
     }
 
     /**
+     * Advance if the current token matches one of the candidates
+     */
+    private advanceIf(...candidates: string[]) {
+        if (this.check(...candidates)) {
+            this.advance();
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Check the previous character
      */
     private checkPrevious(...candidates: string[]) {
@@ -925,6 +952,38 @@ export class Lexer {
                     range: this.rangeOf()
                 });
         }
+    }
+
+    /**
+     * Capture a regex literal token. Returns false if not found.
+     * This is lookahead lexing which might techincally belong in the parser,
+     * but it's easy enough to do here in the lexer
+     */
+    private regexLiteral() {
+        this.pushLookahead();
+
+        //finite loop to prevent infinite loop if something went wrong
+        for (let i = this.current; i < this.source.length; i++) {
+
+            //if we reached the end of the regex, consume any flags
+            if (this.advanceIf('/')) {
+                //consume all flag-like chars (let the parser validate the actual values)
+                while (/[a-z]/i.exec(this.peek())) {
+                    this.advance();
+                }
+                //finalize the regex literal and EXIT
+                this.addToken(TokenKind.RegexLiteral);
+                return true;
+
+                //if we found a non-escaped newline, there's a syntax error with this regex (or it's not a regex), so quit
+            } else if (this.check('\n')) {
+                break;
+            } else {
+                this.advance();
+            }
+        }
+        this.popLookahead();
+        return false;
     }
 
     /**

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -52,6 +52,7 @@ export enum TokenKind {
     DoubleLiteral = 'DoubleLiteral',
     LongIntegerLiteral = 'LongIntegerLiteral',
     EscapedCharCodeLiteral = 'EscapedCharCodeLiteral', //this is used to capture things like `\n`, `\r\n` in template strings
+    RegexLiteral = 'RegexLiteral',
 
     //types
     Void = 'Void',

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1406,6 +1406,46 @@ export class NullCoalescingExpression extends Expression {
     }
 }
 
+export class RegexLiteralExpression extends Expression {
+    public constructor(
+        public tokens: {
+            regexLiteral: Token;
+        }
+    ) {
+        super();
+    }
+
+    public get range() {
+        return this.tokens.regexLiteral.range;
+    }
+
+    public transpile(state: BrsTranspileState): TranspileResult {
+        let text = this.tokens.regexLiteral?.text ?? '';
+        let flags = '';
+        //get any flags from the end
+        const flagMatch = /\/([a-z]+)$/i.exec(text);
+        if (flagMatch) {
+            text = text.substring(0, flagMatch.index + 1);
+            flags = flagMatch[1];
+        }
+        //remove leading and trailing slashes
+        const pattern = text.substring(1, text.length - 1);
+
+        return [
+            state.sourceNode(this.tokens.regexLiteral, [
+                'CreateObject("roRegex", ',
+                `"${pattern}", `,
+                `"${flags}"`,
+                ')'
+            ])
+        ];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+}
+
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 type ExpressionValue = string | number | boolean | Expression | ExpressionValue[] | { [key: string]: ExpressionValue };
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1428,8 +1428,11 @@ export class RegexLiteralExpression extends Expression {
             text = text.substring(0, flagMatch.index + 1);
             flags = flagMatch[1];
         }
-        //remove leading and trailing slashes
-        const pattern = text.substring(1, text.length - 1);
+        let pattern = text
+            //remove leading and trailing slashes
+            .substring(1, text.length - 1)
+            //escape quotemarks
+            .split('"').join('" + chr(34) + "');
 
         return [
             state.sourceNode(this.tokens.regexLiteral, [

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -93,6 +93,7 @@ import { Logger } from '../Logger';
 import { isAnnotationExpression, isCallExpression, isCallfuncExpression, isClassMethodStatement, isCommentStatement, isDottedGetExpression, isIfStatement, isIndexedGetExpression, isVariableExpression } from '../astUtils/reflection';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { createStringLiteral, createToken } from '../astUtils/creators';
+import { RegexLiteralExpression } from '.';
 
 export class Parser {
     /**
@@ -1396,6 +1397,12 @@ export class Parser {
         return new NullCoalescingExpression(test, questionQuestionToken, alternate);
     }
 
+    private regexLiteralExpression() {
+        return new RegexLiteralExpression({
+            regexLiteral: this.advance()
+        });
+    }
+
     private templateString(isTagged: boolean): TemplateStringExpression | TaggedTemplateStringExpression {
         this.warnIfNotBrighterScriptMode('template string');
 
@@ -2544,6 +2551,8 @@ export class Parser {
                 return new VariableExpression(token, this.currentNamespaceName);
             case this.checkAny(TokenKind.Function, TokenKind.Sub):
                 return this.anonymousFunction();
+            case this.check(TokenKind.RegexLiteral):
+                return this.regexLiteralExpression();
             case this.check(TokenKind.Comment):
                 return new CommentStatement([this.advance()]);
             default:

--- a/src/parser/tests/expression/RegexLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/RegexLiteralExpression.spec.ts
@@ -1,0 +1,54 @@
+import { Program } from '../../../Program';
+import { standardizePath as s } from '../../../util';
+import { getTestTranspile } from '../../../testHelpers.spec';
+
+describe('RegexLiteralExpression', () => {
+    let rootDir = s`${process.cwd()}/rootDir`;
+    let program: Program;
+    let testTranspile = getTestTranspile(() => [program, rootDir]);
+
+    beforeEach(() => {
+        program = new Program({ rootDir: rootDir });
+    });
+    afterEach(() => {
+        program.dispose();
+    });
+
+    describe('transpile', () => {
+        it('captures flags', () => {
+            testTranspile(`
+                sub main()
+                    print /hello/gi
+                end sub
+            `, `
+                sub main()
+                    print CreateObject("roRegex", "hello", "gi")
+                end sub
+            `);
+        });
+
+        it('handles when no flags', () => {
+            testTranspile(`
+                sub main()
+                    print /hello/
+                end sub
+            `, `
+                sub main()
+                    print CreateObject("roRegex", "hello", "")
+                end sub
+            `);
+        });
+
+        it('handles weird escapes', () => {
+            testTranspile(`
+                sub main()
+                    print /\\r\\n\\//
+                end sub
+            `, `
+                sub main()
+                    print CreateObject("roRegex", "\\r\\n\\/", "")
+                end sub
+            `);
+        });
+    });
+});

--- a/src/parser/tests/expression/RegexLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/RegexLiteralExpression.spec.ts
@@ -50,5 +50,18 @@ describe('RegexLiteralExpression', () => {
                 end sub
             `);
         });
+
+        it('escapes quotemark', () => {
+            testTranspile(`
+                sub main()
+                    print /"/
+                end sub
+            `, `
+                sub main()
+                    print CreateObject("roRegex", "" + chr(34) + "", "")
+                end sub
+            `);
+        });
+
     });
 });


### PR DESCRIPTION
Adds the ability to declare regular expression literals rather than dealing with strings. Example:
```brightscript
regexp = /[a-z]+/i
```
transpiles to
```
regexp = CreateObject("roRegex", "[a-z]+", "i")
```

Tasks: 
- [x] Lexer functionality for capturing regex literals as a single token
- [x] parser functionality
- [x] handle escape characters e.g. `/capture parens \( \)/`
- [x] transpile functionality
- [x] user docs