### PR TITLE
Caches lookups when checking for symbols on a token

### DIFF
--- a/benchmarks/targets/hover-brs.js
+++ b/benchmarks/targets/hover-brs.js
@@ -1,0 +1,29 @@
+module.exports = async (suite, name, brighterscript, projectPath, options) => {
+    const { ProgramBuilder } = brighterscript;
+
+    const builder = new ProgramBuilder();
+    //run the first run so we we can focus the test on validate
+    await builder.run({
+        cwd: projectPath,
+        createPackage: false,
+        copyToStaging: false,
+        //disable diagnostic reporting (they still get collected)
+        diagnosticFilters: ['**/*'],
+        logLevel: 'error'
+    });
+    const files = Object.values(builder.program.files).filter(x => ['.brs', '.bs'].includes(x.extension));
+    if (files.length === 0) {
+        console.log('[hover-brs] No brs|bs files found in program');
+        return;
+    }
+
+    suite.add(name, () => {
+        for (const file of files) {
+            // Hover every 20th token
+            for (let i = 0; i < file.parser.tokens.length; i += 20) {
+                const token = file.parser.tokens[i];
+                file.getHover(token.range.end);
+            }
+        }
+    }, options);
+};

--- a/benchmarks/targets/parse-brs.js
+++ b/benchmarks/targets/parse-brs.js
@@ -19,9 +19,10 @@ module.exports = async (suite, name, brighterscript, projectPath, options) => {
     }
     suite.add(name, (deferred) => {
         const promises = [];
+        const setFileFuncName = builder.program.setFile ? 'setFile' : 'addOrReplaceFile';
         for (const file of files) {
             promises.push(
-                builder.program.addOrReplaceFile(file.pkgPath, file.fileContents)
+                builder.program[setFileFuncName](file.pkgPath, file.fileContents)
             );
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -48,7 +48,6 @@ export class Scope {
     public isValidated: boolean;
 
     protected cache = new Cache();
-    protected symbolCache = new Map<Token, TokenSymbolLookup>();
 
     public get dependencyGraphKey() {
         return this._dependencyGraphKey;
@@ -70,6 +69,15 @@ export class Scope {
      */
     public getClass(className: string, containingNamespace?: string): ClassStatement {
         return this.getClassFileLink(className, containingNamespace)?.item;
+    }
+
+    /**
+     * A cache of a map of tokens -> TokenSymbolLookups, which are the result of getSymbolTypeFromToken()
+     * Sometimes the lookup of symbols may take a while if there are lazyTypes or multiple tokens in a chain
+     * By caching the result of this lookup, subsequent lookups of the same tokens are quicker
+     */
+    protected get symbolCache() {
+        return this.cache.getOrAdd('symbolCache', () => new Map<Token, TokenSymbolLookup>());
     }
 
     /**
@@ -152,7 +160,6 @@ export class Scope {
         return ancestors;
     }
 
-
     public hasCachedSymbolForToken(token: Token) {
         return this.symbolCache.has(token);
     }
@@ -161,6 +168,10 @@ export class Scope {
         return this.symbolCache.get(token);
     }
 
+    /**
+     * Stores a TokenSymbolLookup object associated with a token
+     * @returns the "lookupValue" that was passed in
+     */
     public setCachedSymbolForToken(token: Token, lookupValue: TokenSymbolLookup): TokenSymbolLookup {
         this.symbolCache.set(token, lookupValue);
         return lookupValue;

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -15,7 +15,7 @@ import { Cache } from './Cache';
 import { URI } from 'vscode-uri';
 import { LogLevel } from './Logger';
 import { isBrsFile, isClassStatement, isFunctionStatement, isFunctionType, isXmlFile, isCustomType, isClassMethodStatement, isInvalidType, isDynamicType, isVariableExpression } from './astUtils/reflection';
-import type { BrsFile } from './files/BrsFile';
+import type { BrsFile, TokenSymbolLookup } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
 import { SymbolTable } from './SymbolTable';
 import type { CustomType } from './types/CustomType';
@@ -23,6 +23,7 @@ import { UninitializedType } from './types/UninitializedType';
 import { ObjectType } from './types/ObjectType';
 import { getTypeFromContext } from './types/BscType';
 import { DynamicType } from './types/DynamicType';
+import type { Token } from './lexer/Token';
 
 
 /**
@@ -47,6 +48,7 @@ export class Scope {
     public isValidated: boolean;
 
     protected cache = new Cache();
+    protected symbolCache = new Map<Token, TokenSymbolLookup>();
 
     public get dependencyGraphKey() {
         return this._dependencyGraphKey;
@@ -148,6 +150,20 @@ export class Scope {
         }
         // TODO TYPES: this should probably be cached
         return ancestors;
+    }
+
+
+    public hasCachedSymbolForToken(token: Token) {
+        return this.symbolCache.has(token);
+    }
+
+    public getCachedSymbolForToken(token: Token): TokenSymbolLookup {
+        return this.symbolCache.get(token);
+    }
+
+    public setCachedSymbolForToken(token: Token, lookupValue: TokenSymbolLookup): TokenSymbolLookup {
+        this.symbolCache.set(token, lookupValue);
+        return lookupValue;
     }
 
     /**
@@ -513,6 +529,7 @@ export class Scope {
         //clear out various lookups (they'll get regenerated on demand the next time they're requested)
         this.cache.clear();
         this.clearSymbolTable();
+        this.symbolCache.clear();
     }
 
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -76,7 +76,7 @@ export class Scope {
      * Sometimes the lookup of symbols may take a while if there are lazyTypes or multiple tokens in a chain
      * By caching the result of this lookup, subsequent lookups of the same tokens are quicker
      */
-    protected get symbolCache() {
+    public get symbolCache() {
         return this.cache.getOrAdd('symbolCache', () => new Map<Token, TokenSymbolLookup>());
     }
 
@@ -158,23 +158,6 @@ export class Scope {
         }
         // TODO TYPES: this should probably be cached
         return ancestors;
-    }
-
-    public hasCachedSymbolForToken(token: Token) {
-        return this.symbolCache.has(token);
-    }
-
-    public getCachedSymbolForToken(token: Token): TokenSymbolLookup {
-        return this.symbolCache.get(token);
-    }
-
-    /**
-     * Stores a TokenSymbolLookup object associated with a token
-     * @returns the "lookupValue" that was passed in
-     */
-    public setCachedSymbolForToken(token: Token, lookupValue: TokenSymbolLookup): TokenSymbolLookup {
-        this.symbolCache.set(token, lookupValue);
-        return lookupValue;
     }
 
     /**

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -832,8 +832,9 @@ export class BrsFile {
         if (!scope) {
             return undefined;
         }
-        if (scope.hasCachedSymbolForToken(currentToken)) {
-            return scope.getCachedSymbolForToken(currentToken);
+        const cachedSymbolData = scope.getCachedSymbolForToken(currentToken);
+        if (cachedSymbolData) {
+            return cachedSymbolData;
         }
         const tokenChainResponse = this.parser.getTokenChain(currentToken);
         if (tokenChainResponse.includesUnknowableTokenType) {


### PR DESCRIPTION
Benchmark results:

```
% npm run benchmark -- --versions=local 1.0.0-alpha.9

> brighterscript@1.0.0-alpha.9 benchmark /Users/mpearce/redspace/roku/brighterscript
> node ./benchmarks/index.js "--versions=local" "1.0.0-alpha.9"

benchmark: Clearing any existing node_modules folder
benchmark: using versions: local,1.0.0-alpha.9
benchmark: build current brighterscript

> brighterscript@1.0.0-alpha.9 build /Users/mpearce/redspace/roku/brighterscript
> rimraf out && tsc

benchmark: pack current brighterscript
benchmark: Writing package.json
benchmark: npm install
npm WARN benchmarks No description
npm WARN benchmarks No repository field.
npm WARN benchmarks No license field.

added 151 packages from 207 contributors in 2.322s

7 packages are looking for funding
  run `npm fund` for details

benchmark: Running benchmarks:

         hover-brs@local         ---------- 10.962 ops/sec
         hover-brs@1.0.0-alpha.9 ----------- 0.786 ops/sec

lex-parse-validate@local         ----------- 5.503 ops/sec
lex-parse-validate@1.0.0-alpha.9 ----------- 5.368 ops/sec

               lex@local         ---------- 53.546 ops/sec
               lex@1.0.0-alpha.9 ---------- 55.259 ops/sec

         parse-brs@local         ----------- 5.253 ops/sec
         parse-brs@1.0.0-alpha.9 ----------- 5.549 ops/sec

         parse-xml@local         --------- 153.171 ops/sec
         parse-xml@1.0.0-alpha.9 --------- 155.565 ops/sec

             parse@local         ---------- 21.426 ops/sec
             parse@1.0.0-alpha.9 ---------- 21.401 ops/sec

     transpile-brs@local         ---------- 28.266 ops/sec
     transpile-brs@1.0.0-alpha.9 ---------- 27.991 ops/sec

     transpile-xml@local         --------- 148.797 ops/sec
     transpile-xml@1.0.0-alpha.9 --------- 151.491 ops/sec

         transpile@local         ---------- 24.419 ops/sec
         transpile@1.0.0-alpha.9 ---------- 17.688 ops/sec

          validate@local         ---------- 32.279 ops/sec
          validate@1.0.0-alpha.9 ---------- 30.947 ops/sec
```