### PR TITLE
Allow diagnostic non-numeric disable code comments

### DIFF
--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -153,4 +153,17 @@ describe('CommentFlagProcessor', () => {
             });
         });
     });
+
+    describe('tryAdd', () => {
+        it('supports non-numeric codes', () => {
+            processor.tryAdd(`'bs:disable-line lint123 LINT2 some-textual-diagnostic`, Range.create(0, 0, 0, 54));
+            expect(
+                processor.commentFlags.flatMap(x => x.codes)
+            ).to.eql([
+                'lint123',
+                'lint2',
+                'some-textual-diagnostic'
+            ]);
+        });
+    });
 });

--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -69,15 +69,18 @@ export class CommentFlagProcessor {
 
             //disable specific diagnostic codes
         } else {
-            let codes = [] as number[];
+            let codes = [] as DiagnosticCode[];
             for (let codeToken of tokenized.codes) {
                 let codeInt = parseInt(codeToken.code);
+                //is a plugin-contributed or non-numeric code
                 if (isNaN(codeInt)) {
-                    //don't validate non-numeric codes
-                    continue;
-                    //add a warning for unknown codes
+                    codes.push(codeToken.code?.toString()?.toLowerCase());
+
+                    //validate numeric codes against the list of known bsc codes
                 } else if (this.diagnosticCodes.includes(codeInt)) {
                     codes.push(codeInt);
+
+                    //add a warning for unknown codes
                 } else {
                     this.diagnostics.push({
                         ...DiagnosticMessages.unknownDiagnosticCode(codeInt),

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -357,15 +357,33 @@ describe('BrsFile', () => {
                 expect(program.getDiagnostics()[0]?.message).to.not.exist;
             });
 
-            it('ignores non-numeric codes', () => {
+            it('recognizes non-numeric codes', () => {
                 let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: LINT9999
                         name = "bob
                     end sub
                 `);
-                expect(file.commentFlags[0]).to.not.exist;
+                expect(file.commentFlags[0]).to.exist;
                 expect(program.getDiagnostics()[0]?.message).to.exist;
+            });
+
+            it('supports disabling non-numeric error codes', () => {
+                const program = new Program({});
+                const file = program.addOrReplaceFile('source/main.brs', `
+                    sub main()
+                        something = true 'bs:disable-line: LINT1005
+                    end sub
+                `);
+                file.addDiagnostics([{
+                    code: 'LINT1005',
+                    file: file,
+                    message: 'Something is not right',
+                    range: util.createRange(2, 16, 2, 26)
+                }]);
+                expect(
+                    program.getScopesForFile(file)[0].getDiagnostics()
+                ).to.be.empty;
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -642,11 +642,12 @@ export class Util {
      * @param diagnostic
      */
     public diagnosticIsSuppressed(diagnostic: BsDiagnostic) {
+        const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
         for (let flag of diagnostic.file?.commentFlags ?? []) {
             //this diagnostic is affected by this flag
             if (this.rangeContains(flag.affectedRange, diagnostic.range.start)) {
                 //if the flag acts upon this diagnostic's code
-                if (flag.codes === null || flag.codes.includes(diagnostic.code as number)) {
+                if (flag.codes === null || flag.codes.includes(diagnosticCode)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fix bug in the bs:disable where per-line disable comments wouldn't work with non-numeric codes. 