### PR TITLE
AST editing

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -228,32 +228,44 @@ export default function () {
 };
 ```
 
-### Example AST modifier plugin
+## Modifying code
+Sometimes plugins will want to modify code before the project is transpiled. While you can technically edit the AST directly at any point in the file's lifecycle, this is not recommended as those changes will remain changed as long as that file exists in memory and could cause issues with file validation if the plugin is used in a language-server context (i.e. inside vscode).
 
-AST modification can be done after parsing (`afterFileParsed`), but it is recommended to modify the AST only before transpilation (`beforeFileTranspile`), otherwise it could cause problems if the plugin is used in a language-server context.
+Instead, we provide an instace of an `AstEditor` class in the `beforeFileTranspile` event that allows you to modify AST before the file is transpiled, and then those modifications are undone `afterFileTranspile`.
+
+For example, consider the following brightscript code:
+```brightscript
+sub main()
+    print "hello <FIRST_NAME>"
+end sub
+```
+
+Here's the plugin:
 
 ```typescript
-// removePrint.ts
-import { CompilerPlugin, Program, TranspileObj } from 'brighterscript';
-import { EmptyStatement } from 'brighterscript/dist/parser';
-import { isBrsFile, createStatementEditor, editStatements } from 'brighterscript/dist/parser/ASTUtils';
+import { CompilerPlugin, BeforeFileTranspileEvent, isBrsFile, WalkMode, createVisitor, TokenKind } from './';
 
 // plugin factory
 export default function () {
     return {
         name: 'removePrint',
         // transform AST before transpilation
-        beforeFileTranspile: (entry: TranspileObj) => {
-            if (isBrsFile(entry.file)) {
-                // visit functions bodies and replace `PrintStatement` nodes with `EmptyStatement`
-                entry.file.parser.functionExpressions.forEach((fun) => {
-                    const visitor = createStatementEditor({
-                        PrintStatement: (statement) => new EmptyStatement()
-                    });
-                    editStatements(fun.body, visitor);
+        beforeFileTranspile: (event: BeforeFileTranspileEvent) => {
+            if (isBrsFile(event.file)) {
+                event.file.ast.walk(createVisitor({
+                    LiteralExpression: (literal) => {
+                        //replace every occurance of <FIRST_NAME> in strings with "world"
+                        if (literal.token.kind === TokenKind.StringLiteral && literal.token.text.includes('<FIRST_NAME>')) {
+                            event.astEditor.setProperty(literal.token, 'text', literal.token.text.replace('<FIRST_NAME>', 'world'));
+                        }
+                    }
+                }), {
+                    walkMode: WalkMode.visitExpressionsRecursive
                 });
             }
         }
     } as CompilerPlugin;
 };
 ```
+
+This plugin will search through every LiteralExpression in the entire project, and every time we find a string literal, we will replace `<FIRST_NAME>` with `world`. This is done with the `event.astEditor` object. `astEditor` allows you to apply edits to the AST, and then the brighterscript compiler will `undo` those edits once the file has been transpiled.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -256,7 +256,7 @@ export default function () {
                     LiteralExpression: (literal) => {
                         //replace every occurance of <FIRST_NAME> in strings with "world"
                         if (literal.token.kind === TokenKind.StringLiteral && literal.token.text.includes('<FIRST_NAME>')) {
-                            event.astEditor.setProperty(literal.token, 'text', literal.token.text.replace('<FIRST_NAME>', 'world'));
+                            event.editor.setProperty(literal.token, 'text', literal.token.text.replace('<FIRST_NAME>', 'world'));
                         }
                     }
                 }), {
@@ -268,4 +268,4 @@ export default function () {
 };
 ```
 
-This plugin will search through every LiteralExpression in the entire project, and every time we find a string literal, we will replace `<FIRST_NAME>` with `world`. This is done with the `event.astEditor` object. `astEditor` allows you to apply edits to the AST, and then the brighterscript compiler will `undo` those edits once the file has been transpiled.
+This plugin will search through every LiteralExpression in the entire project, and every time we find a string literal, we will replace `<FIRST_NAME>` with `world`. This is done with the `event.editor` object. `editor` allows you to apply edits to the AST, and then the brighterscript compiler will `undo` those edits once the file has been transpiled.

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1652,7 +1652,7 @@ describe('Program', () => {
                 name: 'TestPlugin',
                 beforeFileTranspile: (event) => {
                     const stmt = ((event.file as BrsFile).ast.statements[0] as FunctionStatement).func.body.statements[0] as PrintStatement;
-                    event.astEditor.setProperty((stmt.expressions[0] as LiteralExpression).token, 'text', '"hello there"');
+                    event.editor.setProperty((stmt.expressions[0] as LiteralExpression).token, 'text', '"hello there"');
                 }
             });
             await program.transpile([], stagingFolderPath);
@@ -1681,7 +1681,7 @@ describe('Program', () => {
                         event.file.ast.walk(createVisitor({
                             LiteralExpression: (literal) => {
                                 literalExpression = literal;
-                                event.astEditor.setProperty(literal.token, 'text', '"goodbye world"');
+                                event.editor.setProperty(literal.token, 'text', '"goodbye world"');
                             }
                         }), {
                             walkMode: WalkMode.visitExpressionsRecursive

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1225,6 +1225,8 @@ export class Program {
             }
 
             this.plugins.emit('afterFileTranspile', entry);
+
+            //undo all astEditor edits that may have been applied to this file.
             entry.astEditor.undoAll();
         });
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -25,6 +25,7 @@ import type { FunctionStatement, Statement } from './parser/Statement';
 import { ParseMode } from './parser';
 import { TokenKind } from './lexer';
 import { BscPlugin } from './bscPlugin/BscPlugin';
+import { AstEditor } from './astUtils/AstEditor';
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
@@ -1188,7 +1189,8 @@ export class Program {
             outputPath = s`${stagingFolderPath}/${outputPath}`;
             return {
                 file: file,
-                outputPath: outputPath
+                outputPath: outputPath,
+                astEditor: new AstEditor()
             };
         });
 
@@ -1199,6 +1201,7 @@ export class Program {
             if (isBrsFile(entry.file) && entry.file.isTypedef) {
                 return;
             }
+
             this.plugins.emit('beforeFileTranspile', entry);
             const { file, outputPath } = entry;
             const result = file.transpile();
@@ -1222,6 +1225,7 @@ export class Program {
             }
 
             this.plugins.emit('afterFileTranspile', entry);
+            entry.astEditor.undoAll();
         });
 
         //if there's no bslib file already loaded into the program, copy it to the staging directory

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1206,7 +1206,7 @@ export class Program {
             const { file, outputPath } = entry;
             //if we have any edits, assume the file needs to be transpiled
             if (entry.editor.hasChanges) {
-                //use the astEditor because it'll track the previous value for us and revert later on
+                //use the `editor` because it'll track the previous value for us and revert later on
                 entry.editor.setProperty(file, 'needsTranspiled', true);
             }
             const result = file.transpile();
@@ -1231,7 +1231,7 @@ export class Program {
 
             this.plugins.emit('afterFileTranspile', entry);
 
-            //undo all astEditor edits that may have been applied to this file.
+            //undo all `editor` edits that may have been applied to this file.
             entry.editor.undoAll();
         });
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1190,7 +1190,7 @@ export class Program {
             return {
                 file: file,
                 outputPath: outputPath,
-                astEditor: new AstEditor()
+                editor: new AstEditor()
             };
         });
 
@@ -1205,9 +1205,9 @@ export class Program {
             this.plugins.emit('beforeFileTranspile', entry);
             const { file, outputPath } = entry;
             //if we have any edits, assume the file needs to be transpiled
-            if (entry.astEditor.hasChanges) {
+            if (entry.editor.hasChanges) {
                 //use the astEditor because it'll track the previous value for us and revert later on
-                entry.astEditor.setProperty(file, 'needsTranspiled', true);
+                entry.editor.setProperty(file, 'needsTranspiled', true);
             }
             const result = file.transpile();
 
@@ -1232,7 +1232,7 @@ export class Program {
             this.plugins.emit('afterFileTranspile', entry);
 
             //undo all astEditor edits that may have been applied to this file.
-            entry.astEditor.undoAll();
+            entry.editor.undoAll();
         });
 
         //if there's no bslib file already loaded into the program, copy it to the staging directory

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1204,6 +1204,11 @@ export class Program {
 
             this.plugins.emit('beforeFileTranspile', entry);
             const { file, outputPath } = entry;
+            //if we have any edits, assume the file needs to be transpiled
+            if (entry.astEditor.hasChanges) {
+                //use the astEditor because it'll track the previous value for us and revert later on
+                entry.astEditor.setProperty(file, 'needsTranspiled', true);
+            }
             const result = file.transpile();
 
             //make sure the full dir path exists

--- a/src/astUtils/AstEditor.spec.ts
+++ b/src/astUtils/AstEditor.spec.ts
@@ -64,6 +64,16 @@ describe('AstEditor', () => {
         expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
     });
 
+    it('changes the value at an array index', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.setArrayValue(obj.hobbies, 1, 'sleeping');
+        expect(obj.hobbies).to.eql(['gaming', 'sleeping', 'cycling']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
     it('inserts at end of array', () => {
         expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
 

--- a/src/astUtils/AstEditor.spec.ts
+++ b/src/astUtils/AstEditor.spec.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import { AstEditor } from './AstEditor';
+
+describe('AstEditor', () => {
+    let changer: AstEditor;
+    let obj: ReturnType<typeof getTestObject>;
+
+    beforeEach(() => {
+        changer = new AstEditor();
+        obj = getTestObject();
+    });
+
+    function getTestObject() {
+        return {
+            name: 'parent',
+            hobbies: ['gaming', 'reading', 'cycling'],
+            children: [{
+                name: 'oldest',
+                age: 15
+            }, {
+                name: 'middle',
+                age: 10
+            }, {
+                name: 'youngest',
+                age: 5
+            }],
+            jobs: [{
+                title: 'plumber',
+                annualSalary: 50000
+            }, {
+                title: 'carpenter',
+                annualSalary: 75000
+            }]
+        };
+    }
+
+    it('applies single property change', () => {
+        expect(obj.name).to.eql('parent');
+
+        changer.setProperty(obj, 'name', 'jack');
+        expect(obj.name).to.eql('jack');
+
+        changer.undoAll();
+        expect(obj.name).to.eql('parent');
+    });
+
+    it('inserts at beginning of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.addToArray(obj.hobbies, 0, 'climbing');
+        expect(obj.hobbies).to.eql(['climbing', 'gaming', 'reading', 'cycling']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('inserts at middle of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.addToArray(obj.hobbies, 1, 'climbing');
+        expect(obj.hobbies).to.eql(['gaming', 'climbing', 'reading', 'cycling']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('inserts at end of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.addToArray(obj.hobbies, 3, 'climbing');
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling', 'climbing']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('removes at beginning of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.removeFromArray(obj.hobbies, 0);
+        expect(obj.hobbies).to.eql(['reading', 'cycling']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('removes at middle of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.removeFromArray(obj.hobbies, 1);
+        expect(obj.hobbies).to.eql(['gaming', 'cycling']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('removes at middle of array', () => {
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+
+        changer.removeFromArray(obj.hobbies, 2);
+        expect(obj.hobbies).to.eql(['gaming', 'reading']);
+
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('restores array after being removed', () => {
+        changer.removeFromArray(obj.hobbies, 0);
+        changer.setProperty(obj, 'hobbies', undefined);
+        expect(obj.hobbies).to.be.undefined;
+        changer.undoAll();
+        expect(obj.hobbies).to.eql(['gaming', 'reading', 'cycling']);
+    });
+
+    it('works for many changes', () => {
+        expect(obj).to.eql(getTestObject());
+        changer.setProperty(obj, 'name', 'bob');
+        changer.setProperty(obj.children[0], 'name', 'jimmy');
+        changer.addToArray(obj.children, obj.children.length, { name: 'sally', age: 1 });
+        changer.removeFromArray(obj.jobs, 1);
+        changer.removeFromArray(obj.hobbies, 0);
+        changer.removeFromArray(obj.hobbies, 0);
+        changer.removeFromArray(obj.hobbies, 0);
+        changer.setProperty(obj, 'hobbies', undefined);
+
+        expect(obj).to.eql({
+            name: 'bob',
+            hobbies: undefined,
+            children: [{
+                name: 'jimmy',
+                age: 15
+            }, {
+                name: 'middle',
+                age: 10
+            }, {
+                name: 'youngest',
+                age: 5
+            }, {
+                name: 'sally',
+                age: 1
+            }],
+            jobs: [{
+                title: 'plumber',
+                annualSalary: 50000
+            }]
+        });
+
+        changer.undoAll();
+        expect(obj).to.eql(getTestObject());
+    });
+});

--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -1,0 +1,100 @@
+export class AstEditor {
+    private changes: Change[] = [];
+
+    /**
+     * Change the value of an object's property
+     */
+    public setProperty<T, K extends keyof T>(obj: T, key: K, newValue: T[K]) {
+        const change = new EditPropertyChange(obj, key, newValue);
+        this.changes.push(change);
+        change.apply();
+    }
+
+    /**
+     * Insert an element into an array at the specified index
+     */
+    public addToArray<T extends any[]>(array: T, index: number, newValue: T[0]) {
+        const change = new AddToArrayChange(array, index, newValue);
+        this.changes.push(change);
+        change.apply();
+    }
+
+    /**
+     * Remove an element from an array at the specified index
+     */
+    public removeFromArray<T extends any[]>(array: T, index: number) {
+        const change = new RemoveFromArrayChange(array, index);
+        this.changes.push(change);
+        change.apply();
+    }
+
+    /**
+     * Unto all changes.
+     */
+    public undoAll() {
+        for (let i = this.changes.length - 1; i >= 0; i--) {
+            this.changes[i].undo();
+        }
+        this.changes = [];
+    }
+}
+
+interface Change {
+    apply();
+    undo();
+}
+
+class EditPropertyChange<T, K extends keyof T> implements Change {
+    constructor(
+        private obj: T,
+        private propertyName: K,
+        private newValue: T[K]
+    ) { }
+
+    private originalValue: T[K];
+
+    public apply() {
+        this.originalValue = this.obj[this.propertyName];
+        this.obj[this.propertyName] = this.newValue;
+    }
+
+    public undo() {
+        this.obj[this.propertyName] = this.originalValue;
+    }
+}
+
+class AddToArrayChange<T extends any[]> implements Change {
+    constructor(
+        private array: T,
+        private index: number,
+        private newValue: any
+    ) { }
+
+    public apply() {
+        this.array.splice(this.index, 0, this.newValue);
+    }
+
+    public undo() {
+        this.array.splice(this.index, 1);
+    }
+}
+
+/**
+ * Remove an item from an array
+ */
+class RemoveFromArrayChange<T extends any[]> implements Change {
+    constructor(
+        private array: T,
+        private index: number
+    ) { }
+
+    private originalValue: any;
+
+    public apply() {
+        [this.originalValue] = this.array.splice(this.index, 1);
+    }
+
+    public undo() {
+        this.array.splice(this.index, 0, this.originalValue);
+    }
+}

--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -27,6 +27,13 @@ export class AstEditor {
     }
 
     /**
+     * Change the value of an item in an array at the specified index
+     */
+    public setArrayValue<T extends any[], K extends keyof T>(array: T, index: number, newValue: T[K]) {
+        this.setProperty(array, index, newValue);
+    }
+
+    /**
      * Remove an element from an array at the specified index
      */
     public removeFromArray<T extends any[]>(array: T, index: number) {

--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -2,6 +2,13 @@ export class AstEditor {
     private changes: Change[] = [];
 
     /**
+     * Indicates whether the editor have changes that were applied
+     */
+    public get hasChanges() {
+        return this.changes.length > 0;
+    }
+
+    /**
      * Change the value of an object's property
      */
     public setProperty<T, K extends keyof T>(obj: T, key: K, newValue: T[K]) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ import type { Expression, FunctionStatement } from './parser';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
+import type { AstEditor } from './astUtils/AstEditor';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -204,8 +205,8 @@ export interface CompilerPlugin {
     beforeFileParse?: (source: SourceObj) => void;
     afterFileParse?: (file: BscFile) => void;
     afterFileValidate?: (file: BscFile) => void;
-    beforeFileTranspile?: (entry: TranspileObj) => void;
-    afterFileTranspile?: (entry: TranspileObj) => void;
+    beforeFileTranspile?: (entry: BeforeFileTranspileEvent) => void;
+    afterFileTranspile?: (entry: AfterFileTranspileEvent) => void;
     beforeFileDispose?: (file: BscFile) => void;
     afterFileDispose?: (file: BscFile) => void;
 }
@@ -225,6 +226,18 @@ export interface OnGetSemanticTokensEvent {
     file: BscFile;
     scopes: Scope[];
     semanticTokens: SemanticToken[];
+}
+
+export interface BeforeFileTranspileEvent {
+    file: BscFile;
+    outputPath: string;
+    astEditor: AstEditor;
+}
+
+export interface AfterFileTranspileEvent {
+    file: BscFile;
+    outputPath: string;
+    astEditor: AstEditor;
 }
 
 export interface SemanticToken {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -205,8 +205,8 @@ export interface CompilerPlugin {
     beforeFileParse?: (source: SourceObj) => void;
     afterFileParse?: (file: BscFile) => void;
     afterFileValidate?: (file: BscFile) => void;
-    beforeFileTranspile?: (entry: BeforeFileTranspileEvent) => void;
-    afterFileTranspile?: (entry: AfterFileTranspileEvent) => void;
+    beforeFileTranspile?: PluginHandler<BeforeFileTranspileEvent>;
+    afterFileTranspile?: PluginHandler<AfterFileTranspileEvent>;
     beforeFileDispose?: (file: BscFile) => void;
     afterFileDispose?: (file: BscFile) => void;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -231,13 +231,23 @@ export interface OnGetSemanticTokensEvent {
 export interface BeforeFileTranspileEvent {
     file: BscFile;
     outputPath: string;
-    astEditor: AstEditor;
+    /**
+     * An editor that can be used to transform properties or arrays. Once the `afterFileTranspile` event has fired, these changes will be reverted,
+     * restoring the objects to their prior state. This is useful for changing code right before a file gets transpiled, but when you don't want
+     * the changes to persist in the in-memory file.
+     */
+    editor: AstEditor;
 }
 
 export interface AfterFileTranspileEvent {
     file: BscFile;
     outputPath: string;
-    astEditor: AstEditor;
+    /**
+     * An editor that can be used to transform properties or arrays. Once the `afterFileTranspile` event has fired, these changes will be reverted,
+     * restoring the objects to their prior state. This is useful for changing code right before a file gets transpiled, but when you don't want
+     * the changes to persist in the in-memory file.
+     */
+    editor: AstEditor;
 }
 
 export interface SemanticToken {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -228,6 +228,8 @@ export interface OnGetSemanticTokensEvent {
     semanticTokens: SemanticToken[];
 }
 
+export type Editor = Pick<AstEditor, 'addToArray' | 'hasChanges' | 'removeFromArray' | 'setArrayValue' | 'setProperty'>;
+
 export interface BeforeFileTranspileEvent {
     file: BscFile;
     outputPath: string;
@@ -236,7 +238,7 @@ export interface BeforeFileTranspileEvent {
      * restoring the objects to their prior state. This is useful for changing code right before a file gets transpiled, but when you don't want
      * the changes to persist in the in-memory file.
      */
-    editor: AstEditor;
+    editor: Editor;
 }
 
 export interface AfterFileTranspileEvent {
@@ -247,7 +249,7 @@ export interface AfterFileTranspileEvent {
      * restoring the objects to their prior state. This is useful for changing code right before a file gets transpiled, but when you don't want
      * the changes to persist in the in-memory file.
      */
-    editor: AstEditor;
+    editor: Editor;
 }
 
 export interface SemanticToken {


### PR DESCRIPTION
Adds ability to edit AST during `beforeFileTranspile`, and then the changes are reverted after the `afterFileTranspile` event.
 - Adds new `AstEditor` class that applies edits and tracks how to undo them.
 - Adds `editor` property to the `beforeFileTranspile` and `afterFileTranspile` lifecycle events.
 - Once the `afterFileTranspile` event has fired for all plugins, the `editor.undoAll()` method is called which will revert all of the AST changes made during the transpile flow.
 - Update docs with example
 - any files that were edited using `editor` will have the `needsTranspiled` property set to `true` automatically.