### PR TITLE
Add diagnostic test helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
                 "source-map-support": "^0.5.13",
                 "sync-request": "^6.1.0",
                 "testdouble": "^3.5.2",
+                "thenby": "^1.3.4",
                 "ts-node": "8.9.1",
                 "typescript": "^4.4.3",
                 "typescript-formatter": "^7.2.2",
@@ -7774,6 +7775,12 @@
             "integrity": "sha512-xdcqtQl1g3p/49kmcj7ZixPWOcNHA1tYNz+uN0PJEcgtN6zywK74aacTnd3eFGPuBpD7kK8vowmMRkUt6jHU/Q==",
             "dev": true
         },
+        "node_modules/thenby": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+            "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+            "dev": true
+        },
         "node_modules/theredoc": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
@@ -14263,6 +14270,12 @@
                     "dev": true
                 }
             }
+        },
+        "thenby": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+            "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+            "dev": true
         },
         "theredoc": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "source-map-support": "^0.5.13",
         "sync-request": "^6.1.0",
         "testdouble": "^3.5.2",
+        "thenby": "^1.3.4",
         "ts-node": "8.9.1",
         "typescript": "^4.4.3",
         "typescript-formatter": "^7.2.2",

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -13,6 +13,7 @@ import { standardizePath as s, util } from './util';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Program } from './Program';
 import * as assert from 'assert';
+import { expectZeroDiagnostics } from './testHelpers.spec';
 
 let sinon: sinonImport.SinonSandbox;
 beforeEach(() => {
@@ -147,9 +148,7 @@ describe('LanguageServer', () => {
             let filePath = `${rootDir}/.tmp/main.brs`;
             writeToFs(filePath, `sub main(): return: end sub`);
             let firstWorkspace: Workspace = await svr.createStandaloneFileWorkspace(filePath);
-            expect(
-                firstWorkspace.builder.program.getDiagnostics().map(x => x.message).sort()
-            ).to.eql([]);
+            expectZeroDiagnostics(firstWorkspace.builder.program);
         });
     });
 

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1,19 +1,18 @@
 import { assert, expect } from 'chai';
 import * as pick from 'object.pick';
 import * as sinonImport from 'sinon';
-import { CompletionItemKind, Position, Range, DiagnosticSeverity, Location } from 'vscode-languageserver';
+import { CompletionItemKind, Position, Range, Location } from 'vscode-languageserver';
 import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic } from './interfaces';
 import { Program } from './Program';
 import { standardizePath as s, util } from './util';
 import { URI } from 'vscode-uri';
 import PluginInterface from './PluginInterface';
 import type { FunctionStatement, PrintStatement } from './parser/Statement';
 import { EmptyStatement } from './parser/Statement';
-import { expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
+import { expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
 import { doesNotThrow } from 'assert';
 import { Logger } from './Logger';
 import { createToken, createVisitor, isBrsFile, WalkMode } from './astUtils';
@@ -214,11 +213,7 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics()).to.be.lengthOf(2);
-            expect(program.getDiagnostics().map(x => {
-                delete x.file;
-                return x;
-            })).to.eql([{
+            expectDiagnostics(program, [{
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
                 range: Range.create(1, 17, 1, 27),
                 relatedInformation: [{
@@ -276,23 +271,21 @@ describe('Program', () => {
             `);
 
             program.validate();
-
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(1);
+            expectHasDiagnostics(program, 1);
         });
 
         it('detects scripts not loaded by any file', () => {
             //add a main file for sanity check
             program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             program.validate();
-            expect(program.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
 
             //add the orphaned file
             program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, '');
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(1);
-            expect(diagnostics[0].code).to.equal(DiagnosticMessages.fileNotReferencedByAnyOtherFile().code);
+            expectDiagnostics(program, [
+                DiagnosticMessages.fileNotReferencedByAnyOtherFile()
+            ]);
         });
         it('does not throw errors on shadowed init functions in components', () => {
             program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `
@@ -315,11 +308,11 @@ describe('Program', () => {
             `);
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
         });
 
         it('recognizes global function calls', () => {
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
             program.addOrReplaceFile({ src: `${rootDir}/source/file.brs`, dest: 'source/file.brs' }, `
                 function DoB()
                     sleep(100)
@@ -327,9 +320,7 @@ describe('Program', () => {
             `);
             //validate the scope
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            //shouldn't have any errors
-            expect(diagnostics).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
         });
 
         it('shows warning when a child component imports the same script as its parent', () => {
@@ -349,10 +340,9 @@ describe('Program', () => {
 
             program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `'comment`);
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(1);
-            expect(diagnostics[0].code).to.equal(DiagnosticMessages.unnecessaryScriptImportInChildFromParent('').code);
-            expect(diagnostics[0].severity).to.equal(DiagnosticSeverity.Warning);
+            expectDiagnostics(program, [
+                DiagnosticMessages.unnecessaryScriptImportInChildFromParent('ParentScene')
+            ]);
         });
 
         it('adds info diag when child component method shadows parent component method', () => {
@@ -373,9 +363,9 @@ describe('Program', () => {
             program.addOrReplaceFile({ src: `${rootDir}/parent.brs`, dest: 'parent.brs' }, `sub DoSomething()\nend sub`);
             program.addOrReplaceFile({ src: `${rootDir}/child.brs`, dest: 'child.brs' }, `sub DoSomething()\nend sub`);
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(1);
-            expect(diagnostics[0].code).to.equal(DiagnosticMessages.overridesAncestorFunction('', '', '', '').code);
+            expectDiagnostics(program, [
+                DiagnosticMessages.overridesAncestorFunction('', '', '', '').code
+            ]);
         });
 
         it('does not add info diagnostic on shadowed "init" functions', () => {
@@ -396,8 +386,7 @@ describe('Program', () => {
             `);
             //run this validate separately so we can have an easier time debugging just the child component
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics.map(x => x.message)).to.eql([]);
+            expectZeroDiagnostics(program);
         });
 
         it('catches duplicate methods in single file', () => {
@@ -408,8 +397,10 @@ describe('Program', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(2);
-            expect(program.getDiagnostics()[0].message.indexOf('Duplicate sub declaration'));
+            expectDiagnostics(program, [
+                DiagnosticMessages.duplicateFunctionImplementation('DoSomething', 'source'),
+                DiagnosticMessages.duplicateFunctionImplementation('DoSomething', 'source')
+            ]);
         });
 
         it('catches duplicate methods across multiple files', () => {
@@ -422,8 +413,10 @@ describe('Program', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(2);
-            expect(program.getDiagnostics()[0].message.indexOf('Duplicate sub declaration'));
+            expectDiagnostics(program, [
+                DiagnosticMessages.duplicateFunctionImplementation('DoSomething', 'source'),
+                DiagnosticMessages.duplicateFunctionImplementation('DoSomething', 'source')
+            ]);
         });
 
         it('maintains correct callables list', () => {
@@ -455,7 +448,7 @@ describe('Program', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(2);
+            expectHasDiagnostics(program, 2);
             //set the file contents again (resetting the wasProcessed flag)
             program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
@@ -464,7 +457,7 @@ describe('Program', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(2);
+            expectHasDiagnostics(program, 2);
 
             //load in a valid file, the errors should go to zero
             program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
@@ -472,7 +465,7 @@ describe('Program', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
         });
 
         it('identifies invocation of unknown function', () => {
@@ -485,8 +478,9 @@ describe('Program', () => {
             `);
 
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(1);
-            expect(program.getDiagnostics()[0].code).to.equal(DiagnosticMessages.callToUnknownFunction('', '').code);
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('DoSomething', 'source')
+            ]);
         });
 
         it('detects methods from another file in a subdirectory', () => {
@@ -501,7 +495,7 @@ describe('Program', () => {
                 end function
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -583,13 +577,10 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics.length).to.equal(1);
-            expect(diagnostics[0]).to.deep.include(<BsDiagnostic>{
+            expectDiagnostics(program, [{
                 ...DiagnosticMessages.referencedFileDoesNotExist(),
-                file: program.getFileByPathAbsolute(xmlPath),
                 range: Range.create(2, 42, 2, 72)
-            });
+            }]);
         });
 
         it('adds warning instead of error on mismatched upper/lower case script import', () => {
@@ -603,9 +594,8 @@ describe('Program', () => {
 
             //validate
             program.validate();
-            let diagnostics = program.getDiagnostics();
-            expect(diagnostics.map(x => x.message)).to.eql([
-                DiagnosticMessages.scriptImportCaseMismatch(s`components\\COMPONENT1.brs`).message
+            expectDiagnostics(program, [
+                DiagnosticMessages.scriptImportCaseMismatch(s`components\\COMPONENT1.brs`)
             ]);
         });
     });
@@ -621,15 +611,15 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]).to.deep.include(<BsDiagnostic>{
-                message: DiagnosticMessages.referencedFileDoesNotExist().message
-            });
+            expectDiagnostics(program, [
+                DiagnosticMessages.referencedFileDoesNotExist()
+            ]);
 
             //add the file, the error should go away
             let brsPath = s`${rootDir}/components/component1.brs`;
             program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
 
             //add the xml file back in, but change the component brs file name. Should have an error again
             program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
@@ -639,9 +629,9 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]).to.deep.include(<BsDiagnostic>{
-                message: DiagnosticMessages.referencedFileDoesNotExist().message
-            });
+            expectDiagnostics(program, [
+                DiagnosticMessages.referencedFileDoesNotExist()
+            ]);
         });
 
         it('handles when the brs file is added before the component', () => {
@@ -656,7 +646,7 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).to.exist;
         });
 
@@ -673,7 +663,7 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).not.to.exist;
 
             //reload the xml file contents, adding a new script reference.
@@ -1343,10 +1333,9 @@ describe('Program', () => {
             program.validate();
 
             //there should be an error when calling DoParentThing, since it doesn't exist on child or parent
-            expect(program.getDiagnostics()).to.be.lengthOf(1);
-            expect(program.getDiagnostics()[0]).to.deep.include(<BsDiagnostic>{
-                code: DiagnosticMessages.callToUnknownFunction('DoParentThing', '').code
-            });
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('DoParentThing', '').code
+            ]);
 
             //add the script into the parent
             program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
@@ -1364,7 +1353,7 @@ describe('Program', () => {
 
             program.validate();
             //the error should be gone because the child now has access to the parent script
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -1393,15 +1382,16 @@ describe('Program', () => {
                 `);
             }
             program.validate();
-            let diagnostics = program.getDiagnostics();
 
             //the children shouldn't have diagnostics about shadowing their parent lib.brs file.
-            let shadowedDiagnositcs = diagnostics.filter((x) => x.code === DiagnosticMessages.overridesAncestorFunction('', '', '', '').code);
-            expect(shadowedDiagnositcs).to.be.lengthOf(0);
+            expectZeroDiagnostics(
+                program.getDiagnostics().filter((x) => x.code === DiagnosticMessages.overridesAncestorFunction('', '', '', '').code)
+            );
 
             //the children all include a redundant import of lib.brs file which is imported by the parent.
-            let importDiagnositcs = diagnostics.filter((x) => x.code === DiagnosticMessages.unnecessaryScriptImportInChildFromParent('').code);
-            expect(importDiagnositcs).to.be.lengthOf(childCount);
+            expect(
+                program.getDiagnostics().filter((x) => x.code === DiagnosticMessages.unnecessaryScriptImportInChildFromParent('').code)
+            ).to.be.lengthOf(childCount);
         });
 
         it('detects script import changes', () => {
@@ -1475,7 +1465,7 @@ describe('Program', () => {
             //the file should be included in the program
             expect(program.getFileByPathAbsolute(pathAbsolute)).to.exist;
             let diagnostics = program.getDiagnostics();
-            expect(diagnostics.length).to.be.greaterThan(0);
+            expectHasDiagnostics(diagnostics);
             let parseError = diagnostics.filter(x => x.message === 'Unterminated string at end of line')[0];
             expect(parseError).to.exist;
         });
@@ -1496,14 +1486,15 @@ describe('Program', () => {
             `);
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.lengthOf(2);
+            expectHasDiagnostics(program, 2);
 
             program.options.diagnosticFilters = [
                 DiagnosticMessages.mismatchArgumentCount(0, 0).code
             ];
 
-            expect(program.getDiagnostics()).to.be.lengthOf(1);
-            expect(program.getDiagnostics()[0].code).to.equal(DiagnosticMessages.callToUnknownFunction('', '').code);
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('C', 'source')
+            ]);
         });
     });
 
@@ -1863,7 +1854,7 @@ describe('Program', () => {
                 end class
             `);
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -1896,7 +1887,7 @@ describe('Program', () => {
             `);
             for (let col = 0; col < 40; col++) {
                 let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, col)));
-                expect(program.getDiagnostics()).to.be.empty;
+                expectZeroDiagnostics(program);
                 expect(signatureHelp[0]?.signature).to.not.exist;
             }
         });
@@ -1931,7 +1922,7 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 31)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('Person()');
         });
 
@@ -1950,19 +1941,19 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 32)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
 
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 34)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
 
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 27)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
 
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 23)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
         });
 
@@ -1982,11 +1973,11 @@ describe('Program', () => {
                 end namespace
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 40)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
 
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 30)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text)');
         });
 
@@ -2002,7 +1993,7 @@ describe('Program', () => {
                 end namespace
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
@@ -2023,7 +2014,7 @@ describe('Program', () => {
                 end namespace
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 41)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
@@ -2048,7 +2039,7 @@ describe('Program', () => {
             program.validate();
 
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
 
@@ -2073,7 +2064,7 @@ describe('Program', () => {
             program.validate();
 
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             //note - callfunc completions and signatures are not yet correctly identifying methods that are exposed in an interace - waiting on the new xml branch for that
             expect(signatureHelp).to.be.empty;
         });
@@ -2090,7 +2081,7 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 34)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('Person(arg1, arg2)');
         });
 
@@ -2108,7 +2099,7 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 34)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('Roger(arg1, arg2)');
         });
 
@@ -2124,11 +2115,11 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 34)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].index).to.equal(0);
 
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 40)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].index).to.equal(1);
         });
 
@@ -2145,7 +2136,7 @@ describe('Program', () => {
                 end namespace
                     `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 47)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('people.coders.Person(arg1, arg2)');
             expect(signatureHelp[0].index).to.equal(0);
         });
@@ -2159,11 +2150,11 @@ describe('Program', () => {
                 end function
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 27)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function test(arg1, arg2)');
             expect(signatureHelp[0].index).to.equal(0);
             signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 32)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function test(arg1, arg2)');
             expect(signatureHelp[0].index).to.equal(1);
         });
@@ -2181,7 +2172,7 @@ describe('Program', () => {
                 end class
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 25)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 
@@ -2196,7 +2187,7 @@ describe('Program', () => {
                 end namespace
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 31)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 
@@ -2211,7 +2202,7 @@ describe('Program', () => {
                 end namespace
             `);
             let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 38)));
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function test(arg)');
         });
 

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -11,6 +11,7 @@ import type { BscFile, BsDiagnostic } from '.';
 import { Range } from '.';
 import { DiagnosticSeverity } from './astUtils';
 import { BrsFile } from './files/BrsFile';
+import { expectZeroDiagnostics } from './testHelpers.spec';
 
 describe('ProgramBuilder', () => {
 
@@ -145,8 +146,7 @@ describe('ProgramBuilder', () => {
                     dest: 'source/lib.brs'
                 }]
             });
-            const diagnostics = builder.getDiagnostics();
-            expect(diagnostics.map(x => x.message)).to.eql([]);
+            expectZeroDiagnostics(builder)
             expect(builder.program.getFileByPathAbsolute(s``));
         });
     });

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -6,7 +6,7 @@ import { DiagnosticMessages } from './DiagnosticMessages';
 import { Program } from './Program';
 import { ParseMode } from './parser/Parser';
 import PluginInterface from './PluginInterface';
-import { trim } from './testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, trim } from './testHelpers.spec';
 import { Logger } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { FunctionStatement, NamespaceStatement } from './parser';
@@ -38,7 +38,7 @@ describe('Scope', () => {
         `);
 
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+        expectZeroDiagnostics(program);
     });
 
     it('handles variables with javascript prototype names', () => {
@@ -48,6 +48,7 @@ describe('Scope', () => {
             end sub
         `);
         program.validate();
+        expectZeroDiagnostics(program);
     });
 
     it('flags parameter with same name as namespace', () => {
@@ -58,11 +59,9 @@ describe('Scope', () => {
             end sub
         `);
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.eql(
-            DiagnosticMessages.parameterMayNotHaveSameNameAsNamespace('nameA').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.parameterMayNotHaveSameNameAsNamespace('nameA')
+        ]);
     });
 
     it('flags assignments with same name as namespace', () => {
@@ -75,11 +74,9 @@ describe('Scope', () => {
             end sub
         `);
         program.validate();
-        expect(
-            program.getDiagnostics().map(x => x.message)
-        ).to.eql([
-            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('namea').message,
-            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('NAMEA').message
+        expectDiagnostics(program, [
+            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('namea'),
+            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('NAMEA')
         ]);
     });
 
@@ -91,8 +88,7 @@ describe('Scope', () => {
             range: undefined
         }];
         source.addDiagnostics(expected);
-        const actual = source.getDiagnostics();
-        expect(actual).to.deep.equal(expected);
+        expectDiagnostics(source, expected);
     });
 
     it('allows getting all scopes', () => {
@@ -123,7 +119,7 @@ describe('Scope', () => {
                 s`${rootDir}/source/lib.brs`,
                 s`${rootDir}/source/main.brs`
             ]);
-            expect(program.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
             expect(sourceScope.getOwnCallables()).is.lengthOf(3);
             expect(sourceScope.getAllCallables()).is.length.greaterThan(3);
         });
@@ -134,14 +130,14 @@ describe('Scope', () => {
             let originalLength = program.getScopeByName('source').getAllCallables().length;
 
             program.addOrReplaceFile('source/file.brs', `
-            function DoA()
-                print "A"
-            end function
+                function DoA()
+                    print "A"
+                end function
 
-             function DoA()
-                 print "A"
-             end function
-        `);
+                function DoA()
+                    print "A"
+                end function
+            `);
             expect(program.getScopeByName('source').getAllCallables().length).to.equal(originalLength + 2);
         });
     });
@@ -197,8 +193,7 @@ describe('Scope', () => {
                 end namespace
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
-            expect(program.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
         });
         it('resolves local-variable function calls', () => {
             program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
@@ -210,8 +205,7 @@ describe('Scope', () => {
                 end sub`
             );
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
-            expect(program.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(program);
         });
 
         describe('function shadowing', () => {
@@ -225,16 +219,10 @@ describe('Scope', () => {
                     end sub
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics().map(x => {
-                    return {
-                        message: x.message,
-                        range: x.range
-                    };
-                });
-                expect(diagnostics[0]).to.exist.and.to.eql({
-                    message: DiagnosticMessages.localVarFunctionShadowsParentFunction('stdlib').message,
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.localVarFunctionShadowsParentFunction('stdlib'),
                     range: Range.create(2, 24, 2, 27)
-                });
+                }]);
             });
 
             it('warns when local var has same name as built-in function', () => {
@@ -245,8 +233,7 @@ describe('Scope', () => {
                     end sub
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics();
-                expect(diagnostics[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('warns when local var has same name as built-in function', () => {
@@ -257,8 +244,7 @@ describe('Scope', () => {
                     end sub
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics();
-                expect(diagnostics[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('detects local function with same name as scope function', () => {
@@ -275,16 +261,10 @@ describe('Scope', () => {
                     end function
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics().map(x => {
-                    return {
-                        message: x.message,
-                        range: x.range
-                    };
-                });
-                expect(diagnostics[0]).to.exist.and.to.eql({
+                expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarFunctionShadowsParentFunction('scope').message,
                     range: Range.create(2, 24, 2, 32)
-                });
+                }]);
             });
 
             it('detects local function with same name as scope function', () => {
@@ -298,16 +278,10 @@ describe('Scope', () => {
                     end function
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics().map(x => {
-                    return {
-                        message: x.message,
-                        range: x.range
-                    };
-                });
-                expect(diagnostics[0]).to.exist.and.to.eql({
+                expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarShadowedByScopedFunction().message,
                     range: Range.create(2, 24, 2, 32)
-                });
+                }]);
             });
 
             it('flags scope function with same name (but different case) as built-in function', () => {
@@ -320,16 +294,10 @@ describe('Scope', () => {
                     end function
                 `);
                 program.validate();
-                let diagnostics = program.getDiagnostics().map(x => {
-                    return {
-                        message: x.message,
-                        range: x.range
-                    };
-                });
-                expect(diagnostics[0]).to.exist.and.to.eql({
+                expectDiagnostics(program, [{
                     message: DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction().message,
                     range: Range.create(4, 29, 4, 32)
-                });
+                }]);
             });
         });
 
@@ -343,15 +311,13 @@ describe('Scope', () => {
                      print "A"
                  end function
             `);
-            expect(
-                program.getDiagnostics().length
-            ).to.equal(0);
+            expectZeroDiagnostics(program);
             //validate the scope
             program.validate();
             //we should have the "DoA declared more than once" error twice (one for each function named "DoA")
-            expect(program.getDiagnostics().map(x => x.message).sort()).to.eql([
-                DiagnosticMessages.duplicateFunctionImplementation('DoA', 'source').message,
-                DiagnosticMessages.duplicateFunctionImplementation('DoA', 'source').message
+            expectDiagnostics(program, [
+                DiagnosticMessages.duplicateFunctionImplementation('DoA', 'source'),
+                DiagnosticMessages.duplicateFunctionImplementation('DoA', 'source')
             ]);
         });
 
@@ -361,12 +327,12 @@ describe('Scope', () => {
                     DoB()
                 end function
             `);
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
             //validate the scope
             program.validate();
-            expect(program.getDiagnostics()[0]).to.deep.include({
-                code: DiagnosticMessages.callToUnknownFunction('DoB', '').code
-            });
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('DoB', 'source')
+            ]);
         });
 
         it('recognizes known callables', () => {
@@ -380,8 +346,8 @@ describe('Scope', () => {
             `);
             //validate the scope
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message)).to.eql([
-                DiagnosticMessages.callToUnknownFunction('DoC', 'source').message
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('DoC', 'source')
             ]);
         });
 
@@ -399,12 +365,12 @@ describe('Scope', () => {
             `);
             //validate the scope
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
         });
 
         //We don't currently support someObj.callSomething() format, so don't throw errors on those
         it('does not fail on object callables', () => {
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
             program.addOrReplaceFile('source/file.brs', `
                function DoB()
                     m.doSomething()
@@ -413,7 +379,7 @@ describe('Scope', () => {
             //validate the scope
             program.validate();
             //shouldn't have any errors
-            expect(program.getDiagnostics().map(x => x.message)).to.eql([]);
+            expectZeroDiagnostics(program);
         });
 
         it('detects calling functions with too many parameters', () => {
@@ -425,9 +391,31 @@ describe('Scope', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message)).includes(
+            expectDiagnostics(program, [
                 DiagnosticMessages.mismatchArgumentCount(0, 1).message
-            );
+            ]);
+        });
+
+        it('detects calling class constructors with too many parameters', () => {
+            program.addOrReplaceFile('source/main.bs', `
+                function noop0()
+                end function
+
+                function noop1(p1)
+                end function
+
+                sub main()
+                   noop0(1)
+                   noop1(1,2)
+                   noop1()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount(0, 1),
+                DiagnosticMessages.mismatchArgumentCount(1, 2),
+                DiagnosticMessages.mismatchArgumentCount(1, 0)
+            ]);
         });
 
         it('detects calling functions with too many parameters', () => {
@@ -439,9 +427,9 @@ describe('Scope', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message)).to.includes(
-                DiagnosticMessages.mismatchArgumentCount(1, 0).message
-            );
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount(1, 0)
+            ]);
         });
 
         it('allows skipping optional parameter', () => {
@@ -454,7 +442,7 @@ describe('Scope', () => {
             `);
             program.validate();
             //should have an error
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
         });
 
         it('shows expected parameter range in error message', () => {
@@ -467,9 +455,9 @@ describe('Scope', () => {
             `);
             program.validate();
             //should have an error
-            expect(program.getDiagnostics().map(x => x.message)).includes(
-                DiagnosticMessages.mismatchArgumentCount('1-2', 0).message
-            );
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount('1-2', 0)
+            ]);
         });
 
         it('handles expressions as arguments to a function', () => {
@@ -481,7 +469,7 @@ describe('Scope', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(program);
         });
 
         it('Catches extra arguments for expressions as arguments to a function', () => {
@@ -494,9 +482,9 @@ describe('Scope', () => {
             `);
             program.validate();
             //should have an error
-            expect(program.getDiagnostics().map(x => x.message)).to.include(
-                DiagnosticMessages.mismatchArgumentCount(1, 2).message
-            );
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount(1, 2)
+            ]);
         });
 
         it('handles JavaScript reserved names', () => {
@@ -511,7 +499,7 @@ describe('Scope', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
 
         it('Emits validation events', () => {
@@ -567,7 +555,7 @@ describe('Scope', () => {
                     end function
                 `);
                 program.validate();
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
+                expectDiagnostics(program, [
                     DiagnosticMessages.invalidFunctionReturnType('unknownType').message,
                     DiagnosticMessages.invalidFunctionReturnType('unknownType').message
                 ]);
@@ -590,7 +578,7 @@ describe('Scope', () => {
                     end sub
                 `);
                 program.validate();
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
+                expectDiagnostics(program, [
                     DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message,
                     DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message
                 ]);
@@ -609,7 +597,7 @@ describe('Scope', () => {
                     end class
                 `);
                 program.validate();
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
+                expectDiagnostics(program, [
                     DiagnosticMessages.cannotFindType('unknownType').message,
                     DiagnosticMessages.cannotFindType('unknownType').message
                 ]);
@@ -632,7 +620,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('finds custom types from other namespaces', () => {
@@ -647,7 +635,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('detects missing custom types from current namespaces', () => {
@@ -662,7 +650,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
+                expectDiagnostics(program, [
                     DiagnosticMessages.invalidFunctionReturnType('UnknownType').message
                 ]);
             });
@@ -678,7 +666,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('finds custom types from other other files', () => {
@@ -694,7 +682,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('detects missing custom types from another namespaces', () => {
@@ -709,8 +697,8 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
-                    DiagnosticMessages.invalidFunctionReturnType('MyNamespace.UnknownType').message
+                expectDiagnostics(program, [
+                    DiagnosticMessages.invalidFunctionReturnType('MyNamespace.UnknownType')
                 ]);
             });
 
@@ -729,7 +717,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
 
                 program.addOrReplaceFile('components/bar.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
@@ -743,7 +731,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
 
-                expect(program.getDiagnostics().map(x => x.message)).to.eql([
+                expectDiagnostics(program, [
                     DiagnosticMessages.invalidFunctionReturnType('MyClass').message
                 ]);
             });
@@ -774,7 +762,7 @@ describe('Scope', () => {
 
                 program.validate();
 
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
 
             });
         });

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -3,7 +3,7 @@ import { Position, Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import type { XmlFile } from './files/XmlFile';
 import { Program } from './Program';
-import { trim } from './testHelpers.spec';
+import { expectDiagnostics, trim } from './testHelpers.spec';
 import { standardizePath as s, util } from './util';
 let rootDir = s`${process.cwd()}/rootDir`;
 
@@ -109,27 +109,21 @@ describe('XmlScope', () => {
             `);
             program.validate();
             let childScope = program.getComponentScope('child');
-            let diagnostics = childScope.getDiagnostics();
-            expect(diagnostics.length).to.equal(5);
-            expect(diagnostics[0]).to.deep.include({
+            expectDiagnostics(childScope, [{
                 ...DiagnosticMessages.xmlFunctionNotFound('func2'),
                 range: Range.create(4, 24, 4, 29)
-            });
-            expect(diagnostics[1]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
                 range: Range.create(5, 9, 5, 17)
-            });
-            expect(diagnostics[2]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
                 range: Range.create(6, 9, 6, 17)
-            });
-            expect(diagnostics[3]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
                 range: Range.create(7, 9, 7, 17)
-            });
-            expect(diagnostics[4]).to.deep.include({ // syntax error expecting '=' but found '/>'
+            }, { // syntax error expecting '=' but found '/>'
                 code: DiagnosticMessages.xmlGenericParseError('').code
-            });
+            }]);
         });
 
         it('adds an error when an interface field is invalid', () => {
@@ -155,36 +149,27 @@ describe('XmlScope', () => {
                 end sub
             `);
             program.validate();
-            let childScope = program.getComponentScope('child');
-            let diagnostics = childScope.getDiagnostics();
-            expect(diagnostics.length).to.equal(7);
-            expect(diagnostics[0]).to.deep.include({
+            expectDiagnostics(program.getComponentScope('child'), [{
                 ...DiagnosticMessages.xmlInvalidFieldType('no'),
                 range: Range.create(4, 33, 4, 35)
-            });
-            expect(diagnostics[1]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'type'),
                 range: Range.create(5, 9, 5, 14)
-            });
-            expect(diagnostics[2]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
                 range: Range.create(6, 9, 6, 14)
-            });
-            expect(diagnostics[3]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
                 range: Range.create(8, 9, 8, 14)
-            });
-            expect(diagnostics[4]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
                 range: Range.create(9, 9, 9, 14)
-            });
-            expect(diagnostics[5]).to.deep.include({
+            }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'type'),
                 range: Range.create(9, 9, 9, 14)
-            });
-            expect(diagnostics[6]).to.deep.include({ // syntax error expecting '=' but found '/>'
+            }, { // syntax error expecting '=' but found '/>'
                 code: DiagnosticMessages.xmlGenericParseError('').code
-            });
+            }]);
         });
     });
 });

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -4,10 +4,9 @@ import { Program } from '../Program';
 import type { BrsFile } from './BrsFile';
 import { expect } from 'chai';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import type { Diagnostic } from 'vscode-languageserver';
-import { Range, DiagnosticSeverity } from 'vscode-languageserver';
+import { Range } from 'vscode-languageserver';
 import { ParseMode } from '../parser/Parser';
-import { expectZeroDiagnostics, getTestTranspile } from '../testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile } from '../testHelpers.spec';
 import { standardizePath as s } from '../util';
 import * as fsExtra from 'fs-extra';
 import { BrsTranspileState } from '../parser/BrsTranspileState';
@@ -70,11 +69,9 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.equal(
-            DiagnosticMessages.classConstructorMissingSuperCall().message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.classConstructorMissingSuperCall()
+        ]);
     });
 
     it('access modifier is option for override', () => {
@@ -90,7 +87,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+        expectZeroDiagnostics(program);
         let duckClass = file.parser.references.classStatements.find(x => x.name.text.toLowerCase() === 'duck');
         expect(duckClass).to.exist;
         expect(duckClass.memberMap['move']).to.exist;
@@ -117,7 +114,7 @@ describe('BrsFile BrighterScript classes', () => {
             end namespace
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+        expectZeroDiagnostics(program);
     });
     describe('super', () => {
         it('always requires super call in child constructor', () => {
@@ -130,7 +127,9 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).to.eql(DiagnosticMessages.classConstructorMissingSuperCall().message);
+            expectDiagnostics(program, [
+                DiagnosticMessages.classConstructorMissingSuperCall()
+            ]);
         });
 
         it('requires super call in child when parent has own `new` method', () => {
@@ -145,7 +144,9 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).to.eql(DiagnosticMessages.classConstructorMissingSuperCall().message);
+            expectDiagnostics(program, [
+                DiagnosticMessages.classConstructorMissingSuperCall()
+            ]);
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
@@ -164,7 +165,7 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).to.be.undefined;
+            expectZeroDiagnostics(program);
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
@@ -181,13 +182,11 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             `);
             program.validate();
-            expect(
-                program.getDiagnostics().map(x => ({ message: x.message, range: x.range }))
-            ).to.eql([{
-                message: DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall().message,
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
                 range: Range.create(7, 24, 7, 25)
             }, {
-                message: DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall().message,
+                ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
                 range: Range.create(7, 33, 7, 34)
             }]);
         });
@@ -690,7 +689,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects using `new` keyword on non-classes', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             sub quack()
             end sub
             sub main()
@@ -698,15 +697,13 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.equal(
-            DiagnosticMessages.expressionIsNotConstructable('sub').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.expressionIsNotConstructable('sub')
+        ]);
     });
 
     it('detects missing call to super', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                 end sub
@@ -717,11 +714,9 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.equal(
-            DiagnosticMessages.classConstructorMissingSuperCall().message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.classConstructorMissingSuperCall()
+        ]);
     });
 
     it.skip('detects calls to unknown m methods', () => {
@@ -733,11 +728,9 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.equal(
+        expectDiagnostics(program, [
             DiagnosticMessages.methodDoesNotExistOnType('methodThatDoesNotExist', 'Animal')
-        );
+        ]);
     });
 
     it('detects duplicate member names', () => {
@@ -755,15 +748,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        let diagnostics = program.getDiagnostics().map(x => {
-            return {
-                code: x.code,
-                message: x.message,
-                range: x.range,
-                severity: DiagnosticSeverity.Error
-            };
-        });
-        expect(diagnostics).to.eql(<Partial<Diagnostic>[]>[{
+        expectDiagnostics(program, [{
             ...DiagnosticMessages.duplicateIdentifier('name'),
             range: Range.create(3, 23, 3, 27)
         }, {
@@ -784,17 +769,15 @@ describe('BrsFile BrighterScript classes', () => {
                 public name
             end class
             class Duck extends Animal
-                public function name()
+                public override function name()
                     return "Donald"
                 end function
             end class
         `);
         program.validate();
-        expect(
-            program.getDiagnostics().map(x => x.message).sort()[0]
-        ).to.eql(
-            DiagnosticMessages.classChildMemberDifferentMemberTypeThanAncestor('method', 'field', 'Animal').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.classChildMemberDifferentMemberTypeThanAncestor('method', 'field', 'Animal')
+        ]);
     });
 
     it('allows untyped overridden field in child class', () => {
@@ -837,16 +820,16 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => x.message).sort()).to.eql([
-            DiagnosticMessages.cannotFindType('Person').message,
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer').message,
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string').message,
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person').message
+        expectDiagnostics(program, [
+            DiagnosticMessages.cannotFindType('Person'),
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer'),
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string'),
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person')
         ]);
     });
 
     it('detects overridden methods without override keyword', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             class Animal
                 sub speak()
                 end sub
@@ -857,9 +840,9 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]).to.exist.and.to.include({
-            ...DiagnosticMessages.missingOverrideKeyword('Animal')
-        });
+        expectDiagnostics(program, [
+            DiagnosticMessages.missingOverrideKeyword('Animal')
+        ]);
     });
 
     it('detects overridden methods with different visibility', () => {
@@ -882,15 +865,11 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]).to.exist.and.to.include({
-            ...DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakInPublic', 'private', 'public', 'Animal')
-        });
-        expect(program.getDiagnostics()[1]).to.exist.and.to.include({
-            ...DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakWithFriends', 'public', 'protected', 'Animal')
-        });
-        expect(program.getDiagnostics()[2]).to.exist.and.to.include({
-            ...DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakWithFamily', 'public', 'private', 'Animal')
-        });
+        expectDiagnostics(program, [
+            DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakInPublic', 'private', 'public', 'Animal'),
+            DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakWithFriends', 'public', 'protected', 'Animal'),
+            DiagnosticMessages.mismatchedOverriddenMemberVisibility('Duck', 'speakWithFamily', 'public', 'private', 'Animal')
+        ]);
     });
     it('allows overridden methods with matching visibility', () => {
         program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
@@ -912,21 +891,21 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()).to.be.empty;
+        expectZeroDiagnostics(program);
     });
 
     it('detects extending unknown parent class', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.addOrReplaceFile('source/main.bs', `
             class Duck extends Animal
                 sub speak()
                 end sub
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]).to.exist.and.to.deep.include({
+        expectDiagnostics(program, [{
             ...DiagnosticMessages.classCouldNotBeFound('Animal', 'source'),
             range: Range.create(1, 31, 1, 37)
-        });
+        }]);
     });
 
     it('catches newable class without namespace name', () => {
@@ -941,9 +920,9 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
-            DiagnosticMessages.classCouldNotBeFound('Duck', 'source').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.classCouldNotBeFound('Duck', 'source')
+        ]);
     });
 
     it('supports newable class namespace inference', () => {
@@ -957,7 +936,7 @@ describe('BrsFile BrighterScript classes', () => {
             end namespace
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+        expectZeroDiagnostics(program);
     });
 
     it('catches extending unknown namespaced class', () => {
@@ -970,9 +949,9 @@ describe('BrsFile BrighterScript classes', () => {
             end namespace
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
-            DiagnosticMessages.classCouldNotBeFound('NameA.NameB.Animal1', 'source').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.classCouldNotBeFound('NameA.NameB.Animal1', 'source')
+        ]);
     });
 
     it('supports omitting namespace prefix for items in same namespace', () => {
@@ -985,7 +964,7 @@ describe('BrsFile BrighterScript classes', () => {
             end namespace
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).not.to.exist;
+        expectZeroDiagnostics(program);
     });
 
     it('catches duplicate root-level class declarations', () => {
@@ -993,11 +972,12 @@ describe('BrsFile BrighterScript classes', () => {
             class Animal
             end class
             class Animal
+            end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
-            DiagnosticMessages.duplicateClassDeclaration('source', 'Animal').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.duplicateClassDeclaration('source', 'Animal')
+        ]);
     });
 
     it('catches duplicate namespace-level class declarations', () => {
@@ -1006,12 +986,13 @@ describe('BrsFile BrighterScript classes', () => {
                 class Animal
                 end class
                 class Animal
+                end class
             end namespace
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
-            DiagnosticMessages.duplicateClassDeclaration('source', 'NameA.NameB.Animal').message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.duplicateClassDeclaration('source', 'NameA.NameB.Animal')
+        ]);
     });
 
     it('catches namespaced class name which is the same as a global class', () => {
@@ -1024,9 +1005,9 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
+        expectDiagnostics(program, [
             DiagnosticMessages.namespacedClassCannotShareNamewithNonNamespacedClass('Animal').message
-        );
+        ]);
     });
 
     it('catches class with same name as function', () => {
@@ -1037,9 +1018,9 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
+        expectDiagnostics(program, [
             DiagnosticMessages.functionCannotHaveSameNameAsClass('Animal').message
-        );
+        ]);
     });
 
     it('catches class with same name (but different case) as function', () => {
@@ -1050,9 +1031,9 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
+        expectDiagnostics(program, [
             DiagnosticMessages.functionCannotHaveSameNameAsClass('animal').message
-        );
+        ]);
     });
 
     it('catches variable with same name as class', () => {
@@ -1064,9 +1045,9 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.equal(
+        expectDiagnostics(program, [
             DiagnosticMessages.localVarSameNameAsClass('Animal').message
-        );
+        ]);
     });
 
     it('allows extending classes with more than one dot in the filename', () => {
@@ -1203,5 +1184,31 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
         program.validate();
+    });
+
+    it.skip('detects calling class constructors with too many parameters', () => {
+        program.addOrReplaceFile('source/main.bs', `
+            class Parameterless
+                sub new()
+                end sub
+            end class
+
+            class OneParam
+                sub new(param1)
+                end sub
+            end class
+
+            sub main()
+                c1 = new Parameterless(1)
+                c2 = new OneParam(1, 2)
+                c2 = new OneParam()
+            end sub
+        `);
+        program.validate();
+        expectDiagnostics(program, [
+            DiagnosticMessages.mismatchArgumentCount(0, 1),
+            DiagnosticMessages.mismatchArgumentCount(1, 2),
+            DiagnosticMessages.mismatchArgumentCount(1, 0)
+        ]);
     });
 });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2,7 +2,7 @@ import { assert, expect } from 'chai';
 import * as sinonImport from 'sinon';
 import * as path from 'path';
 import { CompletionItemKind, Position, Range } from 'vscode-languageserver';
-import type { Callable, CommentFlag, BsDiagnostic, VariableDeclaration } from '../interfaces';
+import type { Callable, CommentFlag, VariableDeclaration } from '../interfaces';
 import { Program } from '../Program';
 import { BooleanType } from '../types/BooleanType';
 import { DynamicType } from '../types/DynamicType';
@@ -16,7 +16,7 @@ import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
-import { expectZeroDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
+import { expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
 import { ParseMode } from '../parser/Parser';
 import { Logger } from '../Logger';
 
@@ -46,7 +46,7 @@ describe('BrsFile', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.not.exist;
+        expectZeroDiagnostics(program);
     });
 
     it('supports the 6 params in CreateObject for roRegion', () => {
@@ -56,7 +56,7 @@ describe('BrsFile', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics()[0]?.message).to.not.exist;
+        expectZeroDiagnostics(program);
     });
 
     it('sets needsTranspiled to true for .bs files', () => {
@@ -73,8 +73,7 @@ describe('BrsFile', () => {
             range: undefined
         }];
         file.addDiagnostics(expected);
-        const actual = file.getDiagnostics();
-        expect(actual).deep.equal(expected);
+        expectDiagnostics(file, expected);
     });
 
     describe('getPartialVariableName', () => {
@@ -297,7 +296,7 @@ describe('BrsFile', () => {
                 `);
                 //should have an error
                 program.validate();
-                expect(program.getDiagnostics()[0]?.message).to.exist;
+                expectHasDiagnostics(program);
 
                 program.addOrReplaceFile('source/main.brs', `
                     sub main()
@@ -305,9 +304,9 @@ describe('BrsFile', () => {
                         Dim requestData
                     end sub
                 `);
-                //should have an error
+                //should not have an error
                 program.validate();
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('works with leading whitespace', () => {
@@ -319,7 +318,7 @@ describe('BrsFile', () => {
                 `);
                 //should have an error
                 program.validate();
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('works for all', () => {
@@ -337,7 +336,7 @@ describe('BrsFile', () => {
                 } as CommentFlag);
                 program.validate();
                 //the "unterminated string" error should be filtered out
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('works for specific codes', () => {
@@ -354,7 +353,7 @@ describe('BrsFile', () => {
                     affectedRange: util.createRange(3, 0, 3, Number.MAX_SAFE_INTEGER)
                 } as CommentFlag);
                 //the "unterminated string" error should be filtered out
-                expect(program.getDiagnostics()[0]?.message).to.not.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('recognizes non-numeric codes', () => {
@@ -365,7 +364,7 @@ describe('BrsFile', () => {
                     end sub
                 `);
                 expect(file.commentFlags[0]).to.exist;
-                expect(program.getDiagnostics()[0]?.message).to.exist;
+                expectHasDiagnostics(program);
             });
 
             it('supports disabling non-numeric error codes', () => {
@@ -381,9 +380,8 @@ describe('BrsFile', () => {
                     message: 'Something is not right',
                     range: util.createRange(2, 16, 2, 26)
                 }]);
-                expect(
-                    program.getScopesForFile(file)[0].getDiagnostics()
-                ).to.be.empty;
+                const scope = program.getScopesForFile(file)[0];
+                expectZeroDiagnostics(scope);
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {
@@ -394,14 +392,13 @@ describe('BrsFile', () => {
                 `);
 
                 program.validate();
-
-                expect(program.getDiagnostics()).to.be.lengthOf(2);
-                expect(program.getDiagnostics()[0]).to.deep.include({
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownDiagnosticCode(123456),
                     range: Range.create(2, 53, 2, 59)
-                } as BsDiagnostic);
-                expect(program.getDiagnostics()[1]).to.deep.include({
+                }, {
+                    ...DiagnosticMessages.unknownDiagnosticCode(999999),
                     range: Range.create(2, 60, 2, 66)
-                } as BsDiagnostic);
+                }]);
             });
 
         });
@@ -421,7 +418,7 @@ describe('BrsFile', () => {
                 } as CommentFlag);
                 program.validate();
                 //the "unterminated string" error should be filtered out
-                expect(program.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(program);
             });
 
             it('works for specific codes', () => {
@@ -438,10 +435,9 @@ describe('BrsFile', () => {
 
                 program.validate();
 
-                expect(program.getDiagnostics()).to.be.lengthOf(1);
-                expect(program.getDiagnostics()[0]).to.deep.include({
+                expectDiagnostics(program, [{
                     range: Range.create(5, 24, 5, 35)
-                } as BsDiagnostic);
+                }]);
             });
 
             it('handles the erraneous `stop` keyword', () => {
@@ -455,7 +451,7 @@ describe('BrsFile', () => {
                     end sub
                 `);
                 program.validate();
-                expect(program.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(program);
             });
         });
     });
@@ -496,7 +492,7 @@ describe('BrsFile', () => {
                     myLabel:
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports empty print statements', () => {
@@ -505,7 +501,7 @@ describe('BrsFile', () => {
                    print
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         describe('conditional compile', () => {
@@ -523,7 +519,7 @@ describe('BrsFile', () => {
                         #ENDIF
                     end sub
                 `);
-                expect(file.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(file);
             });
 
             it('supports single-word #elseif and #endif', () => {
@@ -537,7 +533,7 @@ describe('BrsFile', () => {
                         #endif
                     end sub
                 `);
-                expect(file.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(file);
             });
 
             it('supports multi-word #else if and #end if', () => {
@@ -551,7 +547,7 @@ describe('BrsFile', () => {
                         #end if
                     end sub
                 `);
-                expect(file.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(file);
             });
 
             it('does not choke on invalid code inside a false conditional compile', () => {
@@ -562,7 +558,7 @@ describe('BrsFile', () => {
                         #end if
                     end sub
                 `);
-                expect(file.getDiagnostics()).to.be.lengthOf(0);
+                expectZeroDiagnostics(file);
             });
 
             it('detects syntax error in #if', () => {
@@ -573,9 +569,9 @@ describe('BrsFile', () => {
                         #end if
                     end sub
                 `);
-                expect(file.getDiagnostics()[0]).to.exist.and.deep.include({
-                    ...DiagnosticMessages.invalidHashConstValue
-                });
+                expectDiagnostics(file, [
+                    DiagnosticMessages.referencedConstDoesNotExist()
+                ]);
             });
 
             it('detects syntax error in #const', () => {
@@ -586,9 +582,10 @@ describe('BrsFile', () => {
                         #end if
                     end sub
                 `);
-                expect(file.getDiagnostics()[0]).to.exist.and.deep.include({
-                    ...DiagnosticMessages.unexpectedCharacter('%')
-                });
+                expectDiagnostics(file, [
+                    DiagnosticMessages.unexpectedCharacter('%'),
+                    DiagnosticMessages.invalidHashIfValue()
+                ]);
             });
 
             it('detects #const name using reserved word', () => {
@@ -597,9 +594,10 @@ describe('BrsFile', () => {
                         #const function = true
                     end sub
                 `);
-                expect(file.getDiagnostics()[0]).to.exist.and.deep.include({
-                    ...DiagnosticMessages.constNameCannotBeReservedWord()
-                });
+                expectDiagnostics(file, [
+                    DiagnosticMessages.constNameCannotBeReservedWord(),
+                    DiagnosticMessages.unexpectedToken('#const')
+                ]);
             });
 
             it('detects syntax error in #const', () => {
@@ -608,9 +606,9 @@ describe('BrsFile', () => {
                         #const someConst = 123
                     end sub
                 `);
-                expect(file.getDiagnostics()[0]).to.exist.and.deep.include({
-                    ...DiagnosticMessages.invalidHashConstValue()
-                });
+                expectDiagnostics(file, [
+                    DiagnosticMessages.invalidHashConstValue()
+                ]);
             });
         });
 
@@ -620,7 +618,7 @@ describe('BrsFile', () => {
                    stop
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports single-line if statements', () => {
@@ -634,7 +632,7 @@ describe('BrsFile', () => {
                     if true then : test = sub() : print "yes" : end sub : end if
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports line_num as global variable', () => {
@@ -643,7 +641,7 @@ describe('BrsFile', () => {
                     print LINE_NUM
                 end sub
             `);
-            expect(file.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(file);
         });
 
         it('supports many keywords as object property names', () => {
@@ -710,7 +708,7 @@ describe('BrsFile', () => {
                     person.new = true
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
         it('does not error on numeric literal type designators', () => {
             file.parse(`
@@ -724,7 +722,7 @@ describe('BrsFile', () => {
                     print 9876543210&
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('does not error when encountering sub with return type', () => {
@@ -733,7 +731,7 @@ describe('BrsFile', () => {
                     return
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('does not lose function scopes when mismatched end sub', () => {
@@ -771,7 +769,7 @@ describe('BrsFile', () => {
                     foo.bar = true and false or 3 > 4
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('does not error with boolean in RHS of set statement', () => {
@@ -785,7 +783,7 @@ describe('BrsFile', () => {
                     m.isTrue = m.isTrue = m.isTrue
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports variable names ending with type designators', () => {
@@ -798,7 +796,7 @@ describe('BrsFile', () => {
                   someHex& = 13
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports multiple spaces between two-word keywords', () => {
@@ -811,7 +809,7 @@ describe('BrsFile', () => {
                     end if
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('does not error with `stop` as object key', () => {
@@ -825,7 +823,7 @@ describe('BrsFile', () => {
                     return obj
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('does not error with `run` as object key', () => {
@@ -839,7 +837,7 @@ describe('BrsFile', () => {
                     return obj
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports assignment operators', () => {
@@ -857,7 +855,7 @@ describe('BrsFile', () => {
                     print x
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports `then` as object property', () => {
@@ -870,7 +868,7 @@ describe('BrsFile', () => {
                     promise.then()
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports function as parameter type', () => {
@@ -880,7 +878,7 @@ describe('BrsFile', () => {
                     end function
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports increment operator', () => {
@@ -890,8 +888,7 @@ describe('BrsFile', () => {
                     x++
                 end function
             `);
-            file.getDiagnostics();
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports decrement operator', () => {
@@ -901,8 +898,7 @@ describe('BrsFile', () => {
                     x--
                 end function
             `);
-            file.getDiagnostics();
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports writing numbers with decimal but no trailing digit', () => {
@@ -912,7 +908,7 @@ describe('BrsFile', () => {
                     print x
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports assignment operators against object properties', () => {
@@ -935,7 +931,7 @@ describe('BrsFile', () => {
                     print m.age
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         //skipped until `brs` supports this
@@ -948,7 +944,7 @@ describe('BrsFile', () => {
                     print x
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         //skipped until `brs` supports this
@@ -961,7 +957,7 @@ describe('BrsFile', () => {
                         print m.x
                     end function
                 `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports leading and trailing periods for numeric literals', () => {
@@ -973,7 +969,7 @@ describe('BrsFile', () => {
                     print pointOne
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports bitshift assignment operators on object properties accessed by array syntax', () => {
@@ -985,7 +981,7 @@ describe('BrsFile', () => {
                         print m.x
                     end function
                 `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('supports weird period AA accessor', () => {
@@ -995,7 +991,7 @@ describe('BrsFile', () => {
                     print m.["_uuid"]
                 end function
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('adds error for library statements NOT at top of file', () => {
@@ -1004,10 +1000,8 @@ describe('BrsFile', () => {
                 end sub
                 import "file.brs"
             `);
-            expect(
-                file.getDiagnostics().map(x => x.message)
-            ).to.eql([
-                DiagnosticMessages.importStatementMustBeDeclaredAtTopOfFile().message
+            expectDiagnostics(file, [
+                DiagnosticMessages.importStatementMustBeDeclaredAtTopOfFile()
             ]);
         });
 
@@ -1015,7 +1009,7 @@ describe('BrsFile', () => {
             file.parse(`
                 Library "v30/bslCore.brs"
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('adds error for library statements NOT at top of file', () => {
@@ -1024,10 +1018,8 @@ describe('BrsFile', () => {
                 end sub
                 Library "v30/bslCore.brs"
             `);
-            expect(
-                file.getDiagnostics().map(x => x.message)
-            ).to.eql([
-                DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile().message
+            expectDiagnostics(file, [
+                DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile()
             ]);
         });
 
@@ -1037,10 +1029,8 @@ describe('BrsFile', () => {
                     Library "v30/bslCore.brs"
                 end sub
             `);
-            expect(
-                file.getDiagnostics().map(x => x.message)
-            ).to.eql([
-                DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile().message
+            expectDiagnostics(file, [
+                DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile()
             ]);
         });
 
@@ -1050,7 +1040,7 @@ describe('BrsFile', () => {
                     obj = {x:0 : y: 1}
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(file);
         });
 
         it('succeeds when finding variables with "sub" in them', () => {
@@ -1146,10 +1136,8 @@ describe('BrsFile', () => {
                 function DoSomething
                 end function
             `);
-            expect(file.getDiagnostics().length).to.be.greaterThan(0);
-            expect(file.getDiagnostics()[0]).to.deep.include({
-                file: file
-            });
+            expectHasDiagnostics(file);
+            expect(file.getDiagnostics()[0].file).to.equal(file);
             expect(file.getDiagnostics()[0].range.start.line).to.equal(1);
         });
 
@@ -1162,7 +1150,7 @@ describe('BrsFile', () => {
                     next
                 end sub
             `);
-            expect(file.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(file);
         });
 
         //test is not working yet, but will be enabled when brs supports this syntax
@@ -1176,7 +1164,7 @@ describe('BrsFile', () => {
                     end sub
                 end function
             `);
-            expect(file.getDiagnostics().length).to.equal(0);
+            expectZeroDiagnostics(file);
         });
     });
 
@@ -1317,11 +1305,9 @@ describe('BrsFile', () => {
                 end sub
             `);
             program.validate();
-            expect(
-                program.getDiagnostics()[0]?.message
-            ).to.equal(
-                DiagnosticMessages.callToUnknownFunction('DoesNotExist', 'source').message
-            );
+            expectDiagnostics(program, [
+                DiagnosticMessages.callToUnknownFunction('DoesNotExist', 'source')
+            ]);
         });
 
         it('finds arguments with variable values', () => {
@@ -1629,7 +1615,7 @@ describe('BrsFile', () => {
                 end sub
             `);
 
-            expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(mainFile);
             mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true Then
@@ -1637,7 +1623,7 @@ describe('BrsFile', () => {
                     end if
                 end sub
             `);
-            expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(mainFile);
 
             mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
@@ -1646,7 +1632,7 @@ describe('BrsFile', () => {
                     end if
                 end sub
             `);
-            expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
+            expectZeroDiagnostics(mainFile);
         });
     });
 
@@ -2263,7 +2249,7 @@ describe('BrsFile', () => {
                     end sub
                 `);
                 program.validate();
-                expect(program.getDiagnostics()[0]?.message).not.to.exist;
+                expectZeroDiagnostics(program);
             });
 
             it('sets invalid on empty callfunc', () => {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -2,7 +2,7 @@ import { assert, expect } from 'chai';
 import * as path from 'path';
 import * as sinonImport from 'sinon';
 import type { CompletionItem } from 'vscode-languageserver';
-import { CompletionItemKind, Position, Range, DiagnosticSeverity } from 'vscode-languageserver';
+import { CompletionItemKind, Position, Range } from 'vscode-languageserver';
 import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { BsDiagnostic, FileReference } from '../interfaces';
@@ -10,7 +10,7 @@ import { Program } from '../Program';
 import { BrsFile } from './BrsFile';
 import { XmlFile } from './XmlFile';
 import { standardizePath as s } from '../util';
-import { expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 import { ProgramBuilder } from '../ProgramBuilder';
 import { LogLevel } from '../Logger';
 
@@ -335,12 +335,9 @@ describe('XmlFile', () => {
             `);
 
             program.validate();
-
-            expect(
-                program.getDiagnostics().map(x => x.message)
-            ).to.include(
-                DiagnosticMessages.fileNotReferencedByAnyOtherFile().message
-            );
+            expectDiagnostics(program, [
+                DiagnosticMessages.fileNotReferencedByAnyOtherFile()
+            ]);
         });
 
         it('is not enabled by default', () => {
@@ -369,9 +366,7 @@ describe('XmlFile', () => {
             program.validate();
 
             //there should be no errors
-            expect(
-                program.getDiagnostics().map(x => x.message)[0]
-            ).not.to.exist;
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -527,8 +522,7 @@ describe('XmlFile', () => {
             range: undefined
         }];
         file.addDiagnostics(expected);
-        const actual = file.getDiagnostics();
-        expect(actual).deep.equal(expected);
+        expectDiagnostics(file, expected);
     });
 
     describe('component extends', () => {
@@ -591,10 +585,9 @@ describe('XmlFile', () => {
                 `
             );
 
-            expect(file.getDiagnostics()[0]).to.include({
-                severity: DiagnosticSeverity.Warning,
-                message: DiagnosticMessages.xmlComponentMissingExtendsAttribute().message
-            });
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlComponentMissingExtendsAttribute()
+            ]);
         });
     });
 
@@ -618,11 +611,9 @@ describe('XmlFile', () => {
         `);
 
         program.validate();
-        expect(
-            program.getDiagnostics()[0]?.message
-        ).to.equal(
-            DiagnosticMessages.unnecessaryCodebehindScriptImport().message
-        );
+        expectDiagnostics(program, [
+            DiagnosticMessages.unnecessaryCodebehindScriptImport()
+        ]);
     });
 
     describe('transpile', () => {
@@ -967,7 +958,7 @@ describe('XmlFile', () => {
             </component>
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => ({ message: x.message, code: x.code }))).to.eql([{
+        expectDiagnostics(program, [{
             message: 'Test diagnostic',
             code: 9999
         }]);
@@ -1018,7 +1009,7 @@ describe('XmlFile', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
             const scope = program.getComponentScope('ChildComponent');
             expect([...scope.namespaceLookup.keys()].sort()).to.eql([
                 'lib',
@@ -1169,8 +1160,8 @@ describe('XmlFile', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message)).to.eql([
-                DiagnosticMessages.xmlComponentMissingExtendsAttribute().message
+            expectDiagnostics(program, [
+                DiagnosticMessages.xmlComponentMissingExtendsAttribute()
             ]);
         });
 
@@ -1193,8 +1184,8 @@ describe('XmlFile', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message)).to.eql([
-                DiagnosticMessages.xmlComponentMissingExtendsAttribute().message
+            expectDiagnostics(program, [
+                DiagnosticMessages.xmlComponentMissingExtendsAttribute()
             ]);
         });
     });
@@ -1217,9 +1208,9 @@ describe('XmlFile', () => {
                 </component>
             `);
             program.validate();
-            expect(program.getDiagnostics().map(x => x.message).sort()).to.eql([
-                DiagnosticMessages.duplicateComponentName('comp1').message,
-                DiagnosticMessages.duplicateComponentName('comp1').message
+            expectDiagnostics(program, [
+                DiagnosticMessages.duplicateComponentName('comp1'),
+                DiagnosticMessages.duplicateComponentName('comp1')
             ]);
         });
 

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -6,7 +6,7 @@ import { Program } from '../../Program';
 import { standardizePath as s } from '../../util';
 import type { XmlFile } from '../XmlFile';
 import type { BrsFile } from '../BrsFile';
-import { expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../../testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;
@@ -98,7 +98,7 @@ describe('import statements', () => {
             end function
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => x.message)[0]).to.not.exist;
+        expectZeroDiagnostics(program);
         expect(
             (component as XmlFile).getAvailableScriptImports().sort()
         ).to.eql([
@@ -128,7 +128,7 @@ describe('import statements', () => {
             end function
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => x.message)[0]).to.not.exist;
+        expectZeroDiagnostics(program);
         expect(
             (component as XmlFile).getAvailableScriptImports()
         ).to.eql([
@@ -157,7 +157,7 @@ describe('import statements', () => {
         //there should be an error because that function doesn't exist
         program.validate();
 
-        expect(program.getDiagnostics().map(x => x.message)).to.eql([
+        expectDiagnostics(program, [
             DiagnosticMessages.callToUnknownFunction('Waddle', s`components/ChildScene.xml`).message
         ]);
 
@@ -219,7 +219,9 @@ describe('import statements', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => x.message)[0]).to.eql(DiagnosticMessages.referencedFileDoesNotExist().message);
+        expectDiagnostics(program, [
+            DiagnosticMessages.referencedFileDoesNotExist()
+        ]);
     });
 
     it('complicated import graph adds correct script tags', () => {

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -1,7 +1,6 @@
 import { standardizePath as s } from './util';
 import { Program } from './Program';
-import { expect } from 'chai';
-import { expectZeroDiagnostics } from './testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics } from './testHelpers.spec';
 import { DiagnosticMessages } from './DiagnosticMessages';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
@@ -39,8 +38,8 @@ describe('globalCallables', () => {
             end sub
         `);
         program.validate();
-        expect(program.getDiagnostics().map(x => x.message)).to.eql([
-            DiagnosticMessages.mismatchArgumentCount('1-6', 0).message
+        expectDiagnostics(program, [
+            DiagnosticMessages.mismatchArgumentCount('1-6', 0)
         ]);
     });
 
@@ -68,7 +67,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
 
         it('allows both parameters', () => {
@@ -78,7 +77,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -90,7 +89,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
 
         it('allows both parameters', () => {
@@ -100,7 +99,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -112,7 +111,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
 
         it('allows 2 parameters', () => {
@@ -122,7 +121,7 @@ describe('globalCallables', () => {
                 end sub
             `);
             program.validate();
-            expect(program.getDiagnostics()[0]?.message).not.to.exist;
+            expectZeroDiagnostics(program);
         });
     });
 });

--- a/src/parser/tests/expression/RegexLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/RegexLiteralExpression.spec.ts
@@ -1,7 +1,6 @@
 import { Program } from '../../../Program';
 import { standardizePath as s } from '../../../util';
-import { getTestTranspile } from '../../../testHelpers.spec';
-import { expect } from 'chai';
+import { expectDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 
 describe('RegexLiteralExpression', () => {
@@ -71,7 +70,9 @@ describe('RegexLiteralExpression', () => {
                     print /"/
                 end sub
             `);
-            expect(program.getDiagnostics()[0].code).to.eql(DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('').code);
+            expectDiagnostics(program, [
+                DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('regular expression literal')
+            ]);
         });
 
         it('handles edge cases', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -12,6 +12,7 @@ import type { Program } from './Program';
 import { standardizePath as s } from './util';
 import type { CodeWithSourceMap } from 'source-map';
 import { getDiagnosticLine } from './diagnosticUtils';
+import { firstBy } from 'thenby';
 
 /**
  * Trim leading whitespace for every line (to make test writing cleaner
@@ -60,21 +61,75 @@ export function trim(strings: TemplateStringsArray, ...args) {
     }
     return trimLeading(text);
 }
+type DiagnosticCollection = { getDiagnostics(): Array<Diagnostic> } | { diagnostics: Diagnostic[] } | Diagnostic[];
+
+function getDiagnostics(arg: DiagnosticCollection): BsDiagnostic[] {
+    if (Array.isArray(arg)) {
+        return arg as BsDiagnostic[];
+    } else if ((arg as any).getDiagnostics) {
+        return (arg as any).getDiagnostics();
+    } else if ((arg as any).diagnostics) {
+        return (arg as any).diagnostics;
+    } else {
+        throw new Error('Cannot derive a list of diagnostics from ' + JSON.stringify(arg));
+    }
+}
+
+function sortDiagnostics(diagnostics: BsDiagnostic[]) {
+    return diagnostics.sort(
+        firstBy<BsDiagnostic>('code')
+            .thenBy<BsDiagnostic>('message')
+            .thenBy<BsDiagnostic>((a, b) => (a.range?.start?.line ?? 0) - (b.range?.start?.line ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.range?.start?.character ?? 0) - (b.range?.start?.character ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.range?.end?.line ?? 0) - (b.range?.end?.line ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.range?.end?.character ?? 0) - (b.range?.end?.character ?? 0))
+    );
+}
+
+/**
+ * Ensure the DiagnosticCollection exactly contains the data from expected list.
+ * @param arg - any object that contains diagnostics (such as `Program`, `Scope`, or even an array of diagnostics)
+ * @param expected an array of expected diagnostics. if it's a string, assume that's a diagnostic error message
+ */
+export function expectDiagnostics(arg: DiagnosticCollection, expected: Array<Partial<Diagnostic> | string | number>) {
+    const diagnostics = sortDiagnostics(
+        getDiagnostics(arg)
+    );
+    const expectedDiagnostics = sortDiagnostics(
+        expected.map(x => {
+            let result = x;
+            if (typeof x === 'string') {
+                result = { message: x };
+            } else if (typeof x === 'number') {
+                result = { code: x };
+            }
+            return result as BsDiagnostic;
+        })
+    );
+
+    const actual = [] as BsDiagnostic[];
+    for (let i = 0; i < diagnostics.length; i++) {
+        const actualDiagnostic = diagnostics[i];
+        const clone = {} as BsDiagnostic;
+        let keys = Object.keys(expectedDiagnostics[i] ?? {}) as Array<keyof BsDiagnostic>;
+        //if there were no keys provided, use some sane defaults
+        keys = keys.length > 0 ? keys : ['message', 'code', 'range', 'severity'];
+
+        //copy only compare the specified keys from actualDiagnostic
+        for (const key of keys) {
+            clone[key] = actualDiagnostic[key];
+        }
+        actual.push(clone);
+    }
+
+    expect(actual).to.eql(expectedDiagnostics);
+}
 
 /**
  * Test that the given object has zero diagnostics. If diagnostics are found, they are printed to the console in a pretty fashion.
  */
-export function expectZeroDiagnostics(arg: { getDiagnostics(): Array<Diagnostic> } | { diagnostics: Diagnostic[] } | Diagnostic[]) {
-    let diagnostics: BsDiagnostic[];
-    if (Array.isArray(arg)) {
-        diagnostics = arg as BsDiagnostic[];
-    } else if ((arg as any).getDiagnostics) {
-        diagnostics = (arg as any).getDiagnostics();
-    } else if ((arg as any).diagnostics) {
-        diagnostics = (arg as any).diagnostics;
-    } else {
-        throw new Error('Cannot derive a list of diagnostics from ' + JSON.stringify(arg));
-    }
+export function expectZeroDiagnostics(arg: DiagnosticCollection) {
+    const diagnostics = getDiagnostics(arg);
     if (diagnostics.length > 0) {
         let message = `Expected 0 diagnostics, but instead found ${diagnostics.length}:`;
         for (const diagnostic of diagnostics) {
@@ -88,6 +143,19 @@ export function expectZeroDiagnostics(arg: { getDiagnostics(): Array<Diagnostic>
             }
         }
         assert.fail(message);
+    }
+}
+
+/**
+ * Test if the arg has any diagnostics. This just checks the count, nothing more.
+ * @param length if specified, checks the diagnostic count is exactly that amount. If omitted, the collection is just verified as non-empty
+ */
+export function expectHasDiagnostics(arg: DiagnosticCollection, length: number = null) {
+    const diagnostics = getDiagnostics(arg);
+    if (length) {
+        expect(diagnostics).lengthOf(length);
+    } else {
+        expect(diagnostics).not.empty;
     }
 }
 


### PR DESCRIPTION
- adds new `expectDiagostics` and `expectHasDiagnostics` functions to streamline diagnostic checks in unit tests. (0e0927888fc608e19b2cdda94188fb7fed21a5f2)
- updates many unit tests to use these simplified test helpers. (e6d2978744d87c6a545bfc61bc51e8aa2912b93a)