### PR TITLE
Parser references expressions

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, Statement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement } from '../parser/Statement';
-import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression } from '../parser/Expression';
+import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -187,6 +187,9 @@ export function isArrayLiteralExpression(element: Statement | Expression | undef
 }
 export function isAALiteralExpression(element: Statement | Expression | undefined): element is AALiteralExpression {
     return element?.constructor.name === 'AALiteralExpression';
+}
+export function isAAMemberExpression(element: Statement | Expression | undefined): element is AAMemberExpression {
+    return element?.constructor.name === 'AAMemberExpression';
 }
 export function isUnaryExpression(element: Statement | Expression | undefined): element is UnaryExpression {
     return element?.constructor.name === 'UnaryExpression';

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -53,8 +53,14 @@ describe('parser', () => {
             });
         }
 
-        it('works for references.expressions', () => {
+        it.only('works for references.expressions', () => {
             const parser = Parser.parse(`
+                obj = {
+                    val1: someValue
+                }
+                arr = [
+                    one
+                ]
                 thing = alpha.bravo
                 alpha.charlie()
                 delta(alpha.delta)
@@ -67,9 +73,11 @@ describe('parser', () => {
 
                 end function
             `);
-            expect(
-                expressionsToStrings(parser.references.expressions)
-            ).to.eql([
+            const expected = [
+                'someValue',
+                '{\n    val1: someValue\n}',
+                'one',
+                '[\n    one\n]',
                 'alpha.bravo',
                 'alpha.charlie()',
                 'alpha.delta',
@@ -80,7 +88,17 @@ describe('parser', () => {
                 'bravo(1 + 2).jump(callMe())',
                 '"bob"',
                 'name.space.getSomething()'
-            ]);
+            ].sort();
+            expect(
+                expressionsToStrings(parser.references.expressions).sort()
+            ).to.eql(expected);
+
+            //tell the parser we modified the AST and need to regenerate references
+            parser.invalidateReferences();
+
+            expect(
+                expressionsToStrings(parser.references.expressions).sort()
+            ).to.eql(expected);
         });
     });
 


### PR DESCRIPTION
Adds support for tracking distinct expressions during parse. This will eliminate the need for AST walking for many validators. 

- [ ] track them during initial parse
- [ ] re-calculate them when `invalidateReferences()` is called (partially done)