### PR TITLE
Adds plugin hooks for file validation

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -2335,4 +2335,34 @@ describe('Program', () => {
             }
         });
     });
+
+    describe('plugins', () => {
+        it('emits file validation events', () => {
+            const plugin = {
+                name: 'test',
+                beforeFileValidate: sinon.spy(),
+                onFileValidate: sinon.spy(),
+                afterFileValidate: sinon.spy()
+            };
+            program.plugins.add(plugin);
+            program.addOrReplaceFile('source/main.brs', '');
+            expect(plugin.beforeFileValidate.callCount).to.equal(1);
+            expect(plugin.onFileValidate.callCount).to.equal(1);
+            expect(plugin.afterFileValidate.callCount).to.equal(1);
+        });
+
+        it('emits file validation events', () => {
+            const plugin = {
+                name: 'test',
+                beforeFileValidate: sinon.spy(),
+                onFileValidate: sinon.spy(),
+                afterFileValidate: sinon.spy()
+            };
+            program.plugins.add(plugin);
+            program.addOrReplaceFile('components/main.xml', '');
+            expect(plugin.beforeFileValidate.callCount).to.equal(1);
+            expect(plugin.onFileValidate.callCount).to.equal(1);
+            expect(plugin.afterFileValidate.callCount).to.equal(1);
+        });
+    });
 });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -276,6 +276,18 @@ export class BrsFile {
             //find all places where a sub/function is being called
             this.findFunctionCalls();
 
+            //emit an event before starting to validate this file
+            this.program.plugins.emit('beforeFileValidate', {
+                file: this,
+                program: this.program
+            });
+
+            //emit an event to allow plugins to contribute to the file validation process
+            this.program.plugins.emit('onFileValidate', {
+                file: this,
+                program: this.program
+            });
+
             this.findAndValidateImportAndImportStatements();
 
             //attach this file to every diagnostic

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -193,16 +193,28 @@ export class XmlFile {
 
         this.getCommentFlags(this.parser.tokens as any[]);
 
-        if (!this.parser.ast.root) {
-            //skip empty XML
-            return;
-        }
-
         //notify AST ready
         this.program.plugins.emit('afterFileParse', this);
 
-        //initial validation
-        this.validateComponent(this.parser.ast);
+        //emit an event before starting to validate this file
+        this.program.plugins.emit('beforeFileValidate', {
+            file: this,
+            program: this.program
+        });
+
+        //emit an event to allow plugins to contribute to the file validation process
+        this.program.plugins.emit('onFileValidate', {
+            file: this,
+            program: this.program
+        });
+
+        if (this.parser.ast.root) {
+
+            //initial validation
+            this.validateComponent(this.parser.ast);
+        } else {
+            //skip empty XML
+        }
     }
 
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -207,6 +207,17 @@ export interface CompilerPlugin {
     //file events
     beforeFileParse?: (source: SourceObj) => void;
     afterFileParse?: (file: BscFile) => void;
+    /**
+     * Called before each file is validated
+     */
+    beforeFileValidate?: PluginHandler<BeforeFileValidateEvent>;
+    /**
+     * Called during the file validation process. If your plugin contributes file validations, this is a good place to contribute them.
+     */
+    onFileValidate?: PluginHandler<OnFileValidateEvent>;
+    /**
+     * Called after each file is validated
+     */
     afterFileValidate?: (file: BscFile) => void;
     beforeFileTranspile?: PluginHandler<BeforeFileTranspileEvent>;
     afterFileTranspile?: PluginHandler<AfterFileTranspileEvent>;
@@ -229,6 +240,16 @@ export interface OnGetSemanticTokensEvent {
     file: BscFile;
     scopes: Scope[];
     semanticTokens: SemanticToken[];
+}
+
+export interface BeforeFileValidateEvent<T extends BscFile = BscFile> {
+    program: Program;
+    file: T;
+}
+
+export interface OnFileValidateEvent<T extends BscFile = BscFile> {
+    program: Program;
+    file: T;
 }
 
 export type Editor = Pick<AstEditor, 'addToArray' | 'hasChanges' | 'removeFromArray' | 'setArrayValue' | 'setProperty'>;


### PR DESCRIPTION
- Adds `beforeFileValidate` plugin hook. While currently the `afterFileParse` event happens at roughly the same time, adding this new hook makes it more approachable to extension authors (i.e. they don't have to read the docs), and also guards against issues that may occur if we add events between `afterFileParse` and `beforeFileValidate` in the future. It also makes things more clear when doing pre-validate work, then doing post-validate cleanup.
- Adds `onFileValidate` plugin hook which is how where plugins should hook in when contributing their own file validations.

Since the v1 plugin system event parameters use a single event object (instead of 1...n parameters), all newly added plugin events in master will also follow that style to minimize impacts of plugins migrating to v1. 