### PR TITLE
Don't import from `..` folders

### DIFF
--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -11,7 +11,8 @@ import { isBlock, isCommentStatement, isFunctionStatement, isIfStatement } from 
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { BrsTranspileState } from './BrsTranspileState';
 import { SourceNode } from 'source-map';
-import { BrsFile, Program } from '..';
+import { BrsFile } from '../files/BrsFile';
+import { Program } from '../Program';
 
 describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {

--- a/src/parser/tests/controlFlow/For.spec.ts
+++ b/src/parser/tests/controlFlow/For.spec.ts
@@ -3,8 +3,8 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
-import type { ForStatement } from '../..';
-import { LiteralExpression } from '../..';
+import type { ForStatement } from '../../Statement';
+import { LiteralExpression } from '../../Expression';
 
 describe('parser for loops', () => {
     it('accepts a \'step\' clause', () => {

--- a/src/parser/tests/controlFlow/ForEach.spec.ts
+++ b/src/parser/tests/controlFlow/ForEach.spec.ts
@@ -3,8 +3,9 @@ import { expect } from 'chai';
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer';
 import { EOF, identifier, token } from '../Parser.spec';
-import { ForEachStatement, VariableExpression } from '../..';
 import { Range } from 'vscode-languageserver';
+import { ForEachStatement } from '../../Statement';
+import { VariableExpression } from '../../Expression';
 
 describe('parser foreach loops', () => {
     it('requires a name and target', () => {

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -14,7 +14,7 @@ import {
     LiteralExpression,
     NullCoalescingExpression
 } from '../../Expression';
-import { Program } from '../../..';
+import { Program } from '../../../Program';
 import { expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 
 describe('NullCoalescingExpression', () => {

--- a/src/parser/tests/statement/Dim.spec.ts
+++ b/src/parser/tests/statement/Dim.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import type { DimStatement } from '../..';
+import type { DimStatement } from '../../Statement';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Parser } from '../../Parser';
 

--- a/src/parser/tests/statement/Throw.spec.ts
+++ b/src/parser/tests/statement/Throw.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import type { TryCatchStatement, ThrowStatement } from '../..';
+import type { TryCatchStatement, ThrowStatement } from '../../Statement';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { LiteralExpression } from '../../Expression';
 import { Parser } from '../../Parser';


### PR DESCRIPTION
Importing from "barrel" files (like index.ts where all it does is import/export other files) can cause circular references. All of our internal code should be importing directly from files that contain the code they want to use. 