### PR TITLE
Move parse and validate events out to program level

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -395,9 +395,26 @@ export class Program {
                 this.logger.time(LogLevel.debug, ['parse', chalk.green(srcPath)], () => {
                     brsFile.parse(sourceObj.source);
                 });
+
+                //notify plugins that this file has finished parsing
+                this.plugins.emit('afterFileParse', brsFile);
+
                 file = brsFile;
 
                 brsFile.attachDependencyGraph(this.dependencyGraph);
+
+                this.plugins.emit('beforeFileValidate', {
+                    program: this,
+                    file: file
+                });
+
+                file.validate();
+
+                //emit an event to allow plugins to contribute to the file validation process
+                this.plugins.emit('onFileValidate', {
+                    program: this,
+                    file: file
+                });
 
                 this.plugins.emit('afterFileValidate', brsFile);
             } else if (
@@ -415,9 +432,13 @@ export class Program {
                     source: fileContents
                 };
                 this.plugins.emit('beforeFileParse', sourceObj);
+
                 this.logger.time(LogLevel.debug, ['parse', chalk.green(srcPath)], () => {
                     xmlFile.parse(sourceObj.source);
                 });
+
+                //notify plugins that this file has finished parsing
+                this.plugins.emit('afterFileParse', xmlFile);
 
                 file = xmlFile;
 
@@ -427,6 +448,21 @@ export class Program {
 
                 //register this compoent now that we have parsed it and know its component name
                 this.registerComponent(xmlFile, scope);
+
+
+                //emit an event before starting to validate this file
+                this.plugins.emit('beforeFileValidate', {
+                    file: file,
+                    program: this
+                });
+
+                xmlFile.validate();
+
+                //emit an event to allow plugins to contribute to the file validation process
+                this.plugins.emit('onFileValidate', {
+                    file: xmlFile,
+                    program: this
+                });
 
                 this.plugins.emit('afterFileValidate', xmlFile);
             } else {

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -102,9 +102,9 @@ describe('astUtils visitors', () => {
             const walker = functionsWalker(visitor);
             program.plugins.add({
                 name: 'walker',
-                afterFileParse: () => walker(file)
+                afterFileParse: file => walker(file as BrsFile)
             });
-            file.parse(PRINTS_SRC);
+            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block:0',                // Main sub body
                 'PrintStatement:1',       // print 1
@@ -139,9 +139,9 @@ describe('astUtils visitors', () => {
             const walker = functionsWalker(s => actual.push(s.constructor.name), cancel.token);
             program.plugins.add({
                 name: 'walker',
-                afterFileParse: () => walker(file)
+                afterFileParse: file => walker(file as BrsFile)
             });
-            file.parse(PRINTS_SRC);
+            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -184,9 +184,9 @@ describe('astUtils visitors', () => {
             }, cancel.token);
             program.plugins.add({
                 name: 'walker',
-                afterFileParse: () => walker(file)
+                afterFileParse: file => walker(file as BrsFile)
             });
-            file.parse(PRINTS_SRC);
+            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -263,10 +263,10 @@ describe('astUtils visitors', () => {
             });
             program.plugins.add({
                 name: 'walker',
-                afterFileParse: () => walker(file)
+                afterFileParse: (file) => walker(file as BrsFile)
             });
 
-            file.parse(EXPRESSIONS_SRC);
+            program.addOrReplaceFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 //The comment statement is weird because it can't be both a statement and expression, but is treated that way. Just ignore it for now until we refactor comments.
                 //'CommentStatement:1:CommentStatement',          // '<comment>

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -4,7 +4,7 @@ import { CancellationTokenSource, Range } from 'vscode-languageserver';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
-import { BrsFile } from '../files/BrsFile';
+import type { BrsFile } from '../files/BrsFile';
 import type { Statement } from '../parser/Statement';
 import { PrintStatement, Block, ReturnStatement } from '../parser/Statement';
 import type { Expression } from '../parser/Expression';
@@ -17,7 +17,6 @@ import { createStackedVisitor } from './stackedVisitor';
 describe('astUtils visitors', () => {
     const rootDir = process.cwd();
     let program: Program;
-    let file: BrsFile;
 
     const PRINTS_SRC = `
         sub Main()
@@ -76,7 +75,6 @@ describe('astUtils visitors', () => {
 
     beforeEach(() => {
         program = new Program({ rootDir: rootDir });
-        file = new BrsFile('abs.bs', 'rel.bs', program);
     });
     afterEach(() => {
         program.dispose();
@@ -104,7 +102,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block:0',                // Main sub body
                 'PrintStatement:1',       // print 1
@@ -141,7 +139,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -186,7 +184,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            file = program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2293,13 +2293,12 @@ describe('BrsFile', () => {
                 name: 'transform callback',
                 afterFileParse: onParsed
             });
-            const file = new BrsFile(`absolute_path/file${ext}`, `relative_path/file${ext}`, program);
-            expect(file.extension).to.equal(ext);
-            file.parse(`
+            file = program.addOrReplaceFile({ src: `absolute_path/file${ext}`, dest: `relative_path/file${ext}` }, `
                 sub Sum()
                     print "hello world"
                 end sub
             `);
+            expect(file.extension).to.equal(ext);
             return file;
         }
 

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -193,24 +193,15 @@ export class XmlFile {
 
         this.getCommentFlags(this.parser.tokens as any[]);
 
-        //notify AST ready
-        this.program.plugins.emit('afterFileParse', this);
+        //needsTranspiled should be true if an import is brighterscript
+        this.needsTranspiled = this.needsTranspiled || this.ast.component?.scripts?.some(
+            script => script.type?.indexOf('brighterscript') > 0 || script.uri?.endsWith('.bs')
+        );
+    }
 
-        //emit an event before starting to validate this file
-        this.program.plugins.emit('beforeFileValidate', {
-            file: this,
-            program: this.program
-        });
 
-        //emit an event to allow plugins to contribute to the file validation process
-        this.program.plugins.emit('onFileValidate', {
-            file: this,
-            program: this.program
-        });
-
+    public validate() {
         if (this.parser.ast.root) {
-
-            //initial validation
             this.validateComponent(this.parser.ast);
         } else {
             //skip empty XML
@@ -265,10 +256,6 @@ export class XmlFile {
             });
         }
 
-        //needsTranspiled should be true if an import is brighterscript
-        this.needsTranspiled = this.needsTranspiled || component.scripts.some(
-            script => script.type?.indexOf('brighterscript') > 0 || script.uri?.endsWith('.bs')
-        );
 
         //catch script imports with same path as the auto-imported codebehind file
         const scriptTagImports = this.parser.references.scriptTagImports;


### PR DESCRIPTION
Moves the `afterFileParse`, `onValidateFile`, and `afterFileValidate` events into the `Program` class and out of `BrsFile.ts` and `XmlFile.ts` to make things more consistent. 

The changes were mostly done to `BrsFile.ts`, `XmlFile.ts`, and `Program.ts`. The other changes are just unit test tweaks to make them work with the changes (i.e. we need to call `program.addOrReplaceFile` now instead of using the `file.parse()` function directly to trigger the plugin event.)