### PR TITLE
Adds Symbol Tables to InterfaceTypes - general refactor of Interfaces

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,64 @@
+# BrighterScript Interfaces
+
+Not to be confused with SceneGraph interfaces (see [<interfaces>](https://developer.roku.com/en-ca/docs/references/scenegraph/xml-elements/interface.md)), BrighterScript introduces the `interface` keyword to describe the public methods and/or fields available on a [class](class.md). This has the benefit of allowing type-checking and validation on different classes as long as they expose the same public functions.
+
+## Interfaces
+
+Interfaces are declared similarly to classes, with the exception of not needing any implementation fo methods, no access modifiers (i.e. nothing is `private` in an `interface`), and nothing is initialized.
+
+```vb
+interface Vehicle
+    name as string
+
+    sub driveKm(distanceKm as float)
+end interface
+```
+
+Since an `interface` is simply a description of a class, it is not transpiled. Interfaces are only useful at compile-time to do type checking and validation. They will not result in any additional transpiled code.
+
+## Type Checking
+
+BrighterScript will validate function calls that use interface types.
+
+For example, (using the same `Vehicle` interface above), there may be two classes that implement the same interface, `Car` and `Truck`:
+
+```vb
+class Car
+    name as string
+
+    sub new(name as string)
+        m.name = name
+    end sub
+
+    sub driveKm(distanceKm as float)
+        ' some implementation
+    end sub
+end class
+
+class Truck
+    name as string = "F150"
+
+    sub driveKm(distanceKm as float)
+        ' some implementation
+    end sub
+end class
+```
+
+Then we could create a function that takes a `Vehicle` parameter and either a `Car` or a `Truck` would pass validation:
+
+```vb
+
+sub driveVehicle100Km(someVehicle as Vehicle)
+    print `Driving ${someVehicle.name} 100 km`
+    someVehicle.distanceKm(100)
+end sub
+
+
+sub main()
+    bmw = new Car("BMW")
+    ford = new Truck()
+
+    driveVehicle100Km(bmw) ' bmw is a Car, which implements Vehicle
+    driveVehicle100Km(ford) ' ford is a Truck, which implements Vehicle
+end sub
+```

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,6 +7,7 @@ See the following pages for more information
  - [Callfunc Operator](callfunc-operator.md)
  - [Classes](classes.md)
  - [Enums](enums.md)
+ - [Interfaces](interfaces.md)
  - [Imports](imports.md)
  - [Namespaces](namespaces.md)
  - [Null-coalescing operator](null-coalescing-operator.md)

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -660,6 +660,21 @@ export let DiagnosticMessages = {
         message: `Argument of type '${actualTypeString}' is not assignable to parameter of type '${expectedTypeString}'`,
         code: 1128,
         severity: DiagnosticSeverity.Error
+    }),
+    duplicateInterfaceDeclaration: (scopeName: string, ifaceName: string) => ({
+        message: `Scope '${scopeName}' already contains an interface with name '${ifaceName}'`,
+        code: 1129,
+        severity: DiagnosticSeverity.Error
+    }),
+    namespacedInterfaceCannotShareNameWithNonNamespacedInterface: (nonNamespacedInterfaceName: string) => ({
+        message: `Namespaced interface cannot have the same name as a non-namespaced interface '${nonNamespacedInterfaceName}'`,
+        code: 1130,
+        severity: DiagnosticSeverity.Error
+    }),
+    classCannotShareNamewithInterface: (className: string) => ({
+        message: `Class cannot have the same name as interface '${className}'`,
+        code: 1131,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1591,7 +1591,7 @@ describe('Program', () => {
             program.setFile('source/main.brs', '');
             let completions = program.getCompletions(`${rootDir}/source/main.brs`, position);
             //get the name of all global completions
-            const globalCompletions = program.globalScope.getAllFiles().flatMap(x => x.getCompletions(position)).map(x => x.label);
+            const globalCompletions = program.globalScope.getAllFiles().flatMap(x => x.getCompletions(position, program.globalScope)).map(x => x.label);
             //filter out completions from global scope
             completions = completions.filter(x => !globalCompletions.includes(x.label));
             expect(completions).to.be.empty;

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Statement, Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement } from '../parser/Statement';
+import type { Statement, Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, InterfaceStatement, InterfaceMethodStatement, InterfaceFieldStatement } from '../parser/Statement';
 import type { AALiteralExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, Expression, FunctionExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 
@@ -99,6 +99,9 @@ export function createVisitor(
         ClassFieldStatement?: (statement: ClassFieldStatement, parent?: Statement) => Statement | void;
         EnumStatement?: (statement: EnumStatement, parent?: Statement) => Statement | void;
         EnumMemberStatement?: (statement: EnumMemberStatement, parent?: Statement) => Statement | void;
+        InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement) => Statement | void;
+        InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement) => Statement | void;
+        InterfaceFieldStatement?: (statement: InterfaceFieldStatement, parent?: Statement) => Statement | void;
         //expressions
         BinaryExpression?: (expression: BinaryExpression, parent?: Statement | Expression) => Expression | void;
         CallExpression?: (expression: CallExpression, parent?: Statement | Expression) => Expression | void;

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3248,7 +3248,7 @@ describe('BrsFile', () => {
             expect(symbol.expandedTokenText).to.equal('klass');
             const classStmt = file.parser.references.classStatements[0];
             expect(classStmt.name.text).to.equal('MyKlass');
-            expect(symbol.type.isAssignableTo(classStmt.getCustomType())).be.true;
+            expect(symbol.type.isAssignableTo(classStmt.getThisBscType())).be.true;
             expectZeroDiagnostics(program);
         });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,13 +6,15 @@ import type { TypedFunctionType } from './types/TypedFunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { FunctionStatement } from './parser/Statement';
+import type { FunctionStatement, ClassStatement, InterfaceStatement } from './parser/Statement';
 import type { Expression, FunctionExpression } from './parser/Expression';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
-import type { BscType } from './types/BscType';
+import type { BscType, SymbolContainer } from './types/BscType';
 import type { Token } from './lexer/Token';
 import type { AstEditor } from './astUtils/AstEditor';
+import type { CustomType } from './types/CustomType';
+import type { InterfaceType } from './types/InterfaceType';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -424,4 +426,45 @@ export type DiagnosticCode = number | string;
 export interface FileLink<T> {
     item: T;
     file: BrsFile;
+}
+
+/**
+ * Common interface to support Statements which define entities that have a member table
+ * e.g. Class, Interface
+ */
+export interface MemberSymbolTableProvider extends SymbolContainer {
+    buildSymbolTable(parent?: InheritableStatement): void;
+    hasParent(): boolean;
+    getPossibleFullParentNames(): string[];
+    getName(parseMode: ParseMode): string;
+    getThisBscType(): BscType;
+}
+
+export type InheritableStatement = ClassStatement | InterfaceStatement;
+
+export type InheritableType = CustomType | InterfaceType;
+
+/**
+ * Options for the parser functionDeclaration() method
+ */
+export interface FunctionDeclarationParseOptions {
+    /**
+     * Function should have a name. Add a diagnostic if it is not there
+     * False for for anonymous functions
+     */
+    hasName?: boolean;
+    /**
+     * Function should have a body. Add a diagnostic if it is not there
+     * False for for functions defined in Interfaces
+     */
+    hasBody?: boolean;
+    /**
+    * Function should have an end token. Add a diagnostic if it is not there
+    * False for for functions defined in Interfaces
+    */
+    hasEnd?: boolean;
+    /**
+     *This function is only callable as a member for a class or interface, etc.
+     */
+    onlyCallableAsMember?: boolean;
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -207,6 +207,21 @@ export class FunctionExpression extends Expression implements TypedefProvider {
      */
     public childFunctionExpressions = [] as FunctionExpression[];
 
+    /**
+    * The range of the function declaration, starting at the 'f' in function or 's' in sub (or the open paren if the keyword is missing),
+    * and ending with the last character in the returnTypeToken, or the 's' in 'as', or the rightParen
+    */
+    public get functionDeclarationRange() {
+        return util.createBoundingRange(
+            this.functionType,
+            this.leftParen,
+            ...(this.parameters ?? []),
+            this.rightParen,
+            this.asToken,
+            this.returnType
+        );
+    }
+
     transpile(state: BrsTranspileState, name?: Identifier, includeBody = true) {
         let results = [];
         //'function'|'sub'
@@ -255,12 +270,14 @@ export class FunctionExpression extends Expression implements TypedefProvider {
             state.lineage.shift();
             results.push(...body);
         }
-        results.push('\n');
-        //'end sub'|'end function'
-        results.push(
-            state.indent(),
-            state.transpileToken(this.end)
-        );
+        if (this.end) {
+            results.push('\n');
+            //'end sub'|'end function'
+            results.push(
+                state.indent(),
+                state.transpileToken(this.end)
+            );
+        }
         return results;
     }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer/TokenKind';
-import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression, AnnotationExpression, FunctionParameterExpression, LiteralExpression, TypeExpression } from './Expression';
+import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression, AnnotationExpression, LiteralExpression, TypeExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
 import type { Range } from 'vscode-languageserver';

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -2,7 +2,7 @@ import { expectDiagnostics, expectZeroDiagnostics, getTestGetTypedef } from '../
 import { standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
 import { expect } from 'chai';
-import { isBooleanType, isFunctionType, isIntegerType, isStringType } from '../../../astUtils/reflection';
+import { isBooleanType, isTypedFunctionType, isIntegerType, isStringType } from '../../../astUtils/reflection';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Lexer } from '../../../lexer/Lexer';
 import { Parser, ParseMode } from '../../Parser';
@@ -241,7 +241,7 @@ describe('InterfaceStatement', () => {
         });
 
 
-        it('adds methods to class statement member symbol table after building', () => {
+        it('adds methods interface statement member symbol table after building', () => {
             let parser = Parser.parse(`
                 interface Animal
                     sub eat()
@@ -251,8 +251,8 @@ describe('InterfaceStatement', () => {
             let ifaceStatement = parser.statements[0] as InterfaceStatement;
             ifaceStatement.buildSymbolTable();
             expect(ifaceStatement.memberTable).to.exist;
-            expect(isFunctionType(ifaceStatement.memberTable.getSymbolType('eat'))).to.be.true;
-            expect(isFunctionType(ifaceStatement.memberTable.getSymbolType('sleep'))).to.be.true;
+            expect(isTypedFunctionType(ifaceStatement.memberTable.getSymbolType('eat'))).to.be.true;
+            expect(isTypedFunctionType(ifaceStatement.memberTable.getSymbolType('sleep'))).to.be.true;
         });
 
         it('adds fields to class statement member symbol table after building', () => {

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -1,6 +1,12 @@
-import { expectZeroDiagnostics, getTestGetTypedef } from '../../../testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, getTestGetTypedef } from '../../../testHelpers.spec';
 import { standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
+import { expect } from 'chai';
+import { isBooleanType, isFunctionType, isIntegerType, isStringType } from '../../../astUtils/reflection';
+import { DiagnosticMessages } from '../../../DiagnosticMessages';
+import { Lexer } from '../../../lexer/Lexer';
+import { Parser, ParseMode } from '../../Parser';
+import { ClassStatement, InterfaceStatement } from '../../Statement';
 
 describe('InterfaceStatement', () => {
     const rootDir = s`${process.cwd()}/.tmp/rootDir`;
@@ -73,5 +79,196 @@ describe('InterfaceStatement', () => {
         `);
         program.validate();
         expectZeroDiagnostics(program);
+    });
+
+    it('throws exception when used in brightscript scope', () => {
+        let { tokens } = Lexer.scan(`
+                interface Iface
+                end interface
+            `);
+        let { diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrightScript });
+        expect(diagnostics[0]?.code).to.equal(DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('').code);
+    });
+
+    it('parses empty interface', () => {
+        let { tokens } = Lexer.scan(`
+                interface Person
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+    });
+
+    it('parses interface with fields', () => {
+        let { tokens } = Lexer.scan(`
+                interface Iface
+                    age as integer
+                    name as string
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+    });
+
+    it('parses interface with methods', () => {
+        let { tokens } = Lexer.scan(`
+                interface Iface
+                    function getNum() as integer
+                    function getData() as Object
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+    });
+
+    it('parses interface with classes as fields', () => {
+        let { tokens } = Lexer.scan(`
+                class Klass
+                end class
+
+                interface Iface
+                    myKlass as Klass
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(ClassStatement);
+        expect(statements[1]).instanceof(InterfaceStatement);
+    });
+
+    it('parses classes with interfaces as fields', () => {
+        let { tokens } = Lexer.scan(`
+                interface Iface
+                   age as integer
+                end interface
+
+                class Klass
+                   myFace as Iface
+                end class
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+        expect(statements[1]).instanceof(ClassStatement);
+    });
+
+    it('parses interfaces with inheritance', () => {
+        let { tokens } = Lexer.scan(`
+                interface Basic
+                   varA as string
+                end interface
+
+                interface Advanced extends Basic
+                    varB as integer
+                end interface
+
+                interface Expert extends Advanced
+                    varC as float
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+        expect(statements[1]).instanceof(InterfaceStatement);
+        expect(statements[2]).instanceof(InterfaceStatement);
+    });
+
+    it('bad property does not invalidate next sibling method', () => {
+        let { tokens } = Lexer.scan(`
+                interface Person
+                     firstName as
+                     sub say(words as string)
+                end interface
+            `);
+        let { statements } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        let iFaceStmt = statements[0] as InterfaceStatement;
+        expect(iFaceStmt.methods[0]).to.exist;
+        expect(iFaceStmt.methods[0].name.text).to.equal('say');
+    });
+
+    it('catches interface without name', () => {
+        let { tokens } = Lexer.scan(`
+                interface
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectDiagnostics(diagnostics, [DiagnosticMessages.expectedIdentifierAfterKeyword('interface')]);
+        expect(statements[0]).instanceof(InterfaceStatement);
+    });
+
+    it('catches malformed interface', () => {
+        let { tokens } = Lexer.scan(`
+                interface Person
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectDiagnostics(diagnostics, [DiagnosticMessages.couldNotFindMatchingEndKeyword('interface')]);
+        expect(statements[0]).instanceof(InterfaceStatement);
+    });
+
+    it('parses multiple interfaces in a row', () => {
+        let { tokens } = Lexer.scan(`
+                interface IFaceA
+                    a as string
+                    sub doA()
+                end interface
+                interface IFaceB
+                    b as string
+                    sub doB()
+                end interface
+            `);
+        let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
+        expectZeroDiagnostics(diagnostics);
+        expect(statements[0]).instanceof(InterfaceStatement);
+        expect(statements[1]).instanceof(InterfaceStatement);
+    });
+
+    describe('symbol table', () => {
+
+        it('does not add methods to parser symbol table', () => {
+            let parser = Parser.parse(`
+                interface Animal
+                    sub eat()
+                    sub sleep()
+                end class
+            `, { mode: ParseMode.BrighterScript });
+
+            expect(parser.symbolTable).to.exist;
+            expect(parser.symbolTable.getSymbolType('eat')).to.be.undefined;
+            expect(parser.symbolTable.getSymbolType('sleep')).to.be.undefined;
+        });
+
+
+        it('adds methods to class statement member symbol table after building', () => {
+            let parser = Parser.parse(`
+                interface Animal
+                    sub eat()
+                    sub sleep()
+                end interface
+            `, { mode: ParseMode.BrighterScript });
+            let ifaceStatement = parser.statements[0] as InterfaceStatement;
+            ifaceStatement.buildSymbolTable();
+            expect(ifaceStatement.memberTable).to.exist;
+            expect(isFunctionType(ifaceStatement.memberTable.getSymbolType('eat'))).to.be.true;
+            expect(isFunctionType(ifaceStatement.memberTable.getSymbolType('sleep'))).to.be.true;
+        });
+
+        it('adds fields to class statement member symbol table after building', () => {
+            let parser = Parser.parse(`
+                interface Animal
+                    teethCount as integer
+                    furType as string
+                    hasWings as boolean
+                end interface
+            `, { mode: ParseMode.BrighterScript });
+            let ifaceStatement = parser.statements[0] as InterfaceStatement;
+            ifaceStatement.buildSymbolTable();
+            expect(ifaceStatement.memberTable).to.exist;
+            expect(isIntegerType(ifaceStatement.memberTable.getSymbolType('teethCount'))).to.be.true;
+            expect(isStringType(ifaceStatement.memberTable.getSymbolType('furType'))).to.be.true;
+            expect(isBooleanType(ifaceStatement.memberTable.getSymbolType('hasWings'))).to.be.true;
+        });
     });
 });

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -1,6 +1,7 @@
 import { isCustomType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { SymbolTable } from '../SymbolTable';
 import type { BscType, SymbolContainer, TypeContext } from './BscType';
+import { checkAssignabilityToInterface } from './BscType';
 
 export class CustomType implements BscType, SymbolContainer {
 
@@ -19,6 +20,12 @@ export class CustomType implements BscType, SymbolContainer {
         const ancestorTypes = context?.scope?.getAncestorTypeListByContext(this, context);
         if (ancestorTypes?.find(ancestorType => targetType.equals(ancestorType, context))) {
             return true;
+        }
+        if (this.memberTable && targetType.memberTable) {
+            // both have symbol tables, so check if the target is an interface and has all the members of the target
+            if (checkAssignabilityToInterface(this, targetType, context)) {
+                return true;
+            }
         }
         return (
             this.equals(targetType, context) ||

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,54 +1,54 @@
 import { isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
-import type { BscType } from './BscType';
+import type { SymbolTable } from '../SymbolTable';
+import type { BscType, SymbolContainer, TypeContext } from './BscType';
+import { checkAssignabilityToInterface } from './BscType';
 
-export class InterfaceType implements BscType {
+export class InterfaceType implements BscType, SymbolContainer {
     public constructor(
-        public members: Map<string, BscType>
+        public name: string, public memberTable: SymbolTable = null
     ) {
 
     }
 
-    /**
-     * The name of the interface. Can be null.
-     */
-    public name: string;
-
-    public isAssignableTo(targetType: BscType) {
-        //we must have all of the members of the target type, and they must be equivalent types
-        if (isInterfaceType(targetType)) {
-            for (const [targetMemberName, targetMemberType] of targetType.members) {
-                //we don't have the target member
-                if (!this.members.has(targetMemberName)) {
-                    return false;
-                }
-                //our member's type is not assignable to the target member type
-                if (!this.members.get(targetMemberName).isAssignableTo(targetMemberType)) {
-                    return false;
-                }
-            }
-            //we have all of the target member's types. we are assignable!
+    public isAssignableTo(targetType: BscType, context?: TypeContext) {
+        const ancestorTypes = context?.scope?.getAncestorTypeListByContext(this, context);
+        if (ancestorTypes?.find(ancestorType => targetType.equals(ancestorType, context))) {
             return true;
-
-            //we are always assignable to dynamic or object
-        } else if (isDynamicType(targetType) || isObjectType(targetType)) {
-            return true;
-
-            //not assignable to any other object types
-        } else {
-            return false;
         }
+        if (this.memberTable && targetType.memberTable) {
+            // both have symbol tables, so check if this interface has all the members of the target
+            return checkAssignabilityToInterface(this, targetType, context);
+        }
+        return (
+            this.equals(targetType, context) ||
+            isObjectType(targetType) ||
+            isDynamicType(targetType)
+        );
     }
 
     public isConvertibleTo(targetType: BscType) {
         return this.isAssignableTo(targetType);
     }
 
-    public toString() {
+    public toString(): string {
+        return this.name;
+    }
+
+    /**
+     * Gets a string representation of the Interface that looks like javascript
+     * @returns {string}
+     */
+    public toJsString() {
         let result = '{';
-        for (const [key, type] of this.members.entries()) {
-            result += ' ' + key + ': ' + type.toString() + ';';
+        const memberSymbols = (this.memberTable?.getAllSymbols() || []).sort((a, b) => a.name.localeCompare(b.name));
+        for (const symbol of memberSymbols) {
+            let symbolTypeString = symbol.type.toString();
+            if (isInterfaceType(symbol.type)) {
+                symbolTypeString = symbol.type.toJsString();
+            }
+            result += ' ' + symbol.name + ': ' + symbolTypeString + ';';
         }
-        if (this.members.size > 0) {
+        if (memberSymbols.length > 0) {
             result += ' ';
         }
         return result + '}';
@@ -58,13 +58,12 @@ export class InterfaceType implements BscType {
         return 'object';
     }
 
-    public equals(targetType: BscType): boolean {
+    public equals(targetType: BscType, context?: TypeContext): boolean {
+
         if (isInterfaceType(targetType)) {
-            if (targetType.members.size !== this.members.size) {
-                return false;
-            }
-            return targetType.isAssignableTo(this);
+            return this.isAssignableTo(targetType, context) && targetType.isAssignableTo(this, context);
         }
         return false;
     }
+
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1030,9 +1030,8 @@ export class Util {
                 }
                 if (!typeClass && allowBrighterscriptTypes) {
                     typeClass = new LazyType((context) => {
-                        return context?.scope?.getClass(typeText, currentNamespaceName?.getName())?.getCustomType();
+                        return context?.scope?.getNamedTypeStatement(typeText, currentNamespaceName?.getName())?.getThisBscType();
                     });
-
                 }
 
                 return typeClass;


### PR DESCRIPTION
- Added Symbol tables to `InterfaceType`
- Refactored assignability to use symbol tables
- Refactored `InterfaceStatment` members - particularly `InterfaceMethodStatement` to more closely align with `ClassMethodStatement`
- Refactored InterfaceStatement parsing to use existing `functionDeclaration()` method
- `functionDeclaration()` changed to have an `options` parameter instead of flags, to make it more generic
- Added validation on Interfaces and interface members.
- Refactored `ClassValidator` to work with both interfaces and classes
- Token symbol lookup is compatible with Interfaces

Still TODO for interfaces:
- Hover support
- `implements` keyword
- Validation on `implements` keyword (e.g. if you're a class and you say you implement an Interface, make sure you do)

Lots of changes. Sorry!