### PR TITLE
Array types

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -341,6 +341,15 @@ export class Scope {
     }
 
     /**
+     * Get the global callable with the specified name.
+     * If there are overridden callables with the same name, the closest callable to this scope is returned
+     * @param name
+     */
+    public getGlobalCallableByName(name: string) {
+        return globalCallableMap.get(name.toLowerCase());
+    }
+
+    /**
      * Iterate over Brs files not shadowed by typedefs
      */
     public enumerateBrsFiles(callback: (file: BrsFile) => void) {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1733,7 +1733,7 @@ describe('BrsFile', () => {
 
             let hover = file.getHover(Position.create(3, 29));
             expect(hover).to.exist;
-            expect(hover.contents).to.equal('function processData(data as Array<MyKlass>) as Array<MyKlass>');
+            expect(hover.contents).to.equal('function processData(data as MyKlass[]) as MyKlass[]');
         });
     });
 
@@ -2958,6 +2958,9 @@ describe('BrsFile', () => {
                     klass = new MyKlass()
                     print klass.name
                     print klass.age
+                    ' verify case insensitivity
+                    print KLASS.NAME
+                    print klass.AGE
                 end sub
 
                 class MyKlass

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -21,6 +21,9 @@ import { expectDiagnostics, expectHasDiagnostics, expectSymbolTableEquals, expec
 import { ParseMode } from '../parser/Parser';
 import { Logger } from '../Logger';
 import { VoidType } from '../types/VoidType';
+import { FloatType } from '../types/FloatType';
+import { ObjectType } from '../types/ObjectType';
+import { ArrayType } from '../types/ArrayType';
 
 let sinon = sinonImport.createSandbox();
 
@@ -2835,6 +2838,206 @@ describe('BrsFile', () => {
                 new Logger()
             );
             testPluginTranspile();
+        });
+    });
+
+    describe('getSymbolTypeFromToken', () => {
+
+        it('gets simple types based on the containing function expression', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething(aInt as integer, aFloat as float, aStr as string, aBool as boolean, aObj as object)
+                    print aInt
+                    print aFloat
+                    print aStr
+                    print aBool
+                    print aObj
+                end sub
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const lookups = [
+                { line: 2, col: 28, name: 'aInt', type: new IntegerType() },
+                { line: 3, col: 28, name: 'aFloat', type: new FloatType() },
+                { line: 4, col: 28, name: 'aStr', type: new StringType() },
+                { line: 5, col: 28, name: 'aBool', type: new BooleanType() },
+                { line: 6, col: 28, name: 'aObj', type: new ObjectType() }
+            ];
+
+            for (const lookup of lookups) {
+                const token = file.parser.getTokenAt(Position.create(lookup.line, lookup.col));
+                const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+                expect(symbol.expandedTokenText).to.equal(lookup.name);
+                expect(symbol.type.isAssignableTo(lookup.type)).be.true;
+            }
+            expectZeroDiagnostics(program);
+        });
+
+        it('gets custom types based on the containing function expression', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething(klass as MyKlass)
+                    print klass
+                end sub
+
+                class MyKlass
+                end class
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const token = file.parser.getTokenAt(Position.create(2, 28));
+            const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+            expect(symbol.expandedTokenText).to.equal('klass');
+            const classStmt = file.parser.references.classStatements[0];
+            expect(classStmt.name.text).to.equal('MyKlass');
+            expect(symbol.type.isAssignableTo(classStmt.getCustomType())).be.true;
+            expectZeroDiagnostics(program);
+        });
+
+        it('gets types of properties of a klass', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething()
+                    klass = new MyKlass()
+                    print klass.name
+                    print klass.age
+                end sub
+
+                class MyKlass
+                    name as string
+                    age as integer
+                end class
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const lookups = [
+                { line: 3, col: 35, name: 'MyKlass.name', type: new StringType() },
+                { line: 4, col: 35, name: 'MyKlass.age', type: new IntegerType() }
+            ];
+
+            for (const lookup of lookups) {
+                const token = file.parser.getTokenAt(Position.create(lookup.line, lookup.col));
+                const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+                expect(symbol.expandedTokenText).to.equal(lookup.name);
+                expect(symbol.type.isAssignableTo(lookup.type)).be.true;
+            }
+            expectZeroDiagnostics(program);
+        });
+
+        it('gets types of properties of an object', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething()
+                    obj = { name: "Joe", age: 37}
+                    print obj.name
+                    print obj.age
+                end sub
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const lookups = [
+                { line: 3, col: 32, name: 'obj.name', type: new StringType() },
+                { line: 4, col: 32, name: 'obj.age', type: new IntegerType() }
+            ];
+
+            for (const lookup of lookups) {
+                const token = file.parser.getTokenAt(Position.create(lookup.line, lookup.col));
+                const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+                expect(symbol.expandedTokenText).to.equal(lookup.name);
+                expect(symbol.type.isAssignableTo(lookup.type)).be.true;
+            }
+            expectZeroDiagnostics(program);
+        });
+
+        it('gets return types of functions', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething()
+                    pi = makeKlass().getSelf().getPi()
+                    print pi
+                end sub
+
+                function makeKlass() as MyKlass
+                    return new MyKlass()
+                end function
+
+                class MyKlass
+                    function getPi() as float
+                        return 3.14
+                    end function
+
+                    function getSelf() as MyKlass
+                        return m
+                    end function
+                end class
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const klassMemberTable = file.parser.references.classStatements[0].memberTable;
+            const lookups = [
+                { line: 2, col: 31, name: 'makeKlass', type: file.parser.references.functionExpressions[1].getFunctionType() },
+                // The expanded text for this should probably be MyKlass.getSelf()
+                { line: 2, col: 41, name: 'MyKlass.MyKlass', type: klassMemberTable.getSymbol('getSelf')[0].type },
+                { line: 2, col: 51, name: 'MyKlass.getPi', type: klassMemberTable.getSymbol('getPi')[0].type },
+                { line: 3, col: 28, name: 'pi', type: new FloatType() }
+            ];
+
+            for (const lookup of lookups) {
+                const position = Position.create(lookup.line, lookup.col);
+                const token = file.parser.getTokenAt(position);
+                const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+                expect(symbol.expandedTokenText).to.equal(lookup.name);
+                const context = {
+                    file: file,
+                    scope: mainScope,
+                    position: position
+                };
+                expect(symbol.type.isAssignableTo(lookup.type, context)).be.true;
+            }
+            expectZeroDiagnostics(program);
+        });
+
+
+        it('gets types of elements of arrays', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub doSomething(words as string[], klasses as MyKlass[])
+                    myWord = words[0]
+                    pi = klasses[0].getPi()
+                    print myWord
+                    print pi
+                end sub
+
+                class MyKlass
+                    function getPi() as float
+                        return 3.14
+                    end function
+                end class
+            `);
+            const mainScope = program.getScopesForFile(file)[0];
+            mainScope.linkSymbolTable();
+            const funcExpr = file.parser.references.functionExpressions[0];
+            const klassMemberTable = file.parser.references.classStatements[0].memberTable;
+            const lookups = [
+                { line: 2, col: 34, name: 'words', type: new ArrayType(new StringType()) },
+                // The expanded text for this should probably be MyKlass.getPi()
+                { line: 3, col: 41, name: 'getPi', type: klassMemberTable.getSymbol('getPi')[0].type },
+                { line: 4, col: 28, name: 'myWord', type: new StringType() },
+                { line: 5, col: 28, name: 'pi', type: new FloatType() }
+            ];
+
+            for (const lookup of lookups) {
+                const position = Position.create(lookup.line, lookup.col);
+                const token = file.parser.getTokenAt(position);
+                const symbol = file.getSymbolTypeFromToken(token, funcExpr, mainScope);
+                expect(symbol.expandedTokenText).to.equal(lookup.name);
+                const context = {
+                    file: file,
+                    scope: mainScope,
+                    position: position
+                };
+                expect(symbol.type.isAssignableTo(lookup.type, context)).be.true;
+            }
+            expectZeroDiagnostics(program);
         });
     });
 });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -908,7 +908,9 @@ export class BrsFile {
 
             if (isArrayType(symbolType) && tokenUsage === TokenUsage.ArrayReference) {
                 symbolType = getTypeFromContext(symbolType.defaultType, typeContext);
-            } else if (symbolType?.memberTable) {
+            }
+
+            if (symbolType?.memberTable) {
                 if (isCustomType(symbolType)) {
                     // we're currently looking at a customType, that has it's own symbol table
                     // use the name of the custom type
@@ -1455,16 +1457,17 @@ export class BrsFile {
 
             for (const scope of this.program.getScopesForFile(this)) {
                 scope.linkSymbolTable();
+                const typeContext = { file: this, scope: scope, position: position };
                 const typeTextPair = this.getSymbolTypeFromToken(token, func, scope);
                 if (typeTextPair) {
                     let scopeTypeText = '';
 
                     if (isFunctionType(typeTextPair.type)) {
-                        scopeTypeText = typeTextPair.type?.toString();
+                        scopeTypeText = typeTextPair.type?.toString(typeContext);
                     } else if (typeTextPair.useExpandedTextOnly) {
                         scopeTypeText = typeTextPair.expandedTokenText;
                     } else {
-                        scopeTypeText = `${typeTextPair.expandedTokenText} as ${typeTextPair.type?.toString()}`;
+                        scopeTypeText = `${typeTextPair.expandedTokenText} as ${typeTextPair.type?.toString(typeContext)}`;
                     }
 
                     if (scopeTypeText && !typeTexts.includes(scopeTypeText)) {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -907,7 +907,7 @@ export class BrsFile {
             }
 
             if (isArrayType(symbolType) && tokenUsage === TokenUsage.ArrayReference) {
-                symbolType = getTypeFromContext(symbolType.defaultType, typeContext);
+                symbolType = getTypeFromContext(symbolType.getDefaultType(typeContext), typeContext);
             }
 
             if (symbolType?.memberTable) {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -940,7 +940,10 @@ export class BrsFile {
 
         }
         if (tokenText.length > 2) {
-            tokenText = tokenText.slice(-2); // only care about last two symbols
+            // TokenText is used for hovers. We only need the last two tokens for a hover
+            // So in a long chain (e.g. klass.getData()[0].anotherKlass.property), the hover
+            // for the last token should just be "AnotherKlass.property", not the whole chain
+            tokenText = tokenText.slice(-2);
         }
         let expandedTokenText = tokenText.join('.');
         let backUpReturnType: BscType;

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -29,7 +29,6 @@ import type { BscType, SymbolContainer } from '../types/BscType';
 import { getTypeFromContext } from '../types/BscType';
 import { UninitializedType } from '../types/UninitializedType';
 import { InvalidType } from '../types/InvalidType';
-import { globalCallableMap } from '../globalCallables';
 import { DynamicType } from '../types/DynamicType';
 import type { SymbolTable } from '../SymbolTable';
 
@@ -889,7 +888,7 @@ export class BrsFile {
             symbolType = currentSymbolTable.getSymbolType(tokenLowerText, true, typeContext);
             if (tokenFoundCount === 0 && !symbolType) {
                 //check for global callable
-                symbolType = globalCallableMap.get(tokenLowerText)?.type;
+                symbolType = scope.getGlobalCallableByName(tokenLowerText)?.type;
             }
             if (symbolType) {
                 // found this symbol, and it's valid. increase found counter

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -24,8 +24,9 @@ import { CustomType } from '../types/CustomType';
 import { VoidType } from '../types/VoidType';
 import { DynamicType } from '../types/DynamicType';
 import { util } from '../util';
+import { ArrayType } from '../types/ArrayType';
 
-describe('parser', () => {
+describe.only('parser', () => {
     it('emits empty object when empty token list is provided', () => {
         expect(Parser.parse([])).to.deep.include({
             statements: [],
@@ -1244,6 +1245,21 @@ describe('parser', () => {
             const type = getBscTypeFromExpression((func.body.statements[0] as AssignmentStatement).value, func) as FunctionType;
             // Return type is LazyType, because "Person" is not fully known yet
             expect(type.returnType).to.be.instanceof(LazyType);
+        });
+
+        it('supports function with array return type', () => {
+            const parser = parse(`
+                sub main()
+                    getNums = sub() as integer[]
+                        return [1,2,3]
+                    end sub
+                end sub
+            `, ParseMode.BrighterScript);
+            expectZeroDiagnostics(parser.diagnostics);
+            const func = (parser.ast.statements[0] as FunctionStatement).func;
+            const type = getBscTypeFromExpression((func.body.statements[0] as AssignmentStatement).value, func) as FunctionType;
+            expect(type.returnType).to.be.instanceof(ArrayType);
+            expect((type.returnType as ArrayType).defaultType).to.be.instanceof(IntegerType);
         });
     });
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1370,12 +1370,12 @@ describe('parser', () => {
 
             it('determines the type of the variable in a for each if the target is an array literal', () => {
                 const parser = parse(`
-                sub doLoop()
-                    someData = [1,2,3]
-                    for each datum in someData
-                      print datum
-                    end for
-                end sub
+                    sub doLoop()
+                        someData = [1,2,3]
+                        for each datum in someData
+                        print datum
+                        end for
+                    end sub
                 `, ParseMode.BrighterScript);
                 expectZeroDiagnostics(parser.diagnostics);
                 const currentSymbolTable = parser.references.functionExpressions[0].symbolTable;
@@ -1384,11 +1384,11 @@ describe('parser', () => {
 
             it('determines the type of the variable in a for each if the target is an array', () => {
                 const parser = parse(`
-                sub doLoop(someData as integer[])
-                    for each datum in someData
-                      print datum
-                    end for
-                end sub
+                    sub doLoop(someData as integer[])
+                        for each datum in someData
+                        print datum
+                        end for
+                    end sub
                 `, ParseMode.BrighterScript);
                 expectZeroDiagnostics(parser.diagnostics);
                 const currentSymbolTable = parser.references.functionExpressions[0].symbolTable;
@@ -1397,15 +1397,15 @@ describe('parser', () => {
 
             it('determines the type of the variable in a for each if the target is an array of some custom type', () => {
                 const parser = parse(`
-                sub doLoop(someData as MyKlass[])
-                    for each datum in someData
-                      print datum.name
-                    end for
-                end sub
+                    sub doLoop(someData as MyKlass[])
+                        for each datum in someData
+                        print datum.name
+                        end for
+                    end sub
 
-                class MyKlass
-                    name as string
-                end class
+                    class MyKlass
+                        name as string
+                    end class
                 `, ParseMode.BrighterScript);
                 expectZeroDiagnostics(parser.diagnostics);
                 const currentSymbolTable = parser.references.functionExpressions[0].symbolTable;

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -26,7 +26,7 @@ import { DynamicType } from '../types/DynamicType';
 import { util } from '../util';
 import { ArrayType } from '../types/ArrayType';
 
-describe.only('parser', () => {
+describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {
         expect(Parser.parse([])).to.deep.include({
             statements: [],

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1259,7 +1259,7 @@ describe('parser', () => {
             const func = (parser.ast.statements[0] as FunctionStatement).func;
             const type = getBscTypeFromExpression((func.body.statements[0] as AssignmentStatement).value, func) as FunctionType;
             expect(type.returnType).to.be.instanceof(ArrayType);
-            expect((type.returnType as ArrayType).defaultType).to.be.instanceof(IntegerType);
+            expect((type.returnType as ArrayType).getDefaultType()).to.be.instanceof(IntegerType);
         });
     });
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -8,7 +8,7 @@ import type { AssignmentStatement, ClassStatement, Statement } from './Statement
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Position, Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import { isBlock, isCommentStatement, isCustomType, isDynamicType, isFunctionStatement, isIfStatement, isIntegerType, isLazyType, isUninitializedType } from '../astUtils/reflection';
+import { isBlock, isCommentStatement, isDynamicType, isFunctionStatement, isIfStatement, isIntegerType, isLazyType, isUninitializedType } from '../astUtils/reflection';
 import { expectSymbolTableEquals, expectZeroDiagnostics } from '../testHelpers.spec';
 import { BrsTranspileState } from './BrsTranspileState';
 import { SourceNode } from 'source-map';

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2435,7 +2435,7 @@ export class Parser {
             typeToken = this.advance();
         } else if (this.options.mode === ParseMode.BrighterScript) {
             try {
-                // see if we can get a namespaced identifer
+                // see if we can get a namespaced identifier
                 const qualifiedType = this.getNamespacedVariableNameExpression();
                 typeToken = createToken(TokenKind.Identifier, qualifiedType.getName(this.options.mode), qualifiedType.range);
             } catch {
@@ -2445,6 +2445,18 @@ export class Parser {
         } else {
             // just get whatever's next
             typeToken = this.advance();
+        }
+
+        if (typeToken && this.options.mode === ParseMode.BrighterScript) {
+            // Check if it is an array - that is, if it has `[]` after the type
+            // eg. `string[]` or `SomeKlass[]`
+            if (this.check(TokenKind.LeftSquareBracket)) {
+                this.advance();
+                if (this.check(TokenKind.RightSquareBracket)) {
+                    const rightBracket = this.advance();
+                    typeToken = createToken(TokenKind.Identifier, typeToken.text + '[]', util.getRange(typeToken, rightBracket));
+                }
+            }
         }
         return typeToken;
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1216,7 +1216,7 @@ export class Parser {
 
         const targetType = getBscTypeFromExpression(target, this.currentFunctionExpression);
         if (isArrayType(targetType)) {
-            itemType = targetType.defaultType;
+            itemType = targetType.getDefaultType();
         }
 
         this.currentSymbolTable.addSymbol(name.text, name.range, itemType);
@@ -3219,7 +3219,10 @@ export class Parser {
         return this.references.namespaceStatements.find((cs) => util.rangeContains(cs.range, currentToken.range.start));
     }
     public getContainingFunctionExpression(currentToken: Token): FunctionExpression {
-        return this.references.functionExpressions.find((fe) => util.rangeContains(fe.range, currentToken.range.start));
+        return this.getContainingFunctionExpressionByPosition(currentToken.range.start);
+    }
+    public getContainingFunctionExpressionByPosition(position: Position): FunctionExpression {
+        return this.references.functionExpressions.find((fe) => util.rangeContains(fe.range, position));
     }
 
     public dispose() {
@@ -3415,7 +3418,7 @@ export function getBscTypeFromExpression(expression: Expression, functionExpress
         } else if (isIndexedGetExpression(expression)) {
             const source = getBscTypeFromExpression(expression.obj, functionExpression);
             if (isArrayType(source)) {
-                return source.defaultType;
+                return source.getDefaultType();
             }
         }
     } catch (e) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -85,7 +85,7 @@ import {
 } from './Expression';
 import type { Diagnostic, Position, Range } from 'vscode-languageserver';
 import { Logger } from '../Logger';
-import { isAALiteralExpression, isAAMemberExpression, isAnnotationExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isClassMethodStatement, isCommentStatement, isDottedGetExpression, isFunctionExpression, isIfStatement, isIndexedGetExpression, isInvalidType, isLiteralExpression, isNewExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isAnnotationExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallfuncExpression, isClassMethodStatement, isCommentStatement, isDottedGetExpression, isFunctionExpression, isIfStatement, isIndexedGetExpression, isInvalidType, isLiteralExpression, isNewExpression, isVariableExpression } from '../astUtils/reflection';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { createStringLiteral, createToken } from '../astUtils/creators';
 import type { BscType } from '../types/BscType';
@@ -1212,8 +1212,12 @@ export class Parser {
         }
 
         let endFor = this.advance();
-        //TODO TYPES infer type from `target`
-        const itemType = new DynamicType();
+        let itemType = new DynamicType();
+
+        const targetType = getBscTypeFromExpression(target, this.currentFunctionExpression);
+        if (isArrayType(targetType)) {
+            itemType = targetType.defaultType;
+        }
 
         this.currentSymbolTable.addSymbol(name.text, name.range, itemType);
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -3412,6 +3412,11 @@ export function getBscTypeFromExpression(expression: Expression, functionExpress
             return getTypeFromVariableExpression(expression, functionExpression);
         } else if (isDottedGetExpression(expression)) {
             return getTypeFromDottedGetExpression(expression, functionExpression);
+        } else if (isIndexedGetExpression(expression)) {
+            const source = getBscTypeFromExpression(expression.obj, functionExpression);
+            if (isArrayType(source)) {
+                return source.defaultType;
+            }
         }
     } catch (e) {
         //do nothing. Just return dynamic

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -3382,7 +3382,10 @@ export function getBscTypeFromExpression(expression: Expression, functionExpress
             return new ObjectType(expression.memberTable);
             //Array literal
         } else if (isArrayLiteralExpression(expression)) {
-            return new ArrayType();
+            const innerTypes = expression.elements.filter((element) => !isCommentStatement(element)).map((element) => {
+                return getBscTypeFromExpression(element, functionExpression);
+            });
+            return new ArrayType(...innerTypes);
             //function call
         } else if (isNewExpression(expression)) {
             return getTypeFromNewExpression(expression, functionExpression); // new CustomType(expression.className.getName(ParseMode.BrighterScript));

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -4,6 +4,7 @@ import { ArrayType } from './ArrayType';
 import { DynamicType } from './DynamicType';
 import { BooleanType } from './BooleanType';
 import { StringType } from './StringType';
+import { CustomType } from './CustomType';
 
 describe('ArrayType', () => {
     it('is equivalent to array types', () => {
@@ -14,6 +15,15 @@ describe('ArrayType', () => {
     it('catches arrays containing different inner types', () => {
         expect(new ArrayType(new BooleanType()).isAssignableTo(new ArrayType(new BooleanType()))).to.be.true;
         expect(new ArrayType(new BooleanType()).isAssignableTo(new ArrayType(new StringType()))).to.be.false;
+    });
+
+    it('sets the innerTypes to unique types', () => {
+        expect(new ArrayType(new BooleanType(), new BooleanType()).toString()).to.eql('Array<boolean>');
+        expect(new ArrayType(new BooleanType(), new StringType(), new BooleanType()).toString()).to.eql('Array<boolean | string>');
+    });
+
+    it('sets the innerTypes to custom types', () => {
+        expect(new ArrayType(new CustomType('MyKlass')).toString()).to.eql('Array<MyKlass>');
     });
 
     it('is not equivalent to other types', () => {

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -18,12 +18,20 @@ describe('ArrayType', () => {
     });
 
     it('sets the innerTypes to unique types', () => {
-        expect(new ArrayType(new BooleanType(), new BooleanType()).toString()).to.eql('Array<boolean>');
-        expect(new ArrayType(new BooleanType(), new StringType(), new BooleanType()).toString()).to.eql('Array<boolean | string>');
+        const boolArray = new ArrayType(new BooleanType(), new BooleanType());
+        expect(boolArray.innerTypes.length).to.eql(1);
+        expect(boolArray.innerTypes[0].equals(new BooleanType())).to.be.true;
+        expect(boolArray.toJsString()).to.eql('Array<boolean>');
+
+        const multiTypeArray = new ArrayType(new BooleanType(), new StringType(), new BooleanType());
+        expect(multiTypeArray.innerTypes.length).to.eql(2);
+        expect(multiTypeArray.innerTypes[0].equals(new BooleanType())).to.be.true;
+        expect(multiTypeArray.innerTypes[1].equals(new StringType())).to.be.true;
+        expect(multiTypeArray.toJsString()).to.eql('Array<boolean | string>');
     });
 
     it('sets the innerTypes to custom types', () => {
-        expect(new ArrayType(new CustomType('MyKlass')).toString()).to.eql('Array<MyKlass>');
+        expect(new ArrayType(new CustomType('MyKlass')).toString()).to.eql('MyKlass[]');
     });
 
     it('is not equivalent to other types', () => {
@@ -36,8 +44,14 @@ describe('ArrayType', () => {
     });
 
     describe('toString', () => {
-        it('prints inner types', () => {
-            expect(new ArrayType(new BooleanType(), new StringType()).toString()).to.eql('Array<boolean | string>');
+        it('returns the default type', () => {
+            expect(new ArrayType(new BooleanType()).toString()).to.eql('boolean[]');
+            expect(new ArrayType(new StringType()).toString()).to.eql('string[]');
+            expect(new ArrayType(new CustomType('MyKlass')).toString()).to.eql('MyKlass[]');
+        });
+
+        it('returns dynamic if more than one type is assigned', () => {
+            expect(new ArrayType(new BooleanType(), new StringType()).toString()).to.eql('dynamic[]');
         });
     });
 });

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -3,7 +3,11 @@ import type { BscType } from './BscType';
 
 export class ArrayType implements BscType {
     constructor(...innerTypes: BscType[]) {
-        this.innerTypes = innerTypes;
+        const innerTypesWithStrings = innerTypes.map((innerType) => {
+            return { innerType: innerType, typeToString: innerType.toString() };
+        });
+        // gets unique types
+        this.innerTypes = [...new Map(innerTypesWithStrings.map(item => [item.typeToString, item])).values()].map(it => it.innerType);
     }
     public innerTypes: BscType[] = [];
 

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,5 @@
 import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
-import type { BscType } from './BscType';
+import type { BscType, TypeContext } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class ArrayType implements BscType {
@@ -12,7 +12,7 @@ export class ArrayType implements BscType {
     }
     public innerTypes: BscType[] = [];
 
-    public isAssignableTo(targetType: BscType) {
+    public isAssignableTo(targetType: BscType, context?: TypeContext) {
         if (isArrayType(targetType)) {
             //this array type is assignable to the target IF
             //1. all of the types in this array are present in the target
@@ -22,7 +22,7 @@ export class ArrayType implements BscType {
                 for (let targetInnerType of targetType.innerTypes) {
                     //TODO TYPES is this loop correct? It ends after 1 iteration but we might need to do more iterations
 
-                    if (innerType.isAssignableTo(targetInnerType)) {
+                    if (innerType.isAssignableTo(targetInnerType, context)) {
                         continue outer;
                     }
 
@@ -38,12 +38,12 @@ export class ArrayType implements BscType {
         return false;
     }
 
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
+    public isConvertibleTo(targetType: BscType, context?: TypeContext) {
+        return this.isAssignableTo(targetType, context);
     }
 
-    public toString() {
-        return `Array<${this.innerTypes.map((x) => x.toString()).join(' | ')}>`;
+    public toString(context?: TypeContext) {
+        return `Array<${this.innerTypes.map((x) => x.toString(context)).join(' | ')}>`;
     }
 
     public toTypeString(): string {
@@ -54,7 +54,7 @@ export class ArrayType implements BscType {
         return this.innerTypes?.length === 1 ? this.innerTypes[0] : new DynamicType();
     }
 
-    public equals(targetType: BscType): boolean {
-        return isArrayType(targetType) && this.isAssignableTo(targetType);
+    public equals(targetType: BscType, context?: TypeContext): boolean {
+        return isArrayType(targetType) && this.isAssignableTo(targetType, context);
     }
 }

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -43,6 +43,12 @@ export class ArrayType implements BscType {
     }
 
     public toString(context?: TypeContext) {
+        // TODO TYPES: When we support union types, the output should be more like:
+        // `Array<${this.innerTypes.map((x) => x.toString(context)).join(' | ')}>`;
+        return `${this.defaultType.toString(context)}[]`;
+    }
+
+    public toJsString(context?: TypeContext) {
         return `Array<${this.innerTypes.map((x) => x.toString(context)).join(' | ')}>`;
     }
 

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,6 @@
 import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
+import { DynamicType } from './DynamicType';
 
 export class ArrayType implements BscType {
     constructor(...innerTypes: BscType[]) {
@@ -47,6 +48,10 @@ export class ArrayType implements BscType {
 
     public toTypeString(): string {
         return 'object';
+    }
+
+    public get defaultType(): BscType {
+        return this.innerTypes?.length === 1 ? this.innerTypes[0] : new DynamicType();
     }
 
     public equals(targetType: BscType): boolean {

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -1,4 +1,4 @@
-import { isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isCustomType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { SymbolTable } from '../SymbolTable';
 import type { BscType, SymbolContainer, TypeContext } from './BscType';
 
@@ -32,6 +32,6 @@ export class CustomType implements BscType, SymbolContainer {
     }
 
     public equals(targetType: BscType, context?: TypeContext): boolean {
-        return this.toString() === targetType?.toString(context);
+        return isCustomType(targetType) && this.toString() === targetType?.toString();
     }
 }

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -15,7 +15,8 @@ export class CustomType implements BscType, SymbolContainer {
         return 'object';
     }
 
-    public isAssignableTo(targetType: BscType, context?: TypeContext, ancestorTypes?: CustomType[]) {
+    public isAssignableTo(targetType: BscType, context?: TypeContext) {
+        const ancestorTypes = context?.scope?.getAncestorTypeListByContext(this, context);
         if (ancestorTypes?.find(ancestorType => targetType.equals(ancestorType, context))) {
             return true;
         }

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -64,19 +64,19 @@ export class FunctionType implements BscType {
         }
     }
 
-    public isConvertibleTo(targetType: BscType, context) {
+    public isConvertibleTo(targetType: BscType, context?: TypeContext) {
         return this.isAssignableTo(targetType, context);
     }
 
-    public toString() {
+    public toString(context?: TypeContext) {
         let paramTexts = [];
         for (let param of this.params) {
-            paramTexts.push(`${param.name}${param.isOptional ? '?' : ''} as ${param.type.toString()}`);
+            paramTexts.push(`${param.name}${param.isOptional ? '?' : ''} as ${param.type.toString(context)}`);
         }
         if (this.isNew) {
             return `new ${this.name ?? ''}(${paramTexts.join(', ')})`;
         }
-        return `${this.isSub ? 'sub' : 'function'} ${this.name ?? ''}(${paramTexts.join(', ')}) as ${this.returnType.toString()}`;
+        return `${this.isSub ? 'sub' : 'function'} ${this.name ?? ''}(${paramTexts.join(', ')}) as ${this.returnType.toString(context)}`;
 
     }
 

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -1,6 +1,6 @@
 import { isFunctionType, isDynamicType } from '../astUtils/reflection';
 import type { CallableParam } from '../interfaces';
-import type { BscType } from './BscType';
+import type { BscType, TypeContext } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class FunctionType implements BscType {
@@ -38,20 +38,20 @@ export class FunctionType implements BscType {
         return this;
     }
 
-    public isAssignableTo(targetType: BscType) {
+    public isAssignableTo(targetType: BscType, context?: TypeContext) {
         if (isFunctionType(targetType)) {
             //compare all parameters
             let len = Math.max(this.params.length, targetType.params.length);
             for (let i = 0; i < len; i++) {
                 let myParam = this.params[i];
                 let targetParam = targetType.params[i];
-                if (!myParam || !targetParam || !myParam.type.isAssignableTo(targetParam.type)) {
+                if (!myParam || !targetParam || !myParam.type.isAssignableTo(targetParam.type, context)) {
                     return false;
                 }
             }
 
             //compare return type
-            if (!this.returnType || !targetType.returnType || !this.returnType.isAssignableTo(targetType.returnType)) {
+            if (!this.returnType || !targetType.returnType || !this.returnType.isAssignableTo(targetType.returnType, context)) {
                 return false;
             }
 
@@ -64,8 +64,8 @@ export class FunctionType implements BscType {
         }
     }
 
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
+    public isConvertibleTo(targetType: BscType, context) {
+        return this.isAssignableTo(targetType, context);
     }
 
     public toString() {
@@ -84,7 +84,7 @@ export class FunctionType implements BscType {
         return 'Function';
     }
 
-    public equals(targetType: BscType): boolean {
-        return (isFunctionType(targetType)) && this.isAssignableTo(targetType);
+    public equals(targetType: BscType, context?: TypeContext): boolean {
+        return (isFunctionType(targetType)) && this.isAssignableTo(targetType, context);
     }
 }

--- a/src/types/LazyType.ts
+++ b/src/types/LazyType.ts
@@ -1,6 +1,4 @@
-import { isCustomType } from '../astUtils/reflection';
 import type { BscType, TypeContext } from './BscType';
-import type { CustomType } from './CustomType';
 
 /**
  * A type whose actual type is not computed until requested.
@@ -19,11 +17,8 @@ export class LazyType implements BscType {
         return this.factory(context);
     }
 
-    public isAssignableTo(targetType: BscType, context?: TypeContext, potentialAncestorTypes?: CustomType[]) {
+    public isAssignableTo(targetType: BscType, context?: TypeContext) {
         const foundType = this.getTypeFromContext(context);
-        if (isCustomType(foundType)) {
-            return foundType.isAssignableTo(targetType, context, potentialAncestorTypes);
-        }
         return foundType?.isAssignableTo(targetType, context);
     }
 

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -108,5 +108,6 @@ export function getTypeFromDottedGetExpression(expr: DottedGetExpression, functi
     const currentToken = isCallExpression(expr) ? ((expr.callee) as any).name : expr.name;
 
     return resolveLazyType(currentToken, functionExpression);
-
 }
+
+

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,4 +1,4 @@
-import { isBrsFile, isCallExpression, isFunctionType, isPrimitiveType } from '../astUtils/reflection';
+import { isArrayType, isBrsFile, isCallExpression, isFunctionType, isPrimitiveType } from '../astUtils/reflection';
 import type { CallExpression, DottedGetExpression, FunctionExpression, NewExpression, VariableExpression } from '../parser/Expression';
 import type { BscType, TypeContext } from './BscType';
 import { LazyType } from './LazyType';
@@ -57,7 +57,7 @@ export function getTypeFromCallExpression(call: CallExpression, functionExpressi
 export function getTypeFromVariableExpression(variable: VariableExpression, functionExpression: FunctionExpression): BscType {
     let variableName = variable.name.text.toLowerCase();
     const currentKnownType = functionExpression.symbolTable.getSymbolType(variableName);
-    if (isPrimitiveType(currentKnownType)) {
+    if (isPrimitiveType(currentKnownType) || isArrayType(currentKnownType)) {
         // for "contextless" types, eg. myVar = 3.14
         return currentKnownType;
     }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -772,12 +772,12 @@ describe('util', () => {
         });
 
         it('sets the default type of an array type', () => {
-            expect(isBooleanType((util.tokenToBscType(createToken(TokenKind.Identifier, 'boolean[]')) as ArrayType).defaultType)).be.true;
-            expect(isStringType((util.tokenToBscType(createToken(TokenKind.Identifier, 'string[]')) as ArrayType).defaultType)).be.true;
+            expect(isBooleanType((util.tokenToBscType(createToken(TokenKind.Identifier, 'boolean[]')) as ArrayType).getDefaultType())).be.true;
+            expect(isStringType((util.tokenToBscType(createToken(TokenKind.Identifier, 'string[]')) as ArrayType).getDefaultType())).be.true;
         });
 
         it('sets the default type of an array type to a customType', () => {
-            expect(isLazyType((util.tokenToBscType(createToken(TokenKind.Identifier, 'MyKlass[]')) as ArrayType).defaultType)).be.true;
+            expect(isLazyType((util.tokenToBscType(createToken(TokenKind.Identifier, 'MyKlass[]')) as ArrayType).getDefaultType())).be.true;
         });
 
         it('does not return array types or custom types if allowBrighterscriptTypes flag is false', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ import type { DottedGetExpression, Expression, NamespacedVariableNameExpression,
 import { Logger, LogLevel } from './Logger';
 import type { Locatable, Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
-import { isDottedGetExpression, isExpression, isInvalidType, isVariableExpression, isVoidType } from './astUtils/reflection';
+import { isDottedGetExpression, isExpression, isVariableExpression } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
 import { SourceNode } from 'source-map';
 import { SGAttribute } from './parser/SGTypes';


### PR DESCRIPTION
Adds fully parsed array type syntax

Allows for valid Brighterscript like:

```
function getSum(numbers as float[])
  sum = 0.0
  for each num in numbers
    sum += num
  end for
  return sum
end function

function getTwoPis() as float[]
   return [3.14, 3.14]
end function

sub main()
  twoPi = getTwoPis()
  myNumbers = [1.2, 4.5, twoPi[0] ]
  print getSum(myNumbers)
end sub

```


