### PR TITLE
Fix bug with optional parameters

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1584,7 +1584,7 @@ describe('BrsFile', () => {
                 (await program.getHover(file.pathAbsolute, Position.create(2, 30))).contents
             ).to.equal([
                 '```brightscript',
-                'function UCase(s? as string) as string',
+                'function UCase(s as string) as string',
                 '```'
             ].join('\n'));
         });
@@ -1601,7 +1601,7 @@ describe('BrsFile', () => {
             ).to.equal([
                 '```brightscript',
                 //TODO this really shouldn't be returning the global function, but it does...so make sure it doesn't crash right now.
-                'function Instr(start? as integer, text? as string, substring? as string) as integer',
+                'function Instr(start as integer, text as string, substring as string) as integer',
                 '```'
             ].join('\n'));
         });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -510,9 +510,9 @@ export class BrsFile {
 
                 functionType.setName(assignment.name.text);
                 for (let param of assignment.value.parameters) {
-                    let isRequired = !param.defaultValue;
+                    let isOptional = !!param.defaultValue;
                     //TODO compute optional parameters
-                    functionType.addParameter(param.name.text, param.type, isRequired);
+                    functionType.addParameter(param.name.text, param.type, isOptional);
                 }
                 return functionType;
 
@@ -573,8 +573,8 @@ export class BrsFile {
                     isRestArgument: false
                 };
                 params.push(callableParam);
-                let isRequired = !param.defaultValue;
-                functionType.addParameter(callableParam.name, callableParam.type, isRequired);
+                let isOptional = !!param.defaultValue;
+                functionType.addParameter(callableParam.name, callableParam.type, isOptional);
             }
 
             this.callables.push({

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -1,7 +1,8 @@
-import { standardizePath as s } from './util';
+import util, { standardizePath as s } from './util';
 import { Program } from './Program';
 import { expectDiagnostics, expectZeroDiagnostics } from './testHelpers.spec';
 import { DiagnosticMessages } from './DiagnosticMessages';
+import { expect } from 'chai';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let rootDir = s`${tmpPath}/rootDir`;
@@ -41,6 +42,33 @@ describe('globalCallables', () => {
         expectDiagnostics(program, [
             DiagnosticMessages.mismatchArgumentCount('1-6', 0)
         ]);
+    });
+
+    it('handles optional params properly', () => {
+        program.addOrReplaceFile('source/main.brs', `
+            sub main()
+                print Mid("value1", 1) 'third param is optional
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
+    it('hover shows correct for optional params', async () => {
+        const file = program.addOrReplaceFile('source/main.brs', `
+            sub main()
+                print Mid("value1", 1)
+            end sub
+        `);
+        program.validate();
+        const hover = await program.getHover(file.pathAbsolute, util.createPosition(2, 25));
+        expect(
+            hover.contents.toString().replace('\r\n', '\n')
+        ).to.eql([
+            '```brightscript',
+            'function Mid(s as string, p as integer, n? as integer) as string',
+            '```'
+        ].join('\n'));
     });
 
     describe('bslCore', () => {

--- a/src/types/FunctionType.spec.ts
+++ b/src/types/FunctionType.spec.ts
@@ -16,15 +16,15 @@ describe('FunctionType', () => {
 
         //different parameter count
         expect(
-            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), true).isAssignableTo(
+            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isAssignableTo(
                 new FunctionType(new VoidType())
             )
         ).to.be.false;
 
         //different parameter types
         expect(
-            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), true).isAssignableTo(
-                new FunctionType(new VoidType()).addParameter('a', new StringType(), true)
+            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isAssignableTo(
+                new FunctionType(new VoidType()).addParameter('a', new StringType(), false)
             )
         ).to.be.false;
 

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -18,18 +18,18 @@ export class FunctionType implements BscType {
      */
     public isSub = false;
 
-    public params = [] as Array<{ name: string; type: BscType; isRequired: boolean }>;
+    public params = [] as Array<{ name: string; type: BscType; isOptional: boolean }>;
 
     public setName(name: string) {
         this.name = name;
         return this;
     }
 
-    public addParameter(name: string, type: BscType, isRequired: boolean) {
+    public addParameter(name: string, type: BscType, isOptional: boolean) {
         this.params.push({
             name: name,
             type: type,
-            isRequired: isRequired === false ? false : true
+            isOptional: isOptional === true ? true : false
         });
         return this;
     }
@@ -67,7 +67,7 @@ export class FunctionType implements BscType {
     public toString() {
         let paramTexts = [];
         for (let param of this.params) {
-            paramTexts.push(`${param.name}${param.isRequired ? '' : '?'} as ${param.type.toString()}`);
+            paramTexts.push(`${param.name}${param.isOptional ? '?' : ''} as ${param.type.toString()}`);
         }
         return `${this.isSub ? 'sub' : 'function'} ${this.name}(${paramTexts.join(', ')}) as ${this.returnType.toString()}`;
 


### PR DESCRIPTION
Fixes a bug introduced in #479 that switched optional and required within the hover logic, when hovering over functions.

One small technically breaking change is renaming the `FunctionType` parameters from `isRequired` to `isOptional`. This aligns with the `isOptional` property change introduced in #479. I'm not sure if plugins utilize this feature or not, so they may need to be updated (we're still in v0 which is unstable, after all :D) 

Bad:
![image](https://user-images.githubusercontent.com/2544493/152203171-1cc5bd52-f7ae-4735-b730-61797a825568.png)

Fixed:
![image](https://user-images.githubusercontent.com/2544493/152203355-98af1dcc-d066-49b6-ab06-84b915574a01.png)
