### PR TITLE
Fire plugin events for getTranspiledFile. Add new event properties

### DIFF
--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -34,28 +34,31 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
     /**
      * Add a plugin to the beginning of the list of plugins
      */
-    public addFirst(plugin: CompilerPlugin) {
+    public addFirst<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
         if (!this.has(plugin)) {
             this.plugins.unshift(plugin);
         }
+        return plugin;
     }
 
     /**
      * Add a plugin to the end of the list of plugins
      */
-    public add(plugin: CompilerPlugin) {
+    public add<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
         if (!this.has(plugin)) {
             this.plugins.push(plugin);
         }
+        return plugin;
     }
 
     public has(plugin: CompilerPlugin) {
         return this.plugins.includes(plugin);
     }
 
-    public remove(plugin: CompilerPlugin) {
+    public remove<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
         if (this.has(plugin)) {
             this.plugins.splice(this.plugins.indexOf(plugin));
         }
+        return plugin;
     }
 }

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1633,6 +1633,64 @@ describe('Program', () => {
         expect(fsExtra.pathExistsSync(s`${stagingFolderPath}/source/bslib.brs`)).is.true;
     });
 
+    describe('getTranspiledFileContents', () => {
+        it('fires plugin events', () => {
+            const file = program.addOrReplaceFile('source/main.brs', trim`
+                sub main()
+                    print "hello world"
+                end sub
+            `);
+            const plugin = program.plugins.add({
+                name: 'TestPlugin',
+                beforeFileTranspile: (event) => {
+                    const stmt = ((event.file as BrsFile).ast.statements[0] as FunctionStatement).func.body.statements[0] as PrintStatement;
+                    event.editor.setProperty((stmt.expressions[0] as LiteralExpression).token, 'text', '"hello there"');
+                },
+                afterFileTranspile: sinon.spy()
+            });
+            expect(
+                program.getTranspiledFileContents(file.pathAbsolute).code
+            ).to.eql(trim`
+                sub main()
+                    print "hello there"
+                end sub`
+            );
+            expect(plugin.afterFileTranspile.callCount).to.be.greaterThan(0);
+        });
+
+        it('allows events to modify the file contents', async () => {
+            program.options.emitDefinitions = true;
+            program.plugins.add({
+                name: 'TestPlugin',
+                afterFileTranspile: (event) => {
+                    event.code = `'code comment\n${event.code}`;
+                    event.typedef = `'typedef comment\n${event.typedef}`;
+                }
+            });
+            program.addOrReplaceFile('source/lib.bs', `
+                sub log(message)
+                    print message
+                end sub
+            `);
+            await program.transpile([], stagingFolderPath);
+            expect(
+                fsExtra.readFileSync(`${stagingFolderPath}/source/lib.brs`).toString()
+            ).to.eql(trim`
+                'code comment
+                sub log(message)
+                    print message
+                end sub`
+            );
+            expect(
+                fsExtra.readFileSync(`${stagingFolderPath}/source/lib.d.bs`).toString()
+            ).to.eql(trim`
+                'typedef comment
+                sub log(message)
+                end sub
+            `);
+        });
+    });
+
     describe('transpile', () => {
 
         it('sets needsTranspiled=true when there is at least one edit', async () => {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -26,7 +26,7 @@ import { ParseMode } from './parser/Parser';
 import { TokenKind } from './lexer/TokenKind';
 import { BscPlugin } from './bscPlugin/BscPlugin';
 import { AstEditor } from './astUtils/AstEditor';
-import { SourceMapGenerator } from 'source-map';
+import type { SourceMapGenerator } from 'source-map';
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
@@ -1389,7 +1389,7 @@ export class Program {
     }
 }
 
-interface FileTranspileResult {
+export interface FileTranspileResult {
     pathAbsolute: string;
     pkgPath: string;
     code: string;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -8,7 +8,7 @@ import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken } from './interfaces';
+import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent } from './interfaces';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
@@ -26,6 +26,7 @@ import { ParseMode } from './parser/Parser';
 import { TokenKind } from './lexer/TokenKind';
 import { BscPlugin } from './bscPlugin/BscPlugin';
 import { AstEditor } from './astUtils/AstEditor';
+import { SourceMapGenerator } from 'source-map';
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
@@ -1194,12 +1195,59 @@ export class Program {
      * This does not write anything to the file system.
      */
     public getTranspiledFileContents(pathAbsolute: string) {
-        let file = this.getFile(pathAbsolute);
-        let result = file.transpile();
+        return this._getTranspiledFileContents(
+            this.getFile(pathAbsolute)
+        );
+    }
+
+
+    /**
+     * Internal function used to transpile files.
+     * This does not write anything to the file system
+     */
+    private _getTranspiledFileContents(file: BscFile, outputPath?: string): FileTranspileResult {
+        const editor = new AstEditor();
+
+        this.plugins.emit('beforeFileTranspile', {
+            file: file,
+            outputPath: outputPath,
+            editor: editor
+        });
+
+        //if we have any edits, assume the file needs to be transpiled
+        if (editor.hasChanges) {
+            //use the `editor` because it'll track the previous value for us and revert later on
+            editor.setProperty(file, 'needsTranspiled', true);
+        }
+
+        //transpile the file
+        const result = file.transpile();
+
+        //generate the typedef if enabled
+        let typedef: string;
+        if (isBrsFile(file) && this.options.emitDefinitions) {
+            typedef = file.getTypedef();
+        }
+
+        const event: AfterFileTranspileEvent = {
+            file: file,
+            outputPath: outputPath,
+            editor: editor,
+            code: result.code,
+            map: result.map,
+            typedef: typedef
+        };
+        this.plugins.emit('afterFileTranspile', event);
+
+        //undo all `editor` edits that may have been applied to this file.
+        editor.undoAll();
+
         return {
-            ...result,
             pathAbsolute: file.pathAbsolute,
-            pkgPath: file.pkgPath
+            pkgPath: file.pkgPath,
+            code: event.code,
+            map: event.map,
+            typedef: event.typedef
         };
     }
 
@@ -1226,8 +1274,7 @@ export class Program {
             outputPath = s`${stagingFolderPath}/${outputPath}`;
             return {
                 file: file,
-                outputPath: outputPath,
-                editor: new AstEditor()
+                outputPath: outputPath
             };
         });
 
@@ -1239,14 +1286,9 @@ export class Program {
                 return;
             }
 
-            this.plugins.emit('beforeFileTranspile', entry);
             const { file, outputPath } = entry;
-            //if we have any edits, assume the file needs to be transpiled
-            if (entry.editor.hasChanges) {
-                //use the `editor` because it'll track the previous value for us and revert later on
-                entry.editor.setProperty(file, 'needsTranspiled', true);
-            }
-            const result = file.transpile();
+
+            const fileTranspileResult = this._getTranspiledFileContents(file, outputPath);
 
             //make sure the full dir path exists
             await fsExtra.ensureDir(path.dirname(outputPath));
@@ -1254,22 +1296,16 @@ export class Program {
             if (await fsExtra.pathExists(outputPath)) {
                 throw new Error(`Error while transpiling "${file.pathAbsolute}". A file already exists at "${outputPath}" and will not be overwritten.`);
             }
-            const writeMapPromise = result.map ? fsExtra.writeFile(`${outputPath}.map`, result.map.toString()) : null;
+            const writeMapPromise = fileTranspileResult.map ? fsExtra.writeFile(`${outputPath}.map`, fileTranspileResult.map.toString()) : null;
             await Promise.all([
-                fsExtra.writeFile(outputPath, result.code),
+                fsExtra.writeFile(outputPath, fileTranspileResult.code),
                 writeMapPromise
             ]);
 
-            if (isBrsFile(file) && this.options.emitDefinitions) {
-                const typedef = file.getTypedef();
+            if (fileTranspileResult.typedef) {
                 const typedefPath = outputPath.replace(/\.brs$/i, '.d.bs');
-                await fsExtra.writeFile(typedefPath, typedef);
+                await fsExtra.writeFile(typedefPath, fileTranspileResult.typedef);
             }
-
-            this.plugins.emit('afterFileTranspile', entry);
-
-            //undo all `editor` edits that may have been applied to this file.
-            entry.editor.undoAll();
         });
 
         //if there's no bslib file already loaded into the program, copy it to the staging directory
@@ -1351,4 +1387,12 @@ export class Program {
         this.globalScope.dispose();
         this.dependencyGraph.dispose();
     }
+}
+
+interface FileTranspileResult {
+    pathAbsolute: string;
+    pkgPath: string;
+    code: string;
+    map: SourceMapGenerator;
+    typedef: string;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,7 @@ import type { ProgramBuilder } from './ProgramBuilder';
 import type { FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/Expression';
 import type { TranspileState } from './parser/TranspileState';
-import type { SourceNode } from 'source-map';
+import type { CodeWithSourceMap, SourceMapGenerator, SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 
@@ -269,6 +269,18 @@ export interface BeforeFileTranspileEvent {
 export interface AfterFileTranspileEvent {
     file: BscFile;
     outputPath: string;
+    /**
+     * The resulting transpiled file contents
+     */
+    code: string;
+    /**
+     * The sourceMaps for the generated code (if emitting source maps is enabled)
+     */
+    map?: SourceMapGenerator;
+    /**
+     * The generated type definition file contents (if emitting type definitions are enabled)
+     */
+    typedef?: string;
     /**
      * An editor that can be used to transform properties or arrays. Once the `afterFileTranspile` event has fired, these changes will be reverted,
      * restoring the objects to their prior state. This is useful for changing code right before a file gets transpiled, but when you don't want

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,7 @@ import type { ProgramBuilder } from './ProgramBuilder';
 import type { FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/Expression';
 import type { TranspileState } from './parser/TranspileState';
-import type { CodeWithSourceMap, SourceMapGenerator, SourceNode } from 'source-map';
+import type { SourceMapGenerator, SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 


### PR DESCRIPTION
 - The "preview transpiled code" feature in vscode utilizes the `getTranspiledFileContents` function. However, plugin-related changes were not showing. This resolves that issue.
 - adds `code`, `map`, `typedef` properties to the `afterFileTranspile` event to allow plugins to manually tweak the output code (at their own risk). 
 - mostly unrelated: return a reference to the plugin in the `add`, `addFirst`, and `remove` methods of the `PluginInterface` class.