### PR TITLE
Support generics for Cache class

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,23 +1,26 @@
 /**
- * Synchronous cache
+ * A cache that will call the factory to create the item if it doesn't exist
  */
-export class Cache {
-    private cache = {} as Record<string, any>;
+export class Cache<TKey = any, TValue = any> {
+    private cache = new Map<TKey, TValue>();
 
     /**
      * Get value from the cache if it exists,
      * otherwise call the factory function to create the value, add it to the cache, and return it.
      */
-    public getOrAdd<T>(key: string, factory: (key: string) => T) {
-        if (this.cache[key] === undefined) {
-            this.cache[key] = factory(key);
+    public getOrAdd<K extends TKey, T extends TValue>(key: K, factory: (key: K) => T): T {
+        if (!this.cache.has(key)) {
+            const value = factory(key);
+            this.cache.set(key, value);
+            return value;
+        } else {
+            return this.cache.get(key) as T;
         }
-        return this.cache[key] as T;
     }
     /**
      * Clear the cache
      */
     public clear() {
-        this.cache = {};
+        this.cache.clear();
     }
 }


### PR DESCRIPTION
Adds generics support to the cache class to help typescript types flow better in our code.
Changes internal storage mechanism to a `Map` which is safer than an object because it prevents key collision with prototypes.