### PR TITLE
Move file validation into  program.validate()

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -2406,6 +2406,7 @@ describe('Program', () => {
             };
             program.plugins.add(plugin);
             program.addOrReplaceFile('source/main.brs', '');
+            program.validate();
             expect(plugin.beforeFileValidate.callCount).to.equal(1);
             expect(plugin.onFileValidate.callCount).to.equal(1);
             expect(plugin.afterFileValidate.callCount).to.equal(1);
@@ -2420,6 +2421,7 @@ describe('Program', () => {
             };
             program.plugins.add(plugin);
             program.addOrReplaceFile('components/main.xml', '');
+            program.validate();
             expect(plugin.beforeFileValidate.callCount).to.equal(1);
             expect(plugin.onFileValidate.callCount).to.equal(1);
             expect(plugin.afterFileValidate.callCount).to.equal(1);

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -23,6 +23,7 @@ describe('CodeActionsProcessor', () => {
                 <component name="comp1">
                 </component>
             `);
+            program.validate();
             expectCodeActions(() => {
                 program.getCodeActions(
                     file.pathAbsolute,
@@ -69,12 +70,12 @@ describe('CodeActionsProcessor', () => {
                 <component name="comp1" attr2="attr3" attr3="attr3">
                 </component>
             `);
+            program.validate();
             const codeActions = program.getCodeActions(
                 file.pathAbsolute,
                 //<comp|onent name="comp1">
                 util.createRange(1, 5, 1, 5)
             );
-
             expect(
                 codeActions[0].edit.changes[URI.file(s`${rootDir}/components/comp1.xml`).toString()][0].range
             ).to.eql(

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -996,41 +996,45 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            let file = program.addOrReplaceFile('source/main.bs', `
+            program.addOrReplaceFile('source/file.brs', ``);
+            program.addOrReplaceFile('source/main.bs', `
                 sub main()
                 end sub
                 import "file.brs"
             `);
-            expectDiagnostics(file, [
+            program.validate();
+            expectDiagnostics(program, [
                 DiagnosticMessages.importStatementMustBeDeclaredAtTopOfFile()
             ]);
         });
 
         it('supports library imports', () => {
-            file.parse(`
+            program.addOrReplaceFile('source/main.brs', `
                 Library "v30/bslCore.brs"
             `);
-            expectZeroDiagnostics(file);
+            expectZeroDiagnostics(program);
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                 end sub
                 Library "v30/bslCore.brs"
             `);
-            expectDiagnostics(file, [
+            program.validate();
+            expectDiagnostics(program, [
                 DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile()
             ]);
         });
 
         it('adds error for library statements inside of function body', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            program.addOrReplaceFile('source/main.brs', `
                 sub main()
                     Library "v30/bslCore.brs"
                 end sub
             `);
-            expectDiagnostics(file, [
+            program.validate();
+            expectDiagnostics(program, [
                 DiagnosticMessages.libraryStatementMustBeDeclaredAtTopOfFile()
             ]);
         });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -72,6 +72,13 @@ export class BrsFile {
      * The key used to identify this file in the dependency graph
      */
     public dependencyGraphKey: string;
+
+    /**
+     * Indicates whether this file needs to be validated.
+     * Files are only ever validated a single time
+     */
+    public isValidated = false;
+
     /**
      * The all-lowercase extension for this file (including the leading dot)
      */
@@ -223,6 +230,8 @@ export class BrsFile {
 
             //if we have a typedef file, skip parsing this file
             if (this.hasTypedef) {
+                //skip validation since the typedef is shadowing this file
+                this.isValidated = true;
                 return;
             }
 

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -192,7 +192,8 @@ describe('XmlFile', () => {
         });
 
         it('Adds error when no component is declared in xml', () => {
-            file = program.addOrReplaceFile('components/comp.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
+            program.addOrReplaceFile('components/comp.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
+            program.validate();
             expectDiagnostics(program, [
                 {
                     ...DiagnosticMessages.xmlUnexpectedTag('script'),
@@ -572,7 +573,7 @@ describe('XmlFile', () => {
         });
 
         it('adds warning when no "extends" attribute is found', () => {
-            file = program.addOrReplaceFile<XmlFile>(
+            program.addOrReplaceFile<XmlFile>(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -583,8 +584,8 @@ describe('XmlFile', () => {
                     </component>
                 `
             );
-
-            expectDiagnostics(file, [
+            program.validate();
+            expectDiagnostics(program, [
                 DiagnosticMessages.xmlComponentMissingExtendsAttribute()
             ]);
         });

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -47,6 +47,12 @@ export class XmlFile {
     private unsubscribeFromDependencyGraph: () => void;
 
     /**
+     * Indicates whether this file needs to be validated.
+     * Files are only ever validated a single time
+     */
+    public isValidated = false;
+
+    /**
      * The extension for this file
      */
     public extension: string;


### PR DESCRIPTION
moves the file validation logic out of `addReplaceFile` and into `program.validate()`. This accomplishes several things:
 - aligns with the flow in v1 which makes more logical sense
 - improve performance slightly when typing in an editor because file validations get deferred until the validate phase
 - prevent file validation events on files shadowed by typedef files, which was a bug introduced in #494

This is technically a breaking change to the event flow. 

Event flow prior to this change:
 - `afterFileParse`
 - `beforeFileValidate`
 - `onFileValidate`
 - `afterFileValidate`
 - `beforeProgramValidate`

Event flow after this change:
- `afterFileParse`
- `beforeProgramValidate`
- `beforeFileValidate`
- `onFileValidate`
- `afterFileValidate`


