### PR TITLE
Adds TypeExpressions

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -990,6 +990,20 @@ describe('Scope', () => {
                 ]);
             });
 
+            it('detects an unknown array type function parameter', () => {
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                    sub a(num as integer)
+                    end sub
+
+                    sub b(unknownParam as someType[]) 'error
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'someType[]').message
+                ]);
+            });
+
             it('detects an unknown field parameter type', () => {
                 program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     class myClass

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, Statement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement } from '../parser/Statement';
-import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, RegexLiteralExpression } from '../parser/Expression';
+import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, RegexLiteralExpression, TypeExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, TypedefProvider } from '../interfaces';
@@ -234,6 +234,9 @@ export function isAnnotationExpression(element: Statement | Expression | undefin
 }
 export function isRegexLiteralExpression(element: Statement | Expression | undefined): element is RegexLiteralExpression {
     return element?.constructor.name === 'RegexLiteralExpression';
+}
+export function isTypeExpression(element: Statement | Expression | undefined): element is TypeExpression {
+    return element?.constructor.name === 'TypeExpression';
 }
 export function isTypedefProvider(element: any): element is TypedefProvider {
     return 'getTypedef' in element;

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -848,7 +848,9 @@ describe('astUtils visitors', () => {
             `, [
                 'ClassStatement',
                 'ClassFieldStatement',
+                'TypeExpression',
                 'ClassFieldStatement',
+                'TypeExpression',
                 'LiteralExpression',
                 'ClassMethodStatement',
                 'FunctionExpression',

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -27,9 +27,9 @@ export class BrsFileSemanticTokensProcessor {
             for (const parm of func.parameters) {
                 if (isCustomType(parm.type)) {
                     classes.push({
-                        className: parm.typeToken.text,
+                        className: parm.type.getText(),
                         namespaceName: parm.namespaceName?.getName(ParseMode.BrighterScript),
-                        range: parm.typeToken.range
+                        range: parm.type.range
                     });
                 }
             }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1498,12 +1498,9 @@ export class TypeExpression extends Expression {
         public namespaceName?: NamespacedVariableNameExpression
     ) {
         super();
+        this.range = util.createBoundingRange(this.tokens.type);
     }
-
-    public get range() {
-        const lastToken = this.tokens.type;
-        return util.createRangeFromPositions(this.tokens.type?.range.start, lastToken?.range.end);
-    }
+    public readonly range: Range;
 
     private _type: BscType;
     /**
@@ -1567,8 +1564,9 @@ export class ArrayTypeExpression extends TypeExpression {
         public namespaceName?: NamespacedVariableNameExpression
     ) {
         super({}, namespaceName);
-
+        this.range = util.createBoundingRange(this.bracketTokens.leftBracket, this.bracketTokens.rightBracket, ...this.innerTypes);
     }
+    public readonly range: Range;
 
     /*
      * TODO - Support union types
@@ -1576,11 +1574,6 @@ export class ArrayTypeExpression extends TypeExpression {
     private get defaultTypeExpression() {
         return this.innerTypes[0];
     }
-
-    public get range() {
-        return util.createRangeFromPositions(this.defaultTypeExpression.range.start, this.bracketTokens.rightBracket?.range.end);
-    }
-
     /**
      * Derive a BscType from the type token
      * Returns an array type with the inner types based on the inner type expressions

--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -199,7 +199,7 @@ describe('parser class', () => {
             expect(field.accessModifier.kind).to.equal(TokenKind.Public);
             expect(field.name.text).to.equal('firstName');
             expect(field.as.text).to.equal('as');
-            expect(field.type.text).to.equal('string');
+            expect(field.type.getText()).to.equal('string');
         });
 
         it('can be solely an identifier', () => {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -8,8 +8,7 @@ import { createSandbox } from 'sinon';
 import type { CallableParam } from './interfaces';
 import { IntegerType } from './types/IntegerType';
 import { createToken, TokenKind } from '.';
-import { isBooleanType, isIntegerType, isFloatType, isObjectType, isFunctionType, isStringType, isLazyType, isArrayType, isDynamicType } from './astUtils/reflection';
-import type { ArrayType } from './types/ArrayType';
+import { isBooleanType, isIntegerType, isFloatType, isObjectType, isFunctionType, isStringType, isLazyType, isDynamicType } from './astUtils/reflection';
 
 
 const sinon = createSandbox();
@@ -743,7 +742,7 @@ describe('util', () => {
             expect(isDynamicType(util.tokenToBscType(createToken(TokenKind.Identifier, 'dynamic')))).be.true;
         });
 
-        it('ignores case and whitespace of identifiers', () => {
+        it('ignores case and surrounding whitespace of identifiers', () => {
             expect(isBooleanType(util.tokenToBscType(createToken(TokenKind.Identifier, 'boolean')))).be.true;
             expect(isBooleanType(util.tokenToBscType(createToken(TokenKind.Identifier, 'BOOLEAN')))).be.true;
             expect(isBooleanType(util.tokenToBscType(createToken(TokenKind.Identifier, 'Boolean')))).be.true;
@@ -752,32 +751,6 @@ describe('util', () => {
 
         it('includes custom types, returned as lazy', () => {
             expect(isLazyType(util.tokenToBscType(createToken(TokenKind.Identifier, 'SomeKlass'), true))).be.true;
-        });
-
-        it('gets array types from identifiers', () => {
-            expect(isArrayType(util.tokenToBscType(createToken(TokenKind.Identifier, 'boolean[]')))).be.true;
-            expect(isArrayType(util.tokenToBscType(createToken(TokenKind.Identifier, 'integer[]')))).be.true;
-            expect(isArrayType(util.tokenToBscType(createToken(TokenKind.Identifier, 'string[]')))).be.true;
-        });
-
-        it('gets array types from identifiers with custom types', () => {
-            expect(isArrayType(util.tokenToBscType(createToken(TokenKind.Identifier, 'SomeKlass[]')))).be.true;
-            expect(isArrayType(util.tokenToBscType(createToken(TokenKind.Identifier, 'MyNamespace.Klass[]')))).be.true;
-        });
-
-        it('sets the default type of an array type', () => {
-            expect(isBooleanType((util.tokenToBscType(createToken(TokenKind.Identifier, 'boolean[]')) as ArrayType).getDefaultType())).be.true;
-            expect(isStringType((util.tokenToBscType(createToken(TokenKind.Identifier, 'string[]')) as ArrayType).getDefaultType())).be.true;
-        });
-
-        it('sets the default type of an array type to a customType', () => {
-            expect(isLazyType((util.tokenToBscType(createToken(TokenKind.Identifier, 'MyKlass[]')) as ArrayType).getDefaultType())).be.true;
-        });
-
-        it('does not return array types or custom types if allowBrighterscriptTypes flag is false', () => {
-            expect(util.tokenToBscType(createToken(TokenKind.Identifier, 'string[]'), false)).be.undefined;
-            expect(util.tokenToBscType(createToken(TokenKind.Identifier, 'SomeKlass'), false)).be.undefined;
-            expect(util.tokenToBscType(createToken(TokenKind.Identifier, 'SomeKlass[]'), false)).be.undefined;
         });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,7 +32,6 @@ import { SourceNode } from 'source-map';
 import { SGAttribute } from './parser/SGTypes';
 import { LazyType } from './types/LazyType';
 import type { BscType } from './types/BscType';
-import { ArrayType } from './types/ArrayType';
 import { UniversalFunctionType } from './types/UniversalFunctionType';
 
 export class Util {
@@ -986,12 +985,7 @@ export class Util {
             case TokenKind.Void:
                 return new VoidType();
             case TokenKind.Identifier:
-                let tokenText = token.text.replace(/\s/g, '').toLowerCase();
-                // regular expression to find a type with optional pair of square brackets afterwards
-                const regex = /([\w._]+)(\[\]){0,1}/;
-                const found = regex.exec(tokenText);
-                const typeText = found[1] ?? tokenText;
-                const isArray = !!found[2];
+                let typeText = token.text.trim().toLowerCase();
                 let typeClass: BscType;
                 switch (typeText) {
                     case 'boolean':
@@ -1034,19 +1028,11 @@ export class Util {
                     });
 
                 }
-                // TODO: Can Arrays be of inner type invalid or void?
 
-                // If this token denotes an array (e.g. ends in `[]`) then may it an array with correct inner type
-                if (allowBrighterscriptTypes && isArray) {
-                    typeClass = new ArrayType(typeClass);
-                } else if (!allowBrighterscriptTypes && isArray) {
-                    // we shouldn't allow array types to be defined when not in Brighterscript mode
-                    // so a type like `string[]` wouldn't be defined
-                    return undefined;
-                }
                 return typeClass;
         }
     }
+
 
     /**
      * Get the extension for the given file path. Basically the part after the final dot, except for

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -212,8 +212,8 @@ export class BsClassValidator {
                             if (!childFieldType.isAssignableTo(ancestorMemberType, this.typeContext)) {
                                 //flag incompatible child field type to ancestor field type
 
-                                const childFieldTypeName = childFieldType?.toString(this.typeContext) ?? member.type?.text;
-                                const ancestorFieldTypeName = ancestorMemberType?.toString(this.typeContext) ?? (ancestorAndMember.member as ClassFieldStatement).type.text;
+                                const childFieldTypeName = childFieldType?.toString(this.typeContext) ?? member.type?.getText();
+                                const ancestorFieldTypeName = ancestorMemberType?.toString(this.typeContext) ?? (ancestorAndMember.member as ClassFieldStatement).type.getText();
                                 this.diagnostics.push({
                                     ...DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty(
                                         classStatement.getName(ParseMode.BrighterScript),
@@ -286,7 +286,7 @@ export class BsClassValidator {
             for (let statement of classStatement.body) {
                 if (isClassFieldStatement(statement)) {
                     let fieldType = getTypeFromContext(statement.getType(), this.typeContext);
-                    const fieldTypeName = fieldType?.toString(this.typeContext) ?? statement.type?.text;
+                    const fieldTypeName = fieldType?.toString(this.typeContext) ?? statement.type?.getText();
                     const lowerFieldTypeName = fieldTypeName?.toLowerCase();
 
                     let addDiagnostic = false;


### PR DESCRIPTION
Since Types are getting more complicated now, `TypeToken`s in `Expressions` and `Statements` have been refactored to being `TypeExpressions`

Also adds support for multidimensional arrays:

```
sub doLoop(data as float[][])
  for each row in data
    for each item in row
      print item ' Brighterscript knows item is a float
    end for
  end for
end sub
```
