### PR TITLE
Add `setFile` method, deprecate `addOrReplaceFile`

### DIFF
--- a/benchmarks/targets/parse-brs.js
+++ b/benchmarks/targets/parse-brs.js
@@ -21,7 +21,7 @@ module.exports = async (suite, name, brighterscript, projectPath, options) => {
         const promises = [];
         for (const file of files) {
             promises.push(
-                builder.program.addOrReplaceFile(file.pkgPath, file.fileContents)
+                (builder.program.addOrReplaceFile ?? builder.program.setFile)(file.pkgPath, file.fileContents)
             );
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -184,7 +184,7 @@ class DocCompiler {
             //use the current bsconfig
             ...(this.bsconfig ?? {})
         });
-        const file = program.addOrReplaceFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code);
+        const file = program.setFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code);
         program.validate();
         let tranpileResult = file.transpile();
         return tranpileResult.code;

--- a/src/FunctionScope.spec.ts
+++ b/src/FunctionScope.spec.ts
@@ -23,7 +23,7 @@ describe('FunctionScope', () => {
         });
 
         it('returns variables defined above the specified line number', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                     var1 = 1
                     var2 = 2

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -114,12 +114,12 @@ describe('LanguageServer', () => {
             ${additionalXmlContents}
             <script type="text/brightscript" uri="${name}.brs" />
         </component>`;
-        program.addOrReplaceFile(filePath, contents);
+        program.setFile(filePath, contents);
     }
 
     function addScriptFile(name: string, contents: string, extension = 'brs') {
         const filePath = s`components/${name}.${extension}`;
-        const file = program.addOrReplaceFile(filePath, contents);
+        const file = program.setFile(filePath, contents);
         if (file) {
             const document = TextDocument.create(util.pathToUri(file.pathAbsolute), 'brightscript', 1, contents);
             svr.documents._documents[document.uri] = document;
@@ -271,7 +271,7 @@ describe('LanguageServer', () => {
 
     describe('handleFileChanges', () => {
         it('only adds files that match the files array', async () => {
-            let addOrReplaceFileStub = sinon.stub().returns(Promise.resolve());
+            let setFileStub = sinon.stub().returns(Promise.resolve());
             const workspace = {
                 builder: {
                     options: {
@@ -282,7 +282,7 @@ describe('LanguageServer', () => {
                     getFileContents: sinon.stub().callsFake(() => Promise.resolve('')) as any,
                     rootDir: rootDir,
                     program: {
-                        addOrReplaceFile: <any>addOrReplaceFileStub
+                        setFile: <any>setFileStub
                     }
                 }
             } as Workspace;
@@ -295,20 +295,20 @@ describe('LanguageServer', () => {
                 pathAbsolute: mainPath
             }]);
 
-            expect(addOrReplaceFileStub.getCalls()[0]?.args[0]).to.eql({
+            expect(setFileStub.getCalls()[0]?.args[0]).to.eql({
                 src: mainPath,
                 dest: s`source/main.brs`
             });
 
             let libPath = s`${rootDir}/components/lib.brs`;
 
-            expect(addOrReplaceFileStub.callCount).to.equal(1);
+            expect(setFileStub.callCount).to.equal(1);
             await server.handleFileChanges(workspace, [{
                 type: FileChangeType.Created,
                 pathAbsolute: libPath
             }]);
             //the function should have ignored the lib file, so no additional files were added
-            expect(addOrReplaceFileStub.callCount).to.equal(1);
+            expect(setFileStub.callCount).to.equal(1);
         });
     });
 

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -846,7 +846,7 @@ export class LanguageServer {
 
             //if we got a dest path, then the program wants this file
             if (destPath) {
-                program.addOrReplaceFile(
+                program.setFile(
                     {
                         src: change.pathAbsolute,
                         dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
@@ -864,7 +864,7 @@ export class LanguageServer {
             //sometimes "changed" events are emitted on files that were actually deleted,
             //so determine file existance and act accordingly
             if (await util.pathExists(change.pathAbsolute)) {
-                program.addOrReplaceFile(
+                program.setFile(
                     {
                         src: change.pathAbsolute,
                         dest: rokuDeploy.getDestPath(change.pathAbsolute, options.files, rootDir)
@@ -930,7 +930,7 @@ export class LanguageServer {
                     if (workspace.builder.program.hasFile(filePath)) {
                         let rootDir = workspace.builder.program.options.rootDir ?? workspace.builder.program.options.cwd;
                         let dest = rokuDeploy.getDestPath(filePath, workspace.builder.program.options.files, rootDir);
-                        workspace.builder.program.addOrReplaceFile({
+                        workspace.builder.program.setFile({
                             src: filePath,
                             dest: dest
                         }, documentText);

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -55,18 +55,18 @@ describe('Program', () => {
 
     describe('addFile', () => {
         it('adds various files to `pkgMap`', () => {
-            program.addOrReplaceFile('source/main.brs', '');
+            program.setFile('source/main.brs', '');
             expect(program['pkgMap']).to.have.property(s`source/main.brs`);
 
-            program.addOrReplaceFile('source/main.bs', '');
+            program.setFile('source/main.bs', '');
             expect(program['pkgMap']).to.have.property(s`source/main.bs`);
 
-            program.addOrReplaceFile('components/comp1.xml', '');
+            program.setFile('components/comp1.xml', '');
             expect(program['pkgMap']).to.have.property(s`components/comp1.xml`);
         });
 
         it('does not crash when given a totally bogus file', () => {
-            program.addOrReplaceFile({
+            program.setFile({
                 src: `${rootDir}/source/main.brs`,
                 dest: 'source/main.brs'
             }, `class Animalpublic name as stringpublic function walk()end functionend class`);
@@ -76,19 +76,19 @@ describe('Program', () => {
         it('only parses xml files as components when file is found within the "components" folder', () => {
             expect(Object.keys(program.files).length).to.equal(0);
 
-            program.addOrReplaceFile({
+            program.setFile({
                 src: s`${rootDir}/components/comp1.xml`,
                 dest: util.pathSepNormalize(`components/comp1.xml`)
             }, '');
             expect(Object.keys(program.files).length).to.equal(1);
 
-            program.addOrReplaceFile({
+            program.setFile({
                 src: s`${rootDir}/notComponents/comp1.xml`,
                 dest: util.pathSepNormalize(`notComponents/comp1.xml`)
             }, '');
             expect(Object.keys(program.files).length).to.equal(1);
 
-            program.addOrReplaceFile({
+            program.setFile({
                 src: s`${rootDir}/componentsExtra/comp1.xml`,
                 dest: util.pathSepNormalize(`componentsExtra/comp1.xml`)
             }, '');
@@ -96,7 +96,7 @@ describe('Program', () => {
         });
 
         it('supports empty statements for transpile', async () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            const file = program.setFile<BrsFile>('source/main.bs', `
                 sub main()
                     m.logError()
                     'some comment
@@ -110,7 +110,7 @@ describe('Program', () => {
             let projectDir = s`${tmpPath}/project2`;
             fsExtra.ensureDirSync(projectDir);
             program = new Program({ cwd: projectDir });
-            program.addOrReplaceFile({ src: 'source/lib.brs', dest: 'source/lib.brs' }, 'function main()\n    print "hello world"\nend function');
+            program.setFile({ src: 'source/lib.brs', dest: 'source/lib.brs' }, 'function main()\n    print "hello world"\nend function');
             // await program.reloadFile('source/lib.brs', `'this is a comment`);
             //if we made it to here, nothing exploded, so the test passes
         });
@@ -122,12 +122,12 @@ describe('Program', () => {
 
             let mainPath = s`${rootDir}/source/main.brs`;
             //add a new source file
-            program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
+            program.setFile({ src: mainPath, dest: 'source/main.brs' }, '');
             //file should be in source scope now
             expect(program.getScopeByName('source').getFile(mainPath)).to.exist;
 
             //add an unreferenced file from the components folder
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1/component1.brs`, dest: 'components/component1/component1.brs' }, '');
+            program.setFile({ src: `${rootDir}/components/component1/component1.brs`, dest: 'components/component1/component1.brs' }, '');
 
             //source scope should have the same number of files
             expect(program.getScopeByName('source').getFile(mainPath)).to.exist;
@@ -136,7 +136,7 @@ describe('Program', () => {
 
         it('normalizes file paths', () => {
             let filePath = `${rootDir}/source\\main.brs`;
-            program.addOrReplaceFile({ src: filePath, dest: 'source/main.brs' }, '');
+            program.setFile({ src: filePath, dest: 'source/main.brs' }, '');
 
             expect(program.getScopeByName('source').getFile(filePath)).to.exist;
 
@@ -177,9 +177,9 @@ describe('Program', () => {
 
             let mainPath = s`${rootDir}/source/main.brs`;
             //add a new source file
-            program.addOrReplaceFile({ src: mainPath, dest: 'source/main.brs' }, '');
+            program.setFile({ src: mainPath, dest: 'source/main.brs' }, '');
             //add a component file
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
@@ -204,12 +204,12 @@ describe('Program', () => {
     describe('validate', () => {
         it('catches duplicate XML component names', () => {
             //add 2 components which both reference the same errored file
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
@@ -251,7 +251,7 @@ describe('Program', () => {
 
         it('does not produce duplicate parse errors for different component scopes', () => {
             //add a file with a parse error
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 sub DoSomething()
                     'random out-of-place open paren, definitely causes parse error
                     (
@@ -259,13 +259,13 @@ describe('Program', () => {
             `);
 
             //add 2 components which both reference the same errored file
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
                 </component>
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component2" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/lib.brs" />
@@ -278,32 +278,32 @@ describe('Program', () => {
 
         it('detects scripts not loaded by any file', () => {
             //add a main file for sanity check
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             program.validate();
             expectZeroDiagnostics(program);
 
             //add the orphaned file
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, '');
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, '');
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.fileNotReferencedByAnyOtherFile()
             ]);
         });
         it('does not throw errors on shadowed init functions in components', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `
+            program.setFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `
                 function DoSomething()
                     return true
                 end function
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/Parent.xml`, dest: 'components/Parent.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/Parent.xml`, dest: 'components/Parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/Child.xml`, dest: 'components/Child.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/Child.xml`, dest: 'components/Child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
@@ -315,7 +315,7 @@ describe('Program', () => {
 
         it('recognizes global function calls', () => {
             expectZeroDiagnostics(program);
-            program.addOrReplaceFile({ src: `${rootDir}/source/file.brs`, dest: 'source/file.brs' }, `
+            program.setFile({ src: `${rootDir}/source/file.brs`, dest: 'source/file.brs' }, `
                 function DoB()
                     sleep(100)
                 end function
@@ -326,21 +326,21 @@ describe('Program', () => {
         });
 
         it('shows warning when a child component imports the same script as its parent', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="pkg:/lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `'comment`);
+            program.setFile({ src: `${rootDir}/lib.brs`, dest: 'lib.brs' }, `'comment`);
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.unnecessaryScriptImportInChildFromParent('ParentScene')
@@ -348,22 +348,22 @@ describe('Program', () => {
         });
 
         it('adds info diag when child component method shadows parent component method', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/parent.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="pkg:/child.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/parent.brs`, dest: 'parent.brs' }, `sub DoSomething()\nend sub`);
-            program.addOrReplaceFile({ src: `${rootDir}/child.brs`, dest: 'child.brs' }, `sub DoSomething()\nend sub`);
+            program.setFile({ src: `${rootDir}/parent.brs`, dest: 'parent.brs' }, `sub DoSomething()\nend sub`);
+            program.setFile({ src: `${rootDir}/child.brs`, dest: 'child.brs' }, `sub DoSomething()\nend sub`);
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.overridesAncestorFunction('', '', '', '').code
@@ -371,16 +371,16 @@ describe('Program', () => {
         });
 
         it('does not add info diagnostic on shadowed "init" functions', () => {
-            program.addOrReplaceFile('components/parent.xml', trim`
+            program.setFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="parent.brs" />
                 </component>
                 `);
-            program.addOrReplaceFile(`components/parent.brs`, `sub Init()\nend sub`);
-            program.addOrReplaceFile(`components/child.brs`, `sub Init()\nend sub`);
+            program.setFile(`components/parent.brs`, `sub Init()\nend sub`);
+            program.setFile(`components/child.brs`, `sub Init()\nend sub`);
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="child.brs" />
@@ -392,7 +392,7 @@ describe('Program', () => {
         });
 
         it('catches duplicate methods in single file', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -406,11 +406,11 @@ describe('Program', () => {
         });
 
         it('catches duplicate methods across multiple files', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub DoSomething()
                 end sub
             `);
@@ -423,7 +423,7 @@ describe('Program', () => {
 
         it('maintains correct callables list', () => {
             let initialCallableCount = program.getScopeByName('source').getAllCallables().length;
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -431,7 +431,7 @@ describe('Program', () => {
             `);
             expect(program.getScopeByName('source').getAllCallables().length).equals(initialCallableCount + 2);
             //set the file contents again (resetting the wasProcessed flag)
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -443,7 +443,7 @@ describe('Program', () => {
         });
 
         it('resets errors on revalidate', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -452,7 +452,7 @@ describe('Program', () => {
             program.validate();
             expectHasDiagnostics(program, 2);
             //set the file contents again (resetting the wasProcessed flag)
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
                 sub DoSomething()
@@ -462,7 +462,7 @@ describe('Program', () => {
             expectHasDiagnostics(program, 2);
 
             //load in a valid file, the errors should go to zero
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething()
                 end sub
             `);
@@ -472,7 +472,7 @@ describe('Program', () => {
 
         it('identifies invocation of unknown function', () => {
             //call a function that doesn't exist
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "Hello"
                     DoSomething(name)
@@ -486,12 +486,12 @@ describe('Program', () => {
         });
 
         it('detects methods from another file in a subdirectory', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     DoSomething()
                 end sub
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/source/ui/lib.brs`, dest: 'source/ui/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/ui/lib.brs`, dest: 'source/ui/lib.brs' }, `
                 function DoSomething()
                     print "hello world"
                 end function
@@ -504,21 +504,21 @@ describe('Program', () => {
     describe('hasFile', () => {
         it('recognizes when it has a file loaded', () => {
             expect(program.hasFile('file1.brs')).to.be.false;
-            program.addOrReplaceFile({ src: 'file1.brs', dest: 'file1.brs' }, `'comment`);
+            program.setFile({ src: 'file1.brs', dest: 'file1.brs' }, `'comment`);
             expect(program.hasFile('file1.brs')).to.be.true;
         });
     });
 
-    describe('addOrReplaceFile', () => {
+    describe('setFile', () => {
         it('links xml scopes based on xml parent-child relationships', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                 </component>
@@ -527,7 +527,7 @@ describe('Program', () => {
             expect(program.getScopeByName('components/ChildScene.xml').getParentScope().name).to.equal(s`components/ParentScene.xml`);
 
             //change the parent's name.
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="NotParentScene" extends="Scene">
                 </component>
@@ -539,25 +539,25 @@ describe('Program', () => {
 
         it('creates a new scope for every added component xml', () => {
             //we have global callables, so get that initial number
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
+            program.setFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
             expect(program.getScopeByName(`components/component1.xml`)).to.exist;
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
-            program.addOrReplaceFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, '');
+            program.setFile({ src: `${rootDir}/components/component1.xml`, dest: 'components/component1.xml' }, '');
+            program.setFile({ src: `${rootDir}/components/component2.xml`, dest: 'components/component2.xml' }, '');
             expect(program.getScopeByName(`components/component1.xml`)).to.exist;
             expect(program.getScopeByName(`components/component2.xml`)).to.exist;
         });
 
         it('includes referenced files in xml scopes', () => {
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
                 </component>
             `);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.setFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let scope = program.getScopeByName(`components/component1.xml`);
             expect(scope.getFile(xmlPath).pkgPath).to.equal(s`components/component1.xml`);
@@ -566,13 +566,13 @@ describe('Program', () => {
 
         it('adds xml file to files map', () => {
             let xmlPath = `${rootDir}/components/component1.xml`;
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, '');
+            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, '');
             expect(program.getFileByPathAbsolute(xmlPath)).to.exist;
         });
 
         it('detects missing script reference', () => {
             let xmlPath = `${rootDir}/components/component1.xml`;
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
@@ -586,13 +586,13 @@ describe('Program', () => {
         });
 
         it('adds warning instead of error on mismatched upper/lower case script import', () => {
-            program.addOrReplaceFile('components/component1.xml', trim`
+            program.setFile('components/component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="component1.brs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/COMPONENT1.brs', '');
+            program.setFile('components/COMPONENT1.brs', '');
 
             //validate
             program.validate();
@@ -606,7 +606,7 @@ describe('Program', () => {
         it('picks up new files in a scope when an xml file is loaded', () => {
             program.options.ignoreErrorCodes.push(1013);
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/comonent1.xml' }, trim`
+            program.setFile({ src: xmlPath, dest: 'components/comonent1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
@@ -619,12 +619,12 @@ describe('Program', () => {
 
             //add the file, the error should go away
             let brsPath = s`${rootDir}/components/component1.brs`;
-            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.setFile({ src: brsPath, dest: 'components/component1.brs' }, '');
             program.validate();
             expectZeroDiagnostics(program);
 
             //add the xml file back in, but change the component brs file name. Should have an error again
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component2.brs" />
@@ -638,10 +638,10 @@ describe('Program', () => {
 
         it('handles when the brs file is added before the component', () => {
             let brsPath = s`${rootDir}/components/component1.brs`;
-            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.setFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            let xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
@@ -655,10 +655,10 @@ describe('Program', () => {
         it('reloads referenced fles when xml file changes', () => {
             program.options.ignoreErrorCodes.push(1013);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.setFile({ src: brsPath, dest: 'components/component1.brs' }, '');
 
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            let xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
 
@@ -669,7 +669,7 @@ describe('Program', () => {
             expect(program.getScopeByName(xmlFile.pkgPath).getFile(brsPath)).not.to.exist;
 
             //reload the xml file contents, adding a new script reference.
-            xmlFile = program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            xmlFile = program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/component1.brs" />
@@ -691,7 +691,7 @@ describe('Program', () => {
 
     describe('getCompletions', () => {
         it('includes `for each` variable', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     items = [1, 2, 3]
                     for each thing in items
@@ -706,7 +706,7 @@ describe('Program', () => {
         });
 
         it('includes `for` variable', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     for i = 0 to 10
                         t =
@@ -719,7 +719,7 @@ describe('Program', () => {
         });
 
         it('should include first-level namespace names for brighterscript files', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
@@ -737,7 +737,7 @@ describe('Program', () => {
         });
 
         it('resolves completions for namespaces with next namespace part for brighterscript file', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
@@ -755,7 +755,7 @@ describe('Program', () => {
         });
 
         it('finds namespace members for brighterscript file', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     NameA.
                     NameA.NameB.
@@ -792,7 +792,7 @@ describe('Program', () => {
         });
 
         it('finds namespace members for classes', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     NameA.
                     NameA.NameB.
@@ -833,7 +833,7 @@ describe('Program', () => {
         });
 
         it('finds only namespaces that have classes, when new keyword is used', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 sub main()
                     a = new NameA.
                     b = new NameA.NameB.
@@ -882,13 +882,13 @@ describe('Program', () => {
 
         //Bron.. pain to get this working.. do we realy need this? seems moot with ropm..
         it.skip('should include translated namespace function names for brightscript files', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
                 namespace NameA.NameB.NameC
                     sub DoSomething()
                     end sub
                 end namespace
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub test()
 
                 end sub
@@ -898,7 +898,7 @@ describe('Program', () => {
         });
 
         it('inlcudes global completions for file with no scope', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'main.brs' }, `
                 function Main()
                     age = 1
                 end function
@@ -908,7 +908,7 @@ describe('Program', () => {
         });
 
         it('filters out text results for top-level function statements', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main()
                     age = 1
                 end function
@@ -918,7 +918,7 @@ describe('Program', () => {
         });
 
         it('does not filter text results for object properties used in conditional statements', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -934,7 +934,7 @@ describe('Program', () => {
         });
 
         it('does not filter text results for object properties used in assignments', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -948,7 +948,7 @@ describe('Program', () => {
         });
 
         it('does not filter text results for object properties', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     p.
                 end sub
@@ -962,7 +962,7 @@ describe('Program', () => {
         });
 
         it('filters out text results for local vars used in conditional statements', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -978,7 +978,7 @@ describe('Program', () => {
         });
 
         it('filters out text results for local variable assignments', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -991,7 +991,7 @@ describe('Program', () => {
         });
 
         it('filters out text results for local variables used in assignments', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -1005,7 +1005,7 @@ describe('Program', () => {
         });
 
         it('does not suggest local variables when initiated to the right of a period', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main()
                     helloMessage = "jack"
                     person.hello
@@ -1017,14 +1017,14 @@ describe('Program', () => {
 
         it('finds all file paths when initiated on xml uri', () => {
             let xmlPath = s`${rootDir}/components/component1.xml`;
-            program.addOrReplaceFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
+            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
                     <script type="text/brightscript" uri="" />
                 </component>
             `);
             let brsPath = s`${rootDir}/components/component1.brs`;
-            program.addOrReplaceFile({ src: brsPath, dest: 'components/component1.brs' }, '');
+            program.setFile({ src: brsPath, dest: 'components/component1.brs' }, '');
             let completions = program.getCompletions(xmlPath, Position.create(2, 42));
             expect(completions[0]).to.include({
                 kind: CompletionItemKind.File,
@@ -1039,7 +1039,7 @@ describe('Program', () => {
         });
 
         it('get all functions and properties in scope when doing any dotted get on non m ', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 sub main()
                     thing.anonPropA = "foo"
                     thing.anonPropB = "bar"
@@ -1083,7 +1083,7 @@ describe('Program', () => {
         });
 
         it('get all functions and properties relevant for m ', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 class MyClassA
                     function new()
                         m.
@@ -1131,7 +1131,7 @@ describe('Program', () => {
     });
 
     it('include non-namespaced classes in the list of general output', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 function regularFunc()
                     MyClass
                 end function
@@ -1150,7 +1150,7 @@ describe('Program', () => {
     });
 
     it('only include classes when using new keyword', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
                 class MyClassA
                 end class
                 class MyClassB
@@ -1169,16 +1169,16 @@ describe('Program', () => {
     });
 
     it('gets completions when using callfunc inovation', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        program.addOrReplaceFile('components/MyNode.bs', `
+        program.setFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
         `);
-        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.setFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1194,18 +1194,18 @@ describe('Program', () => {
     });
 
     it('gets completions for callfunc invocation with multiple nodes', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        program.addOrReplaceFile('components/MyNode.bs', `
+        program.setFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
             function sayHello2(text, text2)
             end function
         `);
-        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.setFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1214,13 +1214,13 @@ describe('Program', () => {
                     <function name="sayHello2"/>
                 </interface>
             </component>`);
-        program.addOrReplaceFile('components/MyNode2.bs', `
+        program.setFile('components/MyNode2.bs', `
             function sayHello3(text, text2)
             end function
             function sayHello4(text, text2)
             end function
         `);
-        program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
+        program.setFile<XmlFile>('components/MyNode2.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component2" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode2.bs" />
@@ -1237,18 +1237,18 @@ describe('Program', () => {
     });
 
     it('gets completions for extended nodes with callfunc invocation - ensure overridden methods included', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             function main()
                 myNode@.sayHello(arg1)
             end function
         `);
-        program.addOrReplaceFile('components/MyNode.bs', `
+        program.setFile('components/MyNode.bs', `
             function sayHello(text, text2)
             end function
             function sayHello2(text, text2)
             end function
         `);
-        program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+        program.setFile<XmlFile>('components/MyNode.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -1257,7 +1257,7 @@ describe('Program', () => {
                     <function name="sayHello2"/>
                 </interface>
             </component>`);
-        program.addOrReplaceFile('components/MyNode2.bs', `
+        program.setFile('components/MyNode2.bs', `
             function sayHello3(text, text2)
             end function
             function sayHello2(text, text2)
@@ -1265,7 +1265,7 @@ describe('Program', () => {
             function sayHello4(text, text2)
             end function
         `);
-        program.addOrReplaceFile<XmlFile>('components/MyNode2.xml',
+        program.setFile<XmlFile>('components/MyNode2.xml',
             trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component2" extends="Component1">
                 <script type="text/brightscript" uri="pkg:/components/MyNode2.bs" />
@@ -1284,14 +1284,14 @@ describe('Program', () => {
     describe('xml inheritance', () => {
         it('handles parent-child attach and detach', () => {
             //create parent component
-            let parentFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            let parentFile = program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            let childFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            let childFile = program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                 </component>
@@ -1301,7 +1301,7 @@ describe('Program', () => {
             expect((childFile as XmlFile).parentComponent).to.equal(parentFile);
 
             //change the name of the parent
-            parentFile = program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            parentFile = program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="NotParentScene" extends="Scene">
                 </component>
@@ -1313,20 +1313,20 @@ describe('Program', () => {
 
         it('provides child components with parent functions', () => {
             //create parent component
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                 </component>
             `);
 
             //create child component
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="ParentScene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
                 </component>
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/components/ChildScene.brs`, dest: 'components/ChildScene.brs' }, `
+            program.setFile({ src: `${rootDir}/components/ChildScene.brs`, dest: 'components/ChildScene.brs' }, `
                 sub Init()
                     DoParentThing()
                 end sub
@@ -1340,14 +1340,14 @@ describe('Program', () => {
             ]);
 
             //add the script into the parent
-            program.addOrReplaceFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
+            program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="Scene">
                     <script type="text/brightscript" uri="ParentScene.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/ParentScene.brs`, dest: 'components/ParentScene.brs' }, `
+            program.setFile({ src: `${rootDir}/components/ParentScene.brs`, dest: 'components/ParentScene.brs' }, `
                 sub DoParentThing()
 
                 end sub
@@ -1361,13 +1361,13 @@ describe('Program', () => {
 
     describe('xml scope', () => {
         it('does not fail on base components with many children', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub DoSomething()
                 end sub
             `);
 
             //add a brs file with invalid syntax
-            program.addOrReplaceFile({ src: `${rootDir}/components/base.xml`, dest: 'components/base.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/base.xml`, dest: 'components/base.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="BaseScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -1376,7 +1376,7 @@ describe('Program', () => {
             let childCount = 20;
             //add many children, we should never encounter an error
             for (let i = 0; i < childCount; i++) {
-                program.addOrReplaceFile({ src: `${rootDir}/components/child${i}.xml`, dest: `components/child${i}.xml` }, trim`
+                program.setFile({ src: `${rootDir}/components/child${i}.xml`, dest: `components/child${i}.xml` }, trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="Child${i}" extends="BaseScene">
                         <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -1398,7 +1398,7 @@ describe('Program', () => {
 
         it('detects script import changes', () => {
             //create the xml file without script imports
-            let xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            let xmlFile = program.setFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                 </component>
@@ -1408,10 +1408,10 @@ describe('Program', () => {
             expect(program.getScopeByName(xmlFile.pkgPath).getOwnFiles().length).to.equal(1);
 
             //create the lib file
-            let libFile = program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `'comment`);
+            let libFile = program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `'comment`);
 
             //change the xml file to have a script import
-            xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            xmlFile = program.setFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -1424,7 +1424,7 @@ describe('Program', () => {
             expect(ctx.getFile(libFile.pathAbsolute)).to.exist;
 
             //reload the xml file again, removing the script import.
-            xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
+            xmlFile = program.setFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyScene" extends="Scene">
                 </component>
@@ -1440,8 +1440,8 @@ describe('Program', () => {
         it('finds file in source folder', () => {
             expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
             expect(program.getFileByPkgPath(s`source/main2.brs`)).not.to.exist;
-            program.addOrReplaceFile({ src: `${rootDir}/source/main2.brs`, dest: 'source/main2.brs' }, '');
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            program.setFile({ src: `${rootDir}/source/main2.brs`, dest: 'source/main2.brs' }, '');
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
             expect(program.getFileByPkgPath(s`source/main2.brs`)).to.exist;
         });
@@ -1449,7 +1449,7 @@ describe('Program', () => {
 
     describe('removeFiles', () => {
         it('removes files by absolute paths', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             expect(program.getFileByPkgPath(s`source/main.brs`)).to.exist;
             program.removeFiles([`${rootDir}/source/main.brs`]);
             expect(program.getFileByPkgPath(s`source/main.brs`)).not.to.exist;
@@ -1459,7 +1459,7 @@ describe('Program', () => {
     describe('getDiagnostics', () => {
         it('includes diagnostics from files not included in any scope', () => {
             let pathAbsolute = s`${rootDir}/components/a/b/c/main.brs`;
-            program.addOrReplaceFile({ src: pathAbsolute, dest: 'components/a/b/c/main.brs' }, `
+            program.setFile({ src: pathAbsolute, dest: 'components/a/b/c/main.brs' }, `
                 sub A()
                     "this string is not terminated
                 end sub
@@ -1474,7 +1474,7 @@ describe('Program', () => {
 
         it('it excludes specified error codes', () => {
             //declare file with two different syntax errors
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub A()
                     'call with wrong param count
                     B(1,2,3)
@@ -1502,7 +1502,7 @@ describe('Program', () => {
 
     describe('getCompletions', () => {
         it('returns all functions in scope', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -1510,7 +1510,7 @@ describe('Program', () => {
                 sub ActionA()
                 end sub
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub ActionB()
                 end sub
             `);
@@ -1529,7 +1529,7 @@ describe('Program', () => {
         });
 
         it('returns all variables in scope', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "bob"
                     age = 20
@@ -1538,7 +1538,7 @@ describe('Program', () => {
                 sub ActionA()
                 end sub
             `);
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub ActionB()
                 end sub
             `);
@@ -1558,7 +1558,7 @@ describe('Program', () => {
 
         it('returns empty set when out of range', () => {
             const position = util.createPosition(99, 99);
-            program.addOrReplaceFile('source/main.brs', '');
+            program.setFile('source/main.brs', '');
             let completions = program.getCompletions(`${rootDir}/source/main.brs`, position);
             //get the name of all global completions
             const globalCompletions = program.globalScope.getAllFiles().flatMap(x => x.getCompletions(position)).map(x => x.label);
@@ -1568,7 +1568,7 @@ describe('Program', () => {
         });
 
         it('finds parameters', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -1584,7 +1584,7 @@ describe('Program', () => {
 
     it('does not create map by default', async () => {
         fsExtra.ensureDirSync(program.options.stagingFolderPath);
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
             end sub
         `);
@@ -1596,11 +1596,11 @@ describe('Program', () => {
 
     it('creates sourcemap for brs and xml files', async () => {
         fsExtra.ensureDirSync(program.options.stagingFolderPath);
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
             end sub
         `);
-        program.addOrReplaceFile('components/comp1.xml', trim`
+        program.setFile('components/comp1.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="SimpleScene" extends="Scene">
             </component>
@@ -1635,7 +1635,7 @@ describe('Program', () => {
 
     describe('getTranspiledFileContents', () => {
         it('fires plugin events', () => {
-            const file = program.addOrReplaceFile('source/main.brs', trim`
+            const file = program.setFile('source/main.brs', trim`
                 sub main()
                     print "hello world"
                 end sub
@@ -1667,7 +1667,7 @@ describe('Program', () => {
                     event.typedef = `'typedef comment\n${event.typedef}`;
                 }
             });
-            program.addOrReplaceFile('source/lib.bs', `
+            program.setFile('source/lib.bs', `
                 sub log(message)
                     print message
                 end sub
@@ -1694,7 +1694,7 @@ describe('Program', () => {
     describe('transpile', () => {
 
         it('sets needsTranspiled=true when there is at least one edit', async () => {
-            program.addOrReplaceFile('source/main.brs', trim`
+            program.setFile('source/main.brs', trim`
                 sub main()
                     print "hello world"
                 end sub
@@ -1718,7 +1718,7 @@ describe('Program', () => {
         });
 
         it('handles AstEditor flow properly', async () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 sub main()
                     print "hello world"
                 end sub
@@ -1761,14 +1761,14 @@ describe('Program', () => {
         });
 
         it('does not copy bslib.brs when found in roku_modules', async () => {
-            program.addOrReplaceFile('source/roku_modules/bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/bslib/bslib.brs', '');
             await program.transpile([], stagingFolderPath);
             expect(fsExtra.pathExistsSync(`${stagingFolderPath}/source/bslib.brs`)).to.be.false;
             expect(fsExtra.pathExistsSync(`${stagingFolderPath}/source/roku_modules/bslib/bslib.brs`)).to.be.true;
         });
 
         it('transpiles in-memory-only files', async () => {
-            program.addOrReplaceFile('source/logger.bs', trim`
+            program.setFile('source/logger.bs', trim`
                 sub logInfo()
                     print SOURCE_LINE_NUM
                 end sub
@@ -1784,7 +1784,7 @@ describe('Program', () => {
         });
 
         it('copies in-memory-only .brs files to stagingDir', async () => {
-            program.addOrReplaceFile('source/logger.brs', trim`
+            program.setFile('source/logger.brs', trim`
                 sub logInfo()
                     print "logInfo"
                 end sub
@@ -1800,7 +1800,7 @@ describe('Program', () => {
         });
 
         it('copies in-memory .xml file', async () => {
-            program.addOrReplaceFile('components/Component1.xml', trim`
+            program.setFile('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                 </component>
@@ -1824,7 +1824,7 @@ describe('Program', () => {
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -1850,7 +1850,7 @@ describe('Program', () => {
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 sub main()
                 end sub
             `);
@@ -1872,7 +1872,7 @@ describe('Program', () => {
     describe('typedef', () => {
         describe('emitDefinitions', () => {
             it('generates typedef for .bs files', async () => {
-                program.addOrReplaceFile<BrsFile>('source/Duck.bs', `
+                program.setFile<BrsFile>('source/Duck.bs', `
                     class Duck
                     end class
                 `);
@@ -1886,7 +1886,7 @@ describe('Program', () => {
             });
 
             it('does not generate typedef for typedef file', async () => {
-                program.addOrReplaceFile<BrsFile>('source/Duck.d.bs', `
+                program.setFile<BrsFile>('source/Duck.d.bs', `
                     class Duck
                     end class
                 `);
@@ -1900,7 +1900,7 @@ describe('Program', () => {
         });
 
         it('ignores bs1018 for d.bs files', () => {
-            program.addOrReplaceFile<BrsFile>('source/main.d.bs', `
+            program.setFile<BrsFile>('source/main.d.bs', `
                 class Duck
                     sub new(name as string)
                     end sub
@@ -1920,7 +1920,7 @@ describe('Program', () => {
 
     describe('getSignatureHelp', () => {
         it('does not crash when second previousToken is undefined', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ` `);
+            const file = program.setFile<BrsFile>('source/main.brs', ` `);
             sinon.stub(file, 'getPreviousToken').returns(undefined);
             //should not crash
             expect(
@@ -1929,7 +1929,7 @@ describe('Program', () => {
         });
 
         it('works with no leading whitespace when the cursor is after the open paren', () => {
-            program.addOrReplaceFile('source/main.brs', `sub main()\nsayHello()\nend sub\nsub sayHello(name)\nend sub`);
+            program.setFile('source/main.brs', `sub main()\nsayHello()\nend sub\nsub sayHello(name)\nend sub`);
             let signatureHelp = program.getSignatureHelp(
                 `${rootDir}/source/main.brs`,
                 //sayHello(|)
@@ -1940,7 +1940,7 @@ describe('Program', () => {
         });
 
         it('ignores comments and invalid ranges', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     ' new func(((
                 end function
@@ -1954,12 +1954,12 @@ describe('Program', () => {
 
         it('does not crash on callfunc operator', () => {
             //there needs to be at least one xml component WITHOUT an interface
-            program.addOrReplaceFile<XmlFile>('components/MyNode.xml', trim`<?xml version="1.0" encoding="utf-8" ?>
+            program.setFile<XmlFile>('components/MyNode.xml', trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
                 </component>
             `);
-            const file = program.addOrReplaceFile('source/main.bs', `
+            const file = program.setFile('source/main.bs', `
                 sub main()
                     someFunc()@.
                 end sub
@@ -1968,7 +1968,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for constructor with no args', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p = new Person()
                 end function
@@ -1987,7 +1987,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for class function on dotted get with params', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p.sayHello("there")
                 end function
@@ -2018,7 +2018,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for namespaced class function', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     person.sayHello("there")
                 end function
@@ -2042,7 +2042,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for namespace function', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     person.sayHello("hey", "you")
                 end function
@@ -2058,7 +2058,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for nested namespace function', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     person.roger.sayHello("hi", "there")
                 end function
@@ -2079,16 +2079,16 @@ describe('Program', () => {
         });
 
         it('gets signature help for callfunc method', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     myNode@.sayHello(arg1)
                 end function
             `);
-            program.addOrReplaceFile('components/MyNode.bs', `
+            program.setFile('components/MyNode.bs', `
                 function sayHello(text, text2)
                 end function
             `);
-            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.setFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2104,16 +2104,16 @@ describe('Program', () => {
         });
 
         it('does not get signature help for callfunc method, referenced by dot', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     myNode.sayHello(arg1)
                 end function
             `);
-            program.addOrReplaceFile('components/MyNode.bs', `
+            program.setFile('components/MyNode.bs', `
                 function sayHello(text, text2)
                 end function
             `);
-            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.setFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2130,7 +2130,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for constructor with args', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p = new Person(arg1, arg2)
                 end function
@@ -2146,7 +2146,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for constructor with args, defined in super class', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p = new Roger(arg1, arg2)
                 end function
@@ -2164,7 +2164,7 @@ describe('Program', () => {
         });
 
         it('identifies arg index', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p = new Person(arg1, arg2)
                 end function
@@ -2184,7 +2184,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for namespaced constructor with args', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p = new people.coders.Person(arg1, arg2)
                 end function
@@ -2202,7 +2202,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for regular method call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     test(arg1, a2)
                 end function
@@ -2220,7 +2220,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for dotted method call, with method in in-scope class', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     p.test(arg1)
                 end function
@@ -2237,7 +2237,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for namespaced method call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     Person.test(arg1)
                 end function
@@ -2252,7 +2252,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for namespaced method call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     Person.roger.test(arg1)
                 end function
@@ -2267,7 +2267,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for regular method call on various index points', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     test(a1, a2, a3)
                 end function
@@ -2292,17 +2292,17 @@ describe('Program', () => {
         });
 
         it('gets signature help for callfunc method call on various index points', () => {
-            program.addOrReplaceFile('components/MyNode.bs', `
+            program.setFile('components/MyNode.bs', `
                 function test(arg1, arg2, arg3)
                 end function
             `);
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     thing@.test(a1, a2, a3)
                 end function
             `);
 
-            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.setFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2330,7 +2330,7 @@ describe('Program', () => {
         });
 
         it('gets signature help for constructor method call on various index points', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     a = new Person(a1, a2, a3)
                 end function
@@ -2357,18 +2357,18 @@ describe('Program', () => {
         });
 
         it('gets signature help for partially typed line', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function main()
                     thing@.test(a1, a2,
                 end function
                 function test(arg1, arg2, arg3)
                 end function
                 `);
-            program.addOrReplaceFile('components/MyNode.bs', `
+            program.setFile('components/MyNode.bs', `
                 function test(arg1, arg2, arg3)
                 end function
                 `);
-            program.addOrReplaceFile<XmlFile>('components/MyNode.xml',
+            program.setFile<XmlFile>('components/MyNode.xml',
                 trim`<?xml version="1.0" encoding="utf-8" ?>
             <component name="Component1" extends="Scene">
                 <script type="text/brightscript" uri="pkg:/components/MyNode.bs" />
@@ -2405,7 +2405,7 @@ describe('Program', () => {
                 afterFileValidate: sinon.spy()
             };
             program.plugins.add(plugin);
-            program.addOrReplaceFile('source/main.brs', '');
+            program.setFile('source/main.brs', '');
             program.validate();
             expect(plugin.beforeFileValidate.callCount).to.equal(1);
             expect(plugin.onFileValidate.callCount).to.equal(1);
@@ -2420,7 +2420,7 @@ describe('Program', () => {
                 afterFileValidate: sinon.spy()
             };
             program.plugins.add(plugin);
-            program.addOrReplaceFile('components/main.xml', '');
+            program.setFile('components/main.xml', '');
             program.validate();
             expect(plugin.beforeFileValidate.callCount).to.equal(1);
             expect(plugin.onFileValidate.callCount).to.equal(1);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -354,18 +354,37 @@ export class Program {
     /**
      * Load a file into the program. If that file already exists, it is replaced.
      * If file contents are provided, those are used, Otherwise, the file is loaded from the file system
-     * @param relativePath the file path relative to the root dir
+     * @param srcPath the file path relative to the root dir
+     * @param fileContents the file contents
+     * @deprecated use `setFile` instead
+     */
+    public addOrReplaceFile<T extends BscFile>(srcPath: string, fileContents: string): T;
+    /**
+     * Load a file into the program. If that file already exists, it is replaced.
+     * @param fileEntry an object that specifies src and dest for the file.
+     * @param fileContents the file contents. If not provided, the file will be loaded from disk
+     * @deprecated use `setFile` instead
+     */
+    public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
+    public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
+        return this.setFile<T>(fileParam as any, fileContents);
+    }
+
+    /**
+     * Load a file into the program. If that file already exists, it is replaced.
+     * If file contents are provided, those are used, Otherwise, the file is loaded from the file system
+     * @param srcDestOrPkgPath the absolute path, the pkg path (i.e. `pkg:/path/to/file.brs`), or the destPath (i.e. `path/to/file.brs` relative to `pkg:/`)
      * @param fileContents the file contents
      */
-    public addOrReplaceFile<T extends BscFile>(relativePath: string, fileContents: string): T;
+    public setFile<T extends BscFile>(srcDestOrPkgPath: string, fileContents: string): T;
     /**
      * Load a file into the program. If that file already exists, it is replaced.
      * @param fileEntry an object that specifies src and dest for the file.
      * @param fileContents the file contents. If not provided, the file will be loaded from disk
      */
-    public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
-    public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
-        assert.ok(fileParam, 'fileEntry is required');
+    public setFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
+    public setFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
+        assert.ok(fileParam, 'fileParam is required');
         let srcPath: string;
         let pkgPath: string;
         if (typeof fileParam === 'string') {
@@ -375,7 +394,7 @@ export class Program {
             srcPath = s`${fileParam.src}`;
             pkgPath = s`${fileParam.dest}`;
         }
-        let file = this.logger.time(LogLevel.debug, ['Program.addOrReplaceFile()', chalk.green(srcPath)], () => {
+        let file = this.logger.time(LogLevel.debug, ['Program.setFile()', chalk.green(srcPath)], () => {
 
             assert.ok(srcPath, 'fileEntry.src is required');
             assert.ok(pkgPath, 'fileEntry.dest is required');

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -56,7 +56,7 @@ describe('ProgramBuilder', () => {
                 dest: 'file4.xml'
             }]));
 
-            let stub = sinon.stub(builder.program, 'addOrReplaceFile');
+            let stub = sinon.stub(builder.program, 'setFile');
             sinon.stub(builder, 'getFileContents').returns(Promise.resolve(''));
             await builder['loadAllFilesAST']();
             expect(stub.getCalls()).to.be.lengthOf(3);
@@ -71,7 +71,7 @@ describe('ProgramBuilder', () => {
             fsExtra.outputFileSync(s`${rootDir}/source/main.d.bs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/lib.d.bs`, '');
             fsExtra.outputFileSync(s`${rootDir}/source/lib.brs`, '');
-            const stub = sinon.stub(builder.program, 'addOrReplaceFile');
+            const stub = sinon.stub(builder.program, 'setFile');
             await builder['loadAllFilesAST']();
             const srcPaths = stub.getCalls().map(x => x.args[0].src);
             //the d files should be first

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -205,7 +205,7 @@ export class ProgramBuilder {
                         util.driveLetterToLower(this.rootDir)
                     )
                 };
-                this.program.addOrReplaceFile(
+                this.program.setFile(
                     fileObj,
                     await this.getFileContents(fileObj.src)
                 );
@@ -458,7 +458,7 @@ export class ProgramBuilder {
             await Promise.all(
                 typedefFiles.map(async (fileObj) => {
                     try {
-                        this.program.addOrReplaceFile(
+                        this.program.setFile(
                             fileObj,
                             await this.getFileContents(fileObj.src)
                         );
@@ -478,7 +478,7 @@ export class ProgramBuilder {
 
                         //only process certain file types
                         if (acceptableExtensions.includes(fileExtension)) {
-                            this.program.addOrReplaceFile(
+                            this.program.setFile(
                                 fileObj,
                                 await this.getFileContents(fileObj.src)
                             );

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -28,7 +28,7 @@ describe('Scope', () => {
     });
 
     it('does not mark namespace functions as collisions with stdlib', () => {
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/main.bs`,
             dest: `source/main.bs`
         }, `
@@ -43,7 +43,7 @@ describe('Scope', () => {
     });
 
     it('handles variables with javascript prototype names', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
                 constructor = true
             end sub
@@ -53,7 +53,7 @@ describe('Scope', () => {
     });
 
     it('flags parameter with same name as namespace', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main(nameA)
@@ -66,7 +66,7 @@ describe('Scope', () => {
     });
 
     it('flags assignments with same name as namespace', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
             end namespace
             sub main()
@@ -101,7 +101,7 @@ describe('Scope', () => {
         it('detects callables from all loaded files', () => {
             const sourceScope = program.getScopeByName('source');
 
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub Main()
 
                 end sub
@@ -109,7 +109,7 @@ describe('Scope', () => {
                 sub ActionA()
                 end sub
             `);
-            program.addOrReplaceFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
                 sub ActionB()
                 end sub
             `);
@@ -126,11 +126,11 @@ describe('Scope', () => {
         });
 
         it('picks up new callables', () => {
-            program.addOrReplaceFile('source/file.brs', '');
+            program.setFile('source/file.brs', '');
             //we have global callables, so get that initial number
             let originalLength = program.getScopeByName('source').getAllCallables().length;
 
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     print "A"
                 end function
@@ -146,7 +146,7 @@ describe('Scope', () => {
     describe('removeFile', () => {
         it('removes callables from list', () => {
             //add the file
-            let file = program.addOrReplaceFile(`source/file.brs`, `
+            let file = program.setFile(`source/file.brs`, `
                 function DoA()
                     print "A"
                 end function
@@ -161,18 +161,18 @@ describe('Scope', () => {
 
     describe('validate', () => {
         it('marks the scope as validated after validation has occurred', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                sub main()
                end sub
             `);
-            let lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            let lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                sub libFunc()
                end sub
             `);
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.false;
             program.validate();
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.true;
-            lib = program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
                 sub libFunc()
                 end sub
             `);
@@ -183,7 +183,7 @@ describe('Scope', () => {
         });
 
         it('does not mark same-named-functions in different namespaces as an error', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                 namespace NameA
                     sub alert()
                     end sub
@@ -197,7 +197,7 @@ describe('Scope', () => {
             expectZeroDiagnostics(program);
         });
         it('resolves local-variable function calls', () => {
-            program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                 sub DoSomething()
                     sayMyName = function(name as string)
                     end function
@@ -211,7 +211,7 @@ describe('Scope', () => {
 
         describe('function shadowing', () => {
             it('warns when local var function has same name as stdlib function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = function(p)
                             return "override"
@@ -227,7 +227,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 12345
                         print str ' prints "12345" (i.e. our local variable is allowed to shadow the built-in function name)
@@ -238,7 +238,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         str = 6789
                         print str(12345) ' prints "12345" (i.e. our local variable did not override the callable global function)
@@ -249,7 +249,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = function()
                             return "override"
@@ -269,7 +269,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         getHello = "override"
                         print getHello ' prints <Function: gethello> (i.e. local variable override does NOT work for same-scope-defined methods)
@@ -286,7 +286,7 @@ describe('Scope', () => {
             });
 
             it('flags scope function with same name (but different case) as built-in function', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
                     sub main()
                         print str(12345) ' prints 12345 (i.e. our str() function below is ignored)
                     end sub
@@ -303,7 +303,7 @@ describe('Scope', () => {
         });
 
         it('detects duplicate callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     print "A"
                 end function
@@ -323,7 +323,7 @@ describe('Scope', () => {
         });
 
         it('detects calls to unknown callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
@@ -337,7 +337,7 @@ describe('Scope', () => {
         });
 
         it('recognizes known callables', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 function DoA()
                     DoB()
                 end function
@@ -353,7 +353,7 @@ describe('Scope', () => {
         });
 
         it('does not error with calls to callables in same namespace', () => {
-            program.addOrReplaceFile('source/file.bs', `
+            program.setFile('source/file.bs', `
                 namespace Name.Space
                     sub a(param as string)
                         print param
@@ -372,7 +372,7 @@ describe('Scope', () => {
         //We don't currently support someObj.callSomething() format, so don't throw errors on those
         it('does not fail on object callables', () => {
             expectZeroDiagnostics(program);
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                function DoB()
                     m.doSomething()
                 end function
@@ -384,7 +384,7 @@ describe('Scope', () => {
         });
 
         it('detects calling functions with too many parameters', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a()
                 end sub
                 sub b()
@@ -398,7 +398,7 @@ describe('Scope', () => {
         });
 
         it('detects calling class constructors with too many parameters', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 function noop0()
                 end function
 
@@ -420,7 +420,7 @@ describe('Scope', () => {
         });
 
         it('detects calling functions with too many parameters', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(name)
                 end sub
                 sub b()
@@ -434,7 +434,7 @@ describe('Scope', () => {
         });
 
         it('allows skipping optional parameter', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(name="Bob")
                 end sub
                 sub b()
@@ -447,7 +447,7 @@ describe('Scope', () => {
         });
 
         it('shows expected parameter range in error message', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
@@ -462,7 +462,7 @@ describe('Scope', () => {
         });
 
         it('handles expressions as arguments to a function', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age, name="Bob")
                 end sub
                 sub b()
@@ -474,7 +474,7 @@ describe('Scope', () => {
         });
 
         it('Catches extra arguments for expressions as arguments to a function', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub a(age)
                 end sub
                 sub b()
@@ -489,7 +489,7 @@ describe('Scope', () => {
         });
 
         it('handles JavaScript reserved names', () => {
-            program.addOrReplaceFile('source/file.brs', `
+            program.setFile('source/file.brs', `
                 sub constructor()
                 end sub
                 sub toString()
@@ -504,14 +504,14 @@ describe('Scope', () => {
         });
 
         it('Emits validation events', () => {
-            program.addOrReplaceFile('source/file.brs', ``);
-            program.addOrReplaceFile('components/comp.xml', trim`
+            program.setFile('source/file.brs', ``);
+            program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp" extends="Scene">
                     <script uri="comp.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/comp.brs`, ``);
+            program.setFile(s`components/comp.brs`, ``);
             const sourceScope = program.getScopeByName('source');
             const compScope = program.getScopeByName('components/comp.xml');
             program.plugins = new PluginInterface([], new Logger());
@@ -540,7 +540,7 @@ describe('Scope', () => {
 
         describe('custom types', () => {
             it('detects an unknown function return type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function a()
                         return invalid
                     end function
@@ -571,7 +571,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown function parameter type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     sub a(num as integer)
                     end sub
 
@@ -594,7 +594,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown field parameter type', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     class myClass
                         foo as unknownType 'error
                     end class
@@ -613,7 +613,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types inside namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -633,7 +633,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -648,7 +648,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from current namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -665,11 +665,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyClass) as MyClass
                     end function
                 `);
-                program.addOrReplaceFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
                     class MyClass
                     end class
                 `);
@@ -679,11 +679,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     function foo(param as MyNameSpace.MyClass) as MyNameSpace.MyClass
                     end function
                 `);
-                program.addOrReplaceFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
                     namespace MyNameSpace
                       class MyClass
                       end class
@@ -695,7 +695,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from another namespaces', () => {
-                program.addOrReplaceFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -714,13 +714,13 @@ describe('Scope', () => {
             it('scopes types to correct scope', () => {
                 program = new Program({ rootDir: rootDir });
 
-                program.addOrReplaceFile('components/foo.xml', trim`
+                program.setFile('components/foo.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="foo" extends="Scene">
                         <script uri="foo.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/foo.bs`, `
+                program.setFile(s`components/foo.bs`, `
                     class MyClass
                     end class
                 `);
@@ -728,13 +728,13 @@ describe('Scope', () => {
 
                 expectZeroDiagnostics(program);
 
-                program.addOrReplaceFile('components/bar.xml', trim`
+                program.setFile('components/bar.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="bar" extends="Scene">
                         <script uri="bar.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/bar.bs`, `
+                program.setFile(s`components/bar.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
@@ -748,23 +748,23 @@ describe('Scope', () => {
             it('can reference types from parent component', () => {
                 program = new Program({ rootDir: rootDir });
 
-                program.addOrReplaceFile('components/parent.xml', trim`
+                program.setFile('components/parent.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="parent" extends="Scene">
                         <script uri="parent.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/parent.bs`, `
+                program.setFile(s`components/parent.bs`, `
                     class MyClass
                     end class
                 `);
-                program.addOrReplaceFile('components/child.xml', trim`
+                program.setFile('components/child.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="child" extends="parent">
                         <script uri="child.bs"/>
                     </component>
                 `);
-                program.addOrReplaceFile(s`components/child.bs`, `
+                program.setFile(s`components/child.bs`, `
                     function getFoo() as MyClass
                     end function
                 `);
@@ -781,24 +781,24 @@ describe('Scope', () => {
         it('inherits callables from parent', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, ``);
+            program.setFile(s`components/child.brs`, ``);
             program.validate();
             let childScope = program.getComponentScope('child');
             expect(childScope.getAllCallables().map(x => x.callable.name)).not.to.include('parentSub');
 
-            program.addOrReplaceFile('components/parent.xml', trim`
+            program.setFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="parent" extends="Scene">
                     <script uri="parent.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/parent.brs`, `
+            program.setFile(s`components/parent.brs`, `
                 sub parentSub()
                 end sub
             `);
@@ -816,7 +816,7 @@ describe('Scope', () => {
 
     describe('getDefinition', () => {
         it('returns empty list when there are no files', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
             let scope = program.getScopeByName('source');
             expect(scope.getDefinition(file, Position.create(0, 0))).to.be.lengthOf(0);
         });
@@ -834,7 +834,7 @@ describe('Scope', () => {
 
     describe('buildNamespaceLookup', () => {
         it('does not crash when class statement is missing `name` prop', () => {
-            program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            program.setFile<BrsFile>('source/main.bs', `
                 namespace NameA
                     class
                     end class
@@ -844,7 +844,7 @@ describe('Scope', () => {
         });
 
         it('does not crash when function statement is missing `name` prop', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            const file = program.setFile<BrsFile>('source/main.bs', `
                 namespace NameA
                     function doSomething()
                     end function

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -25,7 +25,7 @@ describe('XmlScope', () => {
 
     describe('constructor', () => {
         it('listens for attach/detach parent events', () => {
-            let parentXmlFile = program.addOrReplaceFile<XmlFile>('components/parent.xml', trim`
+            let parentXmlFile = program.setFile<XmlFile>('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Parent" extends="Scene">
                 </component>
@@ -35,7 +35,7 @@ describe('XmlScope', () => {
             //should default to global scope
             expect(scope.getParentScope()).to.equal(program.globalScope);
 
-            let childXmlFile = program.addOrReplaceFile<XmlFile>('components/child.xml', trim`
+            let childXmlFile = program.setFile<XmlFile>('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child" extends="Parent">
                 </component>
@@ -61,12 +61,12 @@ describe('XmlScope', () => {
 
     describe('getDefinition', () => {
         it('finds parent file', () => {
-            let parentXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+            let parentXmlFile = program.setFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent">
                 </component>
             `);
-            let childXmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            let childXmlFile = program.setFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                 </component>
@@ -80,7 +80,7 @@ describe('XmlScope', () => {
 
     describe('getFiles', () => {
         it('includes the xml file', () => {
-            let xmlFile = program.addOrReplaceFile('components/child.xml', trim`
+            let xmlFile = program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Child">
                 </component>
@@ -94,7 +94,7 @@ describe('XmlScope', () => {
         it('adds an error when an interface function cannot be found', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -107,7 +107,7 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, `
+            program.setFile(s`components/child.brs`, `
                 sub func1()
                 end sub
             `);
@@ -133,7 +133,7 @@ describe('XmlScope', () => {
         it('adds an error when an interface field is invalid', () => {
             program = new Program({ rootDir: rootDir });
 
-            program.addOrReplaceFile('components/child.xml', trim`
+            program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="child" extends="parent">
                     <interface>
@@ -148,7 +148,7 @@ describe('XmlScope', () => {
                     <script uri="child.brs"/>
                 </component>
             `);
-            program.addOrReplaceFile(s`components/child.brs`, `
+            program.setFile(s`components/child.brs`, `
                 sub init()
                 end sub
             `);

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -102,7 +102,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.setFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block:0',                // Main sub body
                 'PrintStatement:1',       // print 1
@@ -139,7 +139,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.setFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -184,7 +184,7 @@ describe('astUtils visitors', () => {
                 name: 'walker',
                 afterFileParse: file => walker(file as BrsFile)
             });
-            program.addOrReplaceFile('source/main.brs', PRINTS_SRC);
+            program.setFile('source/main.brs', PRINTS_SRC);
             expect(actual).to.deep.equal([
                 'Block',                // Main sub body
                 'PrintStatement',       // print 1
@@ -264,7 +264,7 @@ describe('astUtils visitors', () => {
                 afterFileParse: (file) => walker(file as BrsFile)
             });
 
-            program.addOrReplaceFile('source/main.brs', EXPRESSIONS_SRC);
+            program.setFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 //The comment statement is weird because it can't be both a statement and expression, but is treated that way. Just ignore it for now until we refactor comments.
                 //'CommentStatement:1:CommentStatement',          // '<comment>
@@ -312,7 +312,7 @@ describe('astUtils visitors', () => {
 
     describe('walk', () => {
         function testWalk(text: string, expectedConstructors: string[], walkMode = WalkMode.visitAllRecursive) {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', text);
+            const file = program.setFile<BrsFile>('source/main.bs', text);
             const items = [];
             let index = 1;
             file.ast.walk((element: any) => {
@@ -326,7 +326,7 @@ describe('astUtils visitors', () => {
         }
 
         it('Walks through all expressions until cancelled', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+            const file = program.setFile<BrsFile>('source/main.bs', `
                 sub logger(message = "nil" as string)
                     innerLog = sub(message = "nil" as string)
                         print message

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -18,7 +18,7 @@ describe('CodeActionsProcessor', () => {
 
     describe('getCodeActions', () => {
         it('suggests `extends=Group`', () => {
-            const file = program.addOrReplaceFile('components/comp1.xml', trim`
+            const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>
@@ -65,7 +65,7 @@ describe('CodeActionsProcessor', () => {
         });
 
         it('adds attribute at end of component with multiple attributes`', () => {
-            const file = program.addOrReplaceFile('components/comp1.xml', trim`
+            const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" attr2="attr3" attr3="attr3">
                 </component>
@@ -85,30 +85,30 @@ describe('CodeActionsProcessor', () => {
 
         it('does not produce duplicate code actions for bs imports', () => {
             //define the function in two files
-            program.addOrReplaceFile('components/lib1.brs', `
+            program.setFile('components/lib1.brs', `
                 sub doSomething()
                 end sub
             `);
-            program.addOrReplaceFile('components/lib2.brs', `
+            program.setFile('components/lib2.brs', `
                 sub doSomething()
                 end sub
             `);
 
             //use the function in this file
-            const componentCommonFile = program.addOrReplaceFile('components/ComponentCommon.bs', `
+            const componentCommonFile = program.setFile('components/ComponentCommon.bs', `
                 sub init()
                     doSomething()
                 end sub
             `);
 
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="ComponentCommon.bs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/comp2.xml', trim`
+            program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="ComponentCommon.bs" />
@@ -131,21 +131,21 @@ describe('CodeActionsProcessor', () => {
 
         it('does not suggest imports for brs files', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.brs" />
                 </component>
             `);
             //import the function here
-            const file = program.addOrReplaceFile('components/comp1.brs', `
+            const file = program.setFile('components/comp1.brs', `
                 sub init()
                     DoSomething()
                 end sub
             `);
 
             //define the function here
-            program.addOrReplaceFile('source/lib.brs', `
+            program.setFile('source/lib.brs', `
                 sub DoSomething()
                 end sub
             `);
@@ -163,19 +163,19 @@ describe('CodeActionsProcessor', () => {
 
         it('suggests class imports', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.bs" />
                 </component>
             `);
-            const file = program.addOrReplaceFile('components/comp1.bs', `
+            const file = program.setFile('components/comp1.bs', `
                 sub init()
                     dude = new Person()
                 end sub
             `);
 
-            program.addOrReplaceFile('source/Person.bs', `
+            program.setFile('source/Person.bs', `
                 class Person
                 end class
             `);
@@ -195,19 +195,19 @@ describe('CodeActionsProcessor', () => {
 
         it('suggests class imports', () => {
             //import the file in two scopes
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene">
                     <script uri="comp1.bs" />
                 </component>
             `);
             //import the function here
-            const file = program.addOrReplaceFile('components/comp1.bs', `
+            const file = program.setFile('components/comp1.bs', `
                 sub init()
                     kitty = new Animals.Cat()
                 end sub
             `);
-            program.addOrReplaceFile('source/Animals.bs', `
+            program.setFile('source/Animals.bs', `
                 namespace Animals
                     class Cat
                     end class

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -19,7 +19,7 @@ describe('BrsFileSemanticTokensProcessor', () => {
     });
 
     it('matches each namespace section', () => {
-        const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+        const file = program.setFile<BrsFile>('source/main.bs', `
             namespace Earthlings.Humanoids
                 class Person
                 end class

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -34,11 +34,11 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     function addFile(relativePath: string, text: string) {
-        return program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
+        return program.setFile<BrsFile>({ src: `${rootDir}/${relativePath}`, dest: relativePath }, text);
     }
 
     it('detects all classes after parse', () => {
-        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
             end class
             class Duck
@@ -50,7 +50,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not cause errors with incomplete class statement', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class
         `);
         program.validate();
@@ -58,7 +58,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches child class missing super call in constructor', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Person
                 sub new()
                 end sub
@@ -75,7 +75,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('access modifier is option for override', () => {
-        let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub move()
                 end sub
@@ -94,7 +94,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports various namespace configurations', () => {
-        program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile<BrsFile>({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub new()
                     bigBird = new Birds.Bird()
@@ -118,7 +118,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
     describe('super', () => {
         it('always requires super call in child constructor', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                 end class
                 class Duck extends Bird
@@ -133,7 +133,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('requires super call in child when parent has own `new` method', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new()
                     end sub
@@ -150,7 +150,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -169,7 +169,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('allows non-`m` expressions and statements before the super call', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Bird
                     sub new(name)
                     end sub
@@ -689,7 +689,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects using `new` keyword on non-classes', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             sub quack()
             end sub
             sub main()
@@ -703,7 +703,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects missing call to super', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                 end sub
@@ -720,7 +720,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it.skip('detects calls to unknown m methods', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             class Animal
                 sub new()
                     m.methodThatDoesNotExist()
@@ -734,7 +734,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects duplicate member names', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
                 public name
@@ -764,7 +764,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects mismatched member type in child class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -781,7 +781,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows untyped overridden field in child class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 public name
             end class
@@ -794,7 +794,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows overridden property name in child class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Bird
                 public name = "bird"
             end class
@@ -807,7 +807,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('flags incompatible child field type changes', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Bird
                 public age = 12
                 public name = "bird"
@@ -829,7 +829,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods without override keyword', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
             class Animal
                 sub speak()
                 end sub
@@ -846,7 +846,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods with different visibility', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -873,7 +873,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows overridden methods with matching visibility', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -897,7 +897,7 @@ describe('BrsFile BrighterScript classes', () => {
 
     describe('detects unknown parent class', () => {
         it('non-namespaced parent from outside namespace', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 class Duck extends Animal
                     sub speak()
                     end sub
@@ -916,7 +916,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('non-namespaced parent from within namespace', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 namespace Vertibrates
                     class Duck extends Animal
                         sub speak()
@@ -931,7 +931,7 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('non-namespaced name from outside namespace alongside existing namespace', () => {
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/main.bs', `
                 namespace Vertibrates
                     class Animal
                     end class
@@ -949,13 +949,13 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('namespaced parent class from outside namespace', () => {
-            program.addOrReplaceFile('source/vertibrates.bs', `
+            program.setFile('source/vertibrates.bs', `
                 namespace Vertibrates
                     class Bird
                     end class
                 end namespace
             `);
-            program.addOrReplaceFile('source/Duck.bs', `
+            program.setFile('source/Duck.bs', `
                 class Duck extends Vertibrates.GroundedBird
                     sub speak()
                     end sub
@@ -968,13 +968,13 @@ describe('BrsFile BrighterScript classes', () => {
         });
 
         it('namespaced parent class from inside namespace', () => {
-            program.addOrReplaceFile('source/vertibrates.bs', `
+            program.setFile('source/vertibrates.bs', `
                 namespace Vertibrates
                     class Bird
                     end class
                 end namespace
             `);
-            program.addOrReplaceFile('source/Duck.bs', `
+            program.setFile('source/Duck.bs', `
                 namespace Birdies
                     class Duck extends Vertibrates.GroundedBird
                         sub speak()
@@ -990,7 +990,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches newable class without namespace name', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -1007,7 +1007,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports newable class namespace inference', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -1021,7 +1021,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches extending unknown namespaced class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1036,7 +1036,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports omitting namespace prefix for items in same namespace', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1049,7 +1049,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate root-level class declarations', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             class Animal
             end class
             class Animal
@@ -1062,7 +1062,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate namespace-level class declarations', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1077,7 +1077,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches namespaced class name which is the same as a global class', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1092,7 +1092,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches class with same name as function', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Animal
             end class
             sub Animal()
@@ -1105,7 +1105,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches class with same name (but different case) as function', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class ANIMAL
             end class
             sub animal()
@@ -1118,7 +1118,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches variable with same name as class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Animal
             end class
             sub main()
@@ -1132,7 +1132,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows extending classes with more than one dot in the filename', () => {
-        program.addOrReplaceFile('source/testclass.bs', `
+        program.setFile('source/testclass.bs', `
             class Foo
             end class
 
@@ -1143,7 +1143,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        program.addOrReplaceFile('source/testclass_no_testdot.bs', `
+        program.setFile('source/testclass_no_testdot.bs', `
             class BarNoDot extends Foo
                 sub new()
                     super()
@@ -1151,7 +1151,7 @@ describe('BrsFile BrighterScript classes', () => {
             end class
         `);
 
-        program.addOrReplaceFile('source/testclass.dot.bs', `
+        program.setFile('source/testclass.dot.bs', `
             class BarDot extends Foo
                 sub new()
                 super()
@@ -1164,7 +1164,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('computes correct super index for grandchild class', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             sub Main()
                 c = new App.ClassC()
             end sub
@@ -1204,7 +1204,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('computes correct super index for namespaced child class and global parent class', () => {
-        program.addOrReplaceFile('source/ClassA.bs', `
+        program.setFile('source/ClassA.bs', `
             class ClassA
             end class
         `);
@@ -1232,7 +1232,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not crash when parent class is missing', () => {
-        const file = program.addOrReplaceFile<BrsFile>('source/ClassB.bs', `
+        const file = program.setFile<BrsFile>('source/ClassB.bs', `
             class ClassB extends ClassA
             end class
         `);
@@ -1242,7 +1242,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not crash when child has field with same name as sub in parent', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Parent
                 public function helloWorld()
                 end function
@@ -1255,7 +1255,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('does not crash when child has method with same name as field in parent', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Parent
                 public helloWorld as string
             end class
@@ -1268,7 +1268,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it.skip('detects calling class constructors with too many parameters', () => {
-        program.addOrReplaceFile('source/main.bs', `
+        program.setFile('source/main.bs', `
             class Parameterless
                 sub new()
                 end sub

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -41,7 +41,7 @@ describe('BrsFile', () => {
     });
 
     it('supports the third parameter in CreateObject', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
                 regexp = CreateObject("roRegex", "[a-z]+", "i")
             end sub
@@ -51,7 +51,7 @@ describe('BrsFile', () => {
     });
 
     it('supports the 6 params in CreateObject for roRegion', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub createRegion(bitmap as object)
                 region = CreateObject("roRegion", bitmap, 20, 40, 100, 200)
             end sub
@@ -84,7 +84,7 @@ describe('BrsFile', () => {
         } as StandardizedFileEntry;
 
         it('creates proper tokens', () => {
-            file = program.addOrReplaceFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
+            file = program.setFile<BrsFile>(entry, `call(ModuleA.ModuleB.ModuleC.`);
             expect(file['getPartialVariableName'](file.parser.tokens[7])).to.equal('ModuleA.ModuleB.ModuleC.');
             expect(file['getPartialVariableName'](file.parser.tokens[6])).to.equal('ModuleA.ModuleB.ModuleC');
             expect(file['getPartialVariableName'](file.parser.tokens[5])).to.equal('ModuleA.ModuleB.');
@@ -96,14 +96,14 @@ describe('BrsFile', () => {
 
     describe('getScopesForFile', () => {
         it('finds the scope for the file', () => {
-            let file = program.addOrReplaceFile('source/main.brs', ``);
+            let file = program.setFile('source/main.brs', ``);
             expect(program.getScopesForFile(file)[0]?.name).to.equal('source');
         });
     });
 
     describe('getCompletions', () => {
         it('does not crash for callfunc on a function call', () => {
-            const file = program.addOrReplaceFile('source/main.brs', `
+            const file = program.setFile('source/main.brs', `
                 sub main()
                     getManager()@.
                 end sub
@@ -114,7 +114,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests pkg paths in strings that match that criteria', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print "pkg:"
                 end sub
@@ -127,7 +127,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests libpkg paths in strings that match that criteria', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print "libpkg:"
                 end sub
@@ -140,7 +140,7 @@ describe('BrsFile', () => {
         });
 
         it('suggests pkg paths in template strings', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print \`pkg:\`
                 end sub
@@ -154,7 +154,7 @@ describe('BrsFile', () => {
 
         it('waits for the file to be processed before collecting completions', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub Main()
                     print "hello"
                     Say
@@ -172,7 +172,7 @@ describe('BrsFile', () => {
 
         it('always includes `m`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -185,7 +185,7 @@ describe('BrsFile', () => {
 
         it('does not fail for missing previousToken', () => {
             //add a single character to the file, and get completions after it
-            program.addOrReplaceFile('source/main.brs', `i`);
+            program.setFile('source/main.brs', `i`);
             expect(() => {
                 program.getCompletions(`${rootDir}/source/main.brs`, Position.create(0, 1)).map(x => x.label);
             }).not.to.throw;
@@ -193,7 +193,7 @@ describe('BrsFile', () => {
 
         it('includes all keywords`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
 
                 end sub
@@ -218,7 +218,7 @@ describe('BrsFile', () => {
 
         it('does not provide completions within a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'some comment
                 end sub
@@ -231,7 +231,7 @@ describe('BrsFile', () => {
 
         it('does not provide duplicate entries for variables', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     name = "bob"
                     age = 12
@@ -249,7 +249,7 @@ describe('BrsFile', () => {
 
         it('does not include `as` and `string` text options when used in function params', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
 
                 end sub
@@ -262,7 +262,7 @@ describe('BrsFile', () => {
 
         it('does not provide intellisense results when inside a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                     'this is a comment
                 end sub
@@ -274,7 +274,7 @@ describe('BrsFile', () => {
 
         it('does provide intellisence for labels only after a goto keyword', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                     something:
                     goto \nend sub
@@ -290,7 +290,7 @@ describe('BrsFile', () => {
     describe('comment flags', () => {
         describe('bs:disable-next-line', () => {
             it('disables critical diagnostic issues', () => {
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         Dim requestData
                     end sub
@@ -299,7 +299,7 @@ describe('BrsFile', () => {
                 program.validate();
                 expectHasDiagnostics(program);
 
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         'bs:disable-next-line
                         Dim requestData
@@ -311,7 +311,7 @@ describe('BrsFile', () => {
             });
 
             it('works with leading whitespace', () => {
-                program.addOrReplaceFile('source/main.brs', `
+                program.setFile('source/main.brs', `
                     sub main()
                         ' bs:disable-next-line
                         =asdf=sadf=
@@ -323,7 +323,7 @@ describe('BrsFile', () => {
             });
 
             it('works for all', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line
                         name = "bob
@@ -341,7 +341,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: 1083, 1001
                         name = "bob
@@ -358,7 +358,7 @@ describe('BrsFile', () => {
             });
 
             it('recognizes non-numeric codes', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         'bs:disable-next-line: LINT9999
                         name = "bob
@@ -370,7 +370,7 @@ describe('BrsFile', () => {
 
             it('supports disabling non-numeric error codes', () => {
                 const program = new Program({});
-                const file = program.addOrReplaceFile('source/main.brs', `
+                const file = program.setFile('source/main.brs', `
                     sub main()
                         something = true 'bs:disable-line: LINT1005
                     end sub
@@ -386,7 +386,7 @@ describe('BrsFile', () => {
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         print "hi" 'bs:disable-line: 123456 999999   aaaab
                     end sub
@@ -406,7 +406,7 @@ describe('BrsFile', () => {
 
         describe('bs:disable-line', () => {
             it('works for all', () => {
-                let file = program.addOrReplaceFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub Main()
                         z::;;%%%%%% 'bs:disable-line
                     end sub
@@ -423,7 +423,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         'should not have any errors
                         DoSomething(1) 'bs:disable-line:1002
@@ -445,7 +445,7 @@ describe('BrsFile', () => {
                 //the current version of BRS causes parse errors after the `parse` keyword, showing error in comments
                 //the program should ignore all diagnostics found in brs:* comment lines EXCEPT
                 //for the diagnostics about using unknown error codes
-                program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         stop 'bs:disable-line
                         print "need a valid line to fix stop error"
@@ -459,7 +459,7 @@ describe('BrsFile', () => {
 
     describe('parse', () => {
         it('supports iife in assignment', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     result = sub()
                     end sub()
@@ -472,7 +472,7 @@ describe('BrsFile', () => {
 
         it('uses the proper parse mode based on file extension', () => {
             function testParseMode(destPath: string, expectedParseMode: ParseMode) {
-                const file = program.addOrReplaceFile<BrsFile>(destPath, '');
+                const file = program.setFile<BrsFile>(destPath, '');
                 expect(file.parseMode).to.equal(expectedParseMode);
             }
 
@@ -486,7 +486,7 @@ describe('BrsFile', () => {
         });
 
         it('supports labels and goto statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     'multiple goto statements on one line
                     goto myLabel : goto myLabel
@@ -497,7 +497,7 @@ describe('BrsFile', () => {
         });
 
         it('supports empty print statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    print
                 end sub
@@ -508,7 +508,7 @@ describe('BrsFile', () => {
         describe('conditional compile', () => {
 
             it('works for upper case keywords', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #CONST someFlag = true
                         #IF someFlag
@@ -524,7 +524,7 @@ describe('BrsFile', () => {
             });
 
             it('supports single-word #elseif and #endif', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -538,7 +538,7 @@ describe('BrsFile', () => {
             });
 
             it('supports multi-word #else if and #end if', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -552,7 +552,7 @@ describe('BrsFile', () => {
             });
 
             it('does not choke on invalid code inside a false conditional compile', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if false
                             non-commented code here should not cause parse errors
@@ -563,7 +563,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #if', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if true1
                             print "true"
@@ -576,7 +576,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #if %
                             print "true"
@@ -590,7 +590,7 @@ describe('BrsFile', () => {
             });
 
             it('detects #const name using reserved word', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const function = true
                     end sub
@@ -602,7 +602,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                     sub main()
                         #const someConst = 123
                     end sub
@@ -614,7 +614,7 @@ describe('BrsFile', () => {
         });
 
         it('supports stop statement', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                    stop
                 end sub
@@ -623,7 +623,7 @@ describe('BrsFile', () => {
         });
 
         it('supports single-line if statements', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub main()
                     if 1 < 2: return true: end if
                     if 1 < 2: return true
@@ -996,8 +996,8 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            program.addOrReplaceFile('source/file.brs', ``);
-            program.addOrReplaceFile('source/main.bs', `
+            program.setFile('source/file.brs', ``);
+            program.setFile('source/main.bs', `
                 sub main()
                 end sub
                 import "file.brs"
@@ -1009,14 +1009,14 @@ describe('BrsFile', () => {
         });
 
         it('supports library imports', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 Library "v30/bslCore.brs"
             `);
             expectZeroDiagnostics(program);
         });
 
         it('adds error for library statements NOT at top of file', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                 end sub
                 Library "v30/bslCore.brs"
@@ -1028,7 +1028,7 @@ describe('BrsFile', () => {
         });
 
         it('adds error for library statements inside of function body', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     Library "v30/bslCore.brs"
                 end sub
@@ -1049,7 +1049,7 @@ describe('BrsFile', () => {
         });
 
         it('succeeds when finding variables with "sub" in them', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function DoSomething()
                     return value.subType()
                 end function
@@ -1302,7 +1302,7 @@ describe('BrsFile', () => {
         });
 
         it('finds function calls nested inside statements', () => {
-            program.addOrReplaceFile(`source/main.brs`, `
+            program.setFile(`source/main.brs`, `
                 sub main()
                     if true then
                         DoesNotExist(1, 2)
@@ -1350,7 +1350,7 @@ describe('BrsFile', () => {
         });
 
         it('finds return type', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function DoSomething() as string
                 end function
             `);
@@ -1453,7 +1453,7 @@ describe('BrsFile', () => {
         });
 
         it('finds value from global return', () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                    myName = GetName()
                 end sub
@@ -1504,7 +1504,7 @@ describe('BrsFile', () => {
 
     describe('getHover', () => {
         it('works for param types', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub DoSomething(name as string)
                     name = 1
                     sayMyName = function(name as string)
@@ -1525,7 +1525,7 @@ describe('BrsFile', () => {
 
         //ignore this for now...it's not a huge deal
         it('does not match on keywords or data types', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main(name as string)
                 end sub
                 sub as()
@@ -1538,7 +1538,7 @@ describe('BrsFile', () => {
         });
 
         it('finds declared function', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 function Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -1558,7 +1558,7 @@ describe('BrsFile', () => {
         });
 
         it('finds variable function hover in same scope', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName = sub(name as string)
                     end sub
@@ -1578,7 +1578,7 @@ describe('BrsFile', () => {
         });
 
         it('does not crash when hovering on built-in functions', async () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function doUcase(text)
                     return ucase(text)
                 end function
@@ -1594,7 +1594,7 @@ describe('BrsFile', () => {
         });
 
         it('does not crash when hovering on object method call', async () => {
-            let file = program.addOrReplaceFile('source/main.brs', `
+            let file = program.setFile('source/main.brs', `
                 function getInstr(url, text)
                     return url.instr(text)
                 end function
@@ -1611,7 +1611,7 @@ describe('BrsFile', () => {
         });
 
         it('finds function hover in file scope', () => {
-            let file = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
@@ -1637,13 +1637,13 @@ describe('BrsFile', () => {
                 rootDir: rootDir
             });
 
-            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     sayMyName()
                 end sub
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
                 sub sayMyName(name as string)
 
                 end sub
@@ -1666,7 +1666,7 @@ describe('BrsFile', () => {
                 rootDir: rootDir
             });
 
-            const file = program.addOrReplaceFile('source/lib.brs', `
+            const file = program.setFile('source/lib.brs', `
                 '
                 ' The main function
                 '
@@ -1712,7 +1712,7 @@ describe('BrsFile', () => {
         });
 
         it('handles mixed case `then` partions of conditionals', () => {
-            let mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true then
                         print "works"
@@ -1721,7 +1721,7 @@ describe('BrsFile', () => {
             `);
 
             expectZeroDiagnostics(mainFile);
-            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true Then
                         print "works"
@@ -1730,7 +1730,7 @@ describe('BrsFile', () => {
             `);
             expectZeroDiagnostics(mainFile);
 
-            mainFile = program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
                 sub Main()
                     if true THEN
                         print "works"
@@ -1742,7 +1742,7 @@ describe('BrsFile', () => {
     });
 
     it('does not throw when encountering incomplete import statement', () => {
-        program.addOrReplaceFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
             import
             sub main()
             end sub
@@ -2302,7 +2302,7 @@ describe('BrsFile', () => {
         });
 
         it('simple mapped files include a reference to the source map', () => {
-            let file = program.addOrReplaceFile('source/logger.brs', trim`
+            let file = program.setFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2312,7 +2312,7 @@ describe('BrsFile', () => {
         });
 
         it('AST generated files include a reference to the source map', () => {
-            let file = program.addOrReplaceFile('source/logger.brs', trim`
+            let file = program.setFile('source/logger.brs', trim`
                 sub logInfo()
                 end sub
             `);
@@ -2322,7 +2322,7 @@ describe('BrsFile', () => {
         });
 
         it('replaces custom types in parameter types and return types', () => {
-            program.addOrReplaceFile('source/SomeKlass.bs', `
+            program.setFile('source/SomeKlass.bs', `
                 class SomeKlass
                 end class
             `);
@@ -2348,7 +2348,7 @@ describe('BrsFile', () => {
     describe('callfunc operator', () => {
         describe('transpile', () => {
             it('does not produce diagnostics', () => {
-                program.addOrReplaceFile('source/main.bs', `
+                program.setFile('source/main.bs', `
                     sub main()
                         someObject@.someFunction(paramObject.value)
                     end sub
@@ -2397,7 +2397,7 @@ describe('BrsFile', () => {
                 name: 'transform callback',
                 afterFileParse: onParsed
             });
-            file = program.addOrReplaceFile({ src: `absolute_path/file${ext}`, dest: `relative_path/file${ext}` }, `
+            file = program.setFile({ src: `absolute_path/file${ext}`, dest: `relative_path/file${ext}` }, `
                 sub Sum()
                     print "hello world"
                 end sub
@@ -2422,17 +2422,17 @@ describe('BrsFile', () => {
     describe('typedefKey', () => {
         it('works for .brs files', () => {
             expect(
-                s((program.addOrReplaceFile<BrsFile>('source/main.brs', '')).typedefKey)
+                s((program.setFile<BrsFile>('source/main.brs', '')).typedefKey)
             ).to.equal(
                 s`${rootDir.toLowerCase()}/source/main.d.bs`
             );
         });
         it('returns undefined for files that should not have a typedef', () => {
-            expect((program.addOrReplaceFile<BrsFile>('source/main.bs', '')).typedefKey).to.be.undefined;
+            expect((program.setFile<BrsFile>('source/main.bs', '')).typedefKey).to.be.undefined;
 
-            expect((program.addOrReplaceFile<BrsFile>('source/main.d.bs', '')).typedefKey).to.be.undefined;
+            expect((program.setFile<BrsFile>('source/main.d.bs', '')).typedefKey).to.be.undefined;
 
-            const xmlFile = program.addOrReplaceFile<BrsFile>('components/comp.xml', '');
+            const xmlFile = program.setFile<BrsFile>('components/comp.xml', '');
             expect(xmlFile.typedefKey).to.be.undefined;
         });
     });
@@ -2441,14 +2441,14 @@ describe('BrsFile', () => {
     describe('type definitions', () => {
         it('only exposes defined functions even if source has more', () => {
             //parse the .brs file first so it doesn't know about the typedef
-            program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
                 end sub
             `);
 
-            program.addOrReplaceFile('source/main.d.bs', `
+            program.setFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2460,7 +2460,7 @@ describe('BrsFile', () => {
         });
 
         it('reacts to typedef file changes', () => {
-            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            let file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2469,7 +2469,7 @@ describe('BrsFile', () => {
             expect(file.hasTypedef).to.be.false;
             expect(file.typedefFile).not.to.exist;
 
-            program.addOrReplaceFile('source/main.d.bs', `
+            program.setFile('source/main.d.bs', `
                 sub main()
                 end sub
             `);
@@ -2477,7 +2477,7 @@ describe('BrsFile', () => {
             expect(file.typedefFile).to.exist;
 
             //add replace file, does it still find the typedef
-            file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
                 sub speak()
@@ -2495,33 +2495,33 @@ describe('BrsFile', () => {
 
     describe('typedef', () => {
         it('sets typedef path properly', () => {
-            expect((program.addOrReplaceFile<BrsFile>('source/main1.brs', '')).typedefKey).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
-            expect((program.addOrReplaceFile<BrsFile>('source/main2.d.bs', '')).typedefKey).to.equal(undefined);
-            expect((program.addOrReplaceFile<BrsFile>('source/main3.bs', '')).typedefKey).to.equal(undefined);
+            expect((program.setFile<BrsFile>('source/main1.brs', '')).typedefKey).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
+            expect((program.setFile<BrsFile>('source/main2.d.bs', '')).typedefKey).to.equal(undefined);
+            expect((program.setFile<BrsFile>('source/main3.bs', '')).typedefKey).to.equal(undefined);
             //works for dest with `.brs` extension
-            expect((program.addOrReplaceFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefKey).to.equal(undefined);
+            expect((program.setFile<BrsFile>({ src: 'source/main4.bs', dest: 'source/main4.brs' }, '')).typedefKey).to.equal(undefined);
         });
 
         it('does not link when missing from program', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).not.to.exist;
         });
 
         it('links typedef when added BEFORE .brs file', () => {
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             expect(file.typedefFile).to.equal(typedef);
         });
 
         it('links typedef when added AFTER .brs file', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
             expect(file.typedefFile).to.eql(typedef);
         });
 
         it('removes typedef link when typedef is removed', () => {
-            const typedef = program.addOrReplaceFile<BrsFile>('source/main.d.bs', ``);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', ``);
+            const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
+            const file = program.setFile<BrsFile>('source/main.brs', ``);
             program.removeFile(typedef.pathAbsolute);
             expect(file.typedefFile).to.be.undefined;
         });
@@ -2529,7 +2529,7 @@ describe('BrsFile', () => {
 
     describe('getTypedef', () => {
         function testTypedef(original: string, expected: string) {
-            let file = program.addOrReplaceFile<BrsFile>('source/main.brs', original);
+            let file = program.setFile<BrsFile>('source/main.brs', original);
             expect(file.getTypedef()).to.eql(expected);
         }
 
@@ -2792,7 +2792,7 @@ describe('BrsFile', () => {
 
     describe('parser getter', () => {
         it('recreates the parser when missing', () => {
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `
+            const file = program.setFile<BrsFile>('source/main.brs', `
                 sub main()
                 end sub
             `);
@@ -2810,11 +2810,11 @@ describe('BrsFile', () => {
         });
 
         it('call parse when previously skipped', () => {
-            program.addOrReplaceFile<BrsFile>('source/main.d.bs', `'typedef
+            program.setFile<BrsFile>('source/main.d.bs', `'typedef
                 sub main()
                 end sub
             `);
-            const file = program.addOrReplaceFile<BrsFile>('source/main.brs', `'source
+            const file = program.setFile<BrsFile>('source/main.brs', `'source
                 sub main()
                 end sub
             `);

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -49,7 +49,7 @@ describe('XmlFile', () => {
                     }
                 }
             });
-            file = program.addOrReplaceFile('components/ChildScene.xml', trim`
+            file = program.setFile('components/ChildScene.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                 </component>
@@ -88,7 +88,7 @@ describe('XmlFile', () => {
         });
 
         it('supports importing BrighterScript files', () => {
-            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.bs" />
@@ -99,7 +99,7 @@ describe('XmlFile', () => {
             );
         });
         it('does not include commented-out script imports', () => {
-            file = program.addOrReplaceFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -192,7 +192,7 @@ describe('XmlFile', () => {
         });
 
         it('Adds error when no component is declared in xml', () => {
-            program.addOrReplaceFile('components/comp.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
+            program.setFile('components/comp.xml', '<script type="text/brightscript" uri="ChildScene.brs" />');
             program.validate();
             expectDiagnostics(program, [
                 {
@@ -204,7 +204,7 @@ describe('XmlFile', () => {
         });
 
         it('adds error when component does not declare a name', () => {
-            file = program.addOrReplaceFile('components/comp.xml', trim`
+            file = program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component extends="ParentScene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -219,7 +219,7 @@ describe('XmlFile', () => {
         });
 
         it('catches xml parse errors', () => {
-            file = program.addOrReplaceFile('components/comp.xml', trim`
+            file = program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component 1extends="ParentScene">
                 </component>
@@ -262,7 +262,7 @@ describe('XmlFile', () => {
         });
 
         it('resolves relative paths', () => {
-            file = program.addOrReplaceFile({
+            file = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -279,7 +279,7 @@ describe('XmlFile', () => {
         });
 
         it('finds correct position for empty uri in script tag', () => {
-            file = program.addOrReplaceFile({
+            file = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -297,7 +297,7 @@ describe('XmlFile', () => {
 
     describe('doesReferenceFile', () => {
         it('compares case insensitive', () => {
-            let xmlFile = program.addOrReplaceFile({
+            let xmlFile = program.setFile({
                 src: `${rootDir}/components/comp1.xml`,
                 dest: 'components/comp1.xml'
             }, trim`
@@ -306,7 +306,7 @@ describe('XmlFile', () => {
                     <script type="text/brightscript" uri="HeroGrid.brs" />
                 </component>
             `);
-            let brsFile = program.addOrReplaceFile({
+            let brsFile = program.setFile({
                 src: `${rootDir}/components/HEROGRID.brs`,
                 dest: `components/HEROGRID.brs`
             }, ``);
@@ -316,19 +316,19 @@ describe('XmlFile', () => {
 
     describe('autoImportComponentScript', () => {
         it('is not enabled by default', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
@@ -345,19 +345,19 @@ describe('XmlFile', () => {
                 rootDir: rootDir,
                 autoImportComponentScript: true
             });
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
                 function libFunc()
                 end function
             `);
 
-            program.addOrReplaceFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
                 function init()
                     libFunc()
                 end function
@@ -394,15 +394,15 @@ describe('XmlFile', () => {
         });
 
         it('returns empty set when out of range', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
             expect(file.getCompletions(Position.create(99, 99))).to.be.empty;
         });
 
         //TODO - refine this test once cdata scripts are supported
         it('prevents scope completions entirely', () => {
-            program.addOrReplaceFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
 
-            let xmlFile = program.addOrReplaceFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.setFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./Component1.brs" />
@@ -415,7 +415,7 @@ describe('XmlFile', () => {
 
     describe('getAllDependencies', () => {
         it('returns own imports', () => {
-            file = program.addOrReplaceFile('components/comp1.xml', trim`
+            file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="BaseScene">
                     <script type="text/brightscript" uri="pkg:/source/lib.brs" />
@@ -429,7 +429,7 @@ describe('XmlFile', () => {
     });
 
     it('invalidates dependent scopes on change', () => {
-        let xmlFile = program.addOrReplaceFile<XmlFile>({
+        let xmlFile = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -444,7 +444,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated);
 
         //add lib1
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, ``);
@@ -454,7 +454,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated).to.be.true;
 
         //update lib1 to include an import
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.bs`,
             dest: `source/lib.bs`
         }, `
@@ -467,7 +467,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated).to.be.true;
 
         //add the lib2 imported from lib
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib2.bs`,
             dest: `source/lib2.bs`
         }, ``);
@@ -482,7 +482,7 @@ describe('XmlFile', () => {
     });
 
     it('does not invalidate unrelated scopes on change', () => {
-        let xmlFile1 = program.addOrReplaceFile<XmlFile>({
+        let xmlFile1 = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp1.xml`,
             dest: `components/comp1.xml`
         }, trim`
@@ -492,7 +492,7 @@ describe('XmlFile', () => {
             </component>
         `);
 
-        let xmlFile2 = program.addOrReplaceFile<XmlFile>({
+        let xmlFile2 = program.setFile<XmlFile>({
             src: `${rootDir}/components/comp2.xml`,
             dest: `components/comp2.xml`
         }, trim`
@@ -507,7 +507,7 @@ describe('XmlFile', () => {
         expect(program.getScopesForFile(xmlFile2)[0].isValidated).to.be.true;
 
         //add the lib file
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/source/lib.brs`,
             dest: `source/lib.brs`
         }, ``);
@@ -527,7 +527,7 @@ describe('XmlFile', () => {
 
     describe('component extends', () => {
         it('works for single-line', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -542,7 +542,7 @@ describe('XmlFile', () => {
         });
 
         it('works for multi-line', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -558,7 +558,7 @@ describe('XmlFile', () => {
         });
 
         it('does not throw when unable to find extends', () => {
-            file = program.addOrReplaceFile(
+            file = program.setFile(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -573,7 +573,7 @@ describe('XmlFile', () => {
         });
 
         it('adds warning when no "extends" attribute is found', () => {
-            program.addOrReplaceFile<XmlFile>(
+            program.setFile<XmlFile>(
                 {
                     src: `${rootDir}/components/comp1.xml`,
                     dest: `components/comp1.xml`
@@ -596,11 +596,11 @@ describe('XmlFile', () => {
             autoImportComponentScript: true,
             rootDir: rootDir
         });
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/components/SimpleScene.bs`,
             dest: `components/SimpleScene.bs`
         }, '');
-        program.addOrReplaceFile({
+        program.setFile({
             src: `${rootDir}/components/SimpleScene.xml`,
             dest: `components/SimpleScene.xml`
         }, trim`
@@ -660,7 +660,7 @@ describe('XmlFile', () => {
                     file.needsTranspiled = true;
                 }
             });
-            const file = program.addOrReplaceFile('components/file.xml', trim`
+            const file = program.setFile('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Comp" extends="Group">
                 </component>
@@ -696,8 +696,8 @@ describe('XmlFile', () => {
         });
 
         it('does not include bslib script if already there from ropm', () => {
-            program.addOrReplaceFile('source/roku_modules/bslib/bslib.brs', ``);
-            program.addOrReplaceFile('source/lib.bs', ``);
+            program.setFile('source/roku_modules/bslib/bslib.brs', ``);
+            program.setFile('source/lib.bs', ``);
             //include a bs file to force transpile for the xml file
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -715,7 +715,7 @@ describe('XmlFile', () => {
         });
 
         it('does not transpile xml file when bslib script is already present', () => {
-            const file = program.addOrReplaceFile('components/comp.xml', trim`
+            const file = program.setFile('components/comp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Comp" extends="Group">
                     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
@@ -731,9 +731,9 @@ describe('XmlFile', () => {
          * There was a bug that would incorrectly replace one of the script paths on the second or third transpile, so this test verifies it doesn't do that anymore
          */
         it('does not mangle scripts on multiple transpile', async () => {
-            program.addOrReplaceFile('components/SimpleScene.bs', ``);
+            program.setFile('components/SimpleScene.bs', ``);
 
-            program.addOrReplaceFile(`components/SimpleScene.xml`, trim`
+            program.setFile(`components/SimpleScene.xml`, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
                     <script type="text/brightscript" uri="SimpleScene.bs" />
@@ -758,7 +758,7 @@ describe('XmlFile', () => {
         });
 
         it('keeps all content of the XML', () => {
-            program.addOrReplaceFile(`components/SimpleScene.bs`, `
+            program.setFile(`components/SimpleScene.bs`, `
                 sub b()
                 end sub
             `);
@@ -800,10 +800,10 @@ describe('XmlFile', () => {
         });
 
         it('changes file extensions from bs to brs', () => {
-            program.addOrReplaceFile(`components/SimpleScene.bs`, `
+            program.setFile(`components/SimpleScene.bs`, `
                 import "pkg:/source/lib.bs"
             `);
-            program.addOrReplaceFile('source/lib.bs', ``);
+            program.setFile('source/lib.bs', ``);
 
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -821,7 +821,7 @@ describe('XmlFile', () => {
         });
 
         it('does not fail on missing script type', () => {
-            program.addOrReplaceFile('components/SimpleScene.brs', '');
+            program.setFile('components/SimpleScene.brs', '');
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
@@ -837,7 +837,7 @@ describe('XmlFile', () => {
         });
 
         it('returns the XML unmodified if needsTranspiled is false', () => {
-            let file = program.addOrReplaceFile(
+            let file = program.setFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -858,7 +858,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is false by default', () => {
-            let file = program.addOrReplaceFile(
+            let file = program.setFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -869,7 +869,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is true if an import is brighterscript', () => {
-            let file = program.addOrReplaceFile(
+            let file = program.setFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -882,7 +882,7 @@ describe('XmlFile', () => {
 
         it('simple source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.addOrReplaceFile(
+            let file = program.setFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -897,7 +897,7 @@ describe('XmlFile', () => {
 
         it('AST-based source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.addOrReplaceFile(
+            let file = program.setFile(
                 { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -920,7 +920,7 @@ describe('XmlFile', () => {
                 name: 'Transform plugins',
                 afterFileParse: file => validateXml(file as XmlFile)
             });
-            file = program.addOrReplaceFile<XmlFile>('components/component.xml', trim`
+            file = program.setFile<XmlFile>('components/component.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Cmp1" extends="Scene">
                 </component>
@@ -954,7 +954,7 @@ describe('XmlFile', () => {
             }
         });
 
-        program.addOrReplaceFile('components/comp.xml', trim`
+        program.setFile('components/comp.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
             </component>
@@ -968,43 +968,43 @@ describe('XmlFile', () => {
 
     describe('typedef', () => {
         it('loads d.bs files from parent scope', () => {
-            program.addOrReplaceFile<XmlFile>('components/ParentComponent.xml', trim`
+            program.setFile<XmlFile>('components/ParentComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent" extends="Scene">
                     <script uri="ParentComponent.brs" />
                 </component>
             `);
 
-            program.addOrReplaceFile('components/ParentComponent.d.bs', `
+            program.setFile('components/ParentComponent.d.bs', `
                 import "Lib.brs"
                 namespace Parent
                     sub log()
                     end sub
                 end namespace
             `);
-            program.addOrReplaceFile('components/ParentComponent.brs', `
+            program.setFile('components/ParentComponent.brs', `
                 sub Parent_log()
                 end sub
             `);
 
-            program.addOrReplaceFile('components/Lib.d.bs', `
+            program.setFile('components/Lib.d.bs', `
                 namespace Lib
                     sub log()
                     end sub
                 end namespace
             `);
-            program.addOrReplaceFile('components/Lib.brs', `
+            program.setFile('components/Lib.brs', `
                 sub Lib_log()
                 end sub
             `);
 
-            program.addOrReplaceFile<XmlFile>('components/ChildComponent.xml', trim`
+            program.setFile<XmlFile>('components/ChildComponent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                     <script uri="ChildComponent.bs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/ChildComponent.bs', `
+            program.setFile('components/ChildComponent.bs', `
                 sub init()
                     Parent.log()
                     Lib.log()
@@ -1020,13 +1020,13 @@ describe('XmlFile', () => {
         });
 
         it('loads `d.bs` files into scope', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
                 </component>
             `);
-            program.addOrReplaceFile('components/Component1.d.bs', `
+            program.setFile('components/Component1.d.bs', `
                 sub logInfo()
                 end sub
             `);
@@ -1035,15 +1035,15 @@ describe('XmlFile', () => {
         });
 
         it('does not include `d.bs` script during transpile', () => {
-            program.addOrReplaceFile('source/logger.d.bs', `
+            program.setFile('source/logger.d.bs', `
                 sub logInfo()
                 end sub
             `);
-            program.addOrReplaceFile('source/logger.brs', `
+            program.setFile('source/logger.brs', `
                 sub logInfo()
                 end sub
             `);
-            program.addOrReplaceFile('components/Component1.bs', `
+            program.setFile('components/Component1.bs', `
                 import "pkg:/source/logger.brs"
                 sub init()
                 end sub
@@ -1064,7 +1064,7 @@ describe('XmlFile', () => {
         });
 
         it('does not load .brs information into scope if related d.bs is in scope', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -1073,7 +1073,7 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            program.addOrReplaceFile('components/Component1.brs', `
+            program.setFile('components/Component1.brs', `
                 sub logInfo()
                 end sub
                 sub logWarning()
@@ -1085,7 +1085,7 @@ describe('XmlFile', () => {
             expect(functionNames).to.include('logWarning');
 
             //load d.bs file, which should shadow out the .brs file
-            program.addOrReplaceFile('components/Component1.d.bs', `
+            program.setFile('components/Component1.d.bs', `
                 sub logError()
                 end sub
             `);
@@ -1097,7 +1097,7 @@ describe('XmlFile', () => {
         });
 
         it('updates xml scope when typedef disappears', () => {
-            const xmlFile = program.addOrReplaceFile<XmlFile>('components/Component1.xml', trim`
+            const xmlFile = program.setFile<XmlFile>('components/Component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Component1" extends="Scene">
                     <script uri="Component1.brs" />
@@ -1106,12 +1106,12 @@ describe('XmlFile', () => {
             const scope = program.getScopesForFile(xmlFile)[0];
 
             //load brs file
-            program.addOrReplaceFile('components/Component1.brs', `
+            program.setFile('components/Component1.brs', `
                 sub logBrs()
                 end sub
             `);
             //load d.bs file, which should shadow out the .brs file
-            const typedef = program.addOrReplaceFile('components/Component1.d.bs', `
+            const typedef = program.setFile('components/Component1.d.bs', `
                 sub logTypedef()
                 end sub
             `);
@@ -1131,7 +1131,7 @@ describe('XmlFile', () => {
     });
 
     it('finds script imports for single-quoted script tags', () => {
-        const file = program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+        const file = program.setFile<XmlFile>('components/file.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="Cmp1" extends="Scene">
                 <script uri='SingleQuotedFile.brs' />
@@ -1143,7 +1143,7 @@ describe('XmlFile', () => {
     describe('commentFlags', () => {
         it('ignores warning from previous line comment', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!--bs:disable-next-line-->
                 <component>
@@ -1155,7 +1155,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line just for the specified code', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!--bs:disable-next-line 1006-->
                 <component>
@@ -1169,7 +1169,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line comment', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component> <!--bs:disable-line-->
                 </component>
@@ -1180,7 +1180,7 @@ describe('XmlFile', () => {
 
         it('ignores warning from previous line just for the specified code', () => {
             //component without a name attribute
-            program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+            program.setFile<XmlFile>('components/file.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component> <!--bs:disable-line 1006-->
                 </component>
@@ -1194,16 +1194,16 @@ describe('XmlFile', () => {
 
     describe('duplicate components', () => {
         it('more gracefully handles multiple components with the same name', () => {
-            program.addOrReplaceFile('components/comp1.brs', ``);
-            program.addOrReplaceFile('components/comp1.xml', trim`
+            program.setFile('components/comp1.brs', ``);
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                     <script uri="comp1.brs" />
                 </component>
             `);
             //add another component with the same name
-            program.addOrReplaceFile('components/comp2.brs', ``);
-            program.addOrReplaceFile('components/comp2.xml', trim`
+            program.setFile('components/comp2.brs', ``);
+            program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                     <script uri="comp2.brs" />
@@ -1218,7 +1218,7 @@ describe('XmlFile', () => {
 
         it('maintains consistent component selection', () => {
             //add comp2 first
-            const comp2 = program.addOrReplaceFile('components/comp2.xml', trim`
+            const comp2 = program.setFile('components/comp2.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>
@@ -1226,7 +1226,7 @@ describe('XmlFile', () => {
             expect(program.getComponent('comp1').file.pkgPath).to.equal(comp2.pkgPath);
 
             //add comp1. it should become the main component with this name
-            const comp1 = program.addOrReplaceFile('components/comp1.xml', trim`
+            const comp1 = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1" extends="Group">
                 </component>
@@ -1238,7 +1238,7 @@ describe('XmlFile', () => {
             expect(program.getComponent('comp1').file.pkgPath).to.equal(comp2.pkgPath);
 
             //add comp3
-            program.addOrReplaceFile('components/comp3.xml', trim`
+            program.setFile('components/comp3.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
                 </component>

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -33,14 +33,14 @@ describe('import statements', () => {
     });
 
     it('still transpiles import statements if found at bottom of file', async () => {
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="Scene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
 
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
@@ -48,7 +48,7 @@ describe('import statements', () => {
             import "stringOps.bs"
         `);
 
-        program.addOrReplaceFile('source/stringOps.bs', `
+        program.setFile('source/stringOps.bs', `
             function StringToLower(strVal as string)
                 return true
             end function
@@ -74,25 +74,25 @@ describe('import statements', () => {
 
     it('finds function loaded in by import multiple levels deep', () => {
         //create child component
-        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             import "stringOps.bs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/stringOps.bs', `
+        program.setFile('source/stringOps.bs', `
             import "intOps.bs"
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/intOps.bs', `
+        program.setFile('source/intOps.bs', `
             function isInt(strVal as dynamic)
                 return true
             end function
@@ -110,19 +110,19 @@ describe('import statements', () => {
 
     it('supports importing brs files', () => {
         //create child component
-        let component = program.addOrReplaceFile('components/ChildScene.xml', trim`
+        let component = program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('source/lib.bs', `
+        program.setFile('source/lib.bs', `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile('source/stringOps.brs', `
+        program.setFile('source/stringOps.brs', `
             function StringToLower(strVal as string)
                 return lcase(strVal)
             end function
@@ -139,20 +139,20 @@ describe('import statements', () => {
 
     it('detects when dependency contents have changed', () => {
         //create child component
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile('components/lib.bs', `
+        program.setFile('components/lib.bs', `
             import "animalActions.bs"
             function init1(strVal as string)
                 Waddle()
             end function
         `);
         //add the empty dependency
-        program.addOrReplaceFile('components/animalActions.bs', ``);
+        program.setFile('components/animalActions.bs', ``);
 
         //there should be an error because that function doesn't exist
         program.validate();
@@ -162,7 +162,7 @@ describe('import statements', () => {
         ]);
 
         //add the missing function
-        program.addOrReplaceFile('components/animalActions.bs', `
+        program.setFile('components/animalActions.bs', `
             sub Waddle()
                 print "Waddling"
             end sub
@@ -177,19 +177,19 @@ describe('import statements', () => {
 
     it('adds brs imports to xml file during transpile', () => {
         //create child component
-        let component = program.addOrReplaceFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+        let component = program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.addOrReplaceFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
+        program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.addOrReplaceFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
+        program.setFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function
@@ -207,13 +207,13 @@ describe('import statements', () => {
 
     it('shows diagnostic for missing file in import', () => {
         //create child component
-        program.addOrReplaceFile('components/ChildScene.xml', trim`
+        program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brighterscript" uri="ChildScene.bs" />
             </component>
         `);
-        program.addOrReplaceFile('components/ChildScene.bs', `
+        program.setFile('components/ChildScene.bs', `
             import "stringOps.bs"
             sub init()
             end sub
@@ -225,15 +225,15 @@ describe('import statements', () => {
     });
 
     it('complicated import graph adds correct script tags', () => {
-        program.addOrReplaceFile('source/maestro/ioc/IOCMixin.bs', `
+        program.setFile('source/maestro/ioc/IOCMixin.bs', `
             sub DoIocThings()
             end sub
         `);
-        program.addOrReplaceFile('source/BaseClass.bs', `
+        program.setFile('source/BaseClass.bs', `
             import "pkg:/source/maestro/ioc/IOCMixin.bs"
         `);
 
-        program.addOrReplaceFile('components/AuthManager.bs', `
+        program.setFile('components/AuthManager.bs', `
             import "pkg:/source/BaseClass.bs"
         `);
         testTranspile(trim`
@@ -254,7 +254,7 @@ describe('import statements', () => {
 
     it('handles malformed imports', () => {
         //shouldn't crash
-        const brsFile = program.addOrReplaceFile<BrsFile>('source/SomeFile.bs', `
+        const brsFile = program.setFile<BrsFile>('source/SomeFile.bs', `
             import ""
             import ":"
             import ":/"

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -22,7 +22,7 @@ describe('globalCallables', () => {
 
     describe('Roku_ads', () => {
         it('exists', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     adIface = Roku_Ads()
                 end sub
@@ -33,7 +33,7 @@ describe('globalCallables', () => {
     });
 
     it('isOptional defaults to false', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
                 thing = createObject()
             end sub
@@ -45,7 +45,7 @@ describe('globalCallables', () => {
     });
 
     it('handles optional params properly', () => {
-        program.addOrReplaceFile('source/main.brs', `
+        program.setFile('source/main.brs', `
             sub main()
                 print Mid("value1", 1) 'third param is optional
             end sub
@@ -55,7 +55,7 @@ describe('globalCallables', () => {
     });
 
     it('hover shows correct for optional params', async () => {
-        const file = program.addOrReplaceFile('source/main.brs', `
+        const file = program.setFile('source/main.brs', `
             sub main()
                 print Mid("value1", 1)
             end sub
@@ -73,7 +73,7 @@ describe('globalCallables', () => {
 
     describe('bslCore', () => {
         it('exists', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 Library "v30/bslCore.brs"
 
                 sub main()
@@ -89,7 +89,7 @@ describe('globalCallables', () => {
 
     describe('val', () => {
         it('allows single parameter', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print val("1001")
                 end sub
@@ -99,7 +99,7 @@ describe('globalCallables', () => {
         });
 
         it('allows both parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print val("1001", 10)
                 end sub
@@ -111,7 +111,7 @@ describe('globalCallables', () => {
 
     describe('StrI', () => {
         it('allows single parameter', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print StrI(2)
                 end sub
@@ -121,7 +121,7 @@ describe('globalCallables', () => {
         });
 
         it('allows both parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print StrI(2, 10)
                 end sub
@@ -133,7 +133,7 @@ describe('globalCallables', () => {
 
     describe('parseJson', () => {
         it('allows single parameter', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print ParseJson("{}")
                 end sub
@@ -143,7 +143,7 @@ describe('globalCallables', () => {
         });
 
         it('allows 2 parameters', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                 print ParseJson("{}", "i")
                 end sub

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -23,7 +23,7 @@ describe('SGParser', () => {
     });
 
     it('Parses well formed SG component', () => {
-        const file = program.addOrReplaceFile<XmlFile>('components/file.xml', trim`
+        const file = program.setFile<XmlFile>('components/file.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ParentScene" extends="GrandparentScene">
                 <interface>

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -93,7 +93,7 @@ describe('Statement', () => {
     describe('ImportStatement', () => {
         describe('getTypedef', () => {
             it('changes .bs file extensions to .brs', () => {
-                const file = program.addOrReplaceFile<BrsFile>('source/main.bs', `
+                const file = program.setFile<BrsFile>('source/main.bs', `
                     import "lib1.bs"
                     import "pkg:/source/lib2.bs"
                 `);

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -190,7 +190,7 @@ describe('NullCoalescingExpression', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 'a = user ?? false',
                 `a = rokucommunity_bslib_coalesce(user, false)`

--- a/src/parser/tests/expression/RegexLiteralExpression.spec.ts
+++ b/src/parser/tests/expression/RegexLiteralExpression.spec.ts
@@ -65,7 +65,7 @@ describe('RegexLiteralExpression', () => {
         });
 
         it('warns when in non-brighterscript mode', () => {
-            program.addOrReplaceFile('source/main.brs', `
+            program.setFile('source/main.brs', `
                 sub main()
                     print /"/
                 end sub

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -75,7 +75,7 @@ describe('TemplateStringExpression', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 'a = `${one},${two}`',
                 `a = rokucommunity_bslib_toString(one) + "," + rokucommunity_bslib_toString(two)`

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -266,7 +266,7 @@ describe('ternary expressions', () => {
         });
 
         it('uses the proper prefix when aliased package is installed', () => {
-            program.addOrReplaceFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
+            program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
                 `a = user = invalid ? "no user" : "logged in"`,
                 `a = rokucommunity_bslib_ternary(user = invalid, "no user", "logged in")`

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -63,7 +63,7 @@ describe('InterfaceStatement', () => {
     });
 
     it('allows declaring multiple interfaces in a file', () => {
-        program.addOrReplaceFile('source/interfaces.bs', `
+        program.setFile('source/interfaces.bs', `
             interface Iface1
                 name as dynamic
             end interface

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -203,7 +203,7 @@ function getTestFileAction(
     return function testFileAction(source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) {
         let [program, rootDir] = scopeGetter();
         expected = expected ? expected : source;
-        let file = program.addOrReplaceFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
+        let file = program.setFile<BrsFile>({ src: s`${rootDir}/${pkgPath}`, dest: pkgPath }, source);
         program.validate();
         if (failOnDiagnostic !== false) {
             expectZeroDiagnostics(program);


### PR DESCRIPTION
v1 renamed the `Program.addOrReplaceFile` method to `setFile`, we want to align with that target. While we can't rename it in v0 without breaking the api, we _can_ add `setFile`. This change does not introduce any breaking changes.

- adds `setFile` method
- deprecates `addOrReplaceFile` and internally calls `setFile`
- rename all internal calls of `addOrReplaceFile` to `setFile`
