### PR TITLE
Add transpile override to AstEditor

### DIFF
--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -1,3 +1,6 @@
+import type { Expression } from '../parser/Expression';
+import type { Statement } from '../parser/Statement';
+
 export class AstEditor {
     private changes: Change[] = [];
 
@@ -15,6 +18,17 @@ export class AstEditor {
         const change = new EditPropertyChange(obj, key, newValue);
         this.changes.push(change);
         change.apply();
+    }
+
+    /**
+     * Set custom text that will be emitted during transpile instead of the original text.
+     */
+    public overrideTranspileResult(node: Expression | Statement, value: string) {
+        this.setProperty(node, 'transpile', (state) => {
+            return [
+                state.sourceNode(node, value)
+            ];
+        });
     }
 
     /**


### PR DESCRIPTION
In some situations, a plugin is unable to replace/remove an element from the AST (perhaps due to using an array from `Parser.references`). Without being able to replace/remove the elements themselves, overriding the transpile is a nice alternative. 

- adds a `overrideTranspileResult` method to the `AstEditor` which will return a sourcemap-enabled block of text to replace what would have been transpiled originally.