### PR TITLE
fix offset issue with diagnostic printing in cli

### DIFF
--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { util } from './util';
-import { BrsFile } from './files/BrsFile';
 import chalk from 'chalk';
 
 describe('diagnosticUtils', () => {

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -165,7 +165,7 @@ describe('diagnosticUtils', () => {
         });
     });
 
-    describe.only('getDiagnosticLine', () => {
+    describe('getDiagnosticLine', () => {
         const color = ((text: string) => text) as any;
 
         function testGetDiagnosticLine(range: Range, squigglyText: string, lineLength = 20) {

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { util } from './util';
+import { BrsFile } from './files/BrsFile';
+import chalk from 'chalk';
 
 describe('diagnosticUtils', () => {
     let options: ReturnType<typeof diagnosticUtils.getPrintDiagnosticOptions>;
@@ -161,6 +163,43 @@ describe('diagnosticUtils', () => {
             expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
                 range: Range.create(5, 16, 5, 18)
             }, 'end functionasdf')).to.equal('            ~~~~');
+        });
+    });
+
+    describe.only('getDiagnosticLine', () => {
+        const color = ((text: string) => text) as any;
+
+        function testGetDiagnosticLine(range: Range, squigglyText: string, lineLength = 20) {
+            expect(
+                diagnosticUtils.getDiagnosticLine({ range: range } as any, '1'.repeat(lineLength), color)
+            ).to.eql([
+                chalk.bgWhite(' ' + chalk.black((range.start.line + 1).toString()) + ' ') + ' ' + '1'.repeat(lineLength),
+                chalk.bgWhite(' ' + chalk.white('_'.repeat((range.start.line + 1).toString().length)) + ' ') + ' ' + squigglyText.padEnd(lineLength, ' ')
+            ].join('\n'));
+        }
+
+        it('lines up at beginning of line for single-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(0, 0, 0, 5), '~~~~~');
+        });
+
+        it('lines up in middle of line for single-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(0, 5, 0, 10), '     ~~~~~');
+        });
+
+        it('lines up at end of line for single-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(0, 5, 0, 10), '     ~~~~~', 10);
+        });
+
+        it('lines up at beginning of line for double-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(15, 0, 15, 5), '~~~~~');
+        });
+
+        it('lines up in middle of line for double-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(15, 5, 15, 10), '     ~~~~~');
+        });
+
+        it('lines up at end of line for double-digit line num', () => {
+            testGetDiagnosticLine(util.createRange(15, 5, 15, 10), '     ~~~~~', 10);
         });
     });
 });

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -99,9 +99,9 @@ export function getDiagnosticLine(diagnostic: BsDiagnostic, diagnosticLine: stri
 
     //only print the line information if we have some
     if (diagnostic.range && diagnosticLine) {
-        let lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
-        let blankLineNumberText = chalk.bgWhite(' ' + chalk.white('_') + ' ') + ' ';
-        let squigglyText = getDiagnosticSquigglyText(diagnostic, diagnosticLine);
+        const lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
+        const blankLineNumberText = chalk.bgWhite(' ' + chalk.white('_'.repeat((diagnostic.range.start.line + 1).toString().length)) + ' ') + ' ';
+        const squigglyText = getDiagnosticSquigglyText(diagnostic, diagnosticLine);
         result +=
             lineNumberText + diagnosticLine + '\n' +
             blankLineNumberText + colorFunction(squigglyText);


### PR DESCRIPTION
Before the fix, line numbers larger than 9 would cause offset issues. This PR fixes the issue
![image](https://user-images.githubusercontent.com/2544493/154051703-a901f943-1c31-4519-b0d5-5c72df4f4bb0.png)
![image](https://user-images.githubusercontent.com/2544493/154051752-ed492d82-3786-4b81-97ec-d35c90bd19c3.png)

