### PR TITLE
remove VariableExpression.isCalled

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -794,7 +794,6 @@ export class VariableExpression extends Expression {
     }
 
     public readonly range: Range;
-    public isCalled: boolean;
 
     public getName(parseMode: ParseMode) {
         return parseMode === ParseMode.BrightScript ? this.name.text : this.name.text;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2447,10 +2447,6 @@ export class Parser {
             TokenKind.RightParen
         );
 
-        if (isVariableExpression(callee)) {
-            callee.isCalled = true;
-        }
-
         let expression = new CallExpression(callee, openingParen, closingParen, args, this.currentNamespaceName);
         if (addToCallExpressionList) {
             this.callExpressions.push(expression);


### PR DESCRIPTION
Removing the `isCalled` property on `VariableExpression` because it isn't used anywhere. It's probably left over from the `brs` runtime logic. 