### PR TITLE
Use valid range for interpolatedRange

### DIFF
--- a/src/astUtils/creators.spec.ts
+++ b/src/astUtils/creators.spec.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { interpolatedRange } from '..';
+import { TranspileState } from '../parser/TranspileState';
 import { createStringLiteral } from './creators';
 
 describe('creators', () => {
@@ -16,6 +18,15 @@ describe('creators', () => {
             expect(createStringLiteral('"hello world').token.text).to.equal('"hello world');
             //trailing
             expect(createStringLiteral('hello world"').token.text).to.equal('hello world"');
+        });
+    });
+
+    describe('interpolatedRange', () => {
+        it('can be used in sourcemaps', () => {
+            const state = new TranspileState('source/main.brs', {});
+            const node = state.sourceNode({ range: interpolatedRange }, 'code');
+            //should not crash
+            node.toStringWithSourceMap();
         });
     });
 });

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -7,17 +7,17 @@ import type { SGAttribute } from '../parser/SGTypes';
 import { Block, ClassMethodStatement } from '../parser/Statement';
 
 /**
- * A range that points to nowhere. Used to give non-null ranges to programmatically-added source code.
- * (Hardcoded range to prevent circular dependency issue in `../util.ts`
+ * A range that points to the beginning of the file. Used to give non-null ranges to programmatically-added source code.
+ * (Hardcoded range to prevent circular dependency issue in `../util.ts`)
  */
 export const interpolatedRange = {
     start: {
-        line: -1,
-        character: -1
+        line: 0,
+        character: 0
     },
     end: {
-        line: -1,
-        character: -1
+        line: 0,
+        character: 0
     }
 } as Range;
 


### PR DESCRIPTION
-1 is not valid for line and column numbers, so use 0 instead. This prevents crashes like:

![image](https://user-images.githubusercontent.com/2544493/155738997-7bb21e51-95d5-44dc-b7f4-f29db56759e2.png)
