### PR TITLE
Fix logger.time() not returning accurate timings

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -120,8 +120,8 @@ export class Logger {
     time<T>(logLevel: LogLevel, messages: any[], action: (pause: () => void, resume: () => void) => T): T {
         //call the log if loglevel is in range
         if (this._logLevel >= logLevel) {
-            let stopwatch = new Stopwatch();
-            let logLevelString = LogLevel[logLevel];
+            const stopwatch = new Stopwatch();
+            const logLevelString = LogLevel[logLevel];
 
             //write the initial log
             this[logLevelString](...messages ?? []);
@@ -129,11 +129,11 @@ export class Logger {
 
             stopwatch.start();
             //execute the action
-            let result = action(stopwatch.stop.bind(stopwatch), stopwatch.start.bind(stopwatch)) as any;
-            stopwatch.stop();
+            const result = action(stopwatch.stop.bind(stopwatch), stopwatch.start.bind(stopwatch)) as any;
 
             //return a function to call when the timer is complete
-            let done = () => {
+            const done = () => {
+                stopwatch.stop();
                 this.indent = this.indent.substring(2);
                 this[logLevelString](...messages ?? [], `finished. (${chalk.blue(stopwatch.getDurationText())})`);
             };

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -438,7 +438,7 @@ export class ProgramBuilder {
     private async loadAllFilesAST() {
         await this.logger.time(LogLevel.log, ['Parsing files'], async () => {
             let errorCount = 0;
-            let files = await this.logger.time(LogLevel.debug, ['getFlePaths'], async () => {
+            let files = await this.logger.time(LogLevel.debug, ['getFilePaths'], async () => {
                 return util.getFilePaths(this.options);
             });
             this.logger.trace('ProgramBuilder.loadAllFilesAST() files:', files);


### PR DESCRIPTION
While diagnosing why the compiler is taking so long in our project, we noticed that the reported time is not correct.

![image-before](https://user-images.githubusercontent.com/57358121/156888981-da1e33c6-3f1e-470d-a66f-b91527011434.png)

After debugging a bit, I found that `stopwatch.stop()` was called right after `action(...)`, which doesn't work for async methods (which "Parsing files"/`loadAllFilesAST` is).

Moving the stop inside the `done` callback seems to do the trick.

![image-after](https://user-images.githubusercontent.com/57358121/156889002-d9d37989-7578-406c-837c-5e73526da93b.png)