### PR TITLE
Keep the original type case when transpiling.

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1841,6 +1841,61 @@ describe('BrsFile', () => {
     });
 
     describe('transpile', () => {
+        it('retains casing of parameter types', () => {
+            function test(type: string) {
+                testTranspile(`
+                    sub one(a as ${type}, b as ${type.toUpperCase()}, c as ${type.toLowerCase()})
+                    end sub
+                `);
+            }
+            test('Boolean');
+            test('Double');
+            test('Dynamic');
+            test('Float');
+            test('Integer');
+            test('LongInteger');
+            test('Object');
+            test('String');
+        });
+
+        it('retains casing of return types', () => {
+            function test(type: string) {
+                testTranspile(`
+                    sub one() as ${type}
+                    end sub
+
+                    sub two() as ${type.toLowerCase()}
+                    end sub
+
+                    sub three() as ${type.toUpperCase()}
+                    end sub
+                `);
+            }
+            test('Boolean');
+            test('Double');
+            test('Dynamic');
+            test('Float');
+            test('Integer');
+            test('LongInteger');
+            test('Object');
+            test('String');
+            test('Void');
+        });
+
+        it('retains casing of literal types', () => {
+            function test(type: string) {
+                testTranspile(`
+                    sub main()
+                        thing = ${type}
+                        thing = ${type.toLowerCase()}
+                        thing = ${type.toUpperCase()}
+                    end sub
+                `);
+            }
+            test('Invalid');
+            test('True');
+            test('False');
+        });
         describe('throwStatement', () => {
             it('transpiles properly', () => {
                 testTranspile(`

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -2,6 +2,10 @@ import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class BooleanType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof BooleanType ||
@@ -14,7 +18,7 @@ export class BooleanType implements BscType {
     }
 
     public toString() {
-        return 'boolean';
+        return this.typeText ?? 'boolean';
     }
 
     public toTypeString(): string {

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -5,6 +5,10 @@ import { IntegerType } from './IntegerType';
 import { LongIntegerType } from './LongIntegerType';
 
 export class DoubleType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof DoubleType ||
@@ -26,7 +30,7 @@ export class DoubleType implements BscType {
         }
     }
     public toString() {
-        return 'double';
+        return this.typeText ?? 'double';
     }
 
     public toTypeString(): string {

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -1,6 +1,10 @@
 import type { BscType } from './BscType';
 
 export class DynamicType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         //everything can be dynamic, so as long as a type is provided, this is true
         return !!targetType;
@@ -16,7 +20,7 @@ export class DynamicType implements BscType {
     }
 
     public toString() {
-        return 'dynamic';
+        return this.typeText ?? 'dynamic';
     }
 
     public toTypeString(): string {

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -5,6 +5,10 @@ import { IntegerType } from './IntegerType';
 import { LongIntegerType } from './LongIntegerType';
 
 export class FloatType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof FloatType ||
@@ -27,7 +31,7 @@ export class FloatType implements BscType {
     }
 
     public toString() {
-        return 'float';
+        return this.typeText ?? 'float';
     }
 
     public toTypeString(): string {

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -5,6 +5,10 @@ import { FloatType } from './FloatType';
 import { LongIntegerType } from './LongIntegerType';
 
 export class IntegerType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof IntegerType ||
@@ -27,7 +31,7 @@ export class IntegerType implements BscType {
     }
 
     public toString() {
-        return 'integer';
+        return this.typeText ?? 'integer';
     }
 
     public toTypeString(): string {

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -2,6 +2,10 @@ import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class InvalidType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof InvalidType ||
@@ -14,7 +18,7 @@ export class InvalidType implements BscType {
     }
 
     public toString() {
-        return 'invalid';
+        return this.typeText ?? 'invalid';
     }
 
     public toTypeString(): string {

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -5,6 +5,10 @@ import { FloatType } from './FloatType';
 import { IntegerType } from './IntegerType';
 
 export class LongIntegerType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof LongIntegerType ||
@@ -27,7 +31,7 @@ export class LongIntegerType implements BscType {
     }
 
     public toString() {
-        return 'longinteger';
+        return this.typeText ?? 'longinteger';
     }
 
     public toTypeString(): string {

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -2,6 +2,10 @@ import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class ObjectType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof ObjectType ||
@@ -14,7 +18,7 @@ export class ObjectType implements BscType {
     }
 
     public toString() {
-        return 'object';
+        return this.typeText ?? 'object';
     }
 
     public toTypeString(): string {

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -2,6 +2,10 @@ import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class StringType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof StringType ||
@@ -14,7 +18,7 @@ export class StringType implements BscType {
     }
 
     public toString() {
-        return 'string';
+        return this.typeText ?? 'string';
     }
 
     public toTypeString(): string {

--- a/src/types/UninitializedType.ts
+++ b/src/types/UninitializedType.ts
@@ -17,7 +17,6 @@ export class UninitializedType implements BscType {
         return 'uninitialized';
     }
 
-
     public toTypeString(): string {
         return this.toString();
     }

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -2,6 +2,10 @@ import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
 export class VoidType implements BscType {
+    constructor(
+        public typeText?: string
+    ) { }
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof VoidType ||
@@ -14,9 +18,8 @@ export class VoidType implements BscType {
     }
 
     public toString() {
-        return 'void';
+        return this.typeText ?? 'void';
     }
-
 
     public toTypeString(): string {
         return this.toString();

--- a/src/util.ts
+++ b/src/util.ts
@@ -921,60 +921,66 @@ export class Util {
         // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
         switch (token.kind) {
             case TokenKind.Boolean:
+                return new BooleanType(token.text);
             case TokenKind.True:
             case TokenKind.False:
                 return new BooleanType();
             case TokenKind.Double:
+                return new DoubleType(token.text);
             case TokenKind.DoubleLiteral:
                 return new DoubleType();
             case TokenKind.Dynamic:
-                return new DynamicType();
+                return new DynamicType(token.text);
             case TokenKind.Float:
+                return new FloatType(token.text);
             case TokenKind.FloatLiteral:
                 return new FloatType();
             case TokenKind.Function:
                 //TODO should there be a more generic function type without a signature that's assignable to all other function types?
-                return new FunctionType(new DynamicType());
+                return new FunctionType(new DynamicType(token.text));
             case TokenKind.Integer:
+                return new IntegerType(token.text);
             case TokenKind.IntegerLiteral:
                 return new IntegerType();
             case TokenKind.Invalid:
-                return new InvalidType();
+                return new InvalidType(token.text);
             case TokenKind.LongInteger:
+                return new LongIntegerType(token.text);
             case TokenKind.LongIntegerLiteral:
                 return new LongIntegerType();
             case TokenKind.Object:
-                return new ObjectType();
+                return new ObjectType(token.text);
             case TokenKind.String:
+                return new StringType(token.text);
             case TokenKind.StringLiteral:
             case TokenKind.TemplateStringExpressionBegin:
             case TokenKind.TemplateStringExpressionEnd:
             case TokenKind.TemplateStringQuasi:
                 return new StringType();
             case TokenKind.Void:
-                return new VoidType();
+                return new VoidType(token.text);
             case TokenKind.Identifier:
                 switch (token.text.toLowerCase()) {
                     case 'boolean':
-                        return new BooleanType();
+                        return new BooleanType(token.text);
                     case 'double':
-                        return new DoubleType();
+                        return new DoubleType(token.text);
                     case 'float':
-                        return new FloatType();
+                        return new FloatType(token.text);
                     case 'function':
-                        return new FunctionType(new DynamicType());
+                        return new FunctionType(new DynamicType(token.text));
                     case 'integer':
-                        return new IntegerType();
+                        return new IntegerType(token.text);
                     case 'invalid':
-                        return new InvalidType();
+                        return new InvalidType(token.text);
                     case 'longinteger':
-                        return new LongIntegerType();
+                        return new LongIntegerType(token.text);
                     case 'object':
-                        return new ObjectType();
+                        return new ObjectType(token.text);
                     case 'string':
-                        return new StringType();
+                        return new StringType(token.text);
                     case 'void':
-                        return new VoidType();
+                        return new VoidType(token.text);
                 }
                 if (allowCustomType) {
                     return new CustomType(token.text);


### PR DESCRIPTION
When we transpile the code, we should retain the type tokens the exact way they were written. Previously, we were always transpiling them as all lower case.