### PR TITLE
fix crash when checking for enums to transpile

### DIFF
--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.spec.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.spec.ts
@@ -1,0 +1,33 @@
+import { createSandbox } from 'sinon';
+import * as fsExtra from 'fs-extra';
+import { Program } from '../../Program';
+import { standardizePath as s } from '../../util';
+const sinon = createSandbox();
+
+describe('BrsFile', () => {
+    const tempDir = s`${process.cwd()}/.tmp`;
+    const rootDir = s`${tempDir}/rootDir`;
+    let program: Program;
+
+    beforeEach(() => {
+        fsExtra.emptyDirSync(tempDir);
+        program = new Program({ rootDir: rootDir, sourceMap: true });
+    });
+    afterEach(() => {
+        sinon.restore();
+        program.dispose();
+    });
+
+    describe('BrsFilePreTranspileProcessor', () => {
+        it('does not crash when operating on a file not included by any scope', async () => {
+            program.setFile('components/lib.brs', `
+                sub doSomething()
+                    a = { b: "c"}
+                    print a.b
+                end sub
+            `);
+            await program.transpile([], s`${tempDir}/out`);
+        });
+    });
+});
+

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -17,6 +17,10 @@ export class BrsFilePreTranspileProcessor {
         const membersByEnum = new Cache<string, Map<string, string>>();
 
         const enumLookup = this.event.file.program.getFirstScopeForFile(this.event.file)?.getEnumMap();
+        //skip this logic if current scope has no enums
+        if ((enumLookup?.size ?? 0) === 0) {
+            return;
+        }
         for (const expression of this.event.file.parser.references.expressions) {
             const parts = util.getAllDottedGetParts(expression)?.map(x => x.toLowerCase());
             if (parts) {


### PR DESCRIPTION
Fixes a bug in the BscPlugin that would crash whenever trying to transpile enums in a file not included in any scopes. Now the plugin will skip enum scanning entirely if the file isn't included in any scopes, or if the scope doesn't have any enums. 