### PR TITLE
Prevent `undefined` showing up in type tracking

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3406,4 +3406,24 @@ describe('BrsFile', () => {
             expectZeroDiagnostics(program);
         });
     });
+
+    it('defaults to `dynamic` type complex expression', () => {
+        const file = program.setFile<BrsFile>('source/main.brs', `
+            sub main()
+                name = "cat"
+                thing = m["key"](true)
+            end sub
+        `);
+        program.validate();
+
+        //sanity check
+        expect(
+            file.parser.references.assignmentStatements[0].containingFunction.symbolTable.getSymbolType('name')
+        ).be.instanceof(StringType);
+
+        //this complex expression should resolve to dynamic type when not known
+        expect(
+            file.parser.references.assignmentStatements[0].containingFunction.symbolTable.getSymbolType('thing')
+        ).be.instanceof(DynamicType);
+    });
 });

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -6,6 +6,7 @@ import type { Token } from '../lexer/Token';
 import { UninitializedType } from './UninitializedType';
 import { ParseMode } from '../parser/Parser';
 import { CustomType } from './CustomType';
+import { DynamicType } from './DynamicType';
 
 /**
  * Gets the return type of a function, taking into account that the function may not have been declared yet
@@ -42,6 +43,9 @@ export function getTypeFromCallExpression(call: CallExpression, functionExpressi
 
             return futureType;
         });
+    } else {
+        //return dynamic if we can't figure out the type
+        return new DynamicType();
     }
 }
 


### PR DESCRIPTION
We should never have `undefined` for any object type in our type tracking system. This fixes one of those issues.