### PR TITLE
Better handling of `object` types

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3406,4 +3406,24 @@ describe('BrsFile', () => {
             expectZeroDiagnostics(program);
         });
     });
+
+    it('defaults to `dynamic` type complex expression', () => {
+        const file = program.setFile<BrsFile>('source/main.brs', `
+            sub main()
+                name = "cat"
+                thing = m["key"](true)
+            end sub
+        `);
+        program.validate();
+
+        //sanity check
+        expect(
+            file.parser.references.assignmentStatements[0].containingFunction.symbolTable.getSymbolType('name')
+        ).be.instanceof(StringType);
+
+        //this complex expression should resolve to dynamic type when not known
+        expect(
+            file.parser.references.assignmentStatements[0].containingFunction.symbolTable.getSymbolType('thing')
+        ).be.instanceof(DynamicType);
+    });
 });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3407,7 +3407,7 @@ describe('BrsFile', () => {
         });
     });
 
-    it('defaults to `dynamic` type complex expression', () => {
+    it('defaults to `dynamic` type for a complex expression', () => {
         const file = program.setFile<BrsFile>('source/main.brs', `
             sub main()
                 name = "cat"

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -11,11 +11,13 @@ import { Program } from '../Program';
 import type { TypeContext } from './BscType';
 import { Position } from 'vscode-languageserver-protocol';
 import type { BrsFile } from '../files/BrsFile';
+import { ObjectType } from './ObjectType';
 
 describe('ArrayType', () => {
-    it('is equivalent to array types', () => {
+    it('is assignable to correct types', () => {
         expect(new ArrayType().isAssignableTo(new ArrayType())).to.be.true;
         expect(new ArrayType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new ArrayType().isAssignableTo(new ObjectType())).to.be.true;
     });
 
     it('catches arrays containing different inner types', () => {

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -9,7 +9,9 @@ export class ArrayType implements BscType {
     public innerTypes: BscType[] = [];
 
     public isAssignableTo(targetType: BscType, context?: TypeContext) {
-        if (isArrayType(targetType)) {
+        if (isObjectType(targetType)) {
+            return true;
+        } else if (isArrayType(targetType)) {
             //this array type is assignable to the target IF
             //1. all of the types in this array are present in the target
             outer: for (let innerType of this.innerTypes) {

--- a/src/types/BooleanType.spec.ts
+++ b/src/types/BooleanType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { BooleanType } from './BooleanType';
 import { DynamicType } from './DynamicType';
+import { ObjectType } from './ObjectType';
 
 describe('BooleanType', () => {
-    it('is equivalent to boolean types', () => {
+    it('is assignable to various types', () => {
         expect(new BooleanType().isAssignableTo(new BooleanType())).to.be.true;
         expect(new BooleanType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new BooleanType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -1,4 +1,4 @@
-import { isBooleanType, isDynamicType } from '../astUtils/reflection';
+import { isBooleanType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 export class BooleanType implements BscType {
@@ -9,7 +9,8 @@ export class BooleanType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isBooleanType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -17,6 +17,9 @@ export class CustomType implements BscType, SymbolContainer {
     }
 
     public isAssignableTo(targetType: BscType, context?: TypeContext) {
+        if (isObjectType(targetType)) {
+            return true;
+        }
         const ancestorTypes = context?.scope?.getAncestorTypeListByContext(this, context);
         if (ancestorTypes?.find(ancestorType => targetType.equals(ancestorType, context))) {
             return true;

--- a/src/types/DoubleType.spec.ts
+++ b/src/types/DoubleType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
+import { ObjectType } from './ObjectType';
 
 describe('DoubleType', () => {
-    it('is equivalent to double types', () => {
+    it('is assignable to correct types', () => {
         expect(new DoubleType().isAssignableTo(new DoubleType())).to.be.true;
         expect(new DoubleType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new DoubleType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,4 +1,4 @@
-import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 export class DoubleType implements BscType {
@@ -9,7 +9,8 @@ export class DoubleType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isDoubleType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/FloatType.spec.ts
+++ b/src/types/FloatType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { DynamicType } from './DynamicType';
 import { FloatType } from './FloatType';
+import { ObjectType } from './ObjectType';
 
 describe('FloatType', () => {
     it('is equivalent to double types', () => {
         expect(new FloatType().isAssignableTo(new FloatType())).to.be.true;
         expect(new FloatType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new FloatType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -1,4 +1,4 @@
-import { isDynamicType, isIntegerType, isFloatType, isDoubleType, isLongIntegerType } from '../astUtils/reflection';
+import { isDynamicType, isIntegerType, isFloatType, isDoubleType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 export class FloatType implements BscType {
@@ -9,8 +9,8 @@ export class FloatType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isFloatType(targetType) ||
-            isDynamicType(targetType)
-
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/IntegerType.spec.ts
+++ b/src/types/IntegerType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
+import { ObjectType } from './ObjectType';
 
 describe('IntegerType', () => {
-    it('is equivalent to other integer types', () => {
+    it('is assignable to other proper types', () => {
         expect(new IntegerType().isAssignableTo(new IntegerType())).to.be.true;
         expect(new IntegerType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new IntegerType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -1,4 +1,4 @@
-import { isIntegerType, isDynamicType, isFloatType, isDoubleType, isLongIntegerType } from '../astUtils/reflection';
+import { isIntegerType, isDynamicType, isFloatType, isDoubleType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 
@@ -10,7 +10,8 @@ export class IntegerType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isIntegerType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -170,6 +170,10 @@ describe('InterfaceType', () => {
             });
         });
 
+        it('accepts with source member having dynamic prop type', () => {
+            expect(iface({ name: new StringType() }).isAssignableTo(new ObjectType())).to.be.true;
+        });
+
         it('accepts with target member having dynamic prop type', () => {
             expectAssignable({
                 parent: new DynamicType()

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -11,6 +11,9 @@ export class InterfaceType implements BscType, SymbolContainer {
     }
 
     public isAssignableTo(targetType: BscType, context?: TypeContext) {
+        if (isObjectType(targetType)) {
+            return true;
+        }
         const ancestorTypes = context?.scope?.getAncestorTypeListByContext(this, context);
         if (ancestorTypes?.find(ancestorType => targetType.equals(ancestorType, context))) {
             return true;

--- a/src/types/InvalidType.spec.ts
+++ b/src/types/InvalidType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { DynamicType } from './DynamicType';
 import { InvalidType } from './InvalidType';
+import { ObjectType } from './ObjectType';
 
 describe('InvalidType', () => {
     it('is equivalent to invalid types', () => {
         expect(new InvalidType().isAssignableTo(new InvalidType())).to.be.true;
         expect(new InvalidType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new InvalidType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -9,7 +9,8 @@ export class InvalidType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isInvalidType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/LazyType.ts
+++ b/src/types/LazyType.ts
@@ -1,3 +1,4 @@
+import { isObjectType } from '../astUtils/reflection';
 import type { BscType, TypeContext } from './BscType';
 
 /**
@@ -18,6 +19,9 @@ export class LazyType implements BscType {
     }
 
     public isAssignableTo(targetType: BscType, context?: TypeContext) {
+        if (isObjectType(targetType)) {
+            return true;
+        }
         const foundType = this.getTypeFromContext(context);
         return foundType?.isAssignableTo(targetType, context);
     }

--- a/src/types/LongIntegerType.spec.ts
+++ b/src/types/LongIntegerType.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-
 import { DynamicType } from './DynamicType';
 import { LongIntegerType } from './LongIntegerType';
+import { ObjectType } from './ObjectType';
 
 describe('LongIntegerType', () => {
     it('is equivalent to other long integer types', () => {
         expect(new LongIntegerType().isAssignableTo(new LongIntegerType())).to.be.true;
         expect(new LongIntegerType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new LongIntegerType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -1,6 +1,5 @@
-import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
-
 
 export class LongIntegerType implements BscType {
     constructor(
@@ -10,7 +9,8 @@ export class LongIntegerType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isLongIntegerType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/StringType.spec.ts
+++ b/src/types/StringType.spec.ts
@@ -1,11 +1,13 @@
 import { expect } from 'chai';
 
 import { DynamicType } from './DynamicType';
+import { ObjectType } from './ObjectType';
 import { StringType } from './StringType';
 
 describe('StringType', () => {
     it('is equivalent to string types', () => {
         expect(new StringType().isAssignableTo(new StringType())).to.be.true;
         expect(new StringType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new StringType().isAssignableTo(new ObjectType())).to.be.true;
     });
 });

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -1,4 +1,4 @@
-import { isDynamicType, isStringType } from '../astUtils/reflection';
+import { isDynamicType, isObjectType, isStringType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 export class StringType implements BscType {
@@ -9,7 +9,8 @@ export class StringType implements BscType {
     public isAssignableTo(targetType: BscType) {
         return (
             isStringType(targetType) ||
-            isDynamicType(targetType)
+            isDynamicType(targetType) ||
+            isObjectType(targetType)
         );
     }
 

--- a/src/types/TypedFunctionType.spec.ts
+++ b/src/types/TypedFunctionType.spec.ts
@@ -7,10 +7,12 @@ import { IntegerType } from './IntegerType';
 import { StringType } from './StringType';
 import { FunctionType } from './FunctionType';
 import { VoidType } from './VoidType';
+import { ObjectType } from './ObjectType';
 
 describe('FunctionType', () => {
-    it('is equivalent to dynamic type', () => {
+    it('is equivalent to proper type', () => {
         expect(new TypedFunctionType(new VoidType()).isAssignableTo(new DynamicType())).to.be.true;
+        expect(new TypedFunctionType(new VoidType()).isAssignableTo(new ObjectType())).to.be.true;
     });
 
     it('validates using param and return types', () => {

--- a/src/types/TypedFunctionType.ts
+++ b/src/types/TypedFunctionType.ts
@@ -1,4 +1,4 @@
-import { isTypedFunctionType, isDynamicType } from '../astUtils/reflection';
+import { isTypedFunctionType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { CallableParam } from '../interfaces';
 import type { BscType, TypeContext } from './BscType';
 import { DynamicType } from './DynamicType';
@@ -40,7 +40,9 @@ export class TypedFunctionType implements BscType {
     }
 
     public isAssignableTo(targetType: BscType, context?: TypeContext) {
-        if (isTypedFunctionType(targetType)) {
+        if (isObjectType(targetType)) {
+            return true;
+        } else if (isTypedFunctionType(targetType)) {
             if (!targetType.isVariadic) {
                 //compare all parameters
                 let len = Math.max(this.params.length, targetType.params.length);

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -6,6 +6,7 @@ import type { Token } from '../lexer/Token';
 import { UninitializedType } from './UninitializedType';
 import { ParseMode } from '../parser/Parser';
 import { CustomType } from './CustomType';
+import { DynamicType } from './DynamicType';
 
 /**
  * Gets the return type of a function, taking into account that the function may not have been declared yet
@@ -42,6 +43,9 @@ export function getTypeFromCallExpression(call: CallExpression, functionExpressi
 
             return futureType;
         });
+    } else {
+        //return dynamic if we can't figure out the type
+        return new DynamicType();
     }
 }
 


### PR DESCRIPTION
In BrightScript, the `object` type can represent every type except `uninitialized`. This PR aligns the type system with that assumption.