### PR TITLE
Adds support for requiring external modules on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "prepublishOnly": "npm run build",
         "lint": "eslint \"src/**\"",
         "format": "tsfmt -r",
-        "test": "nyc mocha",
+        "test": "nyc mocha --all",
         "test:nocover": "mocha",
         "test:watch": "mocha --watch",
         "publish-coverage": "nyc report --reporter=text-lcov | coveralls",
@@ -24,6 +24,7 @@
             "ts-node/register"
         ],
         "fullTrace": true,
+        "timeout": 987654321,
         "watchExtensions": [
             "ts"
         ]

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,0 +1,37 @@
+import { standardizePath as s } from './util';
+import * as fsExtra from 'fs-extra';
+import { execSync } from 'child_process';
+import { expect } from 'chai';
+
+const tempDir = s`${process.cwd()}/.tmp`;
+const cliPath = s`${__dirname}/cli.ts`;
+
+describe('cli', () => {
+    let idx = 0;
+    let cwd: string;
+    beforeEach(() => {
+        cwd = s`${tempDir}/cli-test-${idx}`;
+        fsExtra.ensureDirSync(cwd);
+    });
+    afterEach(() => {
+        fsExtra.emptyDirSync(cwd);
+    });
+
+    if (process.argv.includes('--all')) {
+        it('loads ts-node from the --require flag', () => {
+            fsExtra.outputFileSync(s`${cwd}/manifest`, '');
+            const modulePath = s`${cwd}/module.js`;
+            //simple plugin that writes a file. If the file exists, we know the require syntax works
+            fsExtra.outputFileSync(modulePath, `
+            var fs = require('fs');
+            fs.writeFileSync('./testResult.txt', '');
+        `);
+            execSync(`npx ts-node-transpile-only "${cliPath}" --require "${modulePath}"`, {
+                cwd: cwd
+            });
+            expect(
+                fsExtra.pathExistsSync(s`${cwd}/testResult.txt`)
+            ).to.be.true;
+        });
+    }
+});


### PR DESCRIPTION
Adds the ability to `require` external modules as part of the CLI startup process. This allows bsc users to hook up things like ts-node/loader to run their plugins as pure typescript instead of needing a transpile step. 

Usage example:

```bash
npx bsc --require ts-node/register --plugins ./plugin.ts
```