### PR TITLE
Retain quote char when transpiling xml attributes

### DIFF
--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -617,6 +617,25 @@ describe('XmlFile', () => {
     });
 
     describe('transpile', () => {
+        it('handles single quotes properly', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="AnimationExample" extends="Scene">
+                    <children>
+                        <Animated frames='["pkg:/images/animation-1.png"]' />
+                    </children>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="AnimationExample" extends="Scene">
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                    <children>
+                        <Animated frames='["pkg:/images/animation-1.png"]' />
+                    </children>
+                </component>
+            `, 'none', 'components/Comp.xml');
+        });
+
         it('supports instantresume <customization> elements', async () => {
             fsExtra.outputFileSync(`${rootDir}/manifest`, '');
             fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `sub main()\nend sub`);

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -305,9 +305,27 @@ function mapAttributes(attributes: AttributeCstNode[]): SGAttribute[] {
     return attributes?.map(({ children }) => {
         const key = children.Name[0];
         const value = children.STRING?.[0];
+
+        let openQuote: SGToken;
+        let closeQuote: SGToken;
+        //capture the leading and trailing quote tokens
+        const match = /^(["']).*?(["'])$/.exec(value?.image);
+        if (match) {
+            const range = rangeFromTokenValue(value);
+            openQuote = {
+                text: match[1],
+                range: util.createRange(range.start.line, range.start.character, range.start.line, range.start.character + 1)
+            };
+            closeQuote = {
+                text: match[1],
+                range: util.createRange(range.end.line, range.end.character - 1, range.end.line, range.end.character)
+            };
+        }
         return {
             key: mapToken(key),
+            openQuote: openQuote,
             value: mapToken(value, true),
+            closeQuote: closeQuote,
             range: rangeFromTokens(key, value)
         };
     }) || [];

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -13,7 +13,9 @@ export interface SGToken {
 
 export interface SGAttribute {
     key: SGToken;
+    openQuote?: SGToken;
     value: SGToken;
+    closeQuote?: SGToken;
     range?: Range;
 }
 
@@ -77,9 +79,10 @@ export class SGTag {
             result.push(
                 ' ',
                 state.transpileToken(attr.key),
-                '="',
+                '=',
+                state.transpileToken(attr.openQuote ?? { text: '"' }),
                 state.transpileToken(attr.value),
-                '"'
+                state.transpileToken(attr.closeQuote ?? { text: '"' })
             );
         }
         return result;


### PR DESCRIPTION
When transpiling xml attributes, make sure to use the original quote character instead of always using `"`. This was fixed in the v1 branch, but is a big enough issue that it needed to be fixed in v0 as well. 
Fixes #549 