### PR TITLE
Don't add trailing commas for array and aa literals

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1843,6 +1843,36 @@ describe('BrsFile', () => {
     });
 
     describe('transpile', () => {
+        it('excludes trailing commas in array literals', () => {
+            testTranspile(`
+                sub main()
+                    arr = [
+                        1,
+                        2,
+                        3
+                    ]
+                    obj = {
+                        one: 1,
+                        two: 2,
+                        three: 3
+                    }
+                end sub
+            `, `
+                sub main()
+                    arr = [
+                        1
+                        2
+                        3
+                    ]
+                    obj = {
+                        one: 1
+                        two: 2
+                        three: 3
+                    }
+                end sub
+            `);
+        });
+
         it('transpiles if statement keywords as provided', () => {
             const code = `
                 If True Then
@@ -2100,7 +2130,7 @@ describe('BrsFile', () => {
             `, `
                 function Vertibrates_Birds_GetAllBirds()
                     return [
-                        Vertibrates_Birds_GetDuck(),
+                        Vertibrates_Birds_GetDuck()
                         Vertibrates_Birds_GetGoose()
                     ]
                 end function
@@ -2366,20 +2396,20 @@ describe('BrsFile', () => {
             testTranspile(`
                 sub doSomething()
                     person = {
-                        age: 12, 'comment
+                        age: 12 'comment
                         name: "child"
                     }
                     person = {
-                        age: 12, 'comment
+                        age: 12 'comment
                         name: "child" 'comment
                     }
                     person = {
-                        age: 12, 'comment
+                        age: 12 'comment
                         name: "child"
                         'comment
                     }
                     person = {
-                        age: 12, 'comment
+                        age: 12 'comment
                         name: "child" 'comment
                         'comment
                     }
@@ -2395,8 +2425,8 @@ describe('BrsFile', () => {
                 'a function that does something
                 function doSomething(age as integer, name = "bob") 'comment
                     person = { 'comment
-                        name: "parent", 'comment
-                        "age": 12,
+                        name: "parent" 'comment
+                        "age": 12
                         'comment as whole line
                         child: { 'comment
                             name: "child" 'comment
@@ -2432,8 +2462,8 @@ describe('BrsFile', () => {
                     stop 'comment
                     indexes = [ 'comment
                         'comment on its own line
-                        1, 'comment
-                        2, 'comment
+                        1 'comment
+                        2 'comment
                         3 'comment
                     ] 'comment
                     firstIndex = indexes[0] 'comment

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -697,15 +697,6 @@ export class AALiteralExpression extends Expression {
                     ' '
                 );
 
-                //determine if comments are the only members left in the array
-                let onlyCommentsRemaining = true;
-                for (let j = i + 1; j < this.elements.length; j++) {
-                    if (isCommentStatement(this.elements[j]) === false) {
-                        onlyCommentsRemaining = false;
-                        break;
-                    }
-                }
-
                 //value
                 result.push(...element.value.transpile(state));
             }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -594,15 +594,6 @@ export class ArrayLiteralExpression extends Expression {
                     state.indent(),
                     ...element.transpile(state)
                 );
-                //add a comma if we know there will be another non-comment statement after this
-                for (let j = i + 1; j < this.elements.length; j++) {
-                    let el = this.elements[j];
-                    //add a comma if there will be another element after this
-                    if (isCommentStatement(el) === false) {
-                        result.push(',');
-                        break;
-                    }
-                }
             }
         }
         state.blockDepth--;
@@ -717,10 +708,6 @@ export class AALiteralExpression extends Expression {
 
                 //value
                 result.push(...element.value.transpile(state));
-                //add trailing comma if not final element (excluding comments)
-                if (i !== this.elements.length - 1 && onlyCommentsRemaining === false) {
-                    result.push(',');
-                }
             }
 
 

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -154,11 +154,11 @@ describe('TemplateStringExpression', () => {
                 ]
             `, `
                 a = [
-                    "one",
-                    "two",
+                    "one"
+                    "two"
                     "I am a complex example" + bslib_toString(a.isRunning([
-                        "a",
-                        "b",
+                        "a"
+                        "b"
                         "c"
                     ]))
                 ]
@@ -179,12 +179,12 @@ describe('TemplateStringExpression', () => {
                 ]
             `, `
                 a = [
-                    "one",
-                    "two",
+                    "one"
+                    "two"
                     "I am a complex example " + bslib_toString(a.isRunning([
-                        "a",
-                        "b",
-                        "c",
+                        "a"
+                        "b"
+                        "c"
                         "d_open " + bslib_toString("inside" + m.items[i]) + " d_close"
                     ]))
                 ]

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -139,12 +139,12 @@ describe('parser print statements', () => {
                 print ""
             `, `
                 paramArr = [
-                    "This",
-                    "is",
-                    true,
-                    "and",
-                    "this",
-                    "is",
+                    "This"
+                    "is"
+                    true
+                    "and"
+                    "this"
+                    "is"
                     1
                 ]
                 print "This is one line of stuff:";


### PR DESCRIPTION
The comma is optional for mutli-line arrays associative arrays. The transpiler does not need to include them, excluding them would result in a very small size decrease for generated code.