### PR TITLE
Disable strict cli args to empower plugins

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,6 @@ let options = yargs
     .option('source-root', { type: 'string', description: 'Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files.' })
     .option('watch', { type: 'boolean', defaultDescription: 'false', description: 'Watch input files.' })
     .option('require', { type: 'array', description: 'A list of modules to require() on startup. Useful for doing things like ts-node registration.' })
-    .strict()
     .check(argv => {
         const diagnosticLevel = argv.diagnosticLevel as string;
         //if we have the diagnostic level and it's not a known value, then fail


### PR DESCRIPTION
Right now, plugins have no way to be configured from the CLI. Plugins could try to load .env or environment variables, or they could look for custom options in the bsconfig. However, there is a valid use case for supporting custom cli arguments. 

I considered allowing plugins to contribute cli argument specifications, but that can happen in a future update.

The current solution is: don't fail on unknown cli arguments. it's a one-liner, and solves the problem. 