### PR TITLE
Create object fixes

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -248,6 +248,18 @@ describe('Scope', () => {
                 ]);
             });
 
+            it('disregards component library components', () => {
+                program.setFile(`source/file.brs`, `
+                    sub main()
+                        scene = CreateObject("roSGNode", "Complib1:MainScene")
+                        button = CreateObject("roSGNode", "buttonlib:Button")
+                        list = CreateObject("roSGNode", "listlib:List")
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
             it('disregards non-literal args', () => {
                 program.setFile(`source/file.brs`, `
                     sub main()

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,7 +1,7 @@
 import { isBrsFile } from '../astUtils/reflection';
 import type { BrsFile } from '../files/BrsFile';
 import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent } from '../interfaces';
-import { Program } from '../Program';
+import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { BrsFileSemanticTokensProcessor } from './semanticTokens/BrsFileSemanticTokensProcessor';
 import { BrsFilePreTranspileProcessor } from './transpile/BrsFilePreTranspileProcessor';

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,6 +1,7 @@
 import { isBrsFile } from '../astUtils/reflection';
 import type { BrsFile } from '../files/BrsFile';
 import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent } from '../interfaces';
+import { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { BrsFileSemanticTokensProcessor } from './semanticTokens/BrsFileSemanticTokensProcessor';
 import { BrsFilePreTranspileProcessor } from './transpile/BrsFilePreTranspileProcessor';
@@ -26,8 +27,15 @@ export class BscPlugin implements CompilerPlugin {
         }
     }
 
+    private scopeValidator = new ScopeValidator();
+
     public onScopeValidate(event: OnScopeValidateEvent) {
-        return new ScopeValidator(event).process();
+        this.scopeValidator.processEvent(event);
+    }
+
+    public afterProgramValidate(program: Program) {
+        //release memory once the validation cycle has finished
+        this.scopeValidator.reset();
     }
 
     public beforeFileTranspile(event: BeforeFileTranspileEvent) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -170,6 +170,10 @@ export class ScopeValidator {
                 //if this is a `createObject('roSGNode'` call, only support known sg node types
                 if (firstParamStringValue?.toLowerCase() === 'rosgnode' && isLiteralExpression(call?.args[1]?.expression)) {
                     const componentName: Token = (call?.args[1]?.expression as any)?.token;
+                    //don't validate any components with a colon in their name (probably component libraries, but regular components can have them too).
+                    if (componentName?.text?.includes(':')) {
+                        continue;
+                    }
                     //add diagnostic for unknown components
                     const unquotedComponentName = componentName?.text?.replace(/"/g, '');
                     if (unquotedComponentName && !platformNodeNames.has(unquotedComponentName.toLowerCase()) && !event.program.getComponent(unquotedComponentName)) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,7 +1,6 @@
-import type { DiagnosticRelatedInformation } from 'vscode-languageserver';
 import { Location } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
-import { isBrsFile, isLiteralExpression, isXmlScope } from '../../astUtils/reflection';
+import { isBrsFile, isLiteralExpression } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1323,6 +1323,13 @@ export class Util {
             return undefined;
         }
     }
+
+    /**
+     * Converts a range to a string in the format 1:2-3:4
+     */
+    public rangeToString(range: Range) {
+        return `${range?.start?.line}:${range?.start?.character}-${range?.end?.line}:${range?.end?.character}`;
+    }
 }
 
 /**


### PR DESCRIPTION
This PR broke the functionality into 3 parts. 
 - move `CreateObject` validation into the BscPlugin file with no logical changes e733c2d552e49a5732b69137910685726ebe4ee0
 - add dedupe logic for CreateObject validations across multiple scopes 6b9e89eb13008a42bad178c5e90431b045a78422
 - prevent `CreateObject` diagnostics for component library components a09fe6de52c79e6b562e7226ed6e7471c10c145c