### PR TITLE
Adds 'new Component()' syntax as shorthand for CreateObject()

### DIFF
--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
 import type { Statement, Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement } from '../parser/Statement';
-import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, Expression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
+import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, Expression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression, NewCreateObjectExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 
 
@@ -125,6 +125,7 @@ export function createVisitor(
         VariableExpression?: (expression: VariableExpression, parent?: Statement | Expression) => Expression | void;
         SourceLiteralExpression?: (expression: SourceLiteralExpression, parent?: Statement | Expression) => Expression | void;
         NewExpression?: (expression: NewExpression, parent?: Statement | Expression) => Expression | void;
+        NewCreateObjectExpression?: (expression: NewCreateObjectExpression, parent?: Statement | Expression) => Expression | void;
         CallfuncExpression?: (expression: CallfuncExpression, parent?: Statement | Expression) => Expression | void;
         TemplateStringQuasiExpression?: (expression: TemplateStringQuasiExpression, parent?: Statement | Expression) => Expression | void;
         TemplateStringExpression?: (expression: TemplateStringExpression, parent?: Statement | Expression) => Expression | void;

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2594,6 +2594,65 @@ describe('BrsFile', () => {
         });
     });
 
+    describe('new CreateObject operator', () => {
+        describe('transpile', () => {
+            it('does not produce diagnostics', () => {
+                program.setFile('source/main.bs', `
+                    sub main()
+                        poster = new roSGNode("Poster")
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('includes original arguments', () => {
+                testTranspile(`
+                    sub main()
+                        poster = new roSGNode("Poster")
+                    end sub
+                `, `
+                    sub main()
+                        poster = CreateObject("roSGNode", "Poster")
+                    end sub
+                `);
+            });
+
+            it('works for zero args', () => {
+                testTranspile(`
+                    sub main()
+                        screen = new roScreen()
+                    end sub
+                `, `
+                    sub main()
+                        screen = CreateObject("roScreen")
+                    end sub
+                `);
+            });
+
+            it('works for many args', () => {
+                testTranspile(`
+                    sub main()
+                        bitmap1 = new roBitmap("someFileName.png")
+                        bitmap2 = new roBitmap({width:200, height:300, AlphaEnable:false, name:"MyBitmapName"})
+                        region = new roRegion(bitmap2, 10, 10, 10, 100)
+                    end sub
+                `, `
+                    sub main()
+                        bitmap1 = CreateObject("roBitmap", "someFileName.png")
+                        bitmap2 = CreateObject("roBitmap", {
+                            width: 200
+                            height: 300
+                            AlphaEnable: false
+                            name: "MyBitmapName"
+                        })
+                        region = CreateObject("roRegion", bitmap2, 10, 10, 10, 100)
+                    end sub
+                `);
+            });
+        });
+    });
+
     describe('transform callback', () => {
         function parseFileWithCallback(ext: string, onParsed: () => void) {
             const rootDir = process.cwd();

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -2,7 +2,7 @@ import { expect, assert } from 'chai';
 import { Lexer } from '../lexer/Lexer';
 import { ReservedWords, TokenKind } from '../lexer/TokenKind';
 import type { Expression } from './Expression';
-import { TernaryExpression, NewExpression, IndexedGetExpression, DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression } from './Expression';
+import { TernaryExpression, NewExpression, IndexedGetExpression, DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression, NewCreateObjectExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
 import type { AssignmentStatement, ClassStatement, Statement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
@@ -136,6 +136,31 @@ describe('parser', () => {
             `, ParseMode.BrighterScript);
             expect(parser.diagnostics[0]?.message).not.to.exist;
             expect((parser as any).statements[0]?.func?.body?.statements[0]?.expression).to.be.instanceof(CallfuncExpression);
+        });
+    });
+
+    describe('new operator for CreateObject', () => {
+        it('is not allowed in brightscript mode', () => {
+            let parser = parse(`
+                sub main()
+                    poster = new roSGNode("Poster")
+                end sub
+            `, ParseMode.BrightScript);
+            expect(
+                parser.diagnostics[0]?.message
+            ).to.equal(
+                DiagnosticMessages.bsFeatureNotSupportedInBrsFiles(`using 'new' keyword to construct a class`).message
+            );
+        });
+
+        it('does not cause parse errors', () => {
+            let parser = parse(`
+                sub main()
+                    myPoster = new roSGNode("Poster")
+                end sub
+            `, ParseMode.BrighterScript);
+            expectZeroDiagnostics(parser);
+            expect((parser as any).statements[0]?.func?.body?.statements[0]?.value).to.be.instanceof(NewCreateObjectExpression);
         });
     });
 


### PR DESCRIPTION
Implements Issue #259 

Uses `new` syntax as syntactic sugar to replace the `CreateObject()` call

eg.:

```
poster = new roSGNode("Poster")
regex = new roRegex("[a-z]+", "i")
bitmap = new roBitmap("somePath")
```

transpiles to:

```
poster = CreateObject("roSGNode", "Poster")
regex = CreateObject("roRegex", "[a-z]+", "i")
bitmap = CreateObject("roBitmap", "somePath")
```


All current `createObject` validation (wrong number of arguments, deprecation, etc), is applied to these calls as well.

<img width="571" alt="image" src="https://user-images.githubusercontent.com/810290/164123280-11517ca7-7541-4989-9119-5fb78ca97af6.png">
