### PR TITLE
Add AstEditor to before/after programTranspile events

### DIFF
--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -61,4 +61,11 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
         }
         return plugin;
     }
+
+    /**
+     * Remove all plugins
+     */
+    public clear() {
+        this.plugins = [];
+    }
 }

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -6,6 +6,7 @@ import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
+import type { TranspileObj } from './Program';
 import { Program } from './Program';
 import { standardizePath as s, util } from './util';
 import { URI } from 'vscode-uri';
@@ -20,6 +21,7 @@ import { createVisitor, WalkMode } from './astUtils/visitors';
 import { isBrsFile } from './astUtils/reflection';
 import { TokenKind } from './lexer/TokenKind';
 import type { LiteralExpression } from './parser/Expression';
+import type { AstEditor } from './astUtils/AstEditor';
 
 let sinon = sinonImport.createSandbox();
 let tmpPath = s`${process.cwd()}/.tmp`;
@@ -1760,6 +1762,42 @@ describe('Program', () => {
                             walkMode: WalkMode.visitExpressionsRecursive
                         });
                     }
+                }
+            });
+            //transpile the file
+            await program.transpile([], stagingFolderPath);
+            //our changes should be there
+            expect(
+                fsExtra.readFileSync(`${stagingFolderPath}/source/main.brs`).toString()
+            ).to.eql(trim`
+                sub main()
+                    print "goodbye world"
+                end sub`
+            );
+
+            //our literalExpression should have been restored to its original value
+            expect(literalExpression.token.text).to.eql('"hello world"');
+        });
+
+        it('handles AstEditor for beforeProgramTranspile', async () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub main()
+                    print "hello world"
+                end sub
+            `);
+            let literalExpression: LiteralExpression;
+            //replace all strings with "goodbye world"
+            program.plugins.add({
+                name: 'TestPlugin',
+                beforeProgramTranspile: (program: Program, entries: TranspileObj[], editor: AstEditor) => {
+                    file.ast.walk(createVisitor({
+                        LiteralExpression: (literal) => {
+                            literalExpression = literal;
+                            editor.setProperty(literal.token, 'text', '"goodbye world"');
+                        }
+                    }), {
+                        walkMode: WalkMode.visitExpressionsRecursive
+                    });
                 }
             });
             //transpile the file

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1336,7 +1336,9 @@ export class Program {
             };
         });
 
-        this.plugins.emit('beforeProgramTranspile', this, entries);
+        const astEditor = new AstEditor();
+
+        this.plugins.emit('beforeProgramTranspile', this, entries, astEditor);
 
         const promises = entries.map(async (entry) => {
             //skip transpiling typedef files
@@ -1372,7 +1374,8 @@ export class Program {
         }
         await Promise.all(promises);
 
-        this.plugins.emit('afterProgramTranspile', this, entries);
+        this.plugins.emit('afterProgramTranspile', this, entries, astEditor);
+        astEditor.undoAll();
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export * from './astUtils/stackedVisitor';
 export * from './astUtils/reflection';
 export * from './astUtils/creators';
 export * from './astUtils/xml';
+export * from './astUtils/AstEditor';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,8 +198,8 @@ export interface CompilerPlugin {
     afterProgramCreate?: (program: Program) => void;
     beforeProgramValidate?: (program: Program) => void;
     afterProgramValidate?: (program: Program) => void;
-    beforeProgramTranspile?: (program: Program, entries: TranspileObj[]) => void;
-    afterProgramTranspile?: (program: Program, entries: TranspileObj[]) => void;
+    beforeProgramTranspile?: (program: Program, entries: TranspileObj[], editor: AstEditor) => void;
+    afterProgramTranspile?: (program: Program, entries: TranspileObj[], editor: AstEditor) => void;
     onGetCodeActions?: PluginHandler<OnGetCodeActionsEvent>;
     onGetSemanticTokens?: PluginHandler<OnGetSemanticTokensEvent>;
     //scope events


### PR DESCRIPTION
Adds `AstEditor` to `beforeProgramTranspile` and `afterProgramTranspile` plugin events in case a plugin needs that level of granularity. 