### PR TITLE
Transpile files added after start of transpile cycle

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1717,6 +1717,51 @@ describe('Program', () => {
 
     describe('transpile', () => {
 
+        it('detects and transpiles files added between beforeProgramTranspile and afterProgramTranspile', async () => {
+            program.setFile('source/main.bs', trim`
+                sub main()
+                    print "hello world"
+                end sub
+            `);
+            program.plugins.add({
+                name: 'TestPlugin',
+                beforeFileTranspile: (event) => {
+                    if (isBrsFile(event.file)) {
+                        //add lib1
+                        if (event.outputPath.endsWith('main.brs')) {
+                            event.program.setFile('source/lib1.bs', `
+                                sub lib1()
+                                end sub
+                            `);
+                        }
+                        //add lib2 (this should happen during the next cycle of "catch missing files" cycle
+                        if (event.outputPath.endsWith('main.brs')) {
+                            //add another file
+                            event.program.setFile('source/lib2.bs', `
+                                sub lib2()
+                                end sub
+                            `);
+                        }
+                    }
+                }
+            });
+            await program.transpile([], stagingFolderPath);
+            //our new files should exist
+            expect(
+                fsExtra.readFileSync(`${stagingFolderPath}/source/lib1.brs`).toString()
+            ).to.eql(trim`
+                sub lib1()
+                end sub
+            `);
+            //our changes should be there
+            expect(
+                fsExtra.readFileSync(`${stagingFolderPath}/source/lib2.brs`).toString()
+            ).to.eql(trim`
+                sub lib2()
+                end sub
+            `);
+        });
+
         it('sets needsTranspiled=true when there is at least one edit', async () => {
             program.setFile('source/main.brs', trim`
                 sub main()

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -265,6 +265,7 @@ export interface OnScopeValidateEvent {
 export type Editor = Pick<AstEditor, 'addToArray' | 'hasChanges' | 'removeFromArray' | 'setArrayValue' | 'setProperty' | 'overrideTranspileResult'>;
 
 export interface BeforeFileTranspileEvent<TFile extends BscFile = BscFile> {
+    program: Program;
     file: TFile;
     outputPath: string;
     /**
@@ -276,6 +277,10 @@ export interface BeforeFileTranspileEvent<TFile extends BscFile = BscFile> {
 }
 
 export interface AfterFileTranspileEvent<TFile extends BscFile = BscFile> {
+    /**
+     * The program this event was triggered for
+     */
+    program: Program;
     file: TFile;
     outputPath: string;
     /**


### PR DESCRIPTION
Updates `Program.transpile()` to loop through any newly added files that weren't there at the the start of the transpile cycle. 

For example:
plugin wants to inject some code into the `init()` function of a component. However, certain components don't have an init function and don't even have any scripts. So, during the transpile cycle, the plugin will auto-create new files for each component that is missing the init function. Then, afterwords the plugin will delete that file again. 

