### PR TITLE
Adds enum types

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -2266,6 +2266,74 @@ describe('Scope', () => {
             expect(isFunctionType(mainSymbolTable.getSymbolType('someFunc'))).to.be.true;
         });
 
+        it('allows enums as argument types', () => {
+            program.setFile('source/main.bs', `
+                enum myEnum
+                    bar1
+                    bar2
+                end enum
+
+                sub printEnumValue(value as myEnum)
+                    print value
+                end sub
+
+                sub main()
+                    enumValue = myEnum.bar1
+                    printEnumValue(enumValue)
+                    printEnumValue(myEnum.bar2)
+                end sub
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows enums as return types', () => {
+            program.setFile('source/main.bs', `
+                enum myEnum
+                    bar1
+                    bar2
+                end enum
+
+                function getEnumVal() as myEnum
+                    return myEnum.bar1
+                end function
+
+                sub printEnumValue(value as myEnum)
+                    print value
+                end sub
+
+                sub main()
+                    varVal = getEnumVal()
+                    printEnumValue(varVal)
+                    printEnumValue(getEnumVal())
+                end sub
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('does not allow enum values as parameter types', () => {
+            program.setFile('source/main.bs', `
+                enum myEnum
+                    bar1
+                    bar2
+                end enum
+
+                sub printEnumValue(value as myEnum.bar1)
+                    print value
+                end sub
+
+                sub main()
+                    printEnumValue(myEnum.bar1)
+                end sub
+            `);
+
+            program.validate();
+            expectDiagnostics(program, [DiagnosticMessages.functionParameterTypeIsInvalid('value', 'myEnum.bar1')]);
+        });
+
     });
     describe('buildNamespaceLookup', () => {
         it('does not crash when class statement is missing `name` prop', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -148,7 +148,7 @@ export class Scope {
         let enumeration = enumMap.get(
             util.getFullyQualifiedClassName(lowerName, containingNamespace?.toLowerCase())
         );
-        //if we couldn't find the iface by its full namespaced name, look for a global class with that name
+        //if we couldn't find the enum by its full namespaced name, look for a global enum with that name
         if (!enumeration) {
             enumeration = enumMap.get(lowerName);
         }

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -118,6 +118,22 @@ export class SymbolTable {
                     const existingType = getTypeFromContext(symbol.type, context);
                     // if the type is not known yet, imply that the first assignment is the type
                     inferredType = inferredType ?? existingType;
+
+                    // TODO TYPES ... maybe this should look as 'convertibility' to infer a type
+                    // EG.:
+                    // value = 1
+                    // value = 3.4
+                    // print value ' hover here would say "dynamic", but it's been treated like a float
+                    //
+                    // This also impacts Enums, for example, as literal members are different types than a value that is generically a value of the type of the Enum:
+                    //
+                    // function getDataType(defaultValue as DataEnum) as DataEnum
+                    //    returnVal = defaultValue
+                    //    if someCondition
+                    //       returnVal = DataEnum.Other
+                    //    end if
+                    //    return returnVal ' hover here would say dynamic, but returnVal was always some kind of "DataEnum"
+                    // end function
                     sameInferredType = (inferredType?.equals(existingType, context));
                 }
                 if (!sameInferredType) {

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -24,6 +24,7 @@ import type { ArrayType } from '../types/ArrayType';
 import type { LazyType } from '../types/LazyType';
 import type { SGInterfaceField, SGInterfaceFunction, SGNode } from '../parser/SGTypes';
 import type { FunctionType } from '../types/FunctionType';
+import type { EnumMemberType, EnumType } from '../types/EnumType';
 
 // File reflection
 
@@ -303,6 +304,12 @@ export function isDynamicType(e: any): e is DynamicType {
 }
 export function isLazyType(e: any): e is LazyType {
     return e?.constructor.name === 'LazyType';
+}
+export function isEnumType(e: any): e is EnumType {
+    return e?.constructor.name === 'EnumType';
+}
+export function isEnumMemberType(e: any): e is EnumMemberType {
+    return e?.constructor.name === 'EnumMemberType';
 }
 
 const numberConstructorNames = [

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1944,6 +1944,77 @@ describe('BrsFile', () => {
                 '```'
             ].join('\n'));
         });
+
+        it('display literal enum members', () => {
+            let file = program.setFile('source/main.bs', `
+                enum MyEnum
+                    foo
+                    bar
+                end enum
+
+                sub main()
+                    value = MyEnum.foo
+                    print value
+                end sub
+            `);
+
+            let hover = file.getHover(Position.create(7, 38)); // 'myEnum.foo' in value assignnmnt
+            expect(hover).to.exist;
+            expect(hover.contents).to.equal([
+                '```brightscript',
+                'MyEnum.foo as MyEnum',
+                '```'
+            ].join('\n'));
+        });
+
+
+        it('finds enum values from assignments', () => {
+            let file = program.setFile('source/main.bs', `
+                enum MyEnum
+                    foo
+                    bar
+                end enum
+
+                sub main()
+                    value = MyEnum.foo
+                    print value
+                end sub
+            `);
+
+            let hover = file.getHover(Position.create(8, 30)); // 'value' in print statement
+            expect(hover).to.exist;
+            expect(hover.contents).to.equal([
+                '```brightscript',
+                'value as MyEnum',
+                '```'
+            ].join('\n'));
+        });
+
+
+        it('finds enum values as parameters', () => {
+            let file = program.setFile('source/main.bs', `
+                enum MyEnum
+                    foo
+                    bar
+                end enum
+
+                sub printEnum(enumParamVal as MyEnum)
+                    print enumParamVal
+                end sub
+
+                sub main()
+                    printEnum(MyEnum.foo)
+                end sub
+            `);
+
+            let hover = file.getHover(Position.create(7, 30)); // 'enumParamVal' in print statement
+            expect(hover).to.exist;
+            expect(hover.contents).to.equal([
+                '```brightscript',
+                'enumParamVal as MyEnum',
+                '```'
+            ].join('\n'));
+        });
     });
 
     it('does not throw when encountering incomplete import statement', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -949,7 +949,7 @@ export class BrsFile {
 
             if (symbolType?.memberTable) {
                 if (isCustomType(symbolType) || isInterfaceType(symbolType) || isEnumType(symbolType)) {
-                    // we're currently looking at a customType or interface, that has it's own symbol table
+                    // we're currently looking at a type that has its own symbol table
                     // use the name of the custom type
                     // TODO TYPES: get proper parent name for methods/fields defined in super classes
                     tokenText.push(tokenChain.length === 1 ? token.text : symbolType.name);

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -22,7 +22,7 @@ import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { LogLevel } from '../Logger';
 import { serializeError } from 'serialize-error';
-import { isClassMethodStatement, isClassStatement, isCommentStatement, isDottedGetExpression, isFunctionStatement, isTypedFunctionType, isLibraryStatement, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isClassFieldStatement, isEnumStatement, isArrayType, isCustomType, isDynamicType, isObjectType, isPrimitiveType, isRegexLiteralExpression, isInterfaceType } from '../astUtils/reflection';
+import { isClassMethodStatement, isClassStatement, isCommentStatement, isDottedGetExpression, isFunctionStatement, isTypedFunctionType, isLibraryStatement, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isClassFieldStatement, isEnumStatement, isArrayType, isCustomType, isDynamicType, isObjectType, isPrimitiveType, isRegexLiteralExpression, isInterfaceType, isEnumType } from '../astUtils/reflection';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
@@ -948,7 +948,7 @@ export class BrsFile {
             }
 
             if (symbolType?.memberTable) {
-                if (isCustomType(symbolType) || isInterfaceType(symbolType)) {
+                if (isCustomType(symbolType) || isInterfaceType(symbolType) || isEnumType(symbolType)) {
                     // we're currently looking at a customType or interface, that has it's own symbol table
                     // use the name of the custom type
                     // TODO TYPES: get proper parent name for methods/fields defined in super classes

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@ import type { TypedFunctionType } from './types/TypedFunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { FunctionStatement, ClassStatement, InterfaceStatement } from './parser/Statement';
+import type { FunctionStatement, ClassStatement, InterfaceStatement, EnumStatement } from './parser/Statement';
 import type { Expression, FunctionExpression } from './parser/Expression';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
@@ -447,6 +447,9 @@ export interface MemberSymbolTableProvider extends SymbolContainer {
 export type InheritableStatement = ClassStatement | InterfaceStatement;
 
 export type InheritableType = CustomType | InterfaceType;
+
+export type NamedTypeStatement = InheritableStatement | EnumStatement;
+
 
 /**
  * Options for the parser functionDeclaration() method

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -589,6 +589,10 @@ export class Parser {
 
         const result = new EnumStatement(tokens, body, this.currentNamespaceName);
 
+        if (tokens.name) {
+            this.currentSymbolTable.addSymbol(tokens.name.text, tokens.name.range, result.getThisBscType());
+        }
+
         this._references.enumStatements.push(result);
         this.exitAnnotationBlock(parentAnnotations);
         return result;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -18,6 +18,7 @@ import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
 import { CustomType } from '../types/CustomType';
 import { InterfaceType } from '../types/InterfaceType';
+import { EnumMemberType, EnumType } from '../types/EnumType';
 /**
  * A BrightScript statement
  */
@@ -2293,6 +2294,7 @@ export class ThrowStatement extends Statement {
 }
 
 export class EnumStatement extends Statement implements TypedefProvider {
+    readonly symbolTable: SymbolTable = new SymbolTable();
 
     constructor(
         public tokens: {
@@ -2361,6 +2363,14 @@ export class EnumStatement extends Statement implements TypedefProvider {
         return this.getMemberValueMap().get(name.toLowerCase());
     }
 
+    public buildSymbolTable() {
+        this.symbolTable.clear();
+
+        for (const member of this.getMembers()) {
+            this.symbolTable.addSymbol(member?.name, member?.range, new EnumMemberType(this.fullName, member?.name));
+        }
+    }
+
     /**
      * The name of the enum (without the namespace prefix)
      */
@@ -2384,6 +2394,10 @@ export class EnumStatement extends Statement implements TypedefProvider {
             //return undefined which will allow outside callers to know that this doesn't have a name
             return undefined;
         }
+    }
+
+    public getThisBscType(): EnumType {
+        return new EnumType(this.fullName, this.symbolTable);
     }
 
     transpile(state: BrsTranspileState) {

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -34,7 +34,8 @@ export class EnumType implements BscType, SymbolContainer {
 
 export class EnumMemberType implements BscType {
     constructor(
-        public enumName: string, public memberName: string
+        public enumName: string,
+        public memberName: string
     ) { }
 
     public isAssignableTo(targetType: BscType) {

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -1,0 +1,66 @@
+import { isDynamicType, isEnumMemberType, isEnumType } from '../astUtils/reflection';
+import type { BscType, SymbolContainer } from './BscType';
+import type { SymbolTable } from '../SymbolTable';
+
+export class EnumType implements BscType, SymbolContainer {
+    constructor(
+        public name: string, public memberTable: SymbolTable = null
+    ) { }
+
+    public isAssignableTo(targetType: BscType) {
+        return (
+            this.equals(targetType) ||
+            isDynamicType(targetType)
+        );
+    }
+
+    public isConvertibleTo(targetType: BscType) {
+        return this.isAssignableTo(targetType);
+    }
+
+    public toString() {
+        return this.name;
+    }
+
+    public toTypeString(): string {
+        return 'dynamic';
+    }
+
+    public equals(targetType: BscType): boolean {
+        return isEnumType(targetType) && targetType?.name.toLowerCase() === this.name.toLowerCase();
+    }
+}
+
+
+export class EnumMemberType implements BscType {
+    constructor(
+        public enumName: string, public memberName: string
+    ) { }
+
+    public isAssignableTo(targetType: BscType) {
+        return (
+            this.equals(targetType) ||
+            (isEnumType(targetType) &&
+                targetType?.name.toLowerCase() === this.enumName.toLowerCase()) ||
+            isDynamicType(targetType)
+        );
+    }
+
+    public isConvertibleTo(targetType: BscType) {
+        return this.isAssignableTo(targetType);
+    }
+
+    public toString() {
+        return this.enumName;
+    }
+
+    public toTypeString(): string {
+        return 'dynamic';
+    }
+
+    public equals(targetType: BscType): boolean {
+        return isEnumMemberType(targetType) &&
+            targetType?.enumName.toLowerCase() === this.enumName.toLowerCase() &&
+            targetType?.memberName.toLowerCase() === this.memberName.toLowerCase();
+    }
+}


### PR DESCRIPTION
Adds `EnumType`s, and allows enums to be used as parameter types and return values.

Due to the weirdness of enums, I elected to actually define members as a different type than the Enum itself, but we can assign a member to a value of the EnumType.

When enums are used as parameter types, arguments are correctly validated.

