### PR TITLE
Allow interfaces and enums as function param types

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -549,6 +549,46 @@ describe('BrsFile', () => {
     });
 
     describe('parse', () => {
+        it('allows class as parameter type', () => {
+            program.setFile(`source/main.bs`, `
+                class Person
+                    name as string
+                end class
+
+                sub PrintPerson(p as Person)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows interface as parameter type', () => {
+            program.setFile(`source/main.bs`, `
+                interface Person
+                    name as string
+                end interface
+
+                sub PrintPerson(p as Person)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows enum as parameter type', () => {
+            program.setFile(`source/main.bs`, `
+                enum Direction
+                    up
+                    down
+                end enum
+
+                sub PrintDirection(d as Direction)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
         it('supports iife in assignment', () => {
             program.setFile('source/main.brs', `
                 sub main()

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1276,6 +1276,19 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         return this.tokens.name?.text;
     }
 
+    /**
+     * Get the name of this expression based on the parse mode
+     */
+    public getName(parseMode: ParseMode) {
+        if (this.namespaceName) {
+            let delimiter = parseMode === ParseMode.BrighterScript ? '.' : '_';
+            let namespaceName = this.namespaceName.getName(parseMode);
+            return namespaceName + delimiter + this.name;
+        } else {
+            return this.name;
+        }
+    }
+
     public transpile(state: BrsTranspileState): TranspileResult {
         //interfaces should completely disappear at runtime
         return [];


### PR DESCRIPTION
Updates scope validation to allow enum and interface names as function parameter types. 