### PR TITLE
Src path in v0

### DIFF
--- a/benchmarks/targets/parse-xml.js
+++ b/benchmarks/targets/parse-xml.js
@@ -20,7 +20,7 @@ module.exports = async (suite, name, brighterscript, projectPath, options) => {
     suite.add(name, (deferred) => {
         const wait = [];
         for (const x of xmlFiles) {
-            const xmlFile = new XmlFile(x.pathAbsolute, x.pkgPath, builder.program);
+            const xmlFile = new XmlFile(x.srcPath ?? x.pathAbsolute, x.pkgPath, builder.program);
             //handle async and sync parsing
             const prom = xmlFile.parse(x.fileContents);
             if (prom) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
                 "ts-node": "8.9.1",
                 "turndown": "^7.1.1",
                 "turndown-plugin-gfm": "^1.0.2",
-                "typescript": "^4.4.3",
+                "typescript": "^4.6.3",
                 "typescript-formatter": "^7.2.2",
                 "undent": "^0.1.0",
                 "vscode-jsonrpc": "^5.0.1"
@@ -7545,9 +7545,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -13672,9 +13672,9 @@
             }
         },
         "typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true
         },
         "typescript-formatter": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "ts-node": "8.9.1",
         "turndown": "^7.1.1",
         "turndown-plugin-gfm": "^1.0.2",
-        "typescript": "^4.4.3",
+        "typescript": "^4.6.3",
         "typescript-formatter": "^7.2.2",
         "undent": "^0.1.0",
         "vscode-jsonrpc": "^5.0.1"

--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -186,7 +186,7 @@ class DocCompiler {
         });
         const file = program.setFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code);
         program.validate();
-        const tranpileResult = program.getTranspiledFileContents(file.pathAbsolute).code;
+        const tranpileResult = program.getTranspiledFileContents(file.srcPath).code;
         return tranpileResult.trim();
     }
 }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -7,13 +7,13 @@ export class Cache<TKey = any, TValue = any> extends Map<TKey, TValue> {
      * Get value from the cache if it exists,
      * otherwise call the factory function to create the value, add it to the cache, and return it.
      */
-    public getOrAdd(key: TKey, factory: (key: TKey) => TValue): TValue {
+    public getOrAdd<R extends TValue = TValue>(key: TKey, factory: (key: TKey) => R): R {
         if (!this.has(key)) {
             const value = factory(key);
             this.set(key, value);
             return value;
         } else {
-            return this.get(key);
+            return this.get(key) as R;
         }
     }
 }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -13,7 +13,14 @@ export class Cache<TKey = any, TValue = any> extends Map<TKey, TValue> {
             this.set(key, value);
             return value;
         } else {
-            return this.get(key) as R;
+            return this.get(key);
         }
+    }
+
+    /**
+     * Get the item with the specified key.
+     */
+    public get<R extends TValue = TValue>(key: TKey) {
+        return super.get(key) as R;
     }
 }

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -84,22 +84,22 @@ describe('DiagnosticCollection', () => {
         });
     });
 
-    function removeDiagnostic(filePath: string, message: string) {
+    function removeDiagnostic(srcPath: string, message: string) {
         for (let i = 0; i < diagnostics.length; i++) {
             const diagnostic = diagnostics[i];
-            if (diagnostic.file.pathAbsolute === filePath && diagnostic.message === message) {
+            if (diagnostic.file.srcPath === srcPath && diagnostic.message === message) {
                 diagnostics.splice(i, 1);
                 return;
             }
         }
-        throw new Error(`Cannot find diagnostic ${filePath}:${message}`);
+        throw new Error(`Cannot find diagnostic ${srcPath}:${message}`);
     }
 
-    function addDiagnostics(filePath: string, messages: string[]) {
+    function addDiagnostics(srcPath: string, messages: string[]) {
         for (const message of messages) {
             diagnostics.push({
                 file: {
-                    pathAbsolute: filePath
+                    srcPath: srcPath
                 } as BscFile,
                 range: util.createRange(0, 0, 0, 0),
                 //the code doesn't matter as long as the messages are different, so just enforce unique messages for this test files

--- a/src/DiagnosticCollection.ts
+++ b/src/DiagnosticCollection.ts
@@ -34,15 +34,15 @@ export class DiagnosticCollection {
         const keys = {};
         //build the full current set of diagnostics by file
         for (let diagnostic of diagnostics) {
-            const filePath = diagnostic.file.pathAbsolute;
+            const srcPath = diagnostic.file.srcPath ?? diagnostic.file.srcPath;
             //ensure the file entry exists
-            if (!result[filePath]) {
-                result[filePath] = [];
+            if (!result[srcPath]) {
+                result[srcPath] = [];
             }
-            const diagnosticMap = result[filePath];
+            const diagnosticMap = result[srcPath];
 
             diagnostic.key =
-                diagnostic.file.pathAbsolute.toLowerCase() + '-' +
+                srcPath.toLowerCase() + '-' +
                 diagnostic.code + '-' +
                 diagnostic.range.start.line + '-' +
                 diagnostic.range.start.character + '-' +

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -170,10 +170,10 @@ describe('DiagnosticFilterer', () => {
 
 });
 
-function getDiagnostic(code: number | string, pathAbsolute: string) {
+function getDiagnostic(code: number | string, srcPath: string) {
     return {
         file: {
-            pathAbsolute: s`${pathAbsolute}`
+            srcPath: s`${srcPath}`
         },
         code: code
     } as BsDiagnostic;

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -58,11 +58,12 @@ export class DiagnosticFilterer {
         this.byFile = {};
 
         for (let diagnostic of diagnostics) {
+            const srcPath = diagnostic?.file?.srcPath ?? diagnostic?.file?.srcPath;
             //skip diagnostics that have issues
-            if (!diagnostic?.file?.pathAbsolute) {
+            if (!srcPath) {
                 continue;
             }
-            const lowerSrcPath = diagnostic.file.pathAbsolute.toLowerCase();
+            const lowerSrcPath = srcPath.toLowerCase();
             //make a new array for this file if one does not yet exist
             if (!this.byFile[lowerSrcPath]) {
                 this.byFile[lowerSrcPath] = [];

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -82,11 +82,11 @@ describe('LanguageServer', () => {
 
         //hijack the file resolver so we can inject in-memory files for our tests
         let originalResolver = svr.documentFileResolver;
-        svr.documentFileResolver = (pathAbsolute: string) => {
-            if (vfs[pathAbsolute]) {
-                return vfs[pathAbsolute];
+        svr.documentFileResolver = (srcPath: string) => {
+            if (vfs[srcPath]) {
+                return vfs[srcPath];
             } else {
-                return originalResolver.call(svr, pathAbsolute);
+                return originalResolver.call(svr, srcPath);
             }
         };
 
@@ -98,7 +98,7 @@ describe('LanguageServer', () => {
     afterEach(async () => {
         try {
             await Promise.all(
-                physicalFilePaths.map(pathAbsolute => fsExtra.unlinkSync(pathAbsolute))
+                physicalFilePaths.map(srcPath => fsExtra.unlinkSync(srcPath))
             );
         } catch (e) {
 
@@ -121,16 +121,16 @@ describe('LanguageServer', () => {
         const filePath = s`components/${name}.${extension}`;
         const file = program.setFile(filePath, contents);
         if (file) {
-            const document = TextDocument.create(util.pathToUri(file.pathAbsolute), 'brightscript', 1, contents);
+            const document = TextDocument.create(util.pathToUri(file.srcPath), 'brightscript', 1, contents);
             svr.documents._documents[document.uri] = document;
             return document;
         }
     }
 
-    function writeToFs(pathAbsolute: string, contents: string) {
-        physicalFilePaths.push(pathAbsolute);
-        fsExtra.ensureDirSync(path.dirname(pathAbsolute));
-        fsExtra.writeFileSync(pathAbsolute, contents);
+    function writeToFs(srcPath: string, contents: string) {
+        physicalFilePaths.push(srcPath);
+        fsExtra.ensureDirSync(path.dirname(srcPath));
+        fsExtra.writeFileSync(srcPath, contents);
     }
 
     describe('createStandaloneFileWorkspace', () => {
@@ -191,7 +191,7 @@ describe('LanguageServer', () => {
                     getDiagnostics: () => {
                         return [{
                             file: {
-                                pathAbsolute: s`${rootDir}/source/main.brs`
+                                srcPath: s`${rootDir}/source/main.brs`
                             },
                             code: 1000,
                             range: Range.create(1, 2, 3, 4)
@@ -204,7 +204,7 @@ describe('LanguageServer', () => {
                     getDiagnostics: () => {
                         return [{
                             file: {
-                                pathAbsolute: s`${rootDir}/source/main.brs`
+                                srcPath: s`${rootDir}/source/main.brs`
                             },
                             code: 1000,
                             range: Range.create(1, 2, 3, 4)
@@ -292,7 +292,7 @@ describe('LanguageServer', () => {
 
             await server.handleFileChanges(workspace, [{
                 type: FileChangeType.Created,
-                pathAbsolute: mainPath
+                srcPath: mainPath
             }]);
 
             expect(setFileStub.getCalls()[0]?.args[0]).to.eql({
@@ -305,7 +305,7 @@ describe('LanguageServer', () => {
             expect(setFileStub.callCount).to.equal(1);
             await server.handleFileChanges(workspace, [{
                 type: FileChangeType.Created,
-                pathAbsolute: libPath
+                srcPath: libPath
             }]);
             //the function should have ignored the lib file, so no additional files were added
             expect(setFileStub.callCount).to.equal(1);
@@ -345,10 +345,10 @@ describe('LanguageServer', () => {
 
             expect(stub.getCalls()[0].args[1]).to.eql([{
                 type: FileChangeType.Created,
-                pathAbsolute: s`${rootDir}/source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`
             }, {
                 type: FileChangeType.Created,
-                pathAbsolute: s`${rootDir}/source/lib.brs`
+                srcPath: s`${rootDir}/source/lib.brs`
             }]);
         });
 
@@ -383,10 +383,10 @@ describe('LanguageServer', () => {
 
             expect(stub.getCalls()[0].args[1]).to.eql([{
                 type: FileChangeType.Created,
-                pathAbsolute: s`${rootDir}/source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`
             }, {
                 type: FileChangeType.Created,
-                pathAbsolute: s`${rootDir}/source/lib.brs`
+                srcPath: s`${rootDir}/source/lib.brs`
             }]);
         });
     });

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -105,7 +105,7 @@ describe('Program', () => {
                 end sub
             `);
             (file.parser.ast.statements[0] as FunctionStatement).func.body.statements[0] = new EmptyStatement();
-            await program.transpile([{ src: file.pathAbsolute, dest: file.pkgPath }], tmpPath);
+            await program.transpile([{ src: file.srcPath, dest: file.pkgPath }], tmpPath);
         });
 
         it('works with different cwd', () => {
@@ -578,9 +578,9 @@ describe('Program', () => {
         });
 
         it('adds xml file to files map', () => {
-            let xmlPath = `${rootDir}/components/component1.xml`;
-            program.setFile({ src: xmlPath, dest: 'components/component1.xml' }, '');
-            expect(program.getFileByPathAbsolute(xmlPath)).to.exist;
+            let srcPath = `${rootDir}/components/component1.xml`;
+            program.setFile({ src: srcPath, dest: 'components/component1.xml' }, '');
+            expect(program.getFile(srcPath)).to.exist;
         });
 
         it('detects missing script reference', () => {
@@ -1444,8 +1444,8 @@ describe('Program', () => {
             let ctx = program.getScopeByName(xmlFile.pkgPath);
             //the component scope should have the xml file AND the lib file
             expect(ctx.getOwnFiles().length).to.equal(2);
-            expect(ctx.getFile(xmlFile.pathAbsolute)).to.exist;
-            expect(ctx.getFile(libFile.pathAbsolute)).to.exist;
+            expect(ctx.getFile(xmlFile.srcPath)).to.exist;
+            expect(ctx.getFile(libFile.srcPath)).to.exist;
 
             //reload the xml file again, removing the script import.
             xmlFile = program.setFile({ src: `${rootDir}/components/component.xml`, dest: 'components/component.xml' }, trim`
@@ -1482,14 +1482,14 @@ describe('Program', () => {
 
     describe('getDiagnostics', () => {
         it('includes diagnostics from files not included in any scope', () => {
-            let pathAbsolute = s`${rootDir}/components/a/b/c/main.brs`;
-            program.setFile({ src: pathAbsolute, dest: 'components/a/b/c/main.brs' }, `
+            let srcPath = s`${rootDir}/components/a/b/c/main.brs`;
+            program.setFile({ src: srcPath, dest: 'components/a/b/c/main.brs' }, `
                 sub A()
                     "this string is not terminated
                 end sub
             `);
             //the file should be included in the program
-            expect(program.getFileByPathAbsolute(pathAbsolute)).to.exist;
+            expect(program.getFile(srcPath)).to.exist;
             let diagnostics = program.getDiagnostics();
             expectHasDiagnostics(diagnostics);
             let parseError = diagnostics.filter(x => x.message === 'Unterminated string at end of line')[0];
@@ -1673,7 +1673,7 @@ describe('Program', () => {
                 afterFileTranspile: sinon.spy()
             });
             expect(
-                program.getTranspiledFileContents(file.pathAbsolute).code
+                program.getTranspiledFileContents(file.srcPath).code
             ).to.eql(trim`
                 sub main()
                     print "hello there"
@@ -2024,7 +2024,7 @@ describe('Program', () => {
                     someFunc()@.
                 end sub
             `);
-            program.getCompletions(file.pathAbsolute, util.createPosition(2, 32));
+            program.getCompletions(file.srcPath, util.createPosition(2, 32));
         });
 
         it('gets signature help for constructor with no args', () => {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -31,7 +31,11 @@ const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bs
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
 
 export interface SourceObj {
+    /**
+     * @deprecated use `srcPath` instead
+     */
     pathAbsolute: string;
+    srcPath: string;
     source: string;
     definitions?: string;
 }
@@ -336,7 +340,7 @@ export class Program {
      * Update internal maps with this file reference
      */
     private assignFile<T extends BscFile = BscFile>(file: T) {
-        this.files[file.pathAbsolute.toLowerCase()] = file;
+        this.files[file.srcPath.toLowerCase()] = file;
         this.pkgMap[file.pkgPath.toLowerCase()] = file;
         return file;
     }
@@ -345,7 +349,7 @@ export class Program {
      * Remove this file from internal maps
      */
     private unassignFile<T extends BscFile = BscFile>(file: T) {
-        delete this.files[file.pathAbsolute.toLowerCase()];
+        delete this.files[file.srcPath.toLowerCase()];
         delete this.pkgMap[file.pkgPath.toLowerCase()];
         return file;
     }
@@ -418,7 +422,9 @@ export class Program {
                 }
 
                 let sourceObj: SourceObj = {
+                    //TODO remove `pathAbsolute` in v1
                     pathAbsolute: srcPath,
+                    srcPath: srcPath,
                     source: fileContents
                 };
                 this.plugins.emit('beforeFileParse', sourceObj);
@@ -446,7 +452,9 @@ export class Program {
                 );
 
                 let sourceObj: SourceObj = {
+                    //TODO remove `pathAbsolute` in v1
                     pathAbsolute: srcPath,
+                    srcPath: srcPath,
                     source: fileContents
                 };
                 this.plugins.emit('beforeFileParse', sourceObj);
@@ -469,8 +477,8 @@ export class Program {
 
             } else {
                 //TODO do we actually need to implement this? Figure out how to handle img paths
-                // let genericFile = this.files[pathAbsolute] = <any>{
-                //     pathAbsolute: pathAbsolute,
+                // let genericFile = this.files[srcPath] = <any>{
+                //     srcPath: srcPath,
                 //     pkgPath: pkgPath,
                 //     wasProcessed: true
                 // } as File;
@@ -497,13 +505,13 @@ export class Program {
      * Find the file by its absolute path. This is case INSENSITIVE, since
      * Roku is a case insensitive file system. It is an error to have multiple files
      * with the same path with only case being different.
-     * @param pathAbsolute
+     * @param srcPath
      * @deprecated use `getFile` instead, which auto-detects the path type
      */
-    public getFileByPathAbsolute<T extends BrsFile | XmlFile>(pathAbsolute: string) {
-        pathAbsolute = s`${pathAbsolute}`;
+    public getFileByPathAbsolute<T extends BrsFile | XmlFile>(srcPath: string) {
+        srcPath = s`${srcPath}`;
         for (let filePath in this.files) {
-            if (filePath.toLowerCase() === pathAbsolute.toLowerCase()) {
+            if (filePath.toLowerCase() === srcPath.toLowerCase()) {
                 return this.files[filePath] as T;
             }
         }
@@ -669,7 +677,7 @@ export class Program {
                         relatedInformation: xmlFiles.filter(x => x !== xmlFile).map(x => {
                             return {
                                 location: Location.create(
-                                    URI.file(xmlFile.pathAbsolute).toString(),
+                                    URI.file(xmlFile.srcPath ?? xmlFile.srcPath).toString(),
                                     x.componentName.range
                                 ),
                                 message: 'Also defined here'
@@ -879,8 +887,8 @@ export class Program {
      * Given a position in a file, if the position is sitting on some type of identifier,
      * go to the definition of that identifier (where this thing was first defined)
      */
-    public getDefinition(pathAbsolute: string, position: Position) {
-        let file = this.getFile(pathAbsolute);
+    public getDefinition(srcPath: string, position: Position) {
+        let file = this.getFile(srcPath);
         if (!file) {
             return [];
         }
@@ -897,9 +905,9 @@ export class Program {
         }
     }
 
-    public getHover(pathAbsolute: string, position: Position) {
+    public getHover(srcPath: string, position: Position) {
         //find the file
-        let file = this.getFile(pathAbsolute);
+        let file = this.getFile(srcPath);
         if (!file) {
             return null;
         }
@@ -911,9 +919,9 @@ export class Program {
     /**
      * Compute code actions for the given file and range
      */
-    public getCodeActions(pathAbsolute: string, range: Range) {
+    public getCodeActions(srcPath: string, range: Range) {
         const codeActions = [] as CodeAction[];
-        const file = this.getFile(pathAbsolute);
+        const file = this.getFile(srcPath);
         if (file) {
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
@@ -1180,9 +1188,9 @@ export class Program {
 
     }
 
-    public getReferences(pathAbsolute: string, position: Position) {
+    public getReferences(srcPath: string, position: Position) {
         //find the file
-        let file = this.getFile(pathAbsolute);
+        let file = this.getFile(srcPath);
         if (!file) {
             return null;
         }
@@ -1223,7 +1231,7 @@ export class Program {
 
                     result.push({
                         label: relativePath,
-                        detail: file.pathAbsolute,
+                        detail: file.srcPath,
                         kind: CompletionItemKind.File,
                         textEdit: {
                             newText: relativePath,
@@ -1234,7 +1242,7 @@ export class Program {
                     //add the absolute path
                     result.push({
                         label: filePkgPath,
-                        detail: file.pathAbsolute,
+                        detail: file.srcPath,
                         kind: CompletionItemKind.File,
                         textEdit: {
                             newText: filePkgPath,
@@ -1301,7 +1309,8 @@ export class Program {
         editor.undoAll();
 
         return {
-            pathAbsolute: file.pathAbsolute,
+            pathAbsolute: file.srcPath,
+            srcPath: file.srcPath,
             pkgPath: file.pkgPath,
             code: event.code,
             map: event.map,
@@ -1317,7 +1326,7 @@ export class Program {
         }, {});
 
         const entries = Object.values(this.files).map(file => {
-            let filePathObj = mappedFileEntries[s`${file.pathAbsolute}`];
+            let filePathObj = mappedFileEntries[s`${file.srcPath}`];
             if (!filePathObj) {
                 //this file has been added in-memory, from a plugin, for example
                 filePathObj = {
@@ -1354,7 +1363,7 @@ export class Program {
             await fsExtra.ensureDir(path.dirname(outputPath));
 
             if (await fsExtra.pathExists(outputPath)) {
-                throw new Error(`Error while transpiling "${file.pathAbsolute}". A file already exists at "${outputPath}" and will not be overwritten.`);
+                throw new Error(`Error while transpiling "${file.srcPath}". A file already exists at "${outputPath}" and will not be overwritten.`);
             }
             const writeMapPromise = fileTranspileResult.map ? fsExtra.writeFile(`${outputPath}.map`, fileTranspileResult.map.toString()) : null;
             await Promise.all([
@@ -1451,6 +1460,10 @@ export class Program {
 }
 
 export interface FileTranspileResult {
+    srcPath: string;
+    /**
+     * @deprecated use `srcPath`
+     */
     pathAbsolute: string;
     pkgPath: string;
     code: string;

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -148,7 +148,7 @@ describe('ProgramBuilder', () => {
                 }]
             });
             expectZeroDiagnostics(builder);
-            expect(builder.program.getFileByPathAbsolute(s``));
+            expect(builder.program.getFile(s``));
         });
     });
 
@@ -240,7 +240,7 @@ describe('ProgramBuilder', () => {
             f1.fileContents = `l1\nl2\nl3`;
             sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
-            sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
+            sinon.stub(builder.program, 'getFile').returns(f1);
 
             let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
@@ -258,7 +258,7 @@ describe('ProgramBuilder', () => {
         f1.fileContents = null;
         sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
-        sinon.stub(builder.program, 'getFileByPathAbsolute').returns(f1);
+        sinon.stub(builder.program, 'getFile').returns(f1);
 
         let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
@@ -273,7 +273,7 @@ describe('ProgramBuilder', () => {
         let diagnostics = createBsDiagnostic('p1', ['m1']);
         sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
-        sinon.stub(builder.program, 'getFileByPathAbsolute').returns(null);
+        sinon.stub(builder.program, 'getFile').returns(null);
 
         let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -47,16 +47,16 @@ export class ProgramBuilder {
      * This walks backwards through the file resolvers until we get a value.
      * This allow the language server to provide file contents directly from memory.
      */
-    public async getFileContents(pathAbsolute: string) {
-        pathAbsolute = s`${pathAbsolute}`;
+    public async getFileContents(srcPath: string) {
+        srcPath = s`${srcPath}`;
         let reversedResolvers = [...this.fileResolvers].reverse();
         for (let fileResolver of reversedResolvers) {
-            let result = await fileResolver(pathAbsolute);
+            let result = await fileResolver(srcPath);
             if (typeof result === 'string') {
                 return result;
             }
         }
-        throw new Error(`Could not load file "${pathAbsolute}"`);
+        throw new Error(`Could not load file "${srcPath}"`);
     }
 
     /**
@@ -64,12 +64,13 @@ export class ProgramBuilder {
      */
     private staticDiagnostics = [] as BsDiagnostic[];
 
-    public addDiagnostic(filePathAbsolute: string, diagnostic: Partial<BsDiagnostic>) {
-        let file: BscFile = this.program.getFileByPathAbsolute(filePathAbsolute);
+    public addDiagnostic(srcPath: string, diagnostic: Partial<BsDiagnostic>) {
+        let file: BscFile = this.program.getFile(srcPath);
         if (!file) {
             file = {
-                pkgPath: this.program.getPkgPath(filePathAbsolute),
-                pathAbsolute: filePathAbsolute,
+                pkgPath: this.program.getPkgPath(srcPath),
+                srcPath: srcPath, //keep this for back-compat TODO remove in v1
+                srcPath: srcPath,
                 getDiagnostics: () => {
                     return [<any>diagnostic];
                 }
@@ -274,19 +275,19 @@ export class ProgramBuilder {
         //group the diagnostics by file
         let diagnosticsByFile = {} as Record<string, BsDiagnostic[]>;
         for (let diagnostic of diagnostics) {
-            if (!diagnosticsByFile[diagnostic.file.pathAbsolute]) {
-                diagnosticsByFile[diagnostic.file.pathAbsolute] = [];
+            if (!diagnosticsByFile[diagnostic.file.srcPath]) {
+                diagnosticsByFile[diagnostic.file.srcPath] = [];
             }
-            diagnosticsByFile[diagnostic.file.pathAbsolute].push(diagnostic);
+            diagnosticsByFile[diagnostic.file.srcPath].push(diagnostic);
         }
 
         //get printing options
         const options = diagnosticUtils.getPrintDiagnosticOptions(this.options);
         const { cwd, emitFullPaths } = options;
 
-        let pathsAbsolute = Object.keys(diagnosticsByFile).sort();
-        for (let pathAbsolute of pathsAbsolute) {
-            let diagnosticsForFile = diagnosticsByFile[pathAbsolute];
+        let srcPaths = Object.keys(diagnosticsByFile).sort();
+        for (let srcPath of srcPaths) {
+            let diagnosticsForFile = diagnosticsByFile[srcPath];
             //sort the diagnostics in line and column order
             let sortedDiagnostics = diagnosticsForFile.sort((a, b) => {
                 return (
@@ -295,12 +296,12 @@ export class ProgramBuilder {
                 );
             });
 
-            let filePath = pathAbsolute;
+            let filePath = srcPath;
             if (!emitFullPaths) {
                 filePath = path.relative(cwd, filePath);
             }
             //load the file text
-            const file = this.program.getFileByPathAbsolute(pathAbsolute);
+            const file = this.program.getFile(srcPath);
             //get the file's in-memory contents if available
             const lines = file?.fileContents?.split(/\r?\n/g) ?? [];
 
@@ -505,12 +506,12 @@ export class ProgramBuilder {
 
     /**
      * Remove all files from the program that are in the specified folder path
-     * @param folderPathAbsolute
+     * @param srcPath the path to the folder
      */
-    public removeFilesInFolder(folderPathAbsolute: string) {
+    public removeFilesInFolder(srcPath: string) {
         for (let filePath in this.program.files) {
             //if the file path starts with the parent path and the file path does not exactly match the folder path
-            if (filePath.startsWith(folderPathAbsolute) && filePath !== folderPathAbsolute) {
+            if (filePath.startsWith(srcPath) && filePath !== srcPath) {
                 this.program.removeFile(filePath);
             }
         }

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -116,7 +116,7 @@ describe('Scope', () => {
 
             program.validate();
 
-            expect(sourceScope.getOwnFiles().map(x => x.pathAbsolute).sort()).eql([
+            expect(sourceScope.getOwnFiles().map(x => x.srcPath).sort()).eql([
                 s`${rootDir}/source/lib.brs`,
                 s`${rootDir}/source/main.brs`
             ]);
@@ -154,7 +154,7 @@ describe('Scope', () => {
             let initCallableCount = program.getScopeByName('source').getAllCallables().length;
 
             //remove the file
-            program.removeFile(file.pathAbsolute);
+            program.removeFile(file.srcPath);
             expect(program.getScopeByName('source').getAllCallables().length).to.equal(initCallableCount - 1);
         });
     });

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -208,11 +208,11 @@ export class Scope {
     /**
      * Get the file with the specified pkgPath
      */
-    public getFile(pathAbsolute: string) {
-        pathAbsolute = s`${pathAbsolute}`;
+    public getFile(getFile: string) {
+        getFile = s`${getFile}`;
         let files = this.getAllFiles();
         for (let file of files) {
-            if (file.pathAbsolute === pathAbsolute) {
+            if (file.srcPath === getFile) {
                 return file;
             }
         }
@@ -452,7 +452,7 @@ export class Scope {
             callables = callables.sort((a, b) => {
                 return (
                     //sort by path
-                    a.callable.file.pathAbsolute.localeCompare(b.callable.file.pathAbsolute) ||
+                    a.callable.file.srcPath.localeCompare(b.callable.file.srcPath) ||
                     //then sort by method name
                     a.callable.name.localeCompare(b.callable.name)
                 );
@@ -521,7 +521,7 @@ export class Scope {
                         relatedInformation: [{
                             message: 'Namespace declared here',
                             location: Location.create(
-                                URI.file(namespace.file.pathAbsolute).toString(),
+                                URI.file(namespace.file.srcPath).toString(),
                                 namespace.nameRange
                             )
                         }]
@@ -542,7 +542,7 @@ export class Scope {
                     relatedInformation: [{
                         message: 'Namespace declared here',
                         location: Location.create(
-                            URI.file(namespace.file.pathAbsolute).toString(),
+                            URI.file(namespace.file.srcPath).toString(),
                             namespace.nameRange
                         )
                     }]

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -74,7 +74,7 @@ describe('XmlScope', () => {
             let childScope = program.getScopesForFile(childXmlFile);
             let definition = childScope[0].getDefinition(childXmlFile, Position.create(1, 48));
             expect(definition).to.be.lengthOf(1);
-            expect(definition[0].uri).to.equal(util.pathToUri(parentXmlFile.pathAbsolute));
+            expect(definition[0].uri).to.equal(util.pathToUri(parentXmlFile.srcPath));
         });
     });
 

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -171,7 +171,7 @@ export class XmlScope extends Scope {
         ) {
             results.push({
                 range: util.createRange(0, 0, 0, 0),
-                uri: util.pathToUri(file.parentComponent.pathAbsolute)
+                uri: util.pathToUri(file.parentComponent.srcPath)
             });
         }
         return results;

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -26,7 +26,7 @@ describe('CodeActionsProcessor', () => {
             program.validate();
             expectCodeActions(() => {
                 program.getCodeActions(
-                    file.pathAbsolute,
+                    file.srcPath,
                     //<comp|onent name="comp1">
                     util.createRange(1, 5, 1, 5)
                 );
@@ -72,7 +72,7 @@ describe('CodeActionsProcessor', () => {
             `);
             program.validate();
             const codeActions = program.getCodeActions(
-                file.pathAbsolute,
+                file.srcPath,
                 //<comp|onent name="comp1">
                 util.createRange(1, 5, 1, 5)
             );
@@ -119,7 +119,7 @@ describe('CodeActionsProcessor', () => {
 
             //we should only get each file import suggestion exactly once
             const codeActions = program.getCodeActions(
-                componentCommonFile.pathAbsolute,
+                componentCommonFile.srcPath,
                 // doSome|thing()
                 util.createRange(2, 22, 2, 22)
             );
@@ -154,7 +154,7 @@ describe('CodeActionsProcessor', () => {
 
             //there should be no code actions since this is a brs file
             const codeActions = program.getCodeActions(
-                file.pathAbsolute,
+                file.srcPath,
                 // DoSometh|ing()
                 util.createRange(2, 28, 2, 28)
             );
@@ -184,7 +184,7 @@ describe('CodeActionsProcessor', () => {
 
             expect(
                 program.getCodeActions(
-                    file.pathAbsolute,
+                    file.srcPath,
                     // new Per|son()
                     util.createRange(2, 34, 2, 34)
                 ).map(x => x.title).sort()
@@ -218,7 +218,7 @@ describe('CodeActionsProcessor', () => {
 
             expect(
                 program.getCodeActions(
-                    file.pathAbsolute,
+                    file.srcPath,
                     // new Anim|als.Cat()
                     util.createRange(2, 36, 2, 36)
                 ).map(x => x.title).sort()

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -55,7 +55,7 @@ export class CodeActionsProcessor {
                     kind: CodeActionKind.QuickFix,
                     changes: [{
                         type: 'insert',
-                        filePath: this.event.file.pathAbsolute,
+                        filePath: this.event.file.srcPath,
                         position: insertPosition,
                         newText: `import "${pkgPath}"\n`
                     }]
@@ -91,7 +91,7 @@ export class CodeActionsProcessor {
     }
 
     private addMissingExtends(diagnostic: DiagnosticMessageType<'xmlComponentMissingExtendsAttribute'>) {
-        const srcPath = this.event.file.pathAbsolute;
+        const srcPath = this.event.file.srcPath;
         const { component } = (this.event.file as XmlFile).parser.ast;
         //inject new attribute after the final attribute, or after the `<component` if there are no attributes
         const pos = (component.attributes[component.attributes.length - 1] ?? component.tag).range.end;

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -33,7 +33,7 @@ describe('BrsFileSemanticTokensProcessor', () => {
         program.validate();
         expectZeroDiagnostics(program);
         expect(
-            program.getSemanticTokens(file.pathAbsolute)
+            program.getSemanticTokens(file.srcPath)
         ).to.eql([{
             range: util.createRange(7, 34, 7, 44),
             tokenType: SemanticTokenTypes.namespace
@@ -61,7 +61,7 @@ describe('BrsFileSemanticTokensProcessor', () => {
         program.validate();
         expectZeroDiagnostics(program);
         expect(
-            util.sortByRange(program.getSemanticTokens(file.pathAbsolute))
+            util.sortByRange(program.getSemanticTokens(file.srcPath))
         ).to.eql([{
             range: util.createRange(2, 22, 2, 32),
             tokenType: SemanticTokenTypes.namespace

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -97,7 +97,7 @@ export class ScopeValidator {
                             relatedInformation: [{
                                 message: 'Enum declared here',
                                 location: Location.create(
-                                    URI.file(file.pathAbsolute).toString(),
+                                    URI.file(file.srcPath).toString(),
                                     theEnum.tokens.name.range
                                 )
                             }]
@@ -128,7 +128,7 @@ export class ScopeValidator {
         //now that we've collected all enum declarations, flag duplicates
         for (const enumLocations of enumLocationsByName.values()) {
             //sort by srcPath to keep the primary enum location consistent
-            enumLocations.sort((a, b) => a.file?.pathAbsolute?.localeCompare(b.file?.pathAbsolute));
+            enumLocations.sort((a, b) => a.file?.srcPath?.localeCompare(b.file?.srcPath));
             const primaryEnum = enumLocations.shift();
             const fullName = primaryEnum.statement.fullName;
             for (const duplicateEnumInfo of enumLocations) {
@@ -139,7 +139,7 @@ export class ScopeValidator {
                     relatedInformation: [{
                         message: 'Enum declared here',
                         location: Location.create(
-                            URI.file(primaryEnum.file.pathAbsolute).toString(),
+                            URI.file(primaryEnum.file.srcPath).toString(),
                             primaryEnum.statement.tokens.name.range
                         )
                     }]

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -124,7 +124,7 @@ describe('BrsFile', () => {
                 end sub
             `);
             expect(() => {
-                program.getCompletions(file.pathAbsolute, util.createPosition(2, 34));
+                program.getCompletions(file.srcPath, util.createPosition(2, 34));
             }).not.to.throw;
         });
 
@@ -1680,7 +1680,7 @@ describe('BrsFile', () => {
             `);
 
             expect(
-                (await program.getHover(file.pathAbsolute, Position.create(2, 30))).contents
+                (await program.getHover(file.srcPath, Position.create(2, 30))).contents
             ).to.equal([
                 '```brightscript',
                 'function UCase(s as string) as string',
@@ -1696,7 +1696,7 @@ describe('BrsFile', () => {
             `);
 
             expect(
-                (await program.getHover(file.pathAbsolute, Position.create(2, 35))).contents
+                (await program.getHover(file.srcPath, Position.create(2, 35))).contents
             ).to.equal([
                 '```brightscript',
                 //TODO this really shouldn't be returning the global function, but it does...so make sure it doesn't crash right now.
@@ -1780,7 +1780,7 @@ describe('BrsFile', () => {
 
             //hover over log("hello")
             expect(
-                (await program.getHover(file.pathAbsolute, Position.create(5, 22))).contents
+                (await program.getHover(file.srcPath, Position.create(5, 22))).contents
             ).to.equal([
                 '```brightscript',
                 'sub log(message as string) as void',
@@ -1795,7 +1795,7 @@ describe('BrsFile', () => {
             //hover over sub ma|in()
             expect(
                 trim(
-                    (await program.getHover(file.pathAbsolute, Position.create(4, 22))).contents.toString()
+                    (await program.getHover(file.srcPath, Position.create(4, 22))).contents.toString()
                 )
             ).to.equal(trim`
                 \`\`\`brightscript
@@ -2731,7 +2731,7 @@ describe('BrsFile', () => {
         it('removes typedef link when typedef is removed', () => {
             const typedef = program.setFile<BrsFile>('source/main.d.bs', ``);
             const file = program.setFile<BrsFile>('source/main.brs', ``);
-            program.removeFile(typedef.pathAbsolute);
+            program.removeFile(typedef.srcPath);
             expect(file.typedefFile).to.be.undefined;
         });
     });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -129,7 +129,7 @@ export class BrsFile {
             }
             return result;
         }) ?? [];
-        return result as FileReference[];
+        return result;
     }
 
     /**

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -409,7 +409,7 @@ describe('XmlFile', () => {
                 </component>
             `);
 
-            expect(program.getCompletions(xmlFile.pathAbsolute, Position.create(1, 1))).to.be.empty;
+            expect(program.getCompletions(xmlFile.srcPath, Position.create(1, 1))).to.be.empty;
         });
     });
 
@@ -972,7 +972,7 @@ describe('XmlFile', () => {
         program.plugins.add({
             name: 'Xml diagnostic test',
             afterFileParse: (file) => {
-                if (file.pathAbsolute.endsWith('.xml')) {
+                if (file.srcPath.endsWith('.xml')) {
                     file.addDiagnostics([{
                         file: file,
                         message: 'Test diagnostic',
@@ -1150,7 +1150,7 @@ describe('XmlFile', () => {
             expect(functionNames).not.to.include('logBrs');
 
             //remove the typdef file
-            program.removeFile(typedef.pathAbsolute);
+            program.removeFile(typedef.srcPath);
 
             program.validate();
             functionNames = scope.getOwnCallables().map(x => x.callable.name);

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -53,9 +53,9 @@ describe('import statements', () => {
                 return true
             end function
         `);
-        let files = Object.keys(program.files).map(x => program.getFileByPathAbsolute(x)).filter(x => !!x).map(x => {
+        let files = Object.keys(program.files).map(x => program.getFile(x)).filter(x => !!x).map(x => {
             return {
-                src: x.pathAbsolute,
+                src: x.srcPath,
                 dest: x.pkgPath
             };
         });

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -61,7 +61,7 @@ describe('globalCallables', () => {
             end sub
         `);
         program.validate();
-        const hover = await program.getHover(file.pathAbsolute, util.createPosition(2, 25));
+        const hover = await program.getHover(file.srcPath, util.createPosition(2, 25));
         expect(
             hover.contents.toString().replace('\r\n', '\n')
         ).to.eql([

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -130,7 +130,7 @@ export interface File {
      * The absolute path to the file, relative to the pkg
      */
     pkgPath: string;
-    pathAbsolute: string;
+    srcPath: string;
     getDiagnostics(): BsDiagnostic[];
 }
 
@@ -313,7 +313,7 @@ export interface TypedefProvider {
 
 export type TranspileResult = Array<(string | SourceNode)>;
 
-export type FileResolver = (pathAbsolute: string) => string | undefined | Thenable<string | undefined> | void;
+export type FileResolver = (srcPath: string) => string | undefined | Thenable<string | undefined> | void;
 
 export interface ExpressionInfo {
     expressions: Expression[];

--- a/src/parser/BrsTranspileState.ts
+++ b/src/parser/BrsTranspileState.ts
@@ -7,7 +7,7 @@ export class BrsTranspileState extends TranspileState {
     public constructor(
         public file: BrsFile
     ) {
-        super(file.pathAbsolute, file.program.options);
+        super(file.srcPath, file.program.options);
         this.bslibPrefix = this.file.program.bslibPrefix;
     }
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -90,8 +90,8 @@ export function expectZeroDiagnostics(arg: DiagnosticCollection) {
         for (const diagnostic of diagnostics) {
             //escape any newlines
             diagnostic.message = diagnostic.message.replace(/\r/g, '\\r').replace(/\n/g, '\\n');
-            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.file?.pathAbsolute ?? ''}#(${diagnostic.range.start.line}:${diagnostic.range.start.character})-(${diagnostic.range.end.line}:${diagnostic.range.end.character})`;
-            //print the line containing the error (if we can find it)
+            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.file?.srcPath ?? ''}#(${diagnostic.range.start.line}:${diagnostic.range.start.character})-(${diagnostic.range.end.line}:${diagnostic.range.end.character})`;
+            //print the line containing the error (if we can find it)srcPath
             const line = diagnostic.file?.fileContents?.split(/\r?\n/g)?.[diagnostic.range.start.line];
             if (line) {
                 message += '\n' + getDiagnosticLine(diagnostic, line, chalk.red);

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -6,8 +6,7 @@ import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import type { CodeActionShorthand } from './CodeActionUtil';
 import { codeActionUtil } from './CodeActionUtil';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { BrsFile } from './files/BrsFile';
+import type { BrsFile } from './files/BrsFile';
 import type { Program } from './Program';
 import { standardizePath as s } from './util';
 import type { CodeWithSourceMap } from 'source-map';

--- a/src/util.ts
+++ b/src/util.ts
@@ -179,7 +179,8 @@ export class Util {
                 let diagnostic = {
                     ...DiagnosticMessages.bsConfigJsonHasSyntaxErrors(printParseErrorCode(parseErrors[0].error)),
                     file: {
-                        pathAbsolute: configFilePath
+                        srcPath: configFilePath,
+                        srcPath: configFilePath //keep this for back-compat TODO remove in v1
                     },
                     range: this.getRangeFromOffsetLength(projectFileContents, err.offset, err.length)
                 } as BsDiagnostic;
@@ -436,16 +437,16 @@ export class Util {
 
     /**
      * Compute the relative path from the source file to the target file
-     * @param pkgSourcePathAbsolute  - the absolute path to the source relative to the package location
-     * @param pkgTargetPathAbsolute  - the absolute path ro the target relative to the package location
+     * @param pkgSrcPath  - the absolute path to the source, where cwd is the package location
+     * @param pkgTargetPath  - the absolute path to the target, where cwd is the package location
      */
-    public getRelativePath(pkgSourcePathAbsolute: string, pkgTargetPathAbsolute: string) {
-        pkgSourcePathAbsolute = path.normalize(pkgSourcePathAbsolute);
-        pkgTargetPathAbsolute = path.normalize(pkgTargetPathAbsolute);
+    public getRelativePath(pkgSrcPath: string, pkgTargetPath: string) {
+        pkgSrcPath = path.normalize(pkgSrcPath);
+        pkgTargetPath = path.normalize(pkgTargetPath);
 
         //break by path separator
-        let sourceParts = pkgSourcePathAbsolute.split(path.sep);
-        let targetParts = pkgTargetPathAbsolute.split(path.sep);
+        let sourceParts = pkgSrcPath.split(path.sep);
+        let targetParts = pkgTargetPath.split(path.sep);
 
         let commonParts = [] as string[];
         //find their common root
@@ -615,8 +616,8 @@ export class Util {
     /**
      * Given a file path, convert it to a URI string
      */
-    public pathToUri(pathAbsolute: string) {
-        return URI.file(pathAbsolute).toString();
+    public pathToUri(filePath: string) {
+        return URI.file(filePath).toString();
     }
 
     /**

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -99,7 +99,7 @@ export class BsClassValidator {
                     range: classStatement.name.range,
                     relatedInformation: [{
                         location: Location.create(
-                            URI.file(nonNamespaceClass.file.pathAbsolute).toString(),
+                            URI.file(nonNamespaceClass.file.srcPath).toString(),
                             nonNamespaceClass.name.range
                         ),
                         message: 'Original class declared here'
@@ -349,7 +349,7 @@ export class BsClassValidator {
                         range: classStatement.name.range,
                         relatedInformation: [{
                             location: Location.create(
-                                URI.file(alreadyDefinedClass.file.pathAbsolute).toString(),
+                                URI.file(alreadyDefinedClass.file.srcPath).toString(),
                                 this.classes.get(lowerName).range
                             ),
                             message: ''


### PR DESCRIPTION
- Renames `pathAbsolute` to `srcPath` to align with the naming change in v1. 
- changes all internal calls to `getFileByPathAbsolute` to `getFile`
- adds `pathAbsolute` getter and setter to provide backwards compatibility support.

There's a small chance that this is a breaking change to plugins, but since we have the ability to lock bsc versions in vscode, I consider these acceptable risks. 
- if a plugin locks to an exact version of bsc, and vscode updates to a new version of bsc, the diagnostics produced by the latest bsc might cause the plugin to crash when looking for `pathAbsolute`.

NOTE: I tested this change while using bslint against the fubo codebase, and it still works, so I'm pretty comfortable with this change not breaking back-compat for most projects.