### PR TITLE
Fix cwd issue with multi-root workspaces

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -82,7 +82,7 @@ export class LanguageServer {
         return createConnection(ProposedFeatures.all);
     }
 
-    private loggerSubscription;
+    private loggerSubscription: () => void;
 
     private keyedThrottler = new KeyedThrottler(this.debounceTimeout);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -304,11 +304,12 @@ export class Util {
      */
     public normalizeConfig(config: BsConfig) {
         config = config || {} as BsConfig;
+        config.cwd = config.cwd ?? process.cwd();
         config.deploy = config.deploy === true ? true : false;
-        //use default options from rokuDeploy
-        config.files = config.files ?? rokuDeploy.getOptions().files;
+        //use default files array from rokuDeploy
+        config.files = config.files ?? [...rokuDeploy.DefaultFiles];
         config.createPackage = config.createPackage === false ? false : true;
-        let rootFolderName = path.basename(process.cwd());
+        let rootFolderName = path.basename(config.cwd);
         config.outFile = config.outFile ?? `./out/${rootFolderName}.zip`;
         config.sourceMap = config.sourceMap === true;
         config.username = config.username ?? 'rokudev';
@@ -322,7 +323,6 @@ export class Util {
         config.autoImportComponentScript = config.autoImportComponentScript === true ? true : false;
         config.showDiagnosticsInConsole = config.showDiagnosticsInConsole === false ? false : true;
         config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
-        config.cwd = config.cwd ?? process.cwd();
         config.emitDefinitions = config.emitDefinitions === true ? true : false;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];


### PR DESCRIPTION
roku-deploy uses cwd when looking for `bsconfig.json` and `roku-deploy.json`. However, when running the language server in multi-workspace mode, `process.cwd()` is the _first_ workspace folder. This causes roku-deploy to use the wrong bsconfig.json for workspaces without a `files` array.

The issue has been fixed by using the `DefaultFiles` array from roku-deploy instead of calling `rokuDeploy.getOptions().files`. 