### PR TITLE
Allow multiple keys for DependencyGraph.getAllDependencies

### DIFF
--- a/src/DependencyGraph.spec.ts
+++ b/src/DependencyGraph.spec.ts
@@ -162,6 +162,14 @@ describe('DependencyGraph', () => {
                 'e'
             ]);
         });
+
+        it('works with multiple keys', () => {
+            graph.addOrReplace('a', ['b', 'c']);
+            graph.addOrReplace('b', ['c', 'd']);
+            expect(graph.getAllDependencies(['a', 'b']).sort()).to.eql([
+                'b', 'c', 'd'
+            ]);
+        });
     });
 
     describe('onchange', () => {

--- a/src/DependencyGraph.ts
+++ b/src/DependencyGraph.ts
@@ -59,11 +59,22 @@ export class DependencyGraph {
 
     /**
      * Get a list of the dependencies for the given key, recursively.
-     * @param key the key for which to get the dependencies
+     * @param key the key (or keys) for which to get the dependencies
      * @param exclude a list of keys to exclude from traversal. Anytime one of these nodes is encountered, it is skipped.
      */
-    public getAllDependencies(key: string, exclude?: string[]) {
-        return this.nodes[key]?.getAllDependencies(exclude) ?? [];
+    public getAllDependencies(keys: string | string[], exclude?: string[]) {
+        if (typeof keys === 'string') {
+            return this.nodes[keys]?.getAllDependencies(exclude) ?? [];
+        } else {
+            const set = new Set<string>();
+            for (const key of keys) {
+                const dependencies = this.getAllDependencies(key, exclude);
+                for (const dependency of dependencies) {
+                    set.add(dependency);
+                }
+            }
+            return [...set];
+        }
     }
 
     /**


### PR DESCRIPTION
Adds support for an array of keys in the `DependencyGraph.getAllDependencies()` method.