### PR TITLE
Add function-based AstEditor.edit method

### DIFF
--- a/src/astUtils/AstEditor.spec.ts
+++ b/src/astUtils/AstEditor.spec.ts
@@ -278,4 +278,26 @@ describe('AstEditor', () => {
         editor.undoAll();
         expect(arr).to.eql([1, 2, 3]);
     });
+
+    it('edit works', () => {
+        const testObj = getTestObject();
+        editor.edit((data) => {
+            data.oldValue = testObj.name;
+            testObj.name = 'new name';
+        }, (data) => {
+            testObj.name = data.oldValue;
+        });
+        expect(testObj.name).to.eql('new name');
+        editor.undoAll();
+        expect(testObj.name).to.eql(getTestObject().name);
+    });
+
+    it('edit handles missing functions', () => {
+        //missing undo
+        editor.edit((data) => { }, undefined);
+        //missing edit
+        editor.edit(undefined, (data) => { });
+
+        //test passes if no exceptions were thrown
+    });
 });

--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -115,6 +115,15 @@ export class AstEditor {
     }
 
     /**
+     * Add a custom edit. Provide custom `apply` and `undo` functions to apply the change and then undo the change
+     */
+    public edit<T>(onApply: (data: Record<string, any>) => T, onUndo: (data: Record<string, any>) => void) {
+        const change = new ManualChange(onApply, onUndo);
+        this.changes.push(change);
+        return change.apply();
+    }
+
+    /**
      * Unto all changes.
      */
     public undoAll() {
@@ -258,6 +267,23 @@ class ArrayUnshiftChange<T extends any[]> implements Change {
 
     public undo() {
         this.array.splice(0, this.newValues.length);
+    }
+}
+
+/**
+ * A manual change. This will allow the consumer to define custom `apply` and `undo` functions to apply the change and then undo the change
+ */
+class ManualChange<T> implements Change {
+    constructor(
+        private _apply: (data: Record<string, any>) => T,
+        private _undo: (data: Record<string, any>) => any
+    ) { }
+
+    public apply() {
+        return this._apply?.(this);
+    }
+    public undo() {
+        this._undo?.(this);
     }
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -262,7 +262,7 @@ export interface OnScopeValidateEvent {
     scope: Scope;
 }
 
-export type Editor = Pick<AstEditor, 'addToArray' | 'hasChanges' | 'removeFromArray' | 'setArrayValue' | 'setProperty' | 'overrideTranspileResult' | 'arrayPop' | 'arrayPush' | 'arrayShift' | 'arraySplice' | 'arrayUnshift' | 'removeProperty'>;
+export type Editor = Pick<AstEditor, 'addToArray' | 'hasChanges' | 'removeFromArray' | 'setArrayValue' | 'setProperty' | 'overrideTranspileResult' | 'arrayPop' | 'arrayPush' | 'arrayShift' | 'arraySplice' | 'arrayUnshift' | 'removeProperty' | 'edit'>;
 
 export interface BeforeFileTranspileEvent<TFile extends BscFile = BscFile> {
     program: Program;


### PR DESCRIPTION
Adds an `AstEditor.edit` method that allows plugin authors to run a function to apply, and another function to undo. This allows for things like calling methods on objects rather than directly manipulating arrays or properties. 