### PR TITLE
Add object and key to visitor callbacks.

### DIFF
--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -5,13 +5,13 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
-import type { Statement } from '../parser/Statement';
-import { PrintStatement, Block, ReturnStatement } from '../parser/Statement';
+import type { FunctionStatement, Statement } from '../parser/Statement';
+import { PrintStatement, Block, ReturnStatement, ExpressionStatement } from '../parser/Statement';
 import type { Expression } from '../parser/Expression';
 import { TokenKind } from '../lexer/TokenKind';
 import { createVisitor, WalkMode, walkStatements } from './visitors';
 import { isPrintStatement } from './reflection';
-import { createToken } from './creators';
+import { createCall, createToken, createVariableExpression } from './creators';
 import { createStackedVisitor } from './stackedVisitor';
 import { AstEditor } from './AstEditor';
 import { Parser } from '../parser/Parser';
@@ -943,6 +943,67 @@ describe('astUtils visitors', () => {
                 walkMode: WalkMode.visitAllRecursive
             });
             expect(items).to.be.length(17);
+        });
+
+        it('can be used to delete statements', () => {
+            const { ast } = Parser.parse(`
+                sub main()
+                    print 1
+                    print 2
+                    print 3
+                end sub
+            `);
+            let callCount = 0;
+            ast.walk((astNode, parent, owningObject: Statement[], key) => {
+                if (isPrintStatement(astNode)) {
+                    callCount++;
+                    //delete the print statement (we know owningObject is an array based on this specific test)
+                    owningObject.splice(key, 1);
+                }
+            }, {
+                walkMode: WalkMode.visitAllRecursive
+            });
+            //the visitor should have been called for every statement
+            expect(callCount).to.eql(3);
+            expect(
+                (ast.statements[0] as FunctionStatement).func.body.statements
+            ).to.be.lengthOf(0);
+        });
+
+        it('can be used to insert statements', () => {
+            const { ast } = Parser.parse(`
+                sub main()
+                    print 1
+                    print 2
+                    print 3
+                end sub
+            `);
+            let printStatementCount = 0;
+            let callExpressionCount = 0;
+            const calls = [];
+            ast.walk(createVisitor({
+                PrintStatement: (astNode, parent, owningObject: Statement[], key) => {
+                    printStatementCount++;
+                    //add another expression to the list every time. This should result in 1 the first time, 2 the second, 3 the third.
+                    calls.push(new ExpressionStatement(
+                        createCall(
+                            createVariableExpression('doSomethingBeforePrint')
+                        )
+                    ));
+                    owningObject.splice(key, 0, ...calls);
+                },
+                CallExpression: () => {
+                    callExpressionCount++;
+                }
+            }), {
+                walkMode: WalkMode.visitAllRecursive
+            });
+            //the visitor should have been called for every statement
+            expect(printStatementCount).to.eql(3);
+            expect(callExpressionCount).to.eql(0);
+            expect(
+                (ast.statements[0] as FunctionStatement).func.body.statements
+            ).to.be.lengthOf(9);
         });
     });
 });

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -14,6 +14,7 @@ import { isPrintStatement } from './reflection';
 import { createToken } from './creators';
 import { createStackedVisitor } from './stackedVisitor';
 import { AstEditor } from './AstEditor';
+import { Parser } from '../parser/Parser';
 
 describe('astUtils visitors', () => {
     const rootDir = process.cwd();
@@ -923,6 +924,25 @@ describe('astUtils visitors', () => {
                 'LiteralExpression',
                 'LiteralExpression'
             ], WalkMode.visitExpressionsRecursive);
+        });
+
+        it('provides owningObject and key', () => {
+            const items = [];
+            const { ast } = Parser.parse(`
+                sub main()
+                    log = sub(message)
+                        print "hello " + message
+                    end sub
+                    log("hello" + " world")
+                end sub
+            `);
+            ast.walk((astNode, parent, owningObject, key) => {
+                items.push(astNode);
+                expect(owningObject[key]).to.equal(astNode);
+            }, {
+                walkMode: WalkMode.visitAllRecursive
+            });
+            expect(items).to.be.length(17);
         });
     });
 });

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -926,7 +926,7 @@ describe('astUtils visitors', () => {
             ], WalkMode.visitExpressionsRecursive);
         });
 
-        it('provides owningObject and key', () => {
+        it('provides owner and key', () => {
             const items = [];
             const { ast } = Parser.parse(`
                 sub main()
@@ -936,9 +936,9 @@ describe('astUtils visitors', () => {
                     log("hello" + " world")
                 end sub
             `);
-            ast.walk((astNode, parent, owningObject, key) => {
+            ast.walk((astNode, parent, owner, key) => {
                 items.push(astNode);
-                expect(owningObject[key]).to.equal(astNode);
+                expect(owner[key]).to.equal(astNode);
             }, {
                 walkMode: WalkMode.visitAllRecursive
             });
@@ -954,11 +954,11 @@ describe('astUtils visitors', () => {
                 end sub
             `);
             let callCount = 0;
-            ast.walk((astNode, parent, owningObject: Statement[], key) => {
+            ast.walk((astNode, parent, owner: Statement[], key) => {
                 if (isPrintStatement(astNode)) {
                     callCount++;
-                    //delete the print statement (we know owningObject is an array based on this specific test)
-                    owningObject.splice(key, 1);
+                    //delete the print statement (we know owner is an array based on this specific test)
+                    owner.splice(key, 1);
                 }
             }, {
                 walkMode: WalkMode.visitAllRecursive
@@ -982,7 +982,7 @@ describe('astUtils visitors', () => {
             let callExpressionCount = 0;
             const calls = [];
             ast.walk(createVisitor({
-                PrintStatement: (astNode, parent, owningObject: Statement[], key) => {
+                PrintStatement: (astNode, parent, owner: Statement[], key) => {
                     printStatementCount++;
                     //add another expression to the list every time. This should result in 1 the first time, 2 the second, 3 the third.
                     calls.push(new ExpressionStatement(
@@ -990,7 +990,7 @@ describe('astUtils visitors', () => {
                             createVariableExpression('doSomethingBeforePrint')
                         )
                     ));
-                    owningObject.splice(key, 0, ...calls);
+                    owner.splice(key, 0, ...calls);
                 },
                 CallExpression: () => {
                     callExpressionCount++;

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -11,7 +11,7 @@ import type { AstEditor } from './AstEditor';
  */
 export function walkStatements(
     statement: Statement,
-    visitor: (statement: Statement, parent?: Statement, owningObject?: any, key?: any) => Statement | void,
+    visitor: (statement: Statement, parent?: Statement, owner?: any, key?: any) => Statement | void,
     cancel?: CancellationToken
 ): void {
     statement.walk(visitor as any, {
@@ -20,33 +20,33 @@ export function walkStatements(
     });
 }
 
-export type WalkVisitor = <T = Statement | Expression>(stmtExpr: Statement | Expression, parent?: Statement | Expression, owningObject?: any, key?: any) => void | T;
+export type WalkVisitor = <T = Statement | Expression>(stmtExpr: Statement | Expression, parent?: Statement | Expression, owner?: any, key?: any) => void | T;
 
 /**
  * A helper function for Statement and Expression `walkAll` calls.
  */
-export function walk<T>(owningObject: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: Expression | Statement) {
+export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: Expression | Statement) {
     //stop processing if canceled
     if (options.cancel?.isCancellationRequested) {
         return;
     }
 
     //the object we're visiting
-    let element = owningObject[key] as any as Statement | Expression;
+    let element = owner[key] as any as Statement | Expression;
     if (!element) {
         return;
     }
 
     //notify the visitor of this element
     if (element.visitMode & options.walkMode) {
-        const result = visitor(element, parent ?? owningObject as any, owningObject, key);
+        const result = visitor(element, parent ?? owner as any, owner, key);
 
         //replace the value on the parent if the visitor returned a Statement or Expression (this is how visitors can edit AST)
         if (result && (isExpression(result) || isStatement(result))) {
             if (options.editor) {
-                options.editor.setProperty(owningObject, key, result as any);
+                options.editor.setProperty(owner, key, result as any);
             } else {
-                (owningObject as any)[key] = result;
+                (owner as any)[key] = result;
                 //don't walk the new element
                 return;
             }
@@ -59,7 +59,7 @@ export function walk<T>(owningObject: T, key: keyof T, visitor: WalkVisitor, opt
     }
 
     if (!element.walk) {
-        throw new Error(`${owningObject.constructor.name}["${String(key)}"]${parent ? ` for ${parent.constructor.name}` : ''} does not contain a "walk" method`);
+        throw new Error(`${owner.constructor.name}["${String(key)}"]${parent ? ` for ${parent.constructor.name}` : ''} does not contain a "walk" method`);
     }
     //walk the child expressions
     element.walk(visitor, options);
@@ -89,77 +89,77 @@ export function walkArray<T>(array: Array<T>, visitor: WalkVisitor, options: Wal
 export function createVisitor(
     visitor: {
         //statements
-        Body?: (statement: Body, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        AssignmentStatement?: (statement: AssignmentStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        Block?: (statement: Block, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ExpressionStatement?: (statement: ExpressionStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        CommentStatement?: (statement: CommentStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ExitForStatement?: (statement: ExitForStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ExitWhileStatement?: (statement: ExitWhileStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        FunctionStatement?: (statement: FunctionStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        IfStatement?: (statement: IfStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        IncrementStatement?: (statement: IncrementStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        PrintStatement?: (statement: PrintStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        DimStatement?: (statement: DimStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        GotoStatement?: (statement: GotoStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        LabelStatement?: (statement: LabelStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ReturnStatement?: (statement: ReturnStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        EndStatement?: (statement: EndStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        StopStatement?: (statement: StopStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ForStatement?: (statement: ForStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ForEachStatement?: (statement: ForEachStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        WhileStatement?: (statement: WhileStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
+        Body?: (statement: Body, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        AssignmentStatement?: (statement: AssignmentStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        Block?: (statement: Block, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ExpressionStatement?: (statement: ExpressionStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        CommentStatement?: (statement: CommentStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ExitForStatement?: (statement: ExitForStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ExitWhileStatement?: (statement: ExitWhileStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        FunctionStatement?: (statement: FunctionStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        IfStatement?: (statement: IfStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        IncrementStatement?: (statement: IncrementStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        PrintStatement?: (statement: PrintStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        DimStatement?: (statement: DimStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        GotoStatement?: (statement: GotoStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        LabelStatement?: (statement: LabelStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ReturnStatement?: (statement: ReturnStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        EndStatement?: (statement: EndStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        StopStatement?: (statement: StopStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ForStatement?: (statement: ForStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ForEachStatement?: (statement: ForEachStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        WhileStatement?: (statement: WhileStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         DottedSetStatement?: (statement: DottedSetStatement, parent?: Statement) => Statement | void;
-        IndexedSetStatement?: (statement: IndexedSetStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        LibraryStatement?: (statement: LibraryStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        NamespaceStatement?: (statement: NamespaceStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ImportStatement?: (statement: ImportStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
+        IndexedSetStatement?: (statement: IndexedSetStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        LibraryStatement?: (statement: LibraryStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        NamespaceStatement?: (statement: NamespaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ImportStatement?: (statement: ImportStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceFieldStatement?: (statement: InterfaceFieldStatement, parent?: Statement) => Statement | void;
-        InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ClassStatement?: (statement: ClassStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
+        InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ClassStatement?: (statement: ClassStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         /**
          * @deprecated use `MethodStatement`
          */
-        ClassMethodStatement?: (statement: ClassMethodStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
+        ClassMethodStatement?: (statement: ClassMethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         /**
          * @deprecated use `FieldStatement`
          */
-        ClassFieldStatement?: (statement: ClassFieldStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        MethodStatement?: (statement: MethodStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        FieldStatement?: (statement: FieldStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        TryCatchStatement?: (statement: TryCatchStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        CatchStatement?: (statement: CatchStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        ThrowStatement?: (statement: ThrowStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        EnumStatement?: (statement: EnumStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
-        EnumMemberStatement?: (statement: EnumMemberStatement, parent?: Statement, owningObject?: any, key?: any) => Statement | void;
+        ClassFieldStatement?: (statement: ClassFieldStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        MethodStatement?: (statement: MethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        FieldStatement?: (statement: FieldStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        TryCatchStatement?: (statement: TryCatchStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        CatchStatement?: (statement: CatchStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        ThrowStatement?: (statement: ThrowStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        EnumStatement?: (statement: EnumStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        EnumMemberStatement?: (statement: EnumMemberStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         //expressions
-        BinaryExpression?: (expression: BinaryExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        CallExpression?: (expression: CallExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        FunctionExpression?: (expression: FunctionExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        FunctionParameterExpression?: (expression: FunctionParameterExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        NamespacedVariableNameExpression?: (expression: NamespacedVariableNameExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        DottedGetExpression?: (expression: DottedGetExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        XmlAttributeGetExpression?: (expression: XmlAttributeGetExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        IndexedGetExpression?: (expression: IndexedGetExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        GroupingExpression?: (expression: GroupingExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        LiteralExpression?: (expression: LiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        EscapedCharCodeLiteralExpression?: (expression: EscapedCharCodeLiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        ArrayLiteralExpression?: (expression: ArrayLiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        AAMemberExpression?: (expression: AAMemberExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        AALiteralExpression?: (expression: AALiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        UnaryExpression?: (expression: UnaryExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        VariableExpression?: (expression: VariableExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        SourceLiteralExpression?: (expression: SourceLiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        NewExpression?: (expression: NewExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        CallfuncExpression?: (expression: CallfuncExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        TemplateStringQuasiExpression?: (expression: TemplateStringQuasiExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        TemplateStringExpression?: (expression: TemplateStringExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        TaggedTemplateStringExpression?: (expression: TaggedTemplateStringExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        AnnotationExpression?: (expression: AnnotationExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        TernaryExpression?: (expression: TernaryExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        NullCoalescingExpression?: (expression: NullCoalescingExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
-        RegexLiteralExpression?: (expression: RegexLiteralExpression, parent?: Statement | Expression, owningObject?: any, key?: any) => Expression | void;
+        BinaryExpression?: (expression: BinaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        CallExpression?: (expression: CallExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        FunctionExpression?: (expression: FunctionExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        FunctionParameterExpression?: (expression: FunctionParameterExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        NamespacedVariableNameExpression?: (expression: NamespacedVariableNameExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        DottedGetExpression?: (expression: DottedGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        XmlAttributeGetExpression?: (expression: XmlAttributeGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        IndexedGetExpression?: (expression: IndexedGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        GroupingExpression?: (expression: GroupingExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        LiteralExpression?: (expression: LiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        EscapedCharCodeLiteralExpression?: (expression: EscapedCharCodeLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        ArrayLiteralExpression?: (expression: ArrayLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        AAMemberExpression?: (expression: AAMemberExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        AALiteralExpression?: (expression: AALiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        UnaryExpression?: (expression: UnaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        VariableExpression?: (expression: VariableExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        SourceLiteralExpression?: (expression: SourceLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        NewExpression?: (expression: NewExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        CallfuncExpression?: (expression: CallfuncExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        TemplateStringQuasiExpression?: (expression: TemplateStringQuasiExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        TemplateStringExpression?: (expression: TemplateStringExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        TaggedTemplateStringExpression?: (expression: TaggedTemplateStringExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        AnnotationExpression?: (expression: AnnotationExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        TernaryExpression?: (expression: TernaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        NullCoalescingExpression?: (expression: NullCoalescingExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        RegexLiteralExpression?: (expression: RegexLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
     }
 ) {
     //remap some deprecated visitor names TODO remove this in v1
@@ -169,8 +169,8 @@ export function createVisitor(
     if (visitor.ClassMethodStatement) {
         visitor.MethodStatement = visitor.ClassMethodStatement;
     }
-    return <WalkVisitor>((statement: Statement, parent?: Statement, owningObject?: any, key?: any): Statement | void => {
-        return visitor[statement.constructor.name]?.(statement, parent, owningObject, key);
+    return <WalkVisitor>((statement: Statement, parent?: Statement, owner?: any, key?: any): Statement | void => {
+        return visitor[statement.constructor.name]?.(statement, parent, owner, key);
     });
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -8,7 +8,7 @@ import type { BrsTranspileState } from './BrsTranspileState';
 import { ParseMode } from './Parser';
 import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
-import { walk, InternalWalkMode } from '../astUtils/visitors';
+import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
 import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -116,9 +116,7 @@ export class CallExpression extends Expression {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'callee', visitor, options);
-            for (let i = 0; i < this.args.length; i++) {
-                walk(this.args, i, visitor, options, this);
-            }
+            walkArray(this.args, visitor, options, this);
         }
     }
 }
@@ -244,9 +242,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.parameters.length; i++) {
-                walk(this.parameters, i, visitor, options, this);
-            }
+            walkArray(this.parameters, visitor, options, this);
 
             //This is the core of full-program walking...it allows us to step into sub functions
             if (options.walkMode & InternalWalkMode.recurseChildFunctions) {
@@ -625,9 +621,7 @@ export class ArrayLiteralExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.elements.length; i++) {
-                walk(this.elements, i, visitor, options, this);
-            }
+            walkArray(this.elements, visitor, options, this);
         }
     }
 }
@@ -739,13 +733,7 @@ export class AALiteralExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.elements.length; i++) {
-                if (isCommentStatement(this.elements[i])) {
-                    walk(this.elements, i, visitor, options, this);
-                } else {
-                    walk(this.elements, i, visitor, options, this);
-                }
-            }
+            walkArray(this.elements, visitor, options, this);
         }
     }
 }
@@ -990,9 +978,7 @@ export class CallfuncExpression extends Expression {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'callee', visitor, options);
-            for (let i = 0; i < this.args.length; i++) {
-                walk(this.args, i, visitor, options, this);
-            }
+            walkArray(this.args, visitor, options, this);
         }
     }
 }
@@ -1033,9 +1019,7 @@ export class TemplateStringQuasiExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.expressions.length; i++) {
-                walk(this.expressions, i, visitor, options, this);
-            }
+            walkArray(this.expressions, visitor, options, this);
         }
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -9,7 +9,7 @@ import { Position } from 'vscode-languageserver';
 import type { BrsTranspileState } from './BrsTranspileState';
 import { ParseMode } from './Parser';
 import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
-import { InternalWalkMode, walk, createVisitor, WalkMode } from '../astUtils/visitors';
+import { InternalWalkMode, walk, createVisitor, WalkMode, walkArray } from '../astUtils/visitors';
 import { isCallExpression, isClassFieldStatement, isClassMethodStatement, isCommentStatement, isEnumMemberStatement, isExpression, isExpressionStatement, isFunctionStatement, isIfStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInvalidType, isLiteralExpression, isTypedefProvider, isVoidType } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
@@ -128,9 +128,7 @@ export class Body extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
-            for (let i = 0; i < this.statements.length; i++) {
-                walk(this.statements, i, visitor, options, this);
-            }
+            walkArray(this.statements, visitor, options, this);
         }
     }
 }
@@ -221,9 +219,7 @@ export class Block extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
-            for (let i = 0; i < this.statements.length; i++) {
-                walk(this.statements, i, visitor, options, this);
-            }
+            walkArray(this.statements, visitor, options, this);
         }
     }
 }
@@ -598,12 +594,8 @@ export class PrintStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.expressions.length; i++) {
-                //sometimes we have semicolon `Token`s in the expressions list (should probably fix that...), so only emit the actual expressions
-                if (isExpression(this.expressions[i] as any)) {
-                    walk(this.expressions, i, visitor, options, this);
-                }
-            }
+            //sometimes we have semicolon Tokens in the expressions list (should probably fix that...), so only walk the actual expressions
+            walkArray(this.expressions, visitor, options, this, (item) => isExpression(item as any));
         }
     }
 }
@@ -645,9 +637,8 @@ export class DimStatement extends Statement {
 
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (this.dimensions?.length > 0 && options.walkMode & InternalWalkMode.walkExpressions) {
-            for (let i = 0; i < this.dimensions.length; i++) {
-                walk(this.dimensions, i, visitor, options, this);
-            }
+            walkArray(this.dimensions, visitor, options, this);
+
         }
     }
 }
@@ -1348,9 +1339,8 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
-            for (let i = 0; i < this.body.length; i++) {
-                walk(this.body, i, visitor, options, this);
-            }
+            walkArray(this.body, visitor, options, this);
+
         }
     }
 }
@@ -1866,9 +1856,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
-            for (let i = 0; i < this.body.length; i++) {
-                walk(this.body, i, visitor, options, this);
-            }
+            walkArray(this.body, visitor, options, this);
         }
     }
 }
@@ -2388,9 +2376,8 @@ export class EnumStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
-            for (let i = 0; i < this.body.length; i++) {
-                walk(this.body, i, visitor, options, this);
-            }
+            walkArray(this.body, visitor, options, this);
+
         }
     }
 }


### PR DESCRIPTION
 - Provides the parent object and the key used to fetch the item from the parent object in AST walk visitor callbacks. This makes AST editing a little easier when it's desired to actually remove the element from the parent AST. 
 - update all AST `walk` methods to support adding/removing items during the walk cycle without messing up the iteration.

Also 
Resolves #477