### PR TITLE
Fix missing range on interface statement

### DIFF
--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1223,6 +1223,14 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         this.tokens.name = name;
         this.tokens.extends = extendsToken;
         this.tokens.endInterface = endInterfaceToken;
+        this.range = util.createBoundingRange(
+            this.tokens.interface,
+            this.tokens.name,
+            this.tokens.extends,
+            this.parentInterfaceName,
+            ...this.body,
+            this.tokens.endInterface
+        );
     }
 
     public tokens = {} as {

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -1,17 +1,18 @@
-import { expectZeroDiagnostics, getTestGetTypedef } from '../../../testHelpers.spec';
+import { expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
 import { standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
 
+const rootDir = s`${process.cwd()}/.tmp/rootDir`;
+
 describe('InterfaceStatement', () => {
-    const rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
+    const testTranspile = getTestTranspile(() => [program, rootDir]);
+    const testGetTypedef = getTestGetTypedef(() => [program, rootDir]);
     beforeEach(() => {
         program = new Program({
             rootDir: rootDir
         });
     });
-
-    const testGetTypedef = getTestGetTypedef(() => [program, rootDir]);
 
     it('allows strange keywords as property names', () => {
         testGetTypedef(`
@@ -73,5 +74,19 @@ describe('InterfaceStatement', () => {
         `);
         program.validate();
         expectZeroDiagnostics(program);
+    });
+
+    it('allows comments after an interface', () => {
+        testTranspile(`
+            interface Iface1
+                name as dynamic
+            end interface
+            'this comment was throwing exception during transpile
+            interface IFace2
+                prop as dynamic
+            end interface
+        `, `
+            'this comment was throwing exception during transpile
+        `);
     });
 });

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -148,13 +148,13 @@ export function expectInstanceOf<T>(items: any[], constructors: Array<new (...ar
     }
 }
 
-export function getTestTranspile(scopeGetter: () => [Program, string]) {
+export function getTestTranspile(scopeGetter: () => [program: Program, rootDir: string]) {
     return getTestFileAction((file) => {
         return file.program['_getTranspiledFileContents'](file);
     }, scopeGetter);
 }
 
-export function getTestGetTypedef(scopeGetter: () => [Program, string]) {
+export function getTestGetTypedef(scopeGetter: () => [program: Program, rootDir: string]) {
     return getTestFileAction((file) => {
         return {
             code: (file as BrsFile).getTypedef(),
@@ -165,7 +165,7 @@ export function getTestGetTypedef(scopeGetter: () => [Program, string]) {
 
 function getTestFileAction(
     action: (file: BscFile) => CodeWithSourceMap,
-    scopeGetter: () => [Program, string]
+    scopeGetter: () => [program: Program, rootDir: string]
 ) {
     return function testFileAction(source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', pkgPath = 'source/main.bs', failOnDiagnostic = true) {
         let [program, rootDir] = scopeGetter();


### PR DESCRIPTION
Fixes a bug where the `range` for `InterfaceStatement` was always null. This also resulted in transpile failures in certain situations.