### PR TITLE
Emit before/after programTranspile during file transpile preview

### DIFF
--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -59,7 +59,7 @@ class DocCompiler {
         return this.lines[this.index + 1];
     }
 
-    public run() {
+    public async run() {
         //get the docs file contents
         let contents = fsExtra.readFileSync(this.docPath).toString();
         //split the doc by newline
@@ -69,7 +69,7 @@ class DocCompiler {
         while (this.nextLine !== undefined) {
             this.advance();
             if (this.currentLine.includes('```')) {
-                this.processCodeBlock();
+                await this.processCodeBlock();
             }
         }
 
@@ -119,7 +119,7 @@ class DocCompiler {
         }
     }
 
-    public processCodeBlock() {
+    public async processCodeBlock() {
         //get the source code block
         const sourceCodeBlock = this.consumeCodeBlock();
 
@@ -139,7 +139,7 @@ class DocCompiler {
 
         //now that we have the range for the transpiled code, we need to transpile the source code
         console.log(`Transpiling ${sourceCodeBlock.language} block at lines ${sourceCodeBlock.startIndex}-${sourceCodeBlock.endIndex + 1}`);
-        const transpiledCode = this.transpile(sourceCodeBlock.code);
+        const transpiledCode = await this.transpile(sourceCodeBlock.code);
         let transpiledLines = transpiledCode.split(/\r?\n/g);
 
         //replace the old transpiled lines with the new ones
@@ -176,7 +176,7 @@ class DocCompiler {
         );
     }
 
-    public transpile(code: string) {
+    public async transpile(code: string) {
         const program = new Program({
             rootDir: `${__dirname}/rootDir`,
             files: [
@@ -187,12 +187,12 @@ class DocCompiler {
         });
         const file = program.setFile({ src: `${__dirname}/rootDir/source/main.bs`, dest: 'source/main.bs' }, code);
         program.validate();
-        const tranpileResult = program.getTranspiledFileContents(file.srcPath).code;
+        const tranpileResult = (await program.getTranspiledFileContents(file.srcPath)).code;
         return tranpileResult.trim();
     }
 }
 
-(function main() {
+(async function main() {
     const docsFolder = path.resolve(
         path.join(__dirname, '..', 'docs')
     );
@@ -204,6 +204,6 @@ class DocCompiler {
     for (let docPath of docs) {
         console.log('\n', docPath);
         const compiler = new DocCompiler(docPath, enableDebugLogging);
-        compiler.run();
+        await compiler.run();
     }
-}());
+}()).catch((e) => console.error(e));

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1658,7 +1658,7 @@ describe('Program', () => {
     });
 
     describe('getTranspiledFileContents', () => {
-        it('fires plugin events', () => {
+        it('fires plugin events', async () => {
             const file = program.setFile('source/main.brs', trim`
                 sub main()
                     print "hello world"
@@ -1673,7 +1673,7 @@ describe('Program', () => {
                 afterFileTranspile: sinon.spy()
             });
             expect(
-                program.getTranspiledFileContents(file.srcPath).code
+                (await program.getTranspiledFileContents(file.srcPath)).code
             ).to.eql(trim`
                 sub main()
                     print "hello there"


### PR DESCRIPTION
Emit the `beforeProgramTranspile` and `afterProgramTranspile` events anytime the The `preview transpiled code` action in the language server is executed. Some plugins need to run code during that event before the `beforeFileTranspile` event is triggered. This enables a more accurate transpile preview.

This is _technically_ a breaking change for anyone calling the `Program.getTranspiledFileContents` function because it's now async. However, I don't think it's being used that often. 