### PR TITLE
Send program-triggered validate() diagnostics to language client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
         'no-underscore-dangle': 'off',
         'no-unneeded-ternary': 'off',
         'no-useless-escape': 'off',
+        'no-void': 'off',
         'no-warning-comments': 'off',
         'object-property-newline': 'off',
         'object-shorthand': [

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -22,8 +22,8 @@ describe('DiagnosticCollection', () => {
         }] as Project[];
     });
 
-    async function testPatch(expected: Record<string, string[]>) {
-        const patch = await collection.getPatch(projects);
+    function testPatch(expected: Record<string, string[]>) {
+        const patch = collection.getPatch(projects);
         //convert the patch into our test structure
         const actual = {};
         for (const filePath in patch) {
@@ -33,53 +33,53 @@ describe('DiagnosticCollection', () => {
         expect(actual).to.eql(expected);
     }
 
-    it('returns full list of diagnostics on first call, and nothing on second call', async () => {
+    it('returns full list of diagnostics on first call, and nothing on second call', () => {
         addDiagnostics('file1.brs', ['message1', 'message2']);
         addDiagnostics('file2.brs', ['message3', 'message4']);
         //first patch should return all
-        await testPatch({
+        testPatch({
             'file1.brs': ['message1', 'message2'],
             'file2.brs': ['message3', 'message4']
         });
 
         //second patch should return empty (because nothing has changed)
-        await testPatch({});
+        testPatch({});
     });
 
-    it('removes diagnostics in patch', async () => {
+    it('removes diagnostics in patch', () => {
         addDiagnostics('file1.brs', ['message1', 'message2']);
         addDiagnostics('file2.brs', ['message3', 'message4']);
         //first patch should return all
-        await testPatch({
+        testPatch({
             'file1.brs': ['message1', 'message2'],
             'file2.brs': ['message3', 'message4']
         });
         removeDiagnostic('file1.brs', 'message1');
         removeDiagnostic('file1.brs', 'message2');
-        await testPatch({
+        testPatch({
             'file1.brs': []
         });
     });
 
-    it('adds diagnostics in patch', async () => {
+    it('adds diagnostics in patch', () => {
         addDiagnostics('file1.brs', ['message1', 'message2']);
-        await testPatch({
+        testPatch({
             'file1.brs': ['message1', 'message2']
         });
 
         addDiagnostics('file2.brs', ['message3', 'message4']);
-        await testPatch({
+        testPatch({
             'file2.brs': ['message3', 'message4']
         });
     });
 
-    it('sends full list when file diagnostics have changed', async () => {
+    it('sends full list when file diagnostics have changed', () => {
         addDiagnostics('file1.brs', ['message1', 'message2']);
-        await testPatch({
+        testPatch({
             'file1.brs': ['message1', 'message2']
         });
         addDiagnostics('file1.brs', ['message3', 'message4']);
-        await testPatch({
+        testPatch({
             'file1.brs': ['message1', 'message2', 'message3', 'message4']
         });
     });

--- a/src/DiagnosticCollection.ts
+++ b/src/DiagnosticCollection.ts
@@ -4,8 +4,8 @@ import type { Project } from './LanguageServer';
 export class DiagnosticCollection {
     private previousDiagnosticsByFile = {} as Record<string, KeyedDiagnostic[]>;
 
-    public async getPatch(projects: Project[]): Promise<Record<string, KeyedDiagnostic[]>> {
-        const diagnosticsByFile = await this.getDiagnosticsByFileFromProjects(projects);
+    public getPatch(projects: Project[]) {
+        const diagnosticsByFile = this.getDiagnosticsByFileFromProjects(projects);
 
         const patch = {
             ...this.getRemovedPatch(diagnosticsByFile),
@@ -18,13 +18,8 @@ export class DiagnosticCollection {
         return patch;
     }
 
-    private async getDiagnosticsByFileFromProjects(projects: Project[]) {
+    private getDiagnosticsByFileFromProjects(projects: Project[]) {
         const result = {} as Record<string, KeyedDiagnostic[]>;
-
-        //wait for all programs to finish running. This ensures the `Program` exists.
-        await Promise.all(
-            projects.map(x => x.firstRunPromise)
-        );
 
         //get all diagnostics for all projects
         let diagnostics = Array.prototype.concat.apply([] as KeyedDiagnostic[],

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -87,6 +87,9 @@ export class LanguageServer {
     private keyedThrottler = new KeyedThrottler(this.debounceTimeout);
 
     public validateThrottler = new Throttler(0);
+
+    private sendDiagnosticsThrottler = new Throttler(0);
+
     private boundValidateAll = this.validateAll.bind(this);
 
     private validateAllThrottled() {
@@ -357,7 +360,6 @@ export class LanguageServer {
             }
             await this.waitAllProjectFirstRuns(false);
             projectCreatedDeferred.resolve();
-            await this.sendDiagnostics();
         } catch (e: any) {
             this.sendCriticalFailure(
                 `Critical failure during BrighterScript language server startup.
@@ -379,8 +381,8 @@ export class LanguageServer {
     /**
      * Wait for all programs' first run to complete
      */
-    private async waitAllProjectFirstRuns(waitForFirstWorkSpace = true) {
-        if (waitForFirstWorkSpace) {
+    private async waitAllProjectFirstRuns(waitForFirstProject = true) {
+        if (waitForFirstProject) {
             await this.initialProjectsCreated;
         }
 
@@ -460,6 +462,14 @@ export class LanguageServer {
         }
 
         let builder = new ProgramBuilder();
+
+        //flush diagnostics every time the program finishes validating
+        builder.plugins.add({
+            name: 'bsc-language-server',
+            afterProgramValidate: () => {
+                void this.sendDiagnostics();
+            }
+        });
 
         //prevent clearing the console on run...this isn't the CLI so we want to keep a full log of everything
         builder.allowConsoleClearing = false;
@@ -1041,8 +1051,6 @@ export class LanguageServer {
             await Promise.all(
                 projects.map((x) => x.builder.program.validate())
             );
-
-            await this.sendDiagnostics();
         } catch (e: any) {
             this.connection.console.error(e);
             this.sendCriticalFailure(`Critical error validating project: ${e.message}${e.stack ?? ''}`);
@@ -1171,17 +1179,24 @@ export class LanguageServer {
     private diagnosticCollection = new DiagnosticCollection();
 
     private async sendDiagnostics() {
-        //Get only the changes to diagnostics since the last time we sent them to the client
-        const patch = await this.diagnosticCollection.getPatch(this.projects);
+        await this.sendDiagnosticsThrottler.run(async () => {
+            //wait for all programs to finish running. This ensures the `Program` exists.
+            await Promise.all(
+                this.projects.map(x => x.firstRunPromise)
+            );
 
-        for (let filePath in patch) {
-            const diagnostics = patch[filePath].map(d => util.toDiagnostic(d));
+            //Get only the changes to diagnostics since the last time we sent them to the client
+            const patch = this.diagnosticCollection.getPatch(this.projects);
 
-            this.connection.sendDiagnostics({
-                uri: URI.file(filePath).toString(),
-                diagnostics: diagnostics
-            });
-        }
+            for (let filePath in patch) {
+                const diagnostics = patch[filePath].map(d => util.toDiagnostic(d));
+
+                this.connection.sendDiagnostics({
+                    uri: URI.file(filePath).toString(),
+                    diagnostics: diagnostics
+                });
+            }
+        });
     }
 
     @AddStackToErrorMessage

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -594,7 +594,6 @@ export class Program {
 
     /**
      * Traverse the entire project, and validate all scopes
-     * @param force - if true, then all scopes are force to validate, even if they aren't marked as dirty
      */
     public validate() {
         this.logger.time(LogLevel.log, ['Validating project'], () => {


### PR DESCRIPTION
This PR updates the language server to listen to the `afterProgramValidate` event for every program, and triggers sending diagnostics to the language client. 

This allows plugins to trigger a validation cycle, which then will sync any diagnostic changes to the language client. 