### PR TITLE
Flag usage of undefined variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [0.52.3](https://github.com/rokucommunity/brighterscript/compare/v0.52.2...v0.52.3) - 2022-06-14
+### Fixed
+ - fix bug with class transpile in watch mode ([#630](https://github.com/rokucommunity/brighterscript/pull/630))
+ - Send program-triggered `validate()` diagnostics to language client ([#629](https://github.com/rokucommunity/brighterscript/pull/629))
+ - Emit before/after programTranspile during file transpile preview ([#628](https://github.com/rokucommunity/brighterscript/pull/628))
+
+
+
 ## [0.52.2](https://github.com/rokucommunity/brighterscript/compare/v0.52.1...v0.52.2) - 2022-06-13
 ### Fixed
  - transpile crash when file was changed by a plugin in beforeTranspile events ([#627](https://github.com/rokucommunity/brighterscript/pull/627))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "brighterscript",
-    "version": "0.52.2",
+    "version": "0.52.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "brighterscript",
-            "version": "0.52.2",
+            "version": "0.52.3",
             "license": "MIT",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "brighterscript",
-    "version": "0.52.2",
+    "version": "0.52.3",
     "description": "A superset of Roku's BrightScript language.",
     "scripts": {
         "preversion": "npm run build && npm run lint && npm run test",

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -24,3 +24,30 @@ export class Cache<TKey = any, TValue = any> extends Map<TKey, TValue> {
         return super.get(key) as R;
     }
 }
+
+/**
+ * A cache that will call the factory to create the item if it doesn't exist
+ */
+export class WeakMapCache<TKey extends object, TValue = any> extends WeakMap<TKey, TValue> {
+
+    /**
+     * Get value from the cache if it exists,
+     * otherwise call the factory function to create the value, add it to the cache, and return it.
+     */
+    public getOrAdd<R extends TValue = TValue>(key: TKey, factory: (key: TKey) => R): R {
+        if (!this.has(key)) {
+            const value = factory(key);
+            this.set(key, value);
+            return value;
+        } else {
+            return this.get(key);
+        }
+    }
+
+    /**
+     * Get the item with the specified key.
+     */
+    public get<R extends TValue = TValue>(key: TKey) {
+        return super.get(key) as R;
+    }
+}

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -24,30 +24,3 @@ export class Cache<TKey = any, TValue = any> extends Map<TKey, TValue> {
         return super.get(key) as R;
     }
 }
-
-/**
- * A cache that will call the factory to create the item if it doesn't exist
- */
-export class WeakMapCache<TKey extends object, TValue = any> extends WeakMap<TKey, TValue> {
-
-    /**
-     * Get value from the cache if it exists,
-     * otherwise call the factory function to create the value, add it to the cache, and return it.
-     */
-    public getOrAdd<R extends TValue = TValue>(key: TKey, factory: (key: TKey) => R): R {
-        if (!this.has(key)) {
-            const value = factory(key);
-            this.set(key, value);
-            return value;
-        } else {
-            return this.get(key);
-        }
-    }
-
-    /**
-     * Get the item with the specified key.
-     */
-    public get<R extends TValue = TValue>(key: TKey) {
-        return super.get(key) as R;
-    }
-}

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -13,11 +13,11 @@ export let DiagnosticMessages = {
         code: 1000,
         severity: DiagnosticSeverity.Error
     }),
-    callToUnknownFunction: (name: string, scopeName: string) => ({
-        message: `Cannot find function with name '${name}' when this file is included in scope '${scopeName}'`,
+    cannotFindName: (name: string) => ({
+        message: `Cannot find name '${name}'`,
         code: 1001,
         data: {
-            functionName: name
+            name: name
         },
         severity: DiagnosticSeverity.Error
     }),

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -494,7 +494,7 @@ describe('Program', () => {
 
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.callToUnknownFunction('DoSomething', 'source')
+                DiagnosticMessages.cannotFindName('DoSomething')
             ]);
         });
 
@@ -1360,7 +1360,7 @@ describe('Program', () => {
 
             //there should be an error when calling DoParentThing, since it doesn't exist on child or parent
             expectDiagnostics(program, [
-                DiagnosticMessages.callToUnknownFunction('DoParentThing', '').code
+                DiagnosticMessages.cannotFindName('DoParentThing')
             ]);
 
             //add the script into the parent
@@ -1519,7 +1519,7 @@ describe('Program', () => {
             ];
 
             expectDiagnostics(program, [
-                DiagnosticMessages.callToUnknownFunction('C', 'source')
+                DiagnosticMessages.cannotFindName('C')
             ]);
         });
     });
@@ -2186,7 +2186,8 @@ describe('Program', () => {
         it('gets signature help for callfunc method', () => {
             program.setFile('source/main.bs', `
                 function main()
-                    myNode@.sayHello(arg1)
+                    myNode = createObject("roSGNode", "Component1")
+                    myNode@.sayHello(1)
                 end function
             `);
             program.setFile('components/MyNode.bs', `
@@ -2203,7 +2204,7 @@ describe('Program', () => {
                 </component>`);
             program.validate();
 
-            let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
+            let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(3, 36)));
             expectZeroDiagnostics(program);
             expect(signatureHelp[0].signature.label).to.equal('function sayHello(text, text2)');
         });
@@ -2211,7 +2212,8 @@ describe('Program', () => {
         it('does not get signature help for callfunc method, referenced by dot', () => {
             program.setFile('source/main.bs', `
                 function main()
-                    myNode.sayHello(arg1)
+                    myNode = createObject("roSGNode", "Component1")
+                    myNode.sayHello(1, 2)
                 end function
             `);
             program.setFile('components/MyNode.bs', `
@@ -2228,7 +2230,7 @@ describe('Program', () => {
                 </component>`);
             program.validate();
 
-            let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(2, 36)));
+            let signatureHelp = (program.getSignatureHelp(`${rootDir}/source/main.bs`, Position.create(3, 36)));
             expectZeroDiagnostics(program);
             //note - callfunc completions and signatures are not yet correctly identifying methods that are exposed in an interace - waiting on the new xml branch for that
             expect(signatureHelp).to.be.empty;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1489,6 +1489,34 @@ export class Program {
         return files;
     }
 
+    public findFilesForNamespace(name: string) {
+        const files = [] as BscFile[];
+        const lowerName = name.toLowerCase();
+        //find every file with this class defined
+        for (const file of Object.values(this.files)) {
+            if (isBrsFile(file)) {
+                if (file.parser.references.namespaceStatements.find(x => x.name.toLowerCase() === lowerName)) {
+                    files.push(file);
+                }
+            }
+        }
+        return files;
+    }
+
+    public findFilesForEnum(name: string) {
+        const files = [] as BscFile[];
+        const lowerName = name.toLowerCase();
+        //find every file with this class defined
+        for (const file of Object.values(this.files)) {
+            if (isBrsFile(file)) {
+                if (file.parser.references.enumStatementLookup.get(lowerName)) {
+                    files.push(file);
+                }
+            }
+        }
+        return files;
+    }
+
     /**
      * Get a map of the manifest information
      */

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -736,16 +736,21 @@ export class Program {
      * Get a list of all scopes the file is loaded into
      * @param file
      */
-    public getScopesForFile(file: XmlFile | BrsFile) {
-        let result = [] as Scope[];
-        for (let key in this.scopes) {
-            let scope = this.scopes[key];
-
-            if (scope.hasFile(file)) {
-                result.push(scope);
-            }
+    public getScopesForFile(file: XmlFile | BrsFile | string) {
+        if (typeof file === 'string') {
+            file = this.getFile(file);
         }
-        return result;
+        if (file) {
+            let result = [] as Scope[];
+            for (let key in this.scopes) {
+                let scope = this.scopes[key];
+
+                if (scope.hasFile(file)) {
+                    result.push(scope);
+                }
+            }
+            return result;
+        }
     }
 
     /**

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as sinonImport from 'sinon';
 import { Position, Range } from 'vscode-languageserver';
-import { standardizePath as s } from './util';
+import util, { standardizePath as s } from './util';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { Program } from './Program';
 import { ParseMode } from './parser/Parser';
@@ -175,6 +175,23 @@ describe('Scope', () => {
             expectDiagnostics(program, [
                 DiagnosticMessages.cannotFindName('Name2')
             ]);
+        });
+
+        it('detects unknown namespace sub-names', () => {
+            program.setFile('source/main.bs', `
+                sub main()
+                    Name1.subname.thing()
+                end sub
+                namespace Name1
+                    sub thing()
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.cannotFindName('subname'),
+                range: util.createRange(2, 26, 2, 33)
+            }]);
         });
 
         it('detects unknown enum names', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -583,6 +583,7 @@ export class Scope {
             let callableContainerMap = util.getCallableContainersByLowerName(callables);
             let files = this.getOwnFiles();
 
+            //Since statements from files are shared across multiple scopes, we need to link those statements to the current scope
             this.linkSymbolTable();
             this.program.plugins.emit('beforeScopeValidate', this, files, callableContainerMap);
 
@@ -593,6 +594,7 @@ export class Scope {
             this._validate(callableContainerMap);
 
             this.program.plugins.emit('afterScopeValidate', this, files, callableContainerMap);
+            //unlink all symbol tables from this scope (so they don't accidentally stick around)
             this.unlinkSymbolTable();
 
             (this as any).isValidated = true;

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -18,6 +18,7 @@ import { LogLevel } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
 import { isBrsFile, isClassMethodStatement, isClassStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile } from './astUtils/reflection';
+import { SymbolTable } from './SymbolTable';
 
 /**
  * A class to keep track of all declarations within a given scope (like source scope, component scope)
@@ -476,9 +477,9 @@ export class Scope {
     public buildNamespaceLookup() {
         let namespaceLookup = new Map<string, NamespaceContainer>();
         this.enumerateBrsFiles((file) => {
-            for (let namespace of file.parser.references.namespaceStatements) {
+            for (let namespaceStatement of file.parser.references.namespaceStatements) {
                 //TODO should we handle non-brighterscript?
-                let name = namespace.nameExpression.getName(ParseMode.BrighterScript);
+                let name = namespaceStatement.nameExpression.getName(ParseMode.BrighterScript);
                 let nameParts = name.split('.');
 
                 let loopName = null;
@@ -491,19 +492,20 @@ export class Scope {
                         namespaceLookup.set(lowerLoopName, {
                             file: file,
                             fullName: loopName,
-                            nameRange: namespace.nameExpression.range,
+                            nameRange: namespaceStatement.nameExpression.range,
                             lastPartName: part,
                             namespaces: new Map<string, NamespaceContainer>(),
                             classStatements: {},
                             functionStatements: {},
+                            enumStatements: new Map<string, EnumStatement>(),
                             statements: [],
-                            enumStatements: new Map<string, EnumStatement>()
+                            symbolTable: new SymbolTable(this.symbolTable)
                         });
                     }
                 }
                 let ns = namespaceLookup.get(name.toLowerCase());
-                ns.statements.push(...namespace.body.statements);
-                for (let statement of namespace.body.statements) {
+                ns.statements.push(...namespaceStatement.body.statements);
+                for (let statement of namespaceStatement.body.statements) {
                     if (isClassStatement(statement) && statement.name) {
                         ns.classStatements[statement.name.text.toLowerCase()] = statement;
                     } else if (isFunctionStatement(statement) && statement.name) {
@@ -512,6 +514,9 @@ export class Scope {
                         ns.enumStatements.set(statement.fullName.toLowerCase(), statement);
                     }
                 }
+                // Merges all the symbol tables of the namespace statements into the new symbol table created above.
+                // Set those symbol tables to have this new merged table as a parent
+                ns.symbolTable.mergeSymbolTable(namespaceStatement.symbolTable);
             }
 
             //associate child namespaces with their parents
@@ -578,6 +583,7 @@ export class Scope {
             let callableContainerMap = util.getCallableContainersByLowerName(callables);
             let files = this.getOwnFiles();
 
+            this.linkSymbolTable();
             this.program.plugins.emit('beforeScopeValidate', this, files, callableContainerMap);
 
             this.program.plugins.emit('onScopeValidate', {
@@ -587,6 +593,7 @@ export class Scope {
             this._validate(callableContainerMap);
 
             this.program.plugins.emit('afterScopeValidate', this, files, callableContainerMap);
+            this.unlinkSymbolTable();
 
             (this as any).isValidated = true;
         });
@@ -604,7 +611,6 @@ export class Scope {
 
         //do many per-file checks
         this.enumerateBrsFiles((file) => {
-            this.diagnosticDetectCallsToUnknownFunctions(file, callableContainerMap);
             this.diagnosticDetectFunctionCallsWithWrongParamCount(file, callableContainerMap);
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
@@ -620,6 +626,50 @@ export class Scope {
         (this as any).isValidated = false;
         //clear out various lookups (they'll get regenerated on demand the next time they're requested)
         this.cache.clear();
+    }
+
+    public get symbolTable() {
+        return this.cache.getOrAdd('symbolTable', () => {
+            const result = new SymbolTable(this.getParentScope()?.symbolTable);
+            for (let file of this.getOwnFiles()) {
+                if (isBrsFile(file)) {
+                    result.mergeSymbolTable(file.parser?.symbolTable);
+                }
+            }
+            return result;
+        });
+    }
+
+    /**
+    * Builds the current symbol table for the scope, by merging the tables for all the files in this scope.
+    * Also links all file symbols tables to this new table
+    * This will only rebuilt if the symbol table has not been built before
+    */
+    public linkSymbolTable() {
+        for (const file of this.getAllFiles()) {
+            if (isBrsFile(file)) {
+                file.parser.symbolTable.pushParent(this.symbolTable);
+
+                //link each NamespaceStatement's SymbolTable with the aggregate NamespaceLookup SymbolTable
+                for (const namespace of file.parser.references.namespaceStatements) {
+                    const namespaceNameLower = namespace.nameExpression.getName(ParseMode.BrighterScript).toLowerCase();
+                    const namespaceSymbolTable = this.namespaceLookup.get(namespaceNameLower).symbolTable;
+                    namespace.symbolTable.pushParent(namespaceSymbolTable);
+                }
+            }
+        }
+    }
+
+    public unlinkSymbolTable() {
+        for (let file of this.getOwnFiles()) {
+            if (isBrsFile(file)) {
+                file.parser?.symbolTable.popParent();
+
+                for (const namespace of file.parser.references.namespaceStatements) {
+                    namespace.symbolTable.popParent();
+                }
+            }
+        }
     }
 
     private detectVariableNamespaceCollisions(file: BrsFile) {
@@ -851,56 +901,6 @@ export class Scope {
                         });
                     }
                 }
-            }
-        }
-    }
-
-    /**
-     * Detect calls to functions that are not defined in this scope
-     * @param file
-     * @param callablesByLowerName
-     */
-    private diagnosticDetectCallsToUnknownFunctions(file: BscFile, callablesByLowerName: CallableContainerMap) {
-        //validate all expression calls
-        for (let expCall of file.functionCalls) {
-            const lowerName = expCall.name.toLowerCase();
-            //for now, skip validation on any method named "super" within `.bs` contexts.
-            //TODO revise this logic so we know if this function call resides within a class constructor function
-            if (file.extension === '.bs' && lowerName === 'super') {
-                continue;
-            }
-
-            //get the local scope for this expression
-            let scope = file.getFunctionScopeAtPosition(expCall.nameRange.start);
-
-            //if we don't already have a variable with this name.
-            if (!scope?.getVariableByName(lowerName)) {
-                let callablesWithThisName: CallableContainer[];
-
-                if (expCall.functionScope.func.namespaceName) {
-                    // prefer namespaced function
-                    const potentialNamespacedCallable = expCall.functionScope.func.namespaceName.getName(ParseMode.BrightScript).toLowerCase() + '_' + lowerName;
-                    callablesWithThisName = callablesByLowerName.get(potentialNamespacedCallable.toLowerCase());
-                }
-                if (!callablesWithThisName) {
-                    // just try it as is
-                    callablesWithThisName = callablesByLowerName.get(lowerName);
-                }
-
-                //use the first item from callablesByLowerName, because if there are more, that's a separate error
-                let knownCallable = callablesWithThisName ? callablesWithThisName[0] : undefined;
-
-                //detect calls to unknown functions
-                if (!knownCallable) {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.callToUnknownFunction(expCall.name, this.name),
-                        range: expCall.nameRange,
-                        file: file
-                    });
-                }
-            } else {
-                //if we found a variable with the same name as the function, assume the call is "known".
-                //If the variable is a different type, some other check should add a diagnostic for that.
             }
         }
     }
@@ -1156,6 +1156,7 @@ interface NamespaceContainer {
     functionStatements: Record<string, FunctionStatement>;
     enumStatements: Map<string, EnumStatement>;
     namespaces: Map<string, NamespaceContainer>;
+    symbolTable: SymbolTable;
 }
 
 interface AugmentedNewExpression extends NewExpression {

--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -1,0 +1,61 @@
+import { SymbolTable } from './SymbolTable';
+import { expect } from 'chai';
+import { StringType } from './types/StringType';
+import { IntegerType } from './types/IntegerType';
+
+
+describe('SymbolTable', () => {
+    it('is case insensitive', () => {
+        const st = new SymbolTable();
+        st.addSymbol('foo', null, new StringType());
+        expect(st.getSymbol('FOO').length).eq(1);
+        expect(st.getSymbol('FOO')[0].type.toString()).eq('string');
+    });
+
+    it('stores all previous symbols', () => {
+        const st = new SymbolTable();
+        st.addSymbol('foo', null, new StringType());
+        st.addSymbol('foo', null, new IntegerType());
+        expect(st.getSymbol('FOO').length).eq(2);
+    });
+
+
+    it('reads from parent symbol table if not found in current', () => {
+        const parent = new SymbolTable();
+        const st = new SymbolTable(parent);
+        parent.addSymbol('foo', null, new StringType());
+        expect(st.getSymbol('foo')[0].type.toString()).eq('string');
+    });
+
+    it('reads from current table if it exists', () => {
+        const parent = new SymbolTable();
+        const st = new SymbolTable(parent);
+        parent.addSymbol('foo', null, new StringType());
+        st.addSymbol('foo', null, new IntegerType());
+        expect(st.getSymbol('foo')[0].type.toString()).eq('integer');
+    });
+
+    it('correct checks if a symbol is in the table using hasSymbol', () => {
+        const parent = new SymbolTable();
+        const child = new SymbolTable(parent);
+        parent.addSymbol('foo', null, new StringType());
+        child.addSymbol('bar', null, new IntegerType());
+        expect(parent.hasSymbol('foo')).to.be.true;
+        expect(parent.hasSymbol('bar')).to.be.false;
+        expect(child.hasSymbol('foo')).to.be.true;
+        expect(child.hasSymbol('bar')).to.be.true;
+        expect(child.hasSymbol('buz')).to.be.false;
+    });
+
+    describe('mergeSymbolTable', () => {
+
+        it('adds each symbol to the table', () => {
+            const st = new SymbolTable();
+            st.addSymbol('foo', null, new StringType());
+            const otherTable = new SymbolTable();
+            otherTable.addSymbol('bar', null, new IntegerType());
+            otherTable.addSymbol('foo', null, new IntegerType());
+            st.mergeSymbolTable(otherTable);
+        });
+    });
+});

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -1,0 +1,141 @@
+import type { Range } from 'vscode-languageserver';
+import type { BscType } from './types/BscType';
+
+
+/**
+ * Stores the types associated with variables and functions in the Brighterscript code
+ * Can be part of a hierarchy, so lookups can reference parent scopes
+ */
+export class SymbolTable {
+    constructor(
+        parent?: SymbolTable | undefined
+    ) {
+        this.pushParent(parent);
+    }
+
+    /**
+     * The map of symbols declared directly in this SymbolTable (excludes parent SymbolTable).
+     * Indexed by lower symbol name
+     */
+    private symbolMap = new Map<string, BscSymbol[]>();
+
+    public get parent() {
+        return this.parentStack[0];
+    }
+
+    /**
+     * Get list of symbols declared directly in this SymbolTable (excludes parent SymbolTable).
+     */
+    public getOwnSymbols(): BscSymbol[] {
+        return [].concat(...this.symbolMap.values());
+    }
+
+    /**
+     * Get list of all symbols declared in this SymbolTable (includes parent SymbolTable).
+     */
+    public getAllSymbols(): BscSymbol[] {
+        let symbols = this.getOwnSymbols();
+        if (this.parent) {
+            symbols = symbols.concat(this.parent.getAllSymbols());
+        }
+        return symbols;
+    }
+
+    /**
+     * Sets the parent table for lookups. There can only be one parent at a time, but sometimes you
+     * want to temporarily change the parent, and then restore it later. This allows that.
+     *
+     * @param [parent]
+     */
+    private parentStack: SymbolTable[] = [];
+
+    public pushParent(parent?: SymbolTable) {
+        this.parentStack.unshift(parent);
+        return parent;
+    }
+
+    /**
+     * Remove the current parent, restoring the previous parent (if there was one)
+     */
+    public popParent() {
+        return this.parentStack.shift();
+    }
+
+    /**
+     * Checks if the symbol table contains the given symbol by name
+     * If the identifier is not in this table, it will check the parent
+     *
+     * @param name the name to lookup
+     * @param searchParent should we look to our parent if we don't have the symbol?
+     * @returns true if this symbol is in the symbol table
+     */
+    hasSymbol(name: string, searchParent = true): boolean {
+        const key = name.toLowerCase();
+        let result = this.symbolMap.has(key);
+        if (!result && searchParent) {
+            result = !!this.parent?.hasSymbol(key);
+        }
+        return result;
+    }
+
+    /**
+     * Gets the name/type pair for a given named variable or function name
+     * If the identifier is not in this table, it will check the parent
+     *
+     * @param  name the name to lookup
+     * @param searchParent should we look to our parent if we don't have the symbol?
+     * @returns An array of BscSymbols - one for each time this symbol had a type implicitly defined
+     */
+    getSymbol(name: string, searchParent = true): BscSymbol[] {
+        const key = name.toLowerCase();
+        let result = this.symbolMap.get(key);
+        if (!result && searchParent) {
+            result = this.parent?.getSymbol(key);
+        }
+        return result;
+    }
+
+    /**
+     * Adds a new symbol to the table
+     * @param name
+     * @param  type
+     */
+    addSymbol(name: string, range: Range, type: BscType) {
+        const key = name.toLowerCase();
+        if (!this.symbolMap.has(key)) {
+            this.symbolMap.set(key, []);
+        }
+        this.symbolMap.get(key).push({
+            name: name,
+            range: range,
+            type: type
+        });
+    }
+
+    /**
+     * Adds all the symbols from another table to this one
+     * It will overwrite any existing symbols in this table
+     * @param symbolTable
+     */
+    mergeSymbolTable(symbolTable: SymbolTable) {
+        for (let [, value] of symbolTable.symbolMap) {
+            for (const symbol of value) {
+                this.addSymbol(
+                    symbol.name,
+                    symbol.range,
+                    symbol.type
+                );
+            }
+        }
+    }
+
+    clear() {
+        this.symbolMap.clear();
+    }
+}
+
+export interface BscSymbol {
+    name: string;
+    range: Range;
+    type: BscType;
+}

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -19,7 +19,7 @@ export class CodeActionsProcessor {
     public process() {
         for (const diagnostic of this.event.diagnostics) {
             if (diagnostic.code === DiagnosticCodeMap.cannotFindName) {
-                this.suggestFunctionImports(diagnostic as any);
+                this.suggestCannotFindName(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.classCouldNotBeFound) {
                 this.suggestClassImports(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.xmlComponentMissingExtendsAttribute) {
@@ -64,16 +64,22 @@ export class CodeActionsProcessor {
         }
     }
 
-    private suggestFunctionImports(diagnostic: DiagnosticMessageType<'cannotFindName'>) {
+    private suggestCannotFindName(diagnostic: DiagnosticMessageType<'cannotFindName'>) {
         //skip if not a BrighterScript file
         if ((diagnostic.file as BrsFile).parseMode !== ParseMode.BrighterScript) {
             return;
         }
         const lowerName = diagnostic.data.name.toLowerCase();
+
         this.suggestImports(
             diagnostic,
             lowerName,
-            this.event.file.program.findFilesForFunction(lowerName)
+            [
+                ...this.event.file.program.findFilesForFunction(lowerName),
+                ...this.event.file.program.findFilesForClass(lowerName),
+                ...this.event.file.program.findFilesForNamespace(lowerName),
+                ...this.event.file.program.findFilesForEnum(lowerName)
+            ]
         );
     }
 

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -19,7 +19,6 @@ export class CodeActionsProcessor {
     public process() {
         for (const diagnostic of this.event.diagnostics) {
             if (diagnostic.code === DiagnosticCodeMap.cannotFindName) {
-                this.suggestClassImports(diagnostic as any);
                 this.suggestFunctionImports(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.classCouldNotBeFound) {
                 this.suggestClassImports(diagnostic as any);

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -18,7 +18,8 @@ export class CodeActionsProcessor {
 
     public process() {
         for (const diagnostic of this.event.diagnostics) {
-            if (diagnostic.code === DiagnosticCodeMap.callToUnknownFunction) {
+            if (diagnostic.code === DiagnosticCodeMap.cannotFindName) {
+                this.suggestClassImports(diagnostic as any);
                 this.suggestFunctionImports(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.classCouldNotBeFound) {
                 this.suggestClassImports(diagnostic as any);
@@ -64,16 +65,16 @@ export class CodeActionsProcessor {
         }
     }
 
-    private suggestFunctionImports(diagnostic: DiagnosticMessageType<'callToUnknownFunction'>) {
+    private suggestFunctionImports(diagnostic: DiagnosticMessageType<'cannotFindName'>) {
         //skip if not a BrighterScript file
         if ((diagnostic.file as BrsFile).parseMode !== ParseMode.BrighterScript) {
             return;
         }
-        const lowerFunctionName = diagnostic.data.functionName.toLowerCase();
+        const lowerName = diagnostic.data.name.toLowerCase();
         this.suggestImports(
             diagnostic,
-            lowerFunctionName,
-            this.event.file.program.findFilesForFunction(lowerFunctionName)
+            lowerName,
+            this.event.file.program.findFilesForFunction(lowerName)
         );
     }
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1186,7 +1186,7 @@ describe('BrsFile BrighterScript classes', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.classCouldNotBeFound('Duck', 'source')
+            DiagnosticMessages.cannotFindName('Duck')
         ]);
     });
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1107,7 +1107,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.classCouldNotBeFound('Animal', 'source')
+                DiagnosticMessages.cannotFindName('Animal')
             ]);
         });
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1091,7 +1091,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [{
-                ...DiagnosticMessages.classCouldNotBeFound('Animal', 'source'),
+                ...DiagnosticMessages.cannotFindName('Animal'),
                 range: Range.create(1, 35, 1, 41)
             }]);
         });
@@ -1125,7 +1125,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.classCouldNotBeFound('Animal', 'source')
+                DiagnosticMessages.cannotFindName('Animal')
             ]);
         });
 
@@ -1144,7 +1144,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.classCouldNotBeFound('Vertibrates.GroundedBird', 'source')
+                DiagnosticMessages.cannotFindName('GroundedBird')
             ]);
         });
 
@@ -1164,9 +1164,12 @@ describe('BrsFile BrighterScript classes', () => {
                 end namespace
             `);
             program.validate();
-            expectDiagnostics(program, [
-                DiagnosticMessages.classCouldNotBeFound('Vertibrates.GroundedBird', 'source')
-            ]);
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.cannotFindName('GroundedBird'),
+                relatedInformation: [{
+                    message: `Not defined in scope 'source'`
+                }]
+            }]);
         });
     });
 
@@ -1206,13 +1209,13 @@ describe('BrsFile BrighterScript classes', () => {
             namespace NameA.NameB
                 class Animal
                 end class
-                class Duck extends NameA.NameB.Animal1
+                class Duck extends NameA.NameB.AnimalNotDefined
                 end class
             end namespace
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.classCouldNotBeFound('NameA.NameB.Animal1', 'source')
+            DiagnosticMessages.cannotFindName('AnimalNotDefined')
         ]);
     });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -744,11 +744,13 @@ export class BrsFile {
      */
     public getNamespaceStatementForPosition(position: Position): NamespaceStatement {
         if (position) {
-            for (const statement of this.parser.references.namespaceStatements) {
-                if (util.rangeContains(statement.range, position)) {
-                    return statement;
+            return this.cache.getOrAdd(`namespaceStatementForPosition-${position.line}:${position.character}`, () => {
+                for (const statement of this.parser.references.namespaceStatements) {
+                    if (util.rangeContains(statement.range, position)) {
+                        return statement;
+                    }
                 }
-            }
+            });
         }
     }
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -120,12 +120,16 @@ export class BrsFile {
         return this._functionScopes;
     }
 
+    private get cache() {
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        return this._parser?.references['cache'];
+    }
+
     /**
      * files referenced by import statements
      */
     public get ownScriptImports() {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        const result = this._parser?.references['cache'].getOrAdd('BrsFile_ownScriptImports', () => {
+        const result = this.cache?.getOrAdd('BrsFile_ownScriptImports', () => {
             const result = [] as FileReference[];
             for (const statement of this.parser?.references?.importStatements ?? []) {
                 //register import statements
@@ -710,14 +714,20 @@ export class BrsFile {
      * @param position
      * @param functionScopes
      */
-    public getFunctionScopeAtPosition(position: Position, functionScopes?: FunctionScope[]): FunctionScope {
+    public getFunctionScopeAtPosition(position: Position): FunctionScope {
+        return this.cache.getOrAdd(`functionScope-${position.line}:${position.character}`, () => {
+            return this._getFunctionScopeAtPosition(position, this.functionScopes);
+        });
+    }
+
+    public _getFunctionScopeAtPosition(position: Position, functionScopes?: FunctionScope[]): FunctionScope {
         if (!functionScopes) {
             functionScopes = this.functionScopes;
         }
         for (let scope of functionScopes) {
             if (util.rangeContains(scope.range, position)) {
                 //see if any of that scope's children match the position also, and give them priority
-                let childScope = this.getFunctionScopeAtPosition(position, scope.childrenScopes);
+                let childScope = this._getFunctionScopeAtPosition(position, scope.childrenScopes);
                 if (childScope) {
                     return childScope;
                 } else {

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -158,7 +158,7 @@ describe('import statements', () => {
         program.validate();
 
         expectDiagnostics(program, [
-            DiagnosticMessages.callToUnknownFunction('Waddle', s`components/ChildScene.xml`).message
+            DiagnosticMessages.cannotFindName('Waddle')
         ]);
 
         //add the missing function

--- a/src/files/tests/optionalChaning.spec.ts
+++ b/src/files/tests/optionalChaning.spec.ts
@@ -73,10 +73,12 @@ describe('optional chaining', () => {
 
     it('transpiles various use cases', () => {
         testTranspile(`
+            obj = {}
+            arr = []
             print arr?.["0"]
             print arr?.value
-            print assocArray?.[0]
-            print assocArray?.getName()?.first?.second
+            print obj?.[0]
+            print obj?.getName()?.first?.second
             print createObject("roByteArray")?.value
             print createObject("roByteArray")?["0"]
             print createObject("roList")?.value
@@ -85,10 +87,10 @@ describe('optional chaining', () => {
             print createObject("roDateTime")?.value
             print createObject("roDateTime")?.GetTimeZoneOffset
             print createObject("roSGNode", "Node")?[0]
-            print pi?.first?.second
-            print success?.first?.second
-            print a.b.xmlThing?@someAttr
-            print a.b.localFunc?()
+            print obj?.first?.second
+            print obj?.first?.second
+            print obj.b.xmlThing?@someAttr
+            print obj.b.localFunc?()
         `);
     });
 });

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -1015,6 +1015,9 @@ for (let callable of globalCallables) {
 
 }
 globalFile.callables = globalCallables as Callable[];
+for (const callable of globalCallables) {
+    globalFile.parser.symbolTable.addSymbol(callable.name, undefined, callable.type);
+}
 
 /**
  * A map of all built-in function names. We use this extensively in scope validation

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -15,6 +15,7 @@ import { VoidType } from '../types/VoidType';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
+import { SymbolTable } from '../SymbolTable';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -135,7 +136,8 @@ export class FunctionExpression extends Expression implements TypedefProvider {
          * If this function is enclosed within another function, this will reference that parent function
          */
         readonly parentFunction?: FunctionExpression,
-        readonly namespaceName?: NamespacedVariableNameExpression
+        readonly namespaceName?: NamespacedVariableNameExpression,
+        readonly parentSymbolTable?: SymbolTable
     ) {
         super();
         if (this.returnTypeToken) {
@@ -143,9 +145,15 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         } else if (this.functionType.text.toLowerCase() === 'sub') {
             this.returnType = new VoidType();
         } else {
-            this.returnType = new DynamicType();
+            this.returnType = DynamicType.instance;
+        }
+        this.symbolTable = new SymbolTable(parentSymbolTable);
+        for (let param of parameters) {
+            this.symbolTable.addSymbol(param.name.text, param.name.range, DynamicType.instance);
         }
     }
+
+    public symbolTable: SymbolTable;
 
     /**
      * The type this function returns

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1105,10 +1105,10 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     ) {
         super();
         this.name = this.nameExpression.getName(ParseMode.BrighterScript);
-        this.symbolTable.pushParent(parentSymbolTable);
+        this.symbolTable = new SymbolTable(parentSymbolTable);
     }
 
-    public symbolTable = new SymbolTable();
+    public symbolTable: SymbolTable;
 
     /**
      * The string name for this namespace

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -10,7 +10,7 @@ import type { BrsTranspileState } from './BrsTranspileState';
 import { ParseMode } from './Parser';
 import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { InternalWalkMode, walk, createVisitor, WalkMode, walkArray } from '../astUtils/visitors';
-import { isCallExpression, isClassFieldStatement, isClassMethodStatement, isCommentStatement, isEnumMemberStatement, isExpression, isExpressionStatement, isFunctionStatement, isIfStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInvalidType, isLiteralExpression, isTypedefProvider, isVoidType } from '../astUtils/reflection';
+import { isCallExpression, isCommentStatement, isEnumMemberStatement, isExpression, isExpressionStatement, isFieldStatement, isFunctionStatement, isIfStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInvalidType, isLiteralExpression, isMethodStatement, isTypedefProvider, isVoidType } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
@@ -1524,10 +1524,10 @@ export class ClassStatement extends Statement implements TypedefProvider {
         super();
         this.body = this.body ?? [];
         for (let statement of this.body) {
-            if (isClassMethodStatement(statement)) {
+            if (isMethodStatement(statement)) {
                 this.methods.push(statement);
                 this.memberMap[statement?.name?.text.toLowerCase()] = statement;
-            } else if (isClassFieldStatement(statement)) {
+            } else if (isFieldStatement(statement)) {
                 this.fields.push(statement);
                 this.memberMap[statement?.name?.text.toLowerCase()] = statement;
             }
@@ -1751,12 +1751,12 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
         for (let statement of body) {
             //is field statement
-            if (isClassFieldStatement(statement)) {
+            if (isFieldStatement(statement)) {
                 //do nothing with class fields in this situation, they are handled elsewhere
                 continue;
 
                 //methods
-            } else if (isClassMethodStatement(statement)) {
+            } else if (isMethodStatement(statement)) {
 
                 //store overridden parent methods as super{parentIndex}_{methodName}
                 if (
@@ -1922,7 +1922,7 @@ export class MethodStatement extends FunctionStatement {
                 const beginningVariable = util.findBeginningVariableExpression(e);
                 const lowerName = beginningVariable?.getName(ParseMode.BrighterScript).toLowerCase();
                 if (lowerName === 'super') {
-                    beginningVariable.name.text = 'm';
+                    state.editor.setProperty(beginningVariable.name, 'text', 'm');
                     state.editor.setProperty(e.name, 'text', `super${parentClassIndex}_${e.name.text}`);
                 }
             }

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -202,43 +202,61 @@ describe('NullCoalescingExpression', () => {
         });
 
         it('properly transpiles null coalesence assignments - complex consequent', () => {
-            testTranspile(`a = user.getAccount() ?? {"id": "default"}`, `
-                a = (function(user)
-                        __bsConsequent = user.getAccount()
-                        if __bsConsequent <> invalid then
-                            return __bsConsequent
-                        else
-                            return {
-                                "id": "default"
-                            }
-                        end if
-                    end function)(user)
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user.getAccount() ?? {"id": "default"}
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = (function(user)
+                            __bsConsequent = user.getAccount()
+                            if __bsConsequent <> invalid then
+                                return __bsConsequent
+                            else
+                                return {
+                                    "id": "default"
+                                }
+                            end if
+                        end function)(user)
+                end sub
             `);
         });
 
         it('transpiles null coalesence assignment for variable alternate- complex consequent', () => {
-            testTranspile(`a = obj.link ?? fallback`, `
-                a = (function(fallback, obj)
+            testTranspile(`a = obj.link ?? false`, `
+                a = (function(obj)
                         __bsConsequent = obj.link
                         if __bsConsequent <> invalid then
                             return __bsConsequent
                         else
-                            return fallback
+                            return false
                         end if
-                    end function)(fallback, obj)
+                    end function)(obj)
             `);
         });
 
         it('properly transpiles null coalesence assignments - complex alternate', () => {
-            testTranspile(`a = user ?? m.defaults.getAccount(settings.name)`, `
-                a = (function(m, settings, user)
-                        __bsConsequent = user
-                        if __bsConsequent <> invalid then
-                            return __bsConsequent
-                        else
-                            return m.defaults.getAccount(settings.name)
-                        end if
-                    end function)(m, settings, user)
+            testTranspile(`
+                sub main()
+                    user = {}
+                    settings = {}
+                    a = user ?? m.defaults.getAccount(settings.name)
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    settings = {}
+                    a = (function(m, settings, user)
+                            __bsConsequent = user
+                            if __bsConsequent <> invalid then
+                                return __bsConsequent
+                            else
+                                return m.defaults.getAccount(settings.name)
+                            end if
+                        end function)(m, settings, user)
+                end sub
             `);
         });
     });

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -77,15 +77,15 @@ describe('TemplateStringExpression', () => {
         it('uses the proper prefix when aliased package is installed', () => {
             program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
             testTranspile(
-                'a = `${one},${two}`',
-                `a = rokucommunity_bslib_toString(one) + "," + rokucommunity_bslib_toString(two)`
+                'a = `${LINE_NUM},${LINE_NUM}`',
+                `a = rokucommunity_bslib_toString(LINE_NUM) + "," + rokucommunity_bslib_toString(LINE_NUM)`
             );
         });
 
         it('properly transpiles simple template string with no leading text', () => {
             testTranspile(
-                'a = `${one},${two}`',
-                `a = bslib_toString(one) + "," + bslib_toString(two)`
+                'a = `${LINE_NUM},${LINE_NUM}`',
+                `a = bslib_toString(LINE_NUM) + "," + bslib_toString(LINE_NUM)`
             );
         });
 
@@ -98,8 +98,8 @@ describe('TemplateStringExpression', () => {
 
         it('properly transpiles one line template string with expressions', () => {
             testTranspile(
-                'a = `hello ${a.text} world ${"template" + m.getChars()} test`',
-                `a = "hello " + bslib_toString(a.text) + " world " + bslib_toString("template" + m.getChars()) + " test"`
+                'a = `hello ${LINE_NUM.text} world ${"template" + "".getChars()} test`',
+                `a = "hello " + bslib_toString(LINE_NUM.text) + " world " + bslib_toString("template" + "".getChars()) + " test"`
             );
         });
 
@@ -174,7 +174,7 @@ describe('TemplateStringExpression', () => {
                         "a",
                         "b",
                         "c",
-                        \`d_open \${"inside" + m.items[i]} d_close\`
+                        \`d_open \${"inside" + m.items[1]} d_close\`
                     ])}\`
                 ]
             `, `
@@ -185,7 +185,7 @@ describe('TemplateStringExpression', () => {
                         "a"
                         "b"
                         "c"
-                        "d_open " + bslib_toString("inside" + m.items[i]) + " d_close"
+                        "d_open " + bslib_toString("inside" + m.items[1]) + " d_close"
                     ]))
                 ]
             `);

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -267,87 +267,185 @@ describe('ternary expressions', () => {
 
         it('uses the proper prefix when aliased package is installed', () => {
             program.setFile('source/roku_modules/rokucommunity_bslib/bslib.brs', '');
-            testTranspile(
-                `a = user = invalid ? "no user" : "logged in"`,
-                `a = rokucommunity_bslib_ternary(user = invalid, "no user", "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "no user" : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = rokucommunity_bslib_ternary(user = invalid, "no user", "logged in")
+                end sub
+            `);
         });
 
         it('simple consequents', () => {
-            testTranspile(
-                `a = user = invalid ? "no user" : "logged in"`,
-                `a = bslib_ternary(user = invalid, "no user", "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "no user" : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "no user", "logged in")
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? 1 : "logged in"`,
-                `a = bslib_ternary(user = invalid, 1, "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? 1 : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, 1, "logged in")
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? 1.2 : "logged in"`,
-                `a = bslib_ternary(user = invalid, 1.2, "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? 1.2 : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, 1.2, "logged in")
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? {} : "logged in"`,
-                `a = bslib_ternary(user = invalid, {}, "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? {} : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, {}, "logged in")
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? [] : "logged in"`,
-                `a = bslib_ternary(user = invalid, [], "logged in")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? [] : "logged in"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, [], "logged in")
+                end sub
+            `);
         });
 
         it('simple alternates', () => {
-            testTranspile(
-                `a = user = invalid ? "logged in" : "no user" `,
-                `a = bslib_ternary(user = invalid, "logged in", "no user")`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "logged in" : "no user"
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "logged in", "no user")
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? "logged in" : 1 `,
-                `a = bslib_ternary(user = invalid, "logged in", 1)`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "logged in" : 1
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "logged in", 1)
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? "logged in" : 1.2 `,
-                `a = bslib_ternary(user = invalid, "logged in", 1.2)`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "logged in" : 1.2
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "logged in", 1.2)
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? "logged in" :  [] `,
-                `a = bslib_ternary(user = invalid, "logged in", [])`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "logged in" :  []
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "logged in", [])
+                end sub
+            `);
 
-            testTranspile(
-                `a = user = invalid ? "logged in" :  {} `,
-                `a = bslib_ternary(user = invalid, "logged in", {})`
-            );
+            testTranspile(`
+                sub main()
+                    user = {}
+                    a = user = invalid ? "logged in" :  {}
+                end sub
+            `, `
+                sub main()
+                    user = {}
+                    a = bslib_ternary(user = invalid, "logged in", {})
+                end sub
+            `);
         });
 
         it('complex conditions do not cause scope capture', () => {
             testTranspile(
-                `a = IsTrue() = true ? true : false `,
-                `a = bslib_ternary(IsTrue() = true, true, false)`
+                `a = str("true") = "true" ? true : false `,
+                `a = bslib_ternary(str("true") = "true", true, false)`
             );
 
-            testTranspile(
-                `a = m.top.service.IsTrue() ? true : false `,
-                `a = bslib_ternary(m.top.service.IsTrue(), true, false)`
-            );
+            testTranspile(`
+                sub main()
+                    a = m.top.service.IsTrue() ? true : false
+                end sub
+            `, `
+                sub main()
+                    a = bslib_ternary(m.top.service.IsTrue(), true, false)
+                end sub
+            `);
 
-            testTranspile(
-                `a = First(second(third(fourth(m.fifth()[123].truthy(1))))) ? true : false `,
-                `a = bslib_ternary(First(second(third(fourth(m.fifth()[123].truthy(1))))), true, false)`
-            );
+            testTranspile(`
+                sub test(param1)
+                end sub
+
+                sub main()
+                    a = test(test(test(test(m.fifth()[123].truthy(1))))) ? true : false
+                end sub
+            `, `
+                sub test(param1)
+                end sub
+
+                sub main()
+                    a = bslib_ternary(test(test(test(test(m.fifth()[123].truthy(1))))), true, false)
+                end sub
+            `);
         });
 
         it('captures scope for function call conseqent', () => {
-            testTranspile(
-                `name = zombie.getName() <> invalid ? zombie.GetName() : "zombie"`,
-                `
+            testTranspile(`
+                sub main()
+                    zombie = {}
+                    name = zombie.getName() <> invalid ? zombie.GetName() : "zombie"
+                end sub
+            `, `
+                sub main()
+                    zombie = {}
                     name = (function(__bsCondition, zombie)
                             if __bsCondition then
                                 return zombie.GetName()
@@ -355,14 +453,19 @@ describe('ternary expressions', () => {
                                 return "zombie"
                             end if
                         end function)(zombie.getName() <> invalid, zombie)
-                `
-            );
+                end sub
+            `);
         });
 
         it('captures scope for function call alternate', () => {
-            testTranspile(
-                `name = zombie.getName() = invalid ? "zombie" :  zombie.GetName()`,
-                `
+            testTranspile(`
+                sub main()
+                    zombie = {}
+                    name = zombie.getName() = invalid ? "zombie" :  zombie.GetName()
+                end sub
+            `, `
+                sub main()
+                    zombie = {}
                     name = (function(__bsCondition, zombie)
                             if __bsCondition then
                                 return "zombie"
@@ -370,44 +473,63 @@ describe('ternary expressions', () => {
                                 return zombie.GetName()
                             end if
                         end function)(zombie.getName() = invalid, zombie)
-                `
-            );
+                end sub
+            `);
         });
 
         it('captures scope for complex consequent', () => {
-            testTranspile(
-                `name = isLoggedIn ? m.defaults.getAccount(settings.name) : "no"`,
-                `
+            testTranspile(`
+                sub main()
+                    settings = {}
+                    name = {} ? m.defaults.getAccount(settings.name) : "no"
+                end sub
+            `, `
+                sub main()
+                    settings = {}
                     name = (function(__bsCondition, m, settings)
                             if __bsCondition then
                                 return m.defaults.getAccount(settings.name)
                             else
                                 return "no"
                             end if
-                        end function)(isLoggedIn, m, settings)
-                `
-            );
+                        end function)({}, m, settings)
+                end sub
+            `);
         });
 
         it('supports scope-captured outer, and simple inner', () => {
             testTranspile(
-                `name = zombie <> invalid ? zombie.Attack(human <> invalid ? human: zombie) : "zombie"`,
                 `
-                    name = (function(__bsCondition, human, zombie)
-                            if __bsCondition then
-                                return zombie.Attack(bslib_ternary(human <> invalid, human, zombie))
-                            else
-                                return "zombie"
-                            end if
-                        end function)(zombie <> invalid, human, zombie)
+                    sub main()
+                        zombie = {}
+                        human = {}
+                        name = zombie <> invalid ? zombie.Attack(human <> invalid ? human: zombie) : "zombie"
+                    end sub
+                `,
+                `
+                    sub main()
+                        zombie = {}
+                        human = {}
+                        name = (function(__bsCondition, human, zombie)
+                                if __bsCondition then
+                                    return zombie.Attack(bslib_ternary(human <> invalid, human, zombie))
+                                else
+                                    return "zombie"
+                                end if
+                            end function)(zombie <> invalid, human, zombie)
+                    end sub
                 `
             );
         });
 
         it('uses scope capture for property access', () => {
             testTranspile(
-                `name = person <> invalid ? person.name : "John Doe"`,
                 `
+                    person = {}
+                    name = person <> invalid ? person.name : "John Doe"
+                `,
+                `
+                    person = {}
                     name = (function(__bsCondition, person)
                             if __bsCondition then
                                 return person.name

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,7 +1,7 @@
 import type { BscFile, BsDiagnostic } from './interfaces';
 import * as assert from 'assert';
 import chalk from 'chalk';
-import type { CompletionItem, Diagnostic } from 'vscode-languageserver';
+import type { CodeDescription, CompletionItem, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, integer, Range } from 'vscode-languageserver';
 import { createSandbox } from 'sinon';
 import { expect } from 'chai';
 import type { CodeActionShorthand } from './CodeActionUtil';
@@ -41,12 +41,37 @@ function sortDiagnostics(diagnostics: BsDiagnostic[]) {
     );
 }
 
+function cloneObject<TOriginal, TTemplate>(original: TOriginal, template: TTemplate, defaultKeys: Array<keyof TOriginal>) {
+    const clone = {} as Partial<TOriginal>;
+    let keys = Object.keys(template ?? {}) as Array<keyof TOriginal>;
+    //if there were no keys provided, use some sane defaults
+    keys = keys.length > 0 ? keys : defaultKeys;
+
+    //copy only compare the specified keys from actualDiagnostic
+    for (const key of keys) {
+        clone[key] = original[key];
+    }
+    return clone;
+}
+
+interface PartialDiagnostic {
+    range?: Range;
+    severity?: DiagnosticSeverity;
+    code?: integer | string;
+    codeDescription?: Partial<CodeDescription>;
+    source?: string;
+    message?: string;
+    tags?: Partial<DiagnosticTag>[];
+    relatedInformation?: Partial<DiagnosticRelatedInformation>[];
+    data?: unknown;
+}
+
 /**
  * Ensure the DiagnosticCollection exactly contains the data from expected list.
  * @param arg - any object that contains diagnostics (such as `Program`, `Scope`, or even an array of diagnostics)
  * @param expected an array of expected diagnostics. if it's a string, assume that's a diagnostic error message
  */
-export function expectDiagnostics(arg: DiagnosticCollection, expected: Array<Partial<Diagnostic> | string | number>) {
+export function expectDiagnostics(arg: DiagnosticCollection, expected: Array<PartialDiagnostic | string | number>) {
     const diagnostics = sortDiagnostics(
         getDiagnostics(arg)
     );
@@ -58,23 +83,29 @@ export function expectDiagnostics(arg: DiagnosticCollection, expected: Array<Par
             } else if (typeof x === 'number') {
                 result = { code: x };
             }
-            return result as BsDiagnostic;
+            return result as unknown as BsDiagnostic;
         })
     );
 
     const actual = [] as BsDiagnostic[];
     for (let i = 0; i < diagnostics.length; i++) {
-        const actualDiagnostic = diagnostics[i];
-        const clone = {} as BsDiagnostic;
-        let keys = Object.keys(expectedDiagnostics[i] ?? {}) as Array<keyof BsDiagnostic>;
-        //if there were no keys provided, use some sane defaults
-        keys = keys.length > 0 ? keys : ['message', 'code', 'range', 'severity'];
-
-        //copy only compare the specified keys from actualDiagnostic
-        for (const key of keys) {
-            clone[key] = actualDiagnostic[key];
+        const expectedDiagnostic = expectedDiagnostics[i];
+        const clone = cloneObject(
+            diagnostics[i],
+            expectedDiagnostic,
+            ['message', 'code', 'range', 'severity', 'relatedInformation']
+        );
+        //deep clone relatedInformation if available
+        if (clone.relatedInformation) {
+            for (let j = 0; j < clone.relatedInformation.length; j++) {
+                clone.relatedInformation[j] = cloneObject(
+                    clone.relatedInformation[j],
+                    expectedDiagnostic.relatedInformation[j],
+                    ['location', 'message']
+                ) as any;
+            }
         }
-        actual.push(clone);
+        actual.push(clone as any);
     }
 
     expect(actual).to.eql(expectedDiagnostics);

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -5,6 +5,8 @@ export class DynamicType implements BscType {
         public typeText?: string
     ) { }
 
+    public static readonly instance = new DynamicType();
+
     public isAssignableTo(targetType: BscType) {
         //everything can be dynamic, so as long as a type is provided, this is true
         return !!targetType;

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -77,13 +77,8 @@ export class BsClassValidator {
                             range: newExpression.className.range
                         });
 
-                        //could not find a class with this name
                     } else {
-                        // this.diagnostics.push({
-                        //     ...DiagnosticMessages.classCouldNotBeFound(className, this.scope.name),
-                        //     file: file,
-                        //     range: newExpression.className.range
-                        // });
+                        //could not find a class with this name (handled by ScopeValidator)
                     }
                 }
             }
@@ -427,20 +422,15 @@ export class BsClassValidator {
                 } else if (absoluteParent) {
                     parentClass = absoluteParent;
 
-                    //couldn't find the parent class
                 } else {
-                    // this.diagnostics.push({
-                    //     ...DiagnosticMessages.classCouldNotBeFound(parentClassName, this.scope.name),
-                    //     file: classStatement.file,
-                    //     range: classStatement.parentClassName.range
-                    // });
+                    //couldn't find the parent class (validated in ScopeValidator)
                 }
                 classStatement.parentClass = parentClass;
             }
         }
     }
-
 }
+
 type AugmentedClassStatement = ClassStatement & {
     file: BscFile;
     parentClass: AugmentedClassStatement;

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -79,11 +79,11 @@ export class BsClassValidator {
 
                         //could not find a class with this name
                     } else {
-                        this.diagnostics.push({
-                            ...DiagnosticMessages.classCouldNotBeFound(className, this.scope.name),
-                            file: file,
-                            range: newExpression.className.range
-                        });
+                        // this.diagnostics.push({
+                        //     ...DiagnosticMessages.classCouldNotBeFound(className, this.scope.name),
+                        //     file: file,
+                        //     range: newExpression.className.range
+                        // });
                     }
                 }
             }
@@ -429,11 +429,11 @@ export class BsClassValidator {
 
                     //couldn't find the parent class
                 } else {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.classCouldNotBeFound(parentClassName, this.scope.name),
-                        file: classStatement.file,
-                        range: classStatement.parentClassName.range
-                    });
+                    // this.diagnostics.push({
+                    //     ...DiagnosticMessages.classCouldNotBeFound(parentClassName, this.scope.name),
+                    //     file: classStatement.file,
+                    //     range: classStatement.parentClassName.range
+                    // });
                 }
                 classStatement.parentClass = parentClass;
             }


### PR DESCRIPTION
This PR finds usage of all variables that have not been defined. 

This is overlapping functionality with bslint's `LINT1001` rule, but we need this to do additional logic, and it's something a compiler should do natively anyway. LINT1001 is slightly superior in that it also detects "used before defined" errors, but they are not flagged that way in bslint and are included in the same LINT1001 bucket.

This adds basic symbol table support as well, just for name tracking purposes. 