### PR TITLE
Support codeactions at the edges of tokens.

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -935,7 +935,7 @@ export class Program {
                 //only keep diagnostics related to this file
                 .filter(x => x.file === file)
                 //only keep diagnostics that touch this range
-                .filter(x => util.rangesIntersect(x.range, range));
+                .filter(x => util.rangesIntersectOrTouch(x.range, range));
 
             const scopes = this.getScopesForFile(file);
 

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -295,4 +295,24 @@ describe('CodeActionsProcessor', () => {
             testGetCodeActions(file, util.createRange(3, 34, 3, 34), [`import "pkg:/source/second.bs"`]);
         });
     });
+
+    it('suggests imports at very start and very end of diagnostic', () => {
+        program.setFile('source/first.bs', `
+            namespace alpha
+                function firstAction()
+                end function
+            end namespace
+        `);
+        program.setFile('components/MainScene.xml', trim`<component name="MainScene"></component>`);
+        const file = program.setFile('components/MainScene.bs', `
+            sub init()
+                print alpha.firstAction()
+            end sub
+        `);
+
+        // print |alpha.firstAction()
+        testGetCodeActions(file, util.createRange(2, 22, 2, 22), [`import "pkg:/source/first.bs"`]);
+        // print alpha|.firstAction()
+        testGetCodeActions(file, util.createRange(2, 27, 2, 27), [`import "pkg:/source/first.bs"`]);
+    });
 });

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -534,6 +534,22 @@ describe('util', () => {
     });
 
     describe('rangesIntersect', () => {
+        it('does not match when ranges do not touch (a < b)', () => {
+            // AA BB
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 0, 0, 1),
+                util.createRange(0, 2, 0, 3)
+            )).to.be.false;
+        });
+
+        it('does not match when ranges do not touch (a < b)', () => {
+            // BB AA
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 2, 0, 3),
+                util.createRange(0, 0, 0, 1)
+            )).to.be.false;
+        });
+
         it('does not match when ranges touch at right edge', () => {
             // AABB
             expect(util.rangesIntersect(
@@ -601,6 +617,96 @@ describe('util', () => {
         it('matches when B spans multiple lines', () => {
             // ABBA
             expect(util.rangesIntersect(
+                util.createRange(0, 1, 0, 3),
+                util.createRange(0, 1, 2, 0)
+            )).to.be.true;
+        });
+    });
+
+    describe('rangesIntersectOrTouch', () => {
+        it('does not match when ranges do not touch (a < b)', () => {
+            // AA BB
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 0, 0, 1),
+                util.createRange(0, 2, 0, 3)
+            )).to.be.false;
+        });
+
+        it('does not match when ranges do not touch (a < b)', () => {
+            // BB AA
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 2, 0, 3),
+                util.createRange(0, 0, 0, 1)
+            )).to.be.false;
+        });
+
+        it('matches when ranges touch at right edge', () => {
+            // AABB
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 0, 0, 1),
+                util.createRange(0, 1, 0, 2)
+            )).to.be.true;
+        });
+
+        it('matches when ranges touch at left edge', () => {
+            // BBAA
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 1, 0, 2),
+                util.createRange(0, 0, 0, 1)
+            )).to.be.true;
+        });
+
+        it('matches when range overlaps by single character on the right', () => {
+            // A BA B
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 1, 0, 3),
+                util.createRange(0, 2, 0, 4)
+            )).to.be.true;
+        });
+
+        it('matches when range overlaps by single character on the left', () => {
+            // B AB A
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 2, 0, 4),
+                util.createRange(0, 1, 0, 3)
+            )).to.be.true;
+        });
+
+        it('matches when A is contained by B at the edges', () => {
+            // B AA B
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 2, 0, 3),
+                util.createRange(0, 1, 0, 4)
+            )).to.be.true;
+        });
+
+        it('matches when B is contained by A at the edges', () => {
+            // A BB A
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 1, 0, 4),
+                util.createRange(0, 2, 0, 3)
+            )).to.be.true;
+        });
+
+        it('matches when A and B are identical', () => {
+            // ABBA
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 1, 0, 2),
+                util.createRange(0, 1, 0, 2)
+            )).to.be.true;
+        });
+
+        it('matches when A spans multiple lines', () => {
+            // ABBA
+            expect(util.rangesIntersectOrTouch(
+                util.createRange(0, 1, 2, 0),
+                util.createRange(0, 1, 0, 3)
+            )).to.be.true;
+        });
+
+        it('matches when B spans multiple lines', () => {
+            // ABBA
+            expect(util.rangesIntersectOrTouch(
                 util.createRange(0, 1, 0, 3),
                 util.createRange(0, 1, 2, 0)
             )).to.be.true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -494,7 +494,13 @@ export class Util {
     }
 
     /**
-     * Does a touch b in any way?
+     * Do `a` and `b` overlap by at least one character. This returns false if they are at the edges. Here's some examples:
+     * ```
+     * | true | true | true | true | true | false | false | false | false |
+     * |------|------|------|------|------|-------|-------|-------|-------|
+     * | aa   |  aaa |  aaa | aaa  |  a   |  aa   |    aa | a     |     a |
+     * |  bbb | bb   |  bbb |  b   | bbb  |    bb |  bb   |     b | a     |
+     * ```
      */
     public rangesIntersect(a: Range, b: Range) {
         // Check if `a` is before `b`
@@ -504,6 +510,30 @@ export class Util {
 
         // Check if `b` is before `a`
         if (b.end.line < a.start.line || (b.end.line === a.start.line && b.end.character <= a.start.character)) {
+            return false;
+        }
+
+        // These ranges must intersect
+        return true;
+    }
+
+    /**
+     * Do `a` and `b` overlap by at least one character or touch at the edges
+     * ```
+     * | true | true | true | true | true | true  | true  | false | false |
+     * |------|------|------|------|------|-------|-------|-------|-------|
+     * | aa   |  aaa |  aaa | aaa  |  a   |  aa   |    aa | a     |     a |
+     * |  bbb | bb   |  bbb |  b   | bbb  |    bb |  bb   |     b | a     |
+     * ```
+     */
+    public rangesIntersectOrTouch(a: Range, b: Range) {
+        // Check if `a` is before `b`
+        if (a.end.line < b.start.line || (a.end.line === b.start.line && a.end.character < b.start.character)) {
+            return false;
+        }
+
+        // Check if `b` is before `a`
+        if (b.end.line < a.start.line || (b.end.line === a.start.line && b.end.character < a.start.character)) {
             return false;
         }
 


### PR DESCRIPTION
There was a bug where codeactions wouldn't work on the leftmost or rightmost part of a token. This fixes that, so now they'll be present on the edges as well.