### PR TITLE
Better plugin docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -96,13 +96,21 @@ When any file is modified:
 After file addition/removal (note: throttled/debounced):
 
 - `beforeProgramValidate`
+- For each invalidated/not-yet-validated file
+    - `beforeFileValidate`
+    - `onFileValidate`
+    - `afterFileValidate`
 - For each invalidated scope:
     - `beforeScopeValidate`
     - `afterScopeValidate`
 - `afterProgramValidate`
 
 Code Actions
- - `onProgramGetCodeActions`
+ - `onGetCodeActions`
+
+Semantic Tokens
+ - `onGetSemanticTokens`
+
 
 ## Compiler API
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -122,11 +122,14 @@ The top level object is the `ProgramBuilder` which runs the overall process: pre
 
 ### API definition
 
+Here are some important interfaces. You can view them in the code at [this link](https://github.com/rokucommunity/brighterscript/blob/ddcb7b2cd219bd9fecec93d52fbbe7f9b972816b/src/interfaces.ts#L190:~:text=export%20interface%20CompilerPlugin%20%7B).
+
 ```typescript
 export type CompilerPluginFactory = () => CompilierPlugin;
 
 export interface CompilerPlugin {
     name: string;
+    //program events
     beforeProgramCreate?: (builder: ProgramBuilder) => void;
     beforePrepublish?: (builder: ProgramBuilder, files: FileObj[]) => void;
     afterPrepublish?: (builder: ProgramBuilder, files: FileObj[]) => void;
@@ -135,18 +138,34 @@ export interface CompilerPlugin {
     afterProgramCreate?: (program: Program) => void;
     beforeProgramValidate?: (program: Program) => void;
     afterProgramValidate?: (program: Program) => void;
-    beforeProgramTranspile?: (program: Program, entries: TranspileObj[]) => void;
-    afterProgramTranspile?: (program: Program, entries: TranspileObj[]) => void;
+    beforeProgramTranspile?: (program: Program, entries: TranspileObj[], editor: AstEditor) => void;
+    afterProgramTranspile?: (program: Program, entries: TranspileObj[], editor: AstEditor) => void;
+    onGetCodeActions?: PluginHandler<OnGetCodeActionsEvent>;
+    onGetSemanticTokens?: PluginHandler<OnGetSemanticTokensEvent>;
+    //scope events
     afterScopeCreate?: (scope: Scope) => void;
     beforeScopeDispose?: (scope: Scope) => void;
     afterScopeDispose?: (scope: Scope) => void;
     beforeScopeValidate?: ValidateHandler;
+    onScopeValidate?: PluginHandler<OnScopeValidateEvent>;
     afterScopeValidate?: ValidateHandler;
+    //file events
     beforeFileParse?: (source: SourceObj) => void;
     afterFileParse?: (file: BscFile) => void;
+    /**
+     * Called before each file is validated
+     */
+    beforeFileValidate?: PluginHandler<BeforeFileValidateEvent>;
+    /**
+     * Called during the file validation process. If your plugin contributes file validations, this is a good place to contribute them.
+     */
+    onFileValidate?: PluginHandler<OnFileValidateEvent>;
+    /**
+     * Called after each file is validated
+     */
     afterFileValidate?: (file: BscFile) => void;
-    beforeFileTranspile?: (entry: TranspileObj) => void;
-    afterFileTranspile?: (entry: TranspileObj) => void;
+    beforeFileTranspile?: PluginHandler<BeforeFileTranspileEvent>;
+    afterFileTranspile?: PluginHandler<AfterFileTranspileEvent>;
     beforeFileDispose?: (file: BscFile) => void;
     afterFileDispose?: (file: BscFile) => void;
 }

--- a/docs/source-literals.md
+++ b/docs/source-literals.md
@@ -7,14 +7,14 @@ These source literals are converted into inline variables at transpile-time, so 
 ## SOURCE_FILE_PATH
 The absolute path to the source file, including a leading `file:/` scheme indicator. i.e. `"file:/C:/projects/RokuApp/source/main.bs"`.
 
-```BrighterScript
+```vb
 print SOURCE_FILE_PATH
 ```
 
 transpiles to:
 
-```BrightScript
-print "file" + ":///c:/projects/roku/local/brighterscript/scripts/rootDir/source/main.bs"
+```vb
+print "file" + ":///C:/projects/RokuApp/source/main.bs"
 ```
 
 _note: the literal is concatenated to keep the roku static analysis tool happy_
@@ -145,7 +145,7 @@ end function
 ## SOURCE_LOCATION
 A combination of SOURCE_FILE_PATH and SOURCE_LINE_NUM.
 
-```BrighterScript
+```vb
 function main()
     print SOURCE_LOCATION
 end function
@@ -153,9 +153,9 @@ end function
 
 transpiles to:
 
-```BrightScript
+```vb
 function main()
-    print "file" + ":///c:/projects/roku/local/brighterscript/scripts/rootDir/source/main.bs:2"
+    print "file" + ":///C:/projects/RokuApp/source/main.bs:2"
 end function
 ```
 

--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -62,6 +62,7 @@ class DocCompiler {
     public async run() {
         //get the docs file contents
         let contents = fsExtra.readFileSync(this.docPath).toString();
+        const [eol] = /\r?\n/.exec(contents);
         //split the doc by newline
         this.lines = contents.split(/\r?\n/g);
         this.index = -1;
@@ -73,7 +74,7 @@ class DocCompiler {
             }
         }
 
-        const result = this.lines.join('\n');
+        const result = this.lines.join(eol);
         fsExtra.writeFileSync(this.docPath, result);
         delete this.lines;
         this.index = -1;


### PR DESCRIPTION
- Sync the latest `CompilerPlugin` interface every time the `npm run docs` command is run
- Add missing plugin lifecycle event information
- Prevent `SOURCE_LOCATION` and `SOURCE_FILE_PATH` docs from transpiling those specific examples 