### PR TITLE
Fix bug in languageserver hover provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -529,7 +529,7 @@
         "@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
         "@types/marked": {
@@ -2876,7 +2876,7 @@
         "immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
         },
         "import-fresh": {
             "version": "3.3.0",
@@ -3367,7 +3367,7 @@
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "requires": {
                 "graceful-fs": "^4.1.6"
             }

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1003,31 +1003,33 @@ export class LanguageServer {
 
         const srcPath = util.uriToPath(params.textDocument.uri);
         let projects = this.getProjects();
-        let hovers = projects.map((x) => x.builder.program.getHover(srcPath, params.position)).flat();
+        let hovers = projects
+            //get hovers from all projects
+            .map((x) => x.builder.program.getHover(srcPath, params.position))
+            //flatten to a single list
+            .flat();
 
-        //eliminate duplicate hover text, and merge all hovers together into a single newline-separated string
-        const hoverText = [
-            ...hovers
-                //remove undefined hovers
+        const contents = [
+            ...(hovers ?? [])
+                //pull all hover contents out into a flag array of strings
+                .map(x => {
+                    return Array.isArray(x?.contents) ? x?.contents : [x?.contents];
+                }).flat()
+                //remove nulls
                 .filter(x => !!x)
-                //dedupe and merge inner hovers
-                .reduce((set, hover) => {
-                    const hoverContentArray = Array.isArray(hover.contents) ? hover.contents : [hover.contents];
-                    const hoverText = hoverContentArray.map(x => {
-                        return typeof x === 'string' ? x : x?.value;
-                    }).join('\n');
-                    return set.add(hoverText);
-                }, new Set<string>()).values()
-            //merge outer hovers
-        ].join('\n');
+                //dedupe hovers across all projects
+                .reduce((set, content) => set.add(content), new Set<string>()).values()
+        ];
 
-        let hover: Hover = {
-            //use the range from the first hover
-            range: hovers[0]?.range,
-            //merge all the hovers into a single string, separated by newlines
-            contents: hoverText
-        };
-        return hover;
+        if (contents.length > 0) {
+            let hover: Hover = {
+                //use the range from the first hover
+                range: hovers[0]?.range,
+                //the contents of all hovers
+                contents: contents
+            };
+            return hover;
+        }
     }
 
     @AddStackToErrorMessage

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1004,7 +1004,6 @@ export class LanguageServer {
         const srcPath = util.uriToPath(params.textDocument.uri);
         let projects = this.getProjects();
         let hovers = projects.map((x) => x.builder.program.getHover(srcPath, params.position)).flat();
-        hovers = [hovers[0], hovers[0], hovers[0]];
 
         //eliminate duplicate hover text, and merge all hovers together into a single newline-separated string
         const hoverText = [

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -901,6 +901,7 @@ export class Program {
      */
     public getHover(srcPath: string, position: Position): Hover[] {
         let file = this.getFile(srcPath);
+        let result: Hover[];
         if (file) {
             const event = {
                 program: this,
@@ -912,8 +913,10 @@ export class Program {
             this.plugins.emit('beforeProvideHover', event);
             this.plugins.emit('provideHover', event);
             this.plugins.emit('afterProvideHover', event);
-            return event.hovers;
+            result = event.hovers;
         }
+
+        return result ?? [];
     }
 
     /**

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1,14 +1,14 @@
 import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
-import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, Hover } from 'vscode-languageserver';
+import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location } from 'vscode-languageserver';
 import { CompletionItemKind } from 'vscode-languageserver';
 import type { BsConfig } from './BsConfig';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent } from './interfaces';
+import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover } from './interfaces';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,9 +1,8 @@
 import { SourceNode } from 'source-map';
-import type { Hover } from 'vscode-languageserver-types';
 import { isBrsFile, isFunctionType, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
-import type { ProvideHoverEvent } from '../../interfaces';
+import type { Hover, ProvideHoverEvent } from '../../interfaces';
 import type { Token } from '../../lexer/Token';
 import { TokenKind } from '../../lexer/TokenKind';
 import { BrsTranspileState } from '../../parser/BrsTranspileState';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Range, Diagnostic, CodeAction, SemanticTokenTypes, SemanticTokenModifiers, Position, Hover, CompletionItem } from 'vscode-languageserver';
+import type { Range, Diagnostic, CodeAction, SemanticTokenTypes, SemanticTokenModifiers, Position, CompletionItem } from 'vscode-languageserver';
 import type { Scope } from './Scope';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
@@ -283,6 +283,21 @@ export interface ProvideHoverEvent {
     position: Position;
     scopes: Scope[];
     hovers: Hover[];
+}
+export interface Hover {
+    /**
+     * The contents of the hover, written in markdown. If you want to display code in the hover, use code blocks, like this:
+     * ```text
+     *      ```brighterscript
+     *      some = "code" + "here"
+     *      ```
+     * ```
+     */
+    contents: string | string[];
+    /**
+     * An optional range
+     */
+    range?: Range;
 }
 export type BeforeProvideHoverEvent = ProvideHoverEvent;
 export type AfterProvideHoverEvent = ProvideHoverEvent;


### PR DESCRIPTION
- Force all plugin hover contributions to be a markdown string or array of markdown strings, and then return those to the vscode client in an array so they get displayed with proper separators. 
- Remove hardcoded test entries in language server