### PR TITLE
Link children to their parents in AST

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -638,7 +638,9 @@ export class Program {
             this.logger.time(LogLevel.info, ['Validate all scopes'], () => {
                 for (let scopeName in this.scopes) {
                     let scope = this.scopes[scopeName];
+                    scope.linkSymbolTable();
                     scope.validate();
+                    scope.unlinkSymbolTable();
                 }
             });
 

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -1,7 +1,6 @@
 import type { Range } from 'vscode-languageserver';
 import type { BscType } from './types/BscType';
 
-
 /**
  * Stores the types associated with variables and functions in the Brighterscript code
  * Can be part of a hierarchy, so lookups can reference parent scopes

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -261,7 +261,7 @@ export class Parser {
     private body() {
         const parentAnnotations = this.enterAnnotationBlock();
 
-        let body = new Body([]);
+        let body = new Body([], this.symbolTable);
         if (this.tokens.length > 0) {
             this.consumeStatementSeparators(true);
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -42,6 +42,18 @@ export abstract class Statement {
     public visitMode = InternalWalkMode.visitStatements;
 
     public abstract walk(visitor: WalkVisitor, options: WalkOptions);
+
+    /**
+     * The parent node for this statement. This is set dynamically during `onFileValidate`, and should not be set directly.
+     */
+    public parent?: Statement | Expression;
+
+    /**
+     * Get the closest symbol table for this node. Should be overridden in children that directly contain a symbol table
+     */
+    public getSymbolTable(): SymbolTable {
+        return this.parent?.getSymbolTable();
+    }
 }
 
 export class EmptyStatement extends Statement {
@@ -67,9 +79,14 @@ export class EmptyStatement extends Statement {
  */
 export class Body extends Statement implements TypedefProvider {
     constructor(
-        public statements: Statement[] = []
+        public statements: Statement[] = [],
+        public symbolTable = new SymbolTable()
     ) {
         super();
+    }
+
+    public getSymbolTable() {
+        return this.symbolTable;
     }
 
     public get range() {
@@ -1109,6 +1126,10 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     }
 
     public symbolTable: SymbolTable;
+
+    public getSymbolTable() {
+        return this.symbolTable;
+    }
 
     /**
      * The string name for this namespace


### PR DESCRIPTION
Several fixes:
- link every child expression/statement to its parent at the beginning of the `onFileValidate` event. This highly simplifies language service based queries that need to walk up the expression chain to find parent expressions or statements
- use AST walk for BrsFile validation instead of `references`
- add `getSymbolTable()` to every AST node to simplify finding the correct symbols.
