### PR TITLE
Add semantic token color for consts

### DIFF
--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -310,6 +310,14 @@ describe('BrsFileSemanticTokensProcessor', () => {
             range: util.createRange(3, 27, 3, 37),
             tokenType: SemanticTokenTypes.variable,
             tokenModifiers: [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static]
+        }, {
+            range: util.createRange(5, 18, 5, 25),
+            tokenType: SemanticTokenTypes.variable,
+            tokenModifiers: [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static]
+        }, {
+            range: util.createRange(7, 22, 7, 32),
+            tokenType: SemanticTokenTypes.variable,
+            tokenModifiers: [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static]
         }]);
     });
 });

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -1,4 +1,4 @@
-import type { Range } from 'vscode-languageserver-protocol';
+import { Range, SemanticTokenModifiers } from 'vscode-languageserver-protocol';
 import { SemanticTokenTypes } from 'vscode-languageserver-protocol';
 import { isCallExpression, isCustomType, isNewExpression } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
@@ -66,10 +66,11 @@ export class BrsFileSemanticTokensProcessor {
         }
     }
 
-    private addToken(locatable: Locatable, type: SemanticTokenTypes) {
+    private addToken(locatable: Locatable, type: SemanticTokenTypes, modifiers: SemanticTokenModifiers[] = []) {
         this.event.semanticTokens.push({
             range: locatable.range,
-            tokenType: type
+            tokenType: type,
+            tokenModifiers: modifiers
         });
     }
 
@@ -99,6 +100,8 @@ export class BrsFileSemanticTokensProcessor {
                     this.addToken(token, SemanticTokenTypes.function);
                 } else if (scope.namespaceLookup.has(entityName)) {
                     this.addToken(token, SemanticTokenTypes.namespace);
+                } else if (scope.getConstFileLink(entityName)) {
+                    this.addToken(token, SemanticTokenTypes.variable, [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static]);
                 }
             }
         }

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -1,4 +1,5 @@
-import { Range, SemanticTokenModifiers } from 'vscode-languageserver-protocol';
+import type { Range } from 'vscode-languageserver-protocol';
+import { SemanticTokenModifiers } from 'vscode-languageserver-protocol';
 import { SemanticTokenTypes } from 'vscode-languageserver-protocol';
 import { isCallExpression, isCustomType, isNewExpression } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
@@ -16,7 +17,14 @@ export class BrsFileSemanticTokensProcessor {
 
     public process() {
         this.handleClasses();
+        this.handleConstDeclarations();
         this.iterateExpressions();
+    }
+
+    private handleConstDeclarations() {
+        for (const stmt of this.event.file.parser.references.constStatements) {
+            this.addToken(stmt.tokens.name, SemanticTokenTypes.variable, [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static]);
+        }
     }
 
     private handleClasses() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1276,7 +1276,7 @@ export class Util {
     /**
      * Sort an array of objects that have a Range
      */
-    public sortByRange(locatables: Locatable[]) {
+    public sortByRange<T extends Locatable>(locatables: T[]) {
         //sort the tokens by range
         return locatables.sort((a, b) => {
             //start line


### PR DESCRIPTION
Adds semantic token support for coloring const references. Notice how the const declarations and usages are _slightly_ darker than the regular variables.

![image](https://user-images.githubusercontent.com/2544493/182159901-086fc55d-b0c5-4d27-a086-93798497ccf6.png)
