### PR TITLE
Fix typescript error for ast parent setting

### DIFF
--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import type { BrsFile } from '../../files/BrsFile';
+import type { AALiteralExpression, DottedGetExpression } from '../../parser/Expression';
+import type { ClassStatement, FunctionStatement, NamespaceStatement, PrintStatement } from '../../parser/Statement';
+import { Program } from '../../Program';
+
+describe('BrsFileValidator', () => {
+    let program: Program;
+    beforeEach(() => {
+        program = new Program({});
+    });
+
+    it('links dotted get expression parents', () => {
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            sub main()
+                print {}.beta.charlie
+            end sub
+        `);
+        program.validate();
+        const func = (file.parser.ast.statements[0] as FunctionStatement);
+        const print = func.func.body.statements[0] as PrintStatement;
+        expect(print.parent).to.equal(func.func.body);
+
+        const charlie = print.expressions[0] as DottedGetExpression;
+        expect(charlie.parent).to.equal(print);
+
+        const beta = charlie.obj as DottedGetExpression;
+        expect(beta.parent).to.equal(charlie);
+
+        const aaLiteral = beta.obj as AALiteralExpression;
+        expect(aaLiteral.parent).to.equal(beta);
+    });
+
+    it('links NamespacedVariableNameExpression dotted get parents', () => {
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            namespace alpha.bravo
+                class Delta extends alpha.bravo.Charlie
+                end class
+                class Charlie
+                end class
+            end namespace
+        `);
+        program.validate();
+        const namespace = (file.parser.ast.statements[0] as NamespaceStatement);
+        const deltaClass = namespace.body.statements[0] as ClassStatement;
+        expect(deltaClass.parent).to.equal(namespace.body);
+
+        const charlie = (deltaClass.parentClassName.expression as DottedGetExpression);
+        expect(charlie.parent).to.equal(deltaClass.parentClassName);
+
+        const bravo = charlie.obj as DottedGetExpression;
+        expect(bravo.parent).to.equal(charlie);
+
+        const alpha = bravo.obj as DottedGetExpression;
+        expect(alpha.parent).to.equal(bravo);
+    });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ import type { FunctionType } from './types/FunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program, SourceObj, TranspileObj } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { FunctionStatement } from './parser/Statement';
+import type { FunctionStatement, Statement } from './parser/Statement';
 import type { Expression } from './parser/Expression';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
@@ -406,3 +406,5 @@ export interface FileLink<T> {
     item: T;
     file: BrsFile;
 }
+
+export type AstNode = Expression | Statement;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -348,18 +348,6 @@ export class NamespacedVariableNameExpression extends Expression {
     }
     range: Range;
 
-    // @ts-expect-error override the property
-    public get parent() {
-        return this._parent;
-    }
-    public set parent(value) {
-        if (this.expression) {
-            this.expression.parent = value;
-        }
-        this._parent = value;
-    }
-    private _parent: Expression | Statement;
-
     transpile(state: BrsTranspileState) {
         return [
             state.sourceNode(this, this.getName(ParseMode.BrightScript))
@@ -412,18 +400,6 @@ export class DottedGetExpression extends Expression {
     }
 
     public readonly range: Range;
-
-    // @ts-expect-error override the property
-    public get parent() {
-        return this._parent;
-    }
-    public set parent(value) {
-        if (this.obj) {
-            this.obj.parent = value;
-        }
-        this._parent = value;
-    }
-    private _parent: Expression | Statement;
 
     transpile(state: BrsTranspileState) {
         //if the callee starts with a namespace name, transpile the name


### PR DESCRIPTION
Fixes ts error introduced in #650 introduced that only shows up in the typedef files. 

Seems to provide a _slight_ performance boost as well (probably due to the `if (childNode?.parent)` check which prevents duplicate reparenting. 
![image](https://user-images.githubusercontent.com/2544493/182879726-d12d8493-0e9c-4591-9986-5b80551f99d2.png)
