### PR TITLE
Fix scope-specific diagnostic grouping issue

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -198,6 +198,54 @@ describe('Scope', () => {
     });
 
     describe('validate', () => {
+        it('diagnostics are assigned to correct child scope', () => {
+            program.options.autoImportComponentScript = true;
+            program.setFile('components/constants.bs', `
+                namespace constants.alpha.beta
+                    const charlie = "charlie"
+                end namespace
+            `);
+
+            program.setFile('components/ButtonBase.xml', `<component name="ButtonBase" extends="Scene" />`);
+
+            const buttonPrimary = program.setFile('components/ButtonPrimary.bs', `
+                import "constants.bs"
+                sub init()
+                    print constants.alpha.delta.charlie
+                end sub
+            `);
+            program.setFile('components/ButtonPrimary.xml', `<component name="ButtonPrimary" extends="ButtonBase" />`);
+
+            const buttonSecondary = program.setFile('components/ButtonSecondary.bs', `
+                import "constants.bs"
+                sub init()
+                    print constants.alpha.delta.charlie
+                end sub
+            `);
+            program.setFile('components/ButtonSecondary.xml', `<component name="ButtonSecondary" extends="ButtonBase" />`);
+
+            program.validate();
+            expectDiagnostics(program, [
+                {
+                    message: DiagnosticMessages.cannotFindName('delta').message,
+                    file: {
+                        srcPath: buttonPrimary.srcPath
+                    },
+                    relatedInformation: [{
+                        message: `Not defined in scope '${s('components/ButtonPrimary.xml')}'`
+                    }]
+                }, {
+                    message: DiagnosticMessages.cannotFindName('delta').message,
+                    file: {
+                        srcPath: buttonSecondary.srcPath
+                    },
+                    relatedInformation: [{
+                        message: `Not defined in scope '${s('components/ButtonSecondary.xml')}'`
+                    }]
+                }
+            ]);
+        });
+
         it('detects unknown namespace names', () => {
             program.setFile('source/main.bs', `
                 sub main()

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -64,7 +64,7 @@ export class ScopeValidator {
      * Add a diagnostic (to the first scope) that will have `relatedInformation` for each affected scope
      */
     private addMultiScopeDiagnostic(event: OnScopeValidateEvent, diagnostic: BsDiagnostic, message = 'Not defined in scope') {
-        diagnostic = this.multiScopeCache.getOrAdd(`${diagnostic.code}-${diagnostic.message}-${util.rangeToString(diagnostic.range)}`, () => {
+        diagnostic = this.multiScopeCache.getOrAdd(`${diagnostic.file?.srcPath}-${diagnostic.code}-${diagnostic.message}-${util.rangeToString(diagnostic.range)}`, () => {
             if (!diagnostic.relatedInformation) {
                 diagnostic.relatedInformation = [];
             }


### PR DESCRIPTION
Fix issue when building multi-scope diagnostics where bsc wasn't taking the actual file path into consideration. So it was incorrectly grouping all diagnostics together by code+message+range without considering file path. 

Also makes the expectDiagnostics function more flexible so it can check for file paths and relatedInformation.