### PR TITLE
Fix crashes for clients that don't support "workspace/configuration" requests

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1003,6 +1003,24 @@ describe('LanguageServer', () => {
         });
     });
 
+    describe('getConfigFilePath', () => {
+        it('honors the hasConfigurationCapability setting', async () => {
+            server.run();
+            sinon.stub(server['connection'].workspace, 'getConfiguration').returns(
+                Promise.reject(
+                    new Error('Client does not support "workspace/configuration"')
+                )
+            );
+            server['hasConfigurationCapability'] = false;
+            fsExtra.outputFileSync(`${workspacePath}/bsconfig.json`, '{}');
+            expect(
+                await server['getConfigFilePath'](workspacePath)
+            ).to.eql(
+                s`${workspacePath}/bsconfig.json`
+            );
+        });
+    });
+
     describe('getWorkspaceExcludeGlobs', () => {
         it('honors the hasConfigurationCapability setting', async () => {
             server.run();

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1003,6 +1003,23 @@ describe('LanguageServer', () => {
         });
     });
 
+    describe('getWorkspaceExcludeGlobs', () => {
+        it('honors the hasConfigurationCapability setting', async () => {
+            server.run();
+            sinon.stub(server['connection'].workspace, 'getConfiguration').returns(
+                Promise.reject(
+                    new Error('Client does not support "workspace/configuration"')
+                )
+            );
+            server['hasConfigurationCapability'] = false;
+            expect(
+                await server['getWorkspaceExcludeGlobs'](workspaceFolders[0])
+            ).to.eql([
+                '**/node_modules/**/*'
+            ]);
+        });
+    });
+
     describe('CustomCommands', () => {
         describe('TranspileFile', () => {
             it('returns pathAbsolute to support backwards compatibility', async () => {

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -95,6 +95,7 @@ describe('LanguageServer', () => {
         (server as any).createConnection = () => {
             return connection;
         };
+        server['hasConfigurationCapability'] = true;
     });
     afterEach(async () => {
         fsExtra.emptyDirSync(tempDir);
@@ -388,29 +389,6 @@ describe('LanguageServer', () => {
             fsExtra.outputJsonSync(s`${workspacePath}/vendor/someProject/bsconfig.json`, {});
             //it always ignores node_modules
             fsExtra.outputJsonSync(s`${workspacePath}/node_modules/someProject/bsconfig.json`, {});
-
-            await server['syncProjects']();
-
-            //no child bsconfig.json files, use the workspacePath
-            expect(
-                server.projects.map(x => x.projectPath)
-            ).to.eql([
-                workspacePath
-            ]);
-        });
-
-        it('ignores bsconfig.json files from vscode ignored paths', async () => {
-            server.run();
-            sinon.stub(server['connection'].workspace, 'getConfiguration').returns(Promise.resolve({
-                exclude: {
-                    '**/vendor': true
-                }
-            }) as any);
-
-            fsExtra.outputJsonSync(s`${workspacePath}/vendor/someProject/bsconfig.json`, {});
-            //it always ignores node_modules
-            fsExtra.outputJsonSync(s`${workspacePath}/node_modules/someProject/bsconfig.json`, {});
-
             await server['syncProjects']();
 
             //no child bsconfig.json files, use the workspacePath

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -230,14 +230,18 @@ export class LanguageServer {
     /**
      * Ask the client for the list of `files.exclude` patterns. Useful when determining if we should process a file
      */
-    private async getWorkspaceExcludeGlobs(workspaceFolder: string) {
-        //get any `files.exclude` globs to use to filter
-        let config = await this.connection.workspace.getConfiguration({
-            scopeUri: workspaceFolder,
-            section: 'files'
-        }) as {
-            exclude: Record<string, boolean>;
+    private async getWorkspaceExcludeGlobs(workspaceFolder: string): Promise<string[]> {
+        let config = {
+            exclude: {} as Record<string, boolean>
         };
+        //if supported, ask vscode for the `files.exclude` configuration
+        if (this.hasConfigurationCapability) {
+            //get any `files.exclude` globs to use to filter
+            config = await this.connection.workspace.getConfiguration({
+                scopeUri: workspaceFolder,
+                section: 'files'
+            });
+        }
         return Object
             .keys(config?.exclude ?? {})
             .filter(x => config?.exclude?.[x])

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -448,11 +448,16 @@ export class LanguageServer {
         } else {
             scopeUri = URI.file(workspacePath).toString();
         }
-        //look for config group called "brightscript"
-        let config = await this.connection.workspace.getConfiguration({
-            scopeUri: scopeUri,
-            section: 'brightscript'
-        });
+        let config = {
+            configFile: undefined
+        };
+        //if the client supports configuration, look for config group called "brightscript"
+        if (this.hasConfigurationCapability) {
+            await this.connection.workspace.getConfiguration({
+                scopeUri: scopeUri,
+                section: 'brightscript'
+            });
+        }
         let configFilePath: string;
 
         //if there's a setting, we need to find the file or show error if it can't be found


### PR DESCRIPTION
Prevent several crashes related to the language server incorrectly assuming that all clients support "workspace/configuration".