### PR TITLE
Allow const as variable name

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -340,7 +340,7 @@ export class Parser {
                 return this.libraryStatement();
             }
 
-            if (this.check(TokenKind.Const)) {
+            if (this.check(TokenKind.Const) && this.checkAnyNext(TokenKind.Identifier, ...this.allowedLocalIdentifiers)) {
                 return this.constDeclaration();
             }
 
@@ -1471,8 +1471,9 @@ export class Parser {
     }
 
     private constDeclaration(): ConstStatement | undefined {
+        this.warnIfNotBrighterScriptMode('const declaration');
         const constToken = this.advance();
-        const nameToken = this.identifier();
+        const nameToken = this.identifier(...this.allowedLocalIdentifiers);
         const equalToken = this.consumeToken(TokenKind.Equal);
         const expression = this.expression();
         const statement = new ConstStatement({

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -2,7 +2,7 @@ import { expectCompletionsIncludes, expectZeroDiagnostics, getTestGetTypedef, ge
 import util, { standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
-import { Parser } from '../../Parser';
+import { ParseMode, Parser } from '../../Parser';
 import { expect } from 'chai';
 import type { ConstStatement } from '../../Statement';
 import { TokenKind } from '../../../lexer/TokenKind';
@@ -27,8 +27,21 @@ describe('ConstStatement', () => {
         program.dispose();
     });
 
+    it('does not prevent using `const` as a variable name in .brs files', () => {
+        program.setFile('source/main.brs', `
+            sub main()
+                const = {
+                    name: "Bob"
+                }
+                print const.name = {}
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
     it('supports basic structure', () => {
-        parser.parse('const API_KEY = "abc"');
+        parser.parse('const API_KEY = "abc"', { mode: ParseMode.BrighterScript });
         expectZeroDiagnostics(parser);
         const statement = parser.ast.statements[0] as ConstStatement;
         expect(statement.tokens.const?.kind).to.eql(TokenKind.Const);


### PR DESCRIPTION
- Fixes a bug that was preventing the use of `const` as a variable name.
- warn about using `const` statements in non-brighterscript mode