### PR TITLE
Fix compile crash for scope-less files

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -13,7 +13,7 @@ import { URI } from 'vscode-uri';
 import PluginInterface from './PluginInterface';
 import type { FunctionStatement, PrintStatement } from './parser/Statement';
 import { EmptyStatement } from './parser/Statement';
-import { expectCompletionsExcludes, expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from './testHelpers.spec';
+import { expectCompletionsExcludes, expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
 import { doesNotThrow } from 'assert';
 import { Logger } from './Logger';
 import { createToken } from './astUtils/creators';
@@ -30,8 +30,6 @@ let stagingFolderPath = s`${tmpPath}/staging`;
 
 describe('Program', () => {
     let program: Program;
-
-    let testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
         fsExtra.ensureDirSync(tmpPath);

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -36,7 +36,7 @@ export class BrsFilePreTranspileProcessor {
      */
     private getEnumInfo(name: string, containingNamespace: string, scope: Scope) {
         //look for the enum directly
-        let result = scope.getEnumFileLink(name, containingNamespace);
+        let result = scope?.getEnumFileLink(name, containingNamespace);
 
         if (result) {
             return {
@@ -46,7 +46,7 @@ export class BrsFilePreTranspileProcessor {
         //assume we've been given the enum.member syntax, so pop the member and try again
         const parts = name.split('.');
         const memberName = parts.pop();
-        result = scope.getEnumMap().get(parts.join('.'));
+        result = scope?.getEnumMap().get(parts.join('.'));
         if (result) {
             const value = result.item.getMemberValue(memberName);
             return {
@@ -79,7 +79,7 @@ export class BrsFilePreTranspileProcessor {
             let value: Expression;
 
             //did we find a const? transpile the value
-            let constStatement = scope.getConstFileLink(entityName, containingNamespace)?.item;
+            let constStatement = scope?.getConstFileLink(entityName, containingNamespace)?.item;
             if (constStatement) {
                 value = constStatement.value;
             } else {


### PR DESCRIPTION
Fixes compile-time crash when trying to transpile a file that's not included in any scope.

Fixes #666 