### PR TITLE
Add npm caching to speed up workflow times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: "12.22.7"
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
       - run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: "12.22.7"
+          # cache the node_modules folder to reduce build times
           cache: 'npm'
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
Hopefully we'll get a significant time reduction for our CI jobs by using the built-in npm caching for @setup-node