### PR TITLE
Allow `mod` as an aa prop, aa member identifier kinds forced to Identifier

### DIFF
--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -389,6 +389,7 @@ export const AllowedProperties = [
     TokenKind.If,
     TokenKind.Invalid,
     TokenKind.Let,
+    TokenKind.Mod,
     TokenKind.Next,
     TokenKind.Not,
     TokenKind.ObjFun,

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2719,7 +2719,7 @@ export class Parser {
                 range: null as Range
             };
             if (this.checkAny(TokenKind.Identifier, ...AllowedProperties)) {
-                result.keyToken = this.advance();
+                result.keyToken = this.identifier(...AllowedProperties);
             } else if (this.check(TokenKind.StringLiteral)) {
                 result.keyToken = this.advance();
             } else {


### PR DESCRIPTION
- Allow `mod` as an aa prop.
- Force all AA member identifier-like tokens to `Identifier` kind