### PR TITLE
Fix brightscript.configFile workspace config bug

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -997,6 +997,22 @@ describe('LanguageServer', () => {
                 s`${workspacePath}/bsconfig.json`
             );
         });
+
+        it('executes the connection.workspace.getConfiguration call when enabled to do so', async () => {
+            server.run();
+            const bsconfigPath = `${tempDir}/bsconfig.test.json`;
+            //add a dummy bsconfig to reference for the test
+            fsExtra.outputFileSync(bsconfigPath, ``);
+
+            sinon.stub(server['connection'].workspace, 'getConfiguration').returns(Promise.resolve({ configFile: bsconfigPath }) as any);
+            server['hasConfigurationCapability'] = true;
+            fsExtra.outputFileSync(`${workspacePath}/bsconfig.json`, '{}');
+            expect(
+                s`${await server['getConfigFilePath'](workspacePath)}`
+            ).to.eql(
+                s`${bsconfigPath}`
+            );
+        });
     });
 
     describe('getWorkspaceExcludeGlobs', () => {

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -453,7 +453,7 @@ export class LanguageServer {
         };
         //if the client supports configuration, look for config group called "brightscript"
         if (this.hasConfigurationCapability) {
-            await this.connection.workspace.getConfiguration({
+            config = await this.connection.workspace.getConfiguration({
                 scopeUri: scopeUri,
                 section: 'brightscript'
             });


### PR DESCRIPTION
Fixes bug in language server introduced in #667 that wasn't actually reading the configuration data from vscode.