### PR TITLE
Move file validation into BscPlugin

### DIFF
--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,4 +1,4 @@
-import { isBrsFile } from '../astUtils/reflection';
+import { isBrsFile, isXmlFile } from '../astUtils/reflection';
 import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent } from '../interfaces';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
@@ -8,6 +8,7 @@ import { BrsFileSemanticTokensProcessor } from './semanticTokens/BrsFileSemantic
 import { BrsFilePreTranspileProcessor } from './transpile/BrsFilePreTranspileProcessor';
 import { BrsFileValidator } from './validation/BrsFileValidator';
 import { ScopeValidator } from './validation/ScopeValidator';
+import { XmlFileValidator } from './validation/XmlFileValidator';
 
 export class BscPlugin implements CompilerPlugin {
     public name = 'BscPlugin';
@@ -33,6 +34,8 @@ export class BscPlugin implements CompilerPlugin {
     public onFileValidate(event: OnFileValidateEvent) {
         if (isBrsFile(event.file)) {
             return new BrsFileValidator(event as any).process();
+        } else if (isXmlFile(event.file)) {
+            return new XmlFileValidator(event as any).process();
         }
     }
 

--- a/src/bscPlugin/validation/XmlFileValidator.ts
+++ b/src/bscPlugin/validation/XmlFileValidator.ts
@@ -1,0 +1,65 @@
+import { DiagnosticMessages } from '../../DiagnosticMessages';
+import type { XmlFile } from '../../files/XmlFile';
+import type { OnFileValidateEvent } from '../../interfaces';
+import type { SGAst } from '../../parser/SGTypes';
+import util from '../../util';
+
+export class XmlFileValidator {
+    constructor(
+        public event: OnFileValidateEvent<XmlFile>
+    ) {
+    }
+
+    public process() {
+        util.validateTooDeepFile(this.event.file);
+        if (this.event.file.parser.ast.root) {
+            this.validateComponent(this.event.file.parser.ast);
+        } else {
+            //skip empty XML
+        }
+    }
+
+    private validateComponent(ast: SGAst) {
+        const { root, component } = ast;
+        if (!component) {
+            //not a SG component
+            this.event.file.diagnostics.push({
+                ...DiagnosticMessages.xmlComponentMissingComponentDeclaration(),
+                range: root.range,
+                file: this.event.file
+            });
+            return;
+        }
+
+        //component name/extends
+        if (!component.name) {
+            this.event.file.diagnostics.push({
+                ...DiagnosticMessages.xmlComponentMissingNameAttribute(),
+                range: component.tag.range,
+                file: this.event.file
+            });
+        }
+        if (!component.extends) {
+            this.event.file.diagnostics.push({
+                ...DiagnosticMessages.xmlComponentMissingExtendsAttribute(),
+                range: component.tag.range,
+                file: this.event.file
+            });
+        }
+
+
+        //catch script imports with same path as the auto-imported codebehind file
+        const scriptTagImports = this.event.file.parser.references.scriptTagImports;
+        let explicitCodebehindScriptTag = this.event.file.program.options.autoImportComponentScript === true
+            ? scriptTagImports.find(x => this.event.file.possibleCodebehindPkgPaths.includes(x.pkgPath))
+            : undefined;
+        if (explicitCodebehindScriptTag) {
+            this.event.file.diagnostics.push({
+                ...DiagnosticMessages.unnecessaryCodebehindScriptImport(),
+                file: this.event.file,
+                range: explicitCodebehindScriptTag.filePathRange
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Moves remaining `XmlFile` and `BrsFile` validation logic into the `BscPlugin.onFileValidate` event hook. There is now no extraneous validation happening within those file classes.