### PR TITLE
Centralize file path normalization for Program

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -552,6 +552,47 @@ describe('Program', () => {
         });
     });
 
+    describe('getPaths', () => {
+        function getPaths(...args: any[]) {
+            return (program as any).getPaths(...args);
+        }
+        it('works for dest', () => {
+            expect(
+                getPaths('source/main.brs', rootDir)
+            ).to.eql({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`source/main.brs`
+            });
+        });
+
+        it('works for absolute src', () => {
+            expect(
+                getPaths(`${rootDir}/source\\main.brs`, rootDir)
+            ).to.eql({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`source/main.brs`
+            });
+        });
+
+        it('works for missing src', () => {
+            expect(
+                getPaths({ dest: 'source/main.brs' }, rootDir)
+            ).to.eql({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`source/main.brs`
+            });
+        });
+
+        it('works for missing dest', () => {
+            expect(
+                getPaths({ src: `${rootDir}/source/main.brs` }, rootDir)
+            ).to.eql({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`source/main.brs`
+            });
+        });
+    });
+
     describe('setFile', () => {
         it('links xml scopes based on xml parent-child relationships', () => {
             program.setFile({ src: s`${rootDir}/components/ParentScene.xml`, dest: 'components/ParentScene.xml' }, trim`

--- a/src/util.ts
+++ b/src/util.ts
@@ -647,6 +647,19 @@ export class Util {
     }
 
     /**
+     * Replace the first instance of `search` in `subject` with `replacement`
+     */
+    public replaceCaseInsensitive(subject: string, search: string, replacement: string) {
+        let idx = subject.toLowerCase().indexOf(search.toLowerCase());
+        if (idx > -1) {
+            let result = subject.substring(0, idx) + replacement + subject.substring(idx + search.length);
+            return result;
+        } else {
+            return subject;
+        }
+    }
+
+    /**
      * Determine if two arrays containing primitive values are equal.
      * This considers order and compares by equality.
      */


### PR DESCRIPTION
Moves the `src;dest;` sanitizing into a function for reusability and testability.