### PR TITLE
Create common ancestor for Expression and Statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,14 +1643,20 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001312",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-            "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+            "version": "1.0.30001400",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
+            "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                }
+            ]
         },
         "node_modules/caseless": {
             "version": "0.12.0",
@@ -9092,9 +9098,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001312",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-            "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+            "version": "1.0.30001400",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
+            "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
             "dev": true
         },
         "caseless": {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -19,14 +19,15 @@ import { globalFile } from './globalCallables';
 import { parseManifest } from './preprocessor/Manifest';
 import { URI } from 'vscode-uri';
 import PluginInterface from './PluginInterface';
-import { isBrsFile, isXmlFile, isClassMethodStatement, isXmlScope } from './astUtils/reflection';
-import type { FunctionStatement, Statement } from './parser/Statement';
+import { isBrsFile, isXmlFile, isMethodStatement, isXmlScope } from './astUtils/reflection';
+import type { FunctionStatement } from './parser/Statement';
 import { ParseMode } from './parser/Parser';
 import { TokenKind } from './lexer/TokenKind';
 import { BscPlugin } from './bscPlugin/BscPlugin';
 import { AstEditor } from './astUtils/AstEditor';
 import type { SourceMapGenerator } from 'source-map';
 import { rokuDeploy } from 'roku-deploy';
+import type { Statement } from './parser/AstNode';
 
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
@@ -1040,7 +1041,7 @@ export class Program {
                     for (let scope of this.getScopesForFile(myClass.file)) {
                         let classes = scope.getClassHierarchy(myClass.item.getName(ParseMode.BrighterScript).toLowerCase());
                         //and anything from any class in scope to a non m class
-                        for (let statement of [...classes].filter((i) => isClassMethodStatement(i.item))) {
+                        for (let statement of [...classes].filter((i) => isMethodStatement(i.item))) {
                             let sigHelp = statement.file.getSignatureHelpForStatement(statement.item);
                             if (sigHelp && !results.has[sigHelp.key]) {
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -7,7 +7,7 @@ import { DiagnosticMessages } from './DiagnosticMessages';
 import type { CallableContainer, BsDiagnostic, FileReference, BscFile, CallableContainerMap, FileLink } from './interfaces';
 import type { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
-import type { NamespaceStatement, Statement, FunctionStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement } from './parser/Statement';
+import type { NamespaceStatement, FunctionStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement } from './parser/Statement';
 import type { NewExpression } from './parser/Expression';
 import { ParseMode } from './parser/Parser';
 import { standardizePath as s, util } from './util';
@@ -19,6 +19,7 @@ import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
 import { isBrsFile, isClassMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
+import type { Statement } from './parser/AstNode';
 
 /**
  * A class to keep track of all declarations within a given scope (like source scope, component scope)

--- a/src/astUtils/AstEditor.ts
+++ b/src/astUtils/AstEditor.ts
@@ -1,5 +1,4 @@
-import type { Expression } from '../parser/Expression';
-import type { Statement } from '../parser/Statement';
+import type { AstNode } from '../parser/AstNode';
 
 export class AstEditor {
     private changes: Change[] = [];
@@ -32,7 +31,7 @@ export class AstEditor {
     /**
      * Set custom text that will be emitted during transpile instead of the original text.
      */
-    public overrideTranspileResult(node: Expression | Statement, value: string) {
+    public overrideTranspileResult(node: AstNode, value: string) {
         this.setProperty(node, 'transpile', (state) => {
             return [
                 state.sourceNode(node, value)

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -1,7 +1,8 @@
 import type { Range } from 'vscode-languageserver';
 import type { Identifier, Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import type { Expression, NamespacedVariableNameExpression } from '../parser/Expression';
+import type { Expression } from '../parser/AstNode';
+import type { NamespacedVariableNameExpression } from '../parser/Expression';
 import { LiteralExpression, CallExpression, DottedGetExpression, VariableExpression, FunctionExpression } from '../parser/Expression';
 import type { SGAttribute } from '../parser/SGTypes';
 import { Block, MethodStatement } from '../parser/Statement';

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, Statement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, MethodStatement, FieldStatement, ConstStatement } from '../parser/Statement';
-import type { LiteralExpression, Expression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression } from '../parser/Expression';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, MethodStatement, FieldStatement, ConstStatement } from '../parser/Statement';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -19,6 +19,7 @@ import type { XmlScope } from '../XmlScope';
 import { DynamicType } from '../types/DynamicType';
 import type { InterfaceType } from '../types/InterfaceType';
 import type { ObjectType } from '../types/ObjectType';
+import type { AstNode, Expression, Statement } from '../parser/AstNode';
 
 // File reflection
 
@@ -43,128 +44,128 @@ export function isXmlScope(scope: (Scope)): scope is XmlScope {
  * directly extend Statement or FunctionStatement,
  * so it only checks the immediate parent's class name.
  */
-export function isStatement(element: Statement | Expression | undefined): element is Statement {
+export function isStatement(element: AstNode | undefined): element is Statement {
     // eslint-disable-next-line no-bitwise
     return !!(element && element.visitMode & InternalWalkMode.visitStatements);
 }
 
-export function isBody(element: Statement | Expression | undefined): element is Body {
+export function isBody(element: AstNode | undefined): element is Body {
     return element?.constructor?.name === 'Body';
 }
-export function isAssignmentStatement(element: Statement | Expression | undefined): element is AssignmentStatement {
+export function isAssignmentStatement(element: AstNode | undefined): element is AssignmentStatement {
     return element?.constructor?.name === 'AssignmentStatement';
 }
-export function isBlock(element: Statement | Expression | undefined): element is Block {
+export function isBlock(element: AstNode | undefined): element is Block {
     return element?.constructor?.name === 'Block';
 }
-export function isExpressionStatement(element: Statement | Expression | undefined): element is ExpressionStatement {
+export function isExpressionStatement(element: AstNode | undefined): element is ExpressionStatement {
     return element?.constructor?.name === 'ExpressionStatement';
 }
-export function isCommentStatement(element: Statement | Expression | undefined): element is CommentStatement {
+export function isCommentStatement(element: AstNode | undefined): element is CommentStatement {
     return element?.constructor?.name === 'CommentStatement';
 }
-export function isExitForStatement(element: Statement | Expression | undefined): element is ExitForStatement {
+export function isExitForStatement(element: AstNode | undefined): element is ExitForStatement {
     return element?.constructor?.name === 'ExitForStatement';
 }
-export function isExitWhileStatement(element: Statement | Expression | undefined): element is ExitWhileStatement {
+export function isExitWhileStatement(element: AstNode | undefined): element is ExitWhileStatement {
     return element?.constructor?.name === 'ExitWhileStatement';
 }
-export function isFunctionStatement(element: Statement | Expression | undefined): element is FunctionStatement {
+export function isFunctionStatement(element: AstNode | undefined): element is FunctionStatement {
     return element?.constructor?.name === 'FunctionStatement';
 }
-export function isIfStatement(element: Statement | Expression | undefined): element is IfStatement {
+export function isIfStatement(element: AstNode | undefined): element is IfStatement {
     return element?.constructor?.name === 'IfStatement';
 }
-export function isIncrementStatement(element: Statement | Expression | undefined): element is IncrementStatement {
+export function isIncrementStatement(element: AstNode | undefined): element is IncrementStatement {
     return element?.constructor?.name === 'IncrementStatement';
 }
-export function isPrintStatement(element: Statement | Expression | undefined): element is PrintStatement {
+export function isPrintStatement(element: AstNode | undefined): element is PrintStatement {
     return element?.constructor?.name === 'PrintStatement';
 }
-export function isGotoStatement(element: Statement | Expression | undefined): element is GotoStatement {
+export function isGotoStatement(element: AstNode | undefined): element is GotoStatement {
     return element?.constructor?.name === 'GotoStatement';
 }
-export function isLabelStatement(element: Statement | Expression | undefined): element is LabelStatement {
+export function isLabelStatement(element: AstNode | undefined): element is LabelStatement {
     return element?.constructor?.name === 'LabelStatement';
 }
-export function isReturnStatement(element: Statement | Expression | undefined): element is ReturnStatement {
+export function isReturnStatement(element: AstNode | undefined): element is ReturnStatement {
     return element?.constructor?.name === 'ReturnStatement';
 }
-export function isEndStatement(element: Statement | Expression | undefined): element is EndStatement {
+export function isEndStatement(element: AstNode | undefined): element is EndStatement {
     return element?.constructor?.name === 'EndStatement';
 }
-export function isStopStatement(element: Statement | Expression | undefined): element is StopStatement {
+export function isStopStatement(element: AstNode | undefined): element is StopStatement {
     return element?.constructor?.name === 'StopStatement';
 }
-export function isForStatement(element: Statement | Expression | undefined): element is ForStatement {
+export function isForStatement(element: AstNode | undefined): element is ForStatement {
     return element?.constructor?.name === 'ForStatement';
 }
-export function isForEachStatement(element: Statement | Expression | undefined): element is ForEachStatement {
+export function isForEachStatement(element: AstNode | undefined): element is ForEachStatement {
     return element?.constructor?.name === 'ForEachStatement';
 }
-export function isWhileStatement(element: Statement | Expression | undefined): element is WhileStatement {
+export function isWhileStatement(element: AstNode | undefined): element is WhileStatement {
     return element?.constructor?.name === 'WhileStatement';
 }
-export function isDottedSetStatement(element: Statement | Expression | undefined): element is DottedSetStatement {
+export function isDottedSetStatement(element: AstNode | undefined): element is DottedSetStatement {
     return element?.constructor?.name === 'DottedSetStatement';
 }
-export function isIndexedSetStatement(element: Statement | Expression | undefined): element is IndexedSetStatement {
+export function isIndexedSetStatement(element: AstNode | undefined): element is IndexedSetStatement {
     return element?.constructor?.name === 'IndexedSetStatement';
 }
-export function isLibraryStatement(element: Statement | Expression | undefined): element is LibraryStatement {
+export function isLibraryStatement(element: AstNode | undefined): element is LibraryStatement {
     return element?.constructor?.name === 'LibraryStatement';
 }
-export function isNamespaceStatement(element: Statement | Expression | undefined): element is NamespaceStatement {
+export function isNamespaceStatement(element: AstNode | undefined): element is NamespaceStatement {
     return element?.constructor?.name === 'NamespaceStatement';
 }
-export function isClassStatement(element: Statement | Expression | undefined): element is ClassStatement {
+export function isClassStatement(element: AstNode | undefined): element is ClassStatement {
     return element?.constructor?.name === 'ClassStatement';
 }
-export function isImportStatement(element: Statement | Expression | undefined): element is ImportStatement {
+export function isImportStatement(element: AstNode | undefined): element is ImportStatement {
     return element?.constructor?.name === 'ImportStatement';
 }
-export function isMethodStatement(element: Statement | Expression | undefined): element is MethodStatement {
+export function isMethodStatement(element: AstNode | undefined): element is MethodStatement {
     const name = element?.constructor.name;
     return name === 'MethodStatement' || name === 'ClassMethodStatement';
 }
 /**
  * @deprecated use `isMethodStatement`
  */
-export function isClassMethodStatement(element: Statement | Expression | undefined): element is ClassMethodStatement {
+export function isClassMethodStatement(element: AstNode | undefined): element is ClassMethodStatement {
     return isMethodStatement(element);
 }
-export function isFieldStatement(element: Statement | Expression | undefined): element is FieldStatement {
+export function isFieldStatement(element: AstNode | undefined): element is FieldStatement {
     const name = element?.constructor.name;
     return name === 'FieldStatement' || name === 'ClassFieldStatement';
 }
 /**
  * @deprecated use `isFieldStatement`
  */
-export function isClassFieldStatement(element: Statement | Expression | undefined): element is ClassFieldStatement {
+export function isClassFieldStatement(element: AstNode | undefined): element is ClassFieldStatement {
     return isFieldStatement(element);
 }
-export function isInterfaceStatement(element: Statement | Expression | undefined): element is InterfaceStatement {
+export function isInterfaceStatement(element: AstNode | undefined): element is InterfaceStatement {
     return element?.constructor.name === 'InterfaceStatement';
 }
-export function isInterfaceMethodStatement(element: Statement | Expression | undefined): element is InterfaceMethodStatement {
+export function isInterfaceMethodStatement(element: AstNode | undefined): element is InterfaceMethodStatement {
     return element?.constructor.name === 'InterfaceMethodStatement';
 }
-export function isInterfaceFieldStatement(element: Statement | Expression | undefined): element is InterfaceFieldStatement {
+export function isInterfaceFieldStatement(element: AstNode | undefined): element is InterfaceFieldStatement {
     return element?.constructor.name === 'InterfaceFieldStatement';
 }
-export function isEnumStatement(element: Statement | Expression | undefined): element is EnumStatement {
+export function isEnumStatement(element: AstNode | undefined): element is EnumStatement {
     return element?.constructor.name === 'EnumStatement';
 }
-export function isEnumMemberStatement(element: Statement | Expression | undefined): element is EnumMemberStatement {
+export function isEnumMemberStatement(element: AstNode | undefined): element is EnumMemberStatement {
     return element?.constructor.name === 'EnumMemberStatement';
 }
-export function isConstStatement(element: Statement | Expression | undefined): element is ConstStatement {
+export function isConstStatement(element: AstNode | undefined): element is ConstStatement {
     return element?.constructor.name === 'ConstStatement';
 }
-export function isTryCatchStatement(element: Statement | Expression | undefined): element is TryCatchStatement {
+export function isTryCatchStatement(element: AstNode | undefined): element is TryCatchStatement {
     return element?.constructor.name === 'TryCatchStatement';
 }
-export function isCatchStatement(element: Statement | Expression | undefined): element is CatchStatement {
+export function isCatchStatement(element: AstNode | undefined): element is CatchStatement {
     return element?.constructor.name === 'CatchStatement';
 }
 
@@ -176,78 +177,78 @@ export function isCatchStatement(element: Statement | Expression | undefined): e
  * this will work for StringLiteralExpression -> Expression,
  * but will not work CustomStringLiteralExpression -> StringLiteralExpression -> Expression
  */
-export function isExpression(element: Statement | Expression | undefined): element is Expression {
+export function isExpression(element: AstNode | undefined): element is Expression {
     // eslint-disable-next-line no-bitwise
     return !!(element && element.visitMode & InternalWalkMode.visitExpressions);
 }
 
-export function isBinaryExpression(element: Statement | Expression | undefined): element is BinaryExpression {
+export function isBinaryExpression(element: AstNode | undefined): element is BinaryExpression {
     return element?.constructor.name === 'BinaryExpression';
 }
-export function isCallExpression(element: Statement | Expression | undefined): element is CallExpression {
+export function isCallExpression(element: AstNode | undefined): element is CallExpression {
     return element?.constructor.name === 'CallExpression';
 }
-export function isFunctionExpression(element: Statement | Expression | undefined): element is FunctionExpression {
+export function isFunctionExpression(element: AstNode | undefined): element is FunctionExpression {
     return element?.constructor.name === 'FunctionExpression';
 }
-export function isNamespacedVariableNameExpression(element: Statement | Expression | undefined): element is NamespacedVariableNameExpression {
+export function isNamespacedVariableNameExpression(element: AstNode | undefined): element is NamespacedVariableNameExpression {
     return element?.constructor.name === 'NamespacedVariableNameExpression';
 }
-export function isDottedGetExpression(element: Statement | Expression | undefined): element is DottedGetExpression {
+export function isDottedGetExpression(element: AstNode | undefined): element is DottedGetExpression {
     return element?.constructor.name === 'DottedGetExpression';
 }
-export function isXmlAttributeGetExpression(element: Statement | Expression | undefined): element is XmlAttributeGetExpression {
+export function isXmlAttributeGetExpression(element: AstNode | undefined): element is XmlAttributeGetExpression {
     return element?.constructor.name === 'XmlAttributeGetExpression';
 }
-export function isIndexedGetExpression(element: Statement | Expression | undefined): element is IndexedGetExpression {
+export function isIndexedGetExpression(element: AstNode | undefined): element is IndexedGetExpression {
     return element?.constructor.name === 'IndexedGetExpression';
 }
-export function isGroupingExpression(element: Statement | Expression | undefined): element is GroupingExpression {
+export function isGroupingExpression(element: AstNode | undefined): element is GroupingExpression {
     return element?.constructor.name === 'GroupingExpression';
 }
-export function isLiteralExpression(element: Statement | Expression | undefined): element is LiteralExpression {
+export function isLiteralExpression(element: AstNode | undefined): element is LiteralExpression {
     return element?.constructor.name === 'LiteralExpression';
 }
-export function isEscapedCharCodeLiteralExpression(element: Statement | Expression | undefined): element is EscapedCharCodeLiteralExpression {
+export function isEscapedCharCodeLiteralExpression(element: AstNode | undefined): element is EscapedCharCodeLiteralExpression {
     return element?.constructor.name === 'EscapedCharCodeLiteralExpression';
 }
-export function isArrayLiteralExpression(element: Statement | Expression | undefined): element is ArrayLiteralExpression {
+export function isArrayLiteralExpression(element: AstNode | undefined): element is ArrayLiteralExpression {
     return element?.constructor.name === 'ArrayLiteralExpression';
 }
-export function isAALiteralExpression(element: Statement | Expression | undefined): element is AALiteralExpression {
+export function isAALiteralExpression(element: AstNode | undefined): element is AALiteralExpression {
     return element?.constructor.name === 'AALiteralExpression';
 }
-export function isAAMemberExpression(element: Statement | Expression | undefined): element is AAMemberExpression {
+export function isAAMemberExpression(element: AstNode | undefined): element is AAMemberExpression {
     return element?.constructor.name === 'AAMemberExpression';
 }
-export function isUnaryExpression(element: Statement | Expression | undefined): element is UnaryExpression {
+export function isUnaryExpression(element: AstNode | undefined): element is UnaryExpression {
     return element?.constructor.name === 'UnaryExpression';
 }
-export function isVariableExpression(element: Statement | Expression | undefined): element is VariableExpression {
+export function isVariableExpression(element: AstNode | undefined): element is VariableExpression {
     return element?.constructor.name === 'VariableExpression';
 }
-export function isSourceLiteralExpression(element: Statement | Expression | undefined): element is SourceLiteralExpression {
+export function isSourceLiteralExpression(element: AstNode | undefined): element is SourceLiteralExpression {
     return element?.constructor.name === 'SourceLiteralExpression';
 }
-export function isNewExpression(element: Statement | Expression | undefined): element is NewExpression {
+export function isNewExpression(element: AstNode | undefined): element is NewExpression {
     return element?.constructor.name === 'NewExpression';
 }
-export function isCallfuncExpression(element: Statement | Expression | undefined): element is CallfuncExpression {
+export function isCallfuncExpression(element: AstNode | undefined): element is CallfuncExpression {
     return element?.constructor.name === 'CallfuncExpression';
 }
-export function isTemplateStringQuasiExpression(element: Statement | Expression | undefined): element is TemplateStringQuasiExpression {
+export function isTemplateStringQuasiExpression(element: AstNode | undefined): element is TemplateStringQuasiExpression {
     return element?.constructor.name === 'TemplateStringQuasiExpression';
 }
-export function isTemplateStringExpression(element: Statement | Expression | undefined): element is TemplateStringExpression {
+export function isTemplateStringExpression(element: AstNode | undefined): element is TemplateStringExpression {
     return element?.constructor.name === 'TemplateStringExpression';
 }
-export function isTaggedTemplateStringExpression(element: Statement | Expression | undefined): element is TaggedTemplateStringExpression {
+export function isTaggedTemplateStringExpression(element: AstNode | undefined): element is TaggedTemplateStringExpression {
     return element?.constructor.name === 'TaggedTemplateStringExpression';
 }
-export function isFunctionParameterExpression(element: Statement | Expression | undefined): element is FunctionParameterExpression {
+export function isFunctionParameterExpression(element: AstNode | undefined): element is FunctionParameterExpression {
     return element?.constructor.name === 'FunctionParameterExpression';
 }
-export function isAnnotationExpression(element: Statement | Expression | undefined): element is AnnotationExpression {
+export function isAnnotationExpression(element: AstNode | undefined): element is AnnotationExpression {
     return element?.constructor.name === 'AnnotationExpression';
 }
 export function isTypedefProvider(element: any): element is TypedefProvider {

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -5,9 +5,8 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
-import type { FunctionStatement, Statement } from '../parser/Statement';
+import type { FunctionStatement } from '../parser/Statement';
 import { PrintStatement, Block, ReturnStatement, ExpressionStatement } from '../parser/Statement';
-import type { Expression } from '../parser/Expression';
 import { TokenKind } from '../lexer/TokenKind';
 import { createVisitor, WalkMode, walkStatements } from './visitors';
 import { isPrintStatement } from './reflection';
@@ -15,6 +14,7 @@ import { createCall, createToken, createVariableExpression } from './creators';
 import { createStackedVisitor } from './stackedVisitor';
 import { AstEditor } from './AstEditor';
 import { Parser } from '../parser/Parser';
+import type { Statement, Expression, AstNode } from '../parser/AstNode';
 
 describe('astUtils visitors', () => {
     const rootDir = process.cwd();
@@ -278,7 +278,7 @@ describe('astUtils visitors', () => {
             const statementVisitor = createStackedVisitor((statement: Statement, stack: Statement[]) => {
                 curr = { statement: statement, depth: stack.length };
             });
-            function expressionVisitor(expression: Expression, _: Statement | Expression) {
+            function expressionVisitor(expression: Expression, _: AstNode) {
                 const { statement, depth } = curr;
                 actual.push(`${statement.constructor.name}:${depth}:${expression.constructor.name}`);
             }

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Statement, Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement } from '../parser/Statement';
-import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, Expression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement } from '../parser/Statement';
+import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { AstEditor } from './AstEditor';
+import type { Statement, Expression, AstNode } from '../parser/AstNode';
 
 
 /**
@@ -20,19 +21,19 @@ export function walkStatements(
     });
 }
 
-export type WalkVisitor = <T = Statement | Expression>(stmtExpr: Statement | Expression, parent?: Statement | Expression, owner?: any, key?: any) => void | T;
+export type WalkVisitor = <T = AstNode>(node: AstNode, parent?: AstNode, owner?: any, key?: any) => void | T;
 
 /**
  * A helper function for Statement and Expression `walkAll` calls.
  */
-export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: Expression | Statement) {
+export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode) {
     //stop processing if canceled
     if (options.cancel?.isCancellationRequested) {
         return;
     }
 
     //the object we're visiting
-    let element = owner[key] as any as Statement | Expression;
+    let element = owner[key] as any as AstNode;
     if (!element) {
         return;
     }
@@ -69,7 +70,7 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
  * Helper for AST elements to walk arrays when visitors might change the array size (to delete/insert items).
  * @param filter a function used to filter items from the array. return true if that item should be walked
  */
-export function walkArray<T>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: Expression | Statement, filter?: <T>(element: T) => boolean) {
+export function walkArray<T>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode, filter?: <T>(element: T) => boolean) {
     for (let i = 0; i < array.length; i++) {
         if (!filter || filter(array[i])) {
             const startLength = array.length;
@@ -135,32 +136,32 @@ export function createVisitor(
         EnumMemberStatement?: (statement: EnumMemberStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ConstStatement?: (statement: ConstStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         //expressions
-        BinaryExpression?: (expression: BinaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        CallExpression?: (expression: CallExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        FunctionExpression?: (expression: FunctionExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        FunctionParameterExpression?: (expression: FunctionParameterExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        NamespacedVariableNameExpression?: (expression: NamespacedVariableNameExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        DottedGetExpression?: (expression: DottedGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        XmlAttributeGetExpression?: (expression: XmlAttributeGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        IndexedGetExpression?: (expression: IndexedGetExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        GroupingExpression?: (expression: GroupingExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        LiteralExpression?: (expression: LiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        EscapedCharCodeLiteralExpression?: (expression: EscapedCharCodeLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        ArrayLiteralExpression?: (expression: ArrayLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        AAMemberExpression?: (expression: AAMemberExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        AALiteralExpression?: (expression: AALiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        UnaryExpression?: (expression: UnaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        VariableExpression?: (expression: VariableExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        SourceLiteralExpression?: (expression: SourceLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        NewExpression?: (expression: NewExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        CallfuncExpression?: (expression: CallfuncExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        TemplateStringQuasiExpression?: (expression: TemplateStringQuasiExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        TemplateStringExpression?: (expression: TemplateStringExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        TaggedTemplateStringExpression?: (expression: TaggedTemplateStringExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        AnnotationExpression?: (expression: AnnotationExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        TernaryExpression?: (expression: TernaryExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        NullCoalescingExpression?: (expression: NullCoalescingExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
-        RegexLiteralExpression?: (expression: RegexLiteralExpression, parent?: Statement | Expression, owner?: any, key?: any) => Expression | void;
+        BinaryExpression?: (expression: BinaryExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        CallExpression?: (expression: CallExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        FunctionExpression?: (expression: FunctionExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        FunctionParameterExpression?: (expression: FunctionParameterExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        NamespacedVariableNameExpression?: (expression: NamespacedVariableNameExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        DottedGetExpression?: (expression: DottedGetExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        XmlAttributeGetExpression?: (expression: XmlAttributeGetExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        IndexedGetExpression?: (expression: IndexedGetExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        GroupingExpression?: (expression: GroupingExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        LiteralExpression?: (expression: LiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        EscapedCharCodeLiteralExpression?: (expression: EscapedCharCodeLiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        ArrayLiteralExpression?: (expression: ArrayLiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        AAMemberExpression?: (expression: AAMemberExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        AALiteralExpression?: (expression: AALiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        UnaryExpression?: (expression: UnaryExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        VariableExpression?: (expression: VariableExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        SourceLiteralExpression?: (expression: SourceLiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        NewExpression?: (expression: NewExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        CallfuncExpression?: (expression: CallfuncExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        TemplateStringQuasiExpression?: (expression: TemplateStringQuasiExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        TemplateStringExpression?: (expression: TemplateStringExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        TaggedTemplateStringExpression?: (expression: TaggedTemplateStringExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        AnnotationExpression?: (expression: AnnotationExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        TernaryExpression?: (expression: TernaryExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        NullCoalescingExpression?: (expression: NullCoalescingExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        RegexLiteralExpression?: (expression: RegexLiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
     }
 ) {
     //remap some deprecated visitor names TODO remove this in v1

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -3,7 +3,7 @@ import { isBrsFile, isDottedGetExpression, isLiteralExpression, isVariableExpres
 import type { BrsFile } from '../../files/BrsFile';
 import type { BeforeFileTranspileEvent } from '../../interfaces';
 import { TokenKind } from '../../lexer/TokenKind';
-import type { Expression } from '../../parser/Expression';
+import type { Expression } from '../../parser/AstNode';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import type { Scope } from '../../Scope';

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -2,8 +2,9 @@ import { isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpr
 import { WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
-import type { AstNode, OnFileValidateEvent } from '../../interfaces';
+import type { OnFileValidateEvent } from '../../interfaces';
 import { TokenKind } from '../../lexer/TokenKind';
+import type { AstNode } from '../../parser/AstNode';
 import type { LiteralExpression } from '../../parser/Expression';
 import type { EnumMemberStatement, EnumStatement, ImportStatement, LibraryStatement } from '../../parser/Statement';
 import util from '../../util';

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -4,7 +4,6 @@ import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, BsDiagnostic, OnScopeValidateEvent } from '../../interfaces';
-import type { Expression } from '../../parser/Expression';
 import type { EnumStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
@@ -13,6 +12,7 @@ import type { Token } from '../../lexer/Token';
 import type { Scope } from '../../Scope';
 import type { SymbolTable } from '../../SymbolTable';
 import type { DiagnosticRelatedInformation, Position } from 'vscode-languageserver';
+import type { Expression } from '../../parser/AstNode';
 
 /**
  * The lower-case names of all platform-included scenegraph nodes

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -13,8 +13,8 @@ import type { Token } from '../lexer/Token';
 import { Lexer } from '../lexer/Lexer';
 import { TokenKind, AllowedLocalIdentifiers, Keywords } from '../lexer/TokenKind';
 import { Parser, ParseMode } from '../parser/Parser';
-import type { FunctionExpression, VariableExpression, Expression } from '../parser/Expression';
-import type { ClassStatement, FunctionStatement, NamespaceStatement, AssignmentStatement, Statement, MethodStatement, FieldStatement } from '../parser/Statement';
+import type { FunctionExpression, VariableExpression } from '../parser/Expression';
+import type { ClassStatement, FunctionStatement, NamespaceStatement, AssignmentStatement, MethodStatement, FieldStatement } from '../parser/Statement';
 import type { Program, SignatureInfoObj } from '../Program';
 import { DynamicType } from '../types/DynamicType';
 import { FunctionType } from '../types/FunctionType';
@@ -30,6 +30,7 @@ import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
 import { URI } from 'vscode-uri';
+import type { AstNode, Expression, Statement } from '../parser/AstNode';
 
 /**
  * Holds all details about this file within the scope of the whole program
@@ -192,7 +193,7 @@ export class BrsFile {
      */
     public getClosestExpression(position: Position) {
         const handle = new CancellationTokenSource();
-        let containingNode: Expression | Statement;
+        let containingNode: AstNode;
         this.ast.walk((node) => {
             const latestContainer = containingNode;
             //bsc walks depth-first

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from './lexer/TokenKind';
 export * from './lexer/Token';
 export { Lexer } from './lexer/Lexer';
 export * from './parser/Parser';
+export * from './parser/AstNode';
 export * from './parser/Expression';
 export * from './parser/Statement';
 export * from './BsConfig';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,8 +7,8 @@ import type { FunctionType } from './types/FunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program, SourceObj, TranspileObj } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { FunctionStatement, Statement } from './parser/Statement';
-import type { Expression } from './parser/Expression';
+import type { FunctionStatement } from './parser/Statement';
+import type { Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
@@ -406,5 +406,3 @@ export interface FileLink<T> {
     item: T;
     file: BrsFile;
 }
-
-export type AstNode = Expression | Statement;

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -1,0 +1,65 @@
+import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
+import type { Range } from 'vscode-languageserver';
+import { InternalWalkMode } from '../astUtils/visitors';
+import type { SymbolTable } from '../SymbolTable';
+import type { BrsTranspileState } from './BrsTranspileState';
+import type { TranspileResult } from '../interfaces';
+import type { AnnotationExpression } from './Expression';
+
+/**
+ * A BrightScript AST node
+ */
+export abstract class AstNode {
+    /**
+     *  The starting and ending location of the node.
+     **/
+    public abstract range: Range;
+
+    public abstract transpile(state: BrsTranspileState): TranspileResult;
+
+    /**
+     * When being considered by the walk visitor, this describes what type of element the current class is.
+     */
+    public visitMode = InternalWalkMode.visitStatements;
+
+    public abstract walk(visitor: WalkVisitor, options: WalkOptions);
+
+    /**
+     * The parent node for this statement. This is set dynamically during `onFileValidate`, and should not be set directly.
+     */
+    public parent?: AstNode;
+
+    /**
+     * Certain expressions or statements can have a symbol table (such as blocks, functions, namespace bodies, etc).
+     * If you're interested in getting the closest SymbolTable, use `getSymbolTable` instead.
+     */
+    protected symbolTable?: SymbolTable;
+
+    /**
+     * Get the closest symbol table for this node. Should be overridden in children that directly contain a symbol table
+     */
+    public getSymbolTable(): SymbolTable {
+        return this.parent?.getSymbolTable();
+    }
+}
+
+
+export abstract class Statement extends AstNode {
+    /**
+     * When being considered by the walk visitor, this describes what type of element the current class is.
+     */
+    public visitMode = InternalWalkMode.visitStatements;
+    /**
+     * Annotations for this statement
+     */
+    public annotations: AnnotationExpression[];
+}
+
+
+/** A BrightScript expression */
+export abstract class Expression extends AstNode {
+    /**
+     * When being considered by the walk visitor, this describes what type of element the current class is.
+     */
+    public visitMode = InternalWalkMode.visitExpressions;
+}

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import type { Block, CommentStatement, FunctionStatement, Statement } from './Statement';
+import type { Block, CommentStatement, FunctionStatement } from './Statement';
 import type { Range } from 'vscode-languageserver';
 import util from '../util';
 import type { BrsTranspileState } from './BrsTranspileState';
@@ -16,35 +16,9 @@ import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
 import { SymbolTable } from '../SymbolTable';
+import { Expression } from './AstNode';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
-
-/** A BrightScript expression */
-export abstract class Expression {
-    /**
-     * The starting and ending location of the expression.
-     */
-    public abstract range: Range;
-
-    public abstract transpile(state: BrsTranspileState): TranspileResult;
-    /**
-     * When being considered by the walk visitor, this describes what type of element the current class is.
-     */
-    public visitMode = InternalWalkMode.visitExpressions;
-
-    public abstract walk(visitor: WalkVisitor, options: WalkOptions);
-    /**
-     * The parent node for this expression. This is set dynamically during `onFileValidate`, and should not be set directly.
-     */
-    public parent?: Statement | Expression;
-
-    /**
-     * Get the closest symbol table for this node. Should be overridden in children that directly contain a symbol table
-     */
-    public getSymbolTable(): SymbolTable {
-        return this.parent?.getSymbolTable();
-    }
-}
 
 export class BinaryExpression extends Expression {
     constructor(

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,10 +1,10 @@
 import { expect, assert } from 'chai';
 import { Lexer } from '../lexer/Lexer';
 import { ReservedWords, TokenKind } from '../lexer/TokenKind';
-import type { AAMemberExpression, Expression } from './Expression';
+import type { AAMemberExpression } from './Expression';
 import { TernaryExpression, NewExpression, IndexedGetExpression, DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
-import type { AssignmentStatement, ClassStatement, Statement } from './Statement';
+import type { AssignmentStatement, ClassStatement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
@@ -15,6 +15,7 @@ import { SourceNode } from 'source-map';
 import { BrsFile } from '../files/BrsFile';
 import { Program } from '../Program';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
+import type { Expression, Statement } from './AstNode';
 
 describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -14,8 +14,7 @@ import {
 } from '../lexer/TokenKind';
 import type {
     PrintSeparatorSpace,
-    PrintSeparatorTab,
-    Statement
+    PrintSeparatorTab
 } from './Statement';
 import {
     AssignmentStatement,
@@ -59,7 +58,6 @@ import {
 import type { DiagnosticInfo } from '../DiagnosticMessages';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { util } from '../util';
-import type { Expression } from './Expression';
 import {
     AALiteralExpression,
     AAMemberExpression,
@@ -96,6 +94,7 @@ import { createStringLiteral, createToken } from '../astUtils/creators';
 import { Cache } from '../Cache';
 import { SymbolTable } from '../SymbolTable';
 import { DynamicType } from '../types/DynamicType';
+import type { Expression, Statement } from './AstNode';
 
 export class Parser {
     /**

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer/TokenKind';
-import type { BinaryExpression, Expression, NamespacedVariableNameExpression, FunctionExpression, AnnotationExpression, FunctionParameterExpression, LiteralExpression } from './Expression';
+import type { BinaryExpression, NamespacedVariableNameExpression, FunctionExpression, FunctionParameterExpression, LiteralExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
 import type { Range } from 'vscode-languageserver';
@@ -18,43 +18,8 @@ import type { BscType } from '../types/BscType';
 import type { SourceNode } from 'source-map';
 import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
-
-/**
- * A BrightScript statement
- */
-export abstract class Statement {
-
-    /**
-     *  The starting and ending location of the statement.
-     **/
-    public abstract range: Range;
-
-    /**
-     * Statement annotations
-     */
-    public annotations: AnnotationExpression[];
-
-    public abstract transpile(state: BrsTranspileState): TranspileResult;
-
-    /**
-     * When being considered by the walk visitor, this describes what type of element the current class is.
-     */
-    public visitMode = InternalWalkMode.visitStatements;
-
-    public abstract walk(visitor: WalkVisitor, options: WalkOptions);
-
-    /**
-     * The parent node for this statement. This is set dynamically during `onFileValidate`, and should not be set directly.
-     */
-    public parent?: Statement | Expression;
-
-    /**
-     * Get the closest symbol table for this node. Should be overridden in children that directly contain a symbol table
-     */
-    public getSymbolTable(): SymbolTable {
-        return this.parent?.getSymbolTable();
-    }
-}
+import type { Expression } from './AstNode';
+import { Statement } from './AstNode';
 
 export class EmptyStatement extends Statement {
     constructor(

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,7 @@ import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';
 import { VoidType } from './types/VoidType';
 import { ParseMode } from './parser/Parser';
-import type { DottedGetExpression, Expression, VariableExpression } from './parser/Expression';
+import type { DottedGetExpression, VariableExpression } from './parser/Expression';
 import { Logger, LogLevel } from './Logger';
 import type { Identifier, Locatable, Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
@@ -34,6 +34,7 @@ import type { SGAttribute } from './parser/SGTypes';
 import * as requireRelative from 'require-relative';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
+import type { Expression } from './parser/AstNode';
 
 export class Util {
     public clearConsole() {


### PR DESCRIPTION
Creates a superclass `AstNode` that both `Expression` and `Statement` extend.