### PR TITLE
Rename refs  to isClass(field|method)Statement

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -17,7 +17,7 @@ import { URI } from 'vscode-uri';
 import { LogLevel } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
-import { isBrsFile, isClassMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile } from './astUtils/reflection';
+import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
 import type { Statement } from './parser/AstNode';
 
@@ -1178,7 +1178,7 @@ export class Scope {
                     if (!results.has(s.name.text) && s.name.text.toLowerCase() !== 'new') {
                         results.set(s.name.text, {
                             label: s.name.text,
-                            kind: isClassMethodStatement(s) ? CompletionItemKind.Method : CompletionItemKind.Field
+                            kind: isMethodStatement(s) ? CompletionItemKind.Method : CompletionItemKind.Field
                         });
                     }
                 }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -24,7 +24,7 @@ import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { LogLevel } from '../Logger';
 import { serializeError } from 'serialize-error';
-import { isCallExpression, isClassMethodStatement, isClassStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isClassFieldStatement, isEnumStatement, isConstStatement } from '../astUtils/reflection';
+import { isCallExpression, isMethodStatement, isClassStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isFieldStatement, isEnumStatement, isConstStatement } from '../astUtils/reflection';
 import type { BscType } from '../types/BscType';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
@@ -932,7 +932,7 @@ export class BrsFile {
                     if (!results.has(member.name.text.toLowerCase())) {
                         results.set(member.name.text.toLowerCase(), {
                             label: member.name.text,
-                            kind: isClassFieldStatement(member) ? CompletionItemKind.Field : CompletionItemKind.Function
+                            kind: isFieldStatement(member) ? CompletionItemKind.Field : CompletionItemKind.Function
                         });
                     }
                 }
@@ -946,7 +946,7 @@ export class BrsFile {
         if (previousToken?.kind === TokenKind.Dot) {
             previousToken = this.getPreviousToken(previousToken);
         }
-        if (previousToken?.kind === TokenKind.Identifier && previousToken?.text.toLowerCase() === 'm' && isClassMethodStatement(functionScope.func.functionStatement)) {
+        if (previousToken?.kind === TokenKind.Identifier && previousToken?.text.toLowerCase() === 'm' && isMethodStatement(functionScope.func.functionStatement)) {
             return { item: this.parser.references.classStatements.find((cs) => util.rangeContains(cs.range, position)), file: this };
         }
         return undefined;
@@ -1349,9 +1349,9 @@ export class BrsFile {
 
         if (isFunctionStatement(statement)) {
             symbolKind = SymbolKind.Function;
-        } else if (isClassMethodStatement(statement)) {
+        } else if (isMethodStatement(statement)) {
             symbolKind = SymbolKind.Method;
-        } else if (isClassFieldStatement(statement)) {
+        } else if (isFieldStatement(statement)) {
             symbolKind = SymbolKind.Field;
         } else if (isNamespaceStatement(statement)) {
             symbolKind = SymbolKind.Namespace;
@@ -1373,7 +1373,7 @@ export class BrsFile {
             return;
         }
 
-        const name = isClassFieldStatement(statement) ? statement.name.text : statement.getName(ParseMode.BrighterScript);
+        const name = isFieldStatement(statement) ? statement.name.text : statement.getName(ParseMode.BrighterScript);
         return DocumentSymbol.create(name, '', symbolKind, statement.range, statement.range, children);
     }
 
@@ -1386,7 +1386,7 @@ export class BrsFile {
 
         if (isFunctionStatement(statement)) {
             symbolKind = SymbolKind.Function;
-        } else if (isClassMethodStatement(statement)) {
+        } else if (isMethodStatement(statement)) {
             symbolKind = SymbolKind.Method;
         } else if (isNamespaceStatement(statement)) {
             symbolKind = SymbolKind.Namespace;
@@ -1603,7 +1603,7 @@ export class BrsFile {
     }
 
     public getSignatureHelpForStatement(statement: Statement): SignatureInfoObj {
-        if (!isFunctionStatement(statement) && !isClassMethodStatement(statement)) {
+        if (!isFunctionStatement(statement) && !isMethodStatement(statement)) {
             return undefined;
         }
         const func = statement.func;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -88,7 +88,7 @@ import {
 } from './Expression';
 import type { Diagnostic, Range } from 'vscode-languageserver';
 import { Logger } from '../Logger';
-import { isAAMemberExpression, isAnnotationExpression, isBinaryExpression, isCallExpression, isCallfuncExpression, isClassMethodStatement, isCommentStatement, isDottedGetExpression, isIfStatement, isIndexedGetExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAAMemberExpression, isAnnotationExpression, isBinaryExpression, isCallExpression, isCallfuncExpression, isMethodStatement, isCommentStatement, isDottedGetExpression, isIfStatement, isIndexedGetExpression, isVariableExpression } from '../astUtils/reflection';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { createStringLiteral, createToken } from '../astUtils/creators';
 import { Cache } from '../Cache';
@@ -3102,7 +3102,7 @@ export class Parser {
                 this._references.libraryStatements.push(s);
             },
             FunctionExpression: (expression, parent) => {
-                if (!isClassMethodStatement(parent)) {
+                if (!isMethodStatement(parent)) {
                     this._references.functionExpressions.push(expression);
                 }
             },

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -6,7 +6,7 @@ import type { ClassStatement, MethodStatement } from '../parser/Statement';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import util from '../util';
-import { isCallExpression, isClassFieldStatement, isClassMethodStatement, isCustomType } from '../astUtils/reflection';
+import { isCallExpression, isFieldStatement, isMethodStatement, isCustomType } from '../astUtils/reflection';
 import type { BscFile, BsDiagnostic } from '../interfaces';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { BrsFile } from '../files/BrsFile';
@@ -184,7 +184,7 @@ export class BsClassValidator {
             let fields = {};
 
             for (let statement of classStatement.body) {
-                if (isClassMethodStatement(statement) || isClassFieldStatement(statement)) {
+                if (isMethodStatement(statement) || isFieldStatement(statement)) {
                     let member = statement;
                     let lowerMemberName = member.name.text.toLowerCase();
 
@@ -197,10 +197,10 @@ export class BsClassValidator {
                         });
                     }
 
-                    let memberType = isClassFieldStatement(member) ? 'field' : 'method';
+                    let memberType = isFieldStatement(member) ? 'field' : 'method';
                     let ancestorAndMember = this.getAncestorMember(classStatement, lowerMemberName);
                     if (ancestorAndMember) {
-                        let ancestorMemberKind = isClassFieldStatement(ancestorAndMember.member) ? 'field' : 'method';
+                        let ancestorMemberKind = isFieldStatement(ancestorAndMember.member) ? 'field' : 'method';
 
                         //mismatched member type (field/method in child, opposite in ancestor)
                         if (memberType !== ancestorMemberKind) {
@@ -216,11 +216,11 @@ export class BsClassValidator {
                         }
 
                         //child field has same name as parent
-                        if (isClassFieldStatement(member)) {
+                        if (isFieldStatement(member)) {
                             let ancestorMemberType = new DynamicType();
-                            if (isClassFieldStatement(ancestorAndMember.member)) {
+                            if (isFieldStatement(ancestorAndMember.member)) {
                                 ancestorMemberType = ancestorAndMember.member.getType();
-                            } else if (isClassMethodStatement(ancestorAndMember.member)) {
+                            } else if (isMethodStatement(ancestorAndMember.member)) {
                                 ancestorMemberType = ancestorAndMember.member.func.getFunctionType();
                             }
                             const childFieldType = member.getType();
@@ -243,7 +243,7 @@ export class BsClassValidator {
                         //child method missing the override keyword
                         if (
                             //is a method
-                            isClassMethodStatement(member) &&
+                            isMethodStatement(member) &&
                             //does not have an override keyword
                             !member.override &&
                             //is not the constructur function
@@ -261,7 +261,7 @@ export class BsClassValidator {
                         //child member has different visiblity
                         if (
                             //is a method
-                            isClassMethodStatement(member) &&
+                            isMethodStatement(member) &&
                             (member.accessModifier?.kind ?? TokenKind.Public) !== (ancestorAndMember.member.accessModifier?.kind ?? TokenKind.Public)
                         ) {
                             this.diagnostics.push({
@@ -278,10 +278,10 @@ export class BsClassValidator {
                         }
                     }
 
-                    if (isClassMethodStatement(member)) {
+                    if (isMethodStatement(member)) {
                         methods[lowerMemberName] = member;
 
-                    } else if (isClassFieldStatement(member)) {
+                    } else if (isFieldStatement(member)) {
                         fields[lowerMemberName] = member;
                     }
                 }
@@ -296,7 +296,7 @@ export class BsClassValidator {
     private validateFieldTypes() {
         for (const [, classStatement] of this.classes) {
             for (let statement of classStatement.body) {
-                if (isClassFieldStatement(statement)) {
+                if (isFieldStatement(statement)) {
                     let fieldType = statement.getType();
 
                     if (isCustomType(fieldType)) {


### PR DESCRIPTION
Renames references to `isClassFieldStatement` and `isClassMethodStatement` in favor of `isFieldStatement` and `isMethodStatement`