### PR TITLE
Support `pkg:/` paths for `setFile`

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -560,8 +560,8 @@ describe('Program', () => {
             expect(
                 getPaths('source/main.brs', rootDir)
             ).to.eql({
-                src: s`${rootDir}/source/main.brs`,
-                dest: s`source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
             });
         });
 
@@ -569,8 +569,8 @@ describe('Program', () => {
             expect(
                 getPaths(`${rootDir}/source\\main.brs`, rootDir)
             ).to.eql({
-                src: s`${rootDir}/source/main.brs`,
-                dest: s`source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
             });
         });
 
@@ -578,8 +578,8 @@ describe('Program', () => {
             expect(
                 getPaths({ dest: 'source/main.brs' }, rootDir)
             ).to.eql({
-                src: s`${rootDir}/source/main.brs`,
-                dest: s`source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
             });
         });
 
@@ -587,8 +587,35 @@ describe('Program', () => {
             expect(
                 getPaths({ src: `${rootDir}/source/main.brs` }, rootDir)
             ).to.eql({
-                src: s`${rootDir}/source/main.brs`,
-                dest: s`source/main.brs`
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
+            });
+        });
+
+        it('works for pkg string', () => {
+            expect(
+                getPaths('pkg:/source/main.brs', rootDir)
+            ).to.eql({
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
+            });
+        });
+
+        it('favors pkgPath over destPath', () => {
+            expect(
+                getPaths({ srcPath: `${rootDir}/source/main.brs`, destPath: 'source/DontUse.brs', pkgPath: `pkg:/source/main.brs` })
+            ).to.eql({
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
+            });
+        });
+
+        it('works when given a file', () => {
+            expect(
+                getPaths({ srcPath: `${rootDir}/source/main.brs`, pkgPath: `source/main.brs` })
+            ).to.eql({
+                srcPath: s`${rootDir}/source/main.brs`,
+                pkgPath: s`source/main.brs`
             });
         });
     });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -398,7 +398,7 @@ export class Program {
     public setFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
     public setFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
         //normalize the file paths
-        const { src: srcPath, dest: pkgPath } = this.getPaths(fileParam, this.options.rootDir);
+        const { srcPath, pkgPath } = this.getPaths(fileParam, this.options.rootDir);
 
         let file = this.logger.time(LogLevel.debug, ['Program.setFile()', chalk.green(srcPath)], () => {
             //if the file is already loaded, remove it
@@ -492,46 +492,63 @@ export class Program {
      * Given a srcPath, a pkgPath, or both, resolve whichever is missing, relative to rootDir.
      * @param rootDir must be a pre-normalized path
      */
-    private getPaths(fileParam: string | FileObj, rootDir: string) {
-        let src: string;
-        let dest: string;
+    private getPaths(fileParam: string | FileObj | { srcPath?: string; pkgPath?: string }, rootDir: string) {
+        let srcPath: string;
+        let pkgPath: string;
 
         assert.ok(fileParam, 'fileParam is required');
+
         //lift the srcPath and pkgPath vars from the incoming param
         if (typeof fileParam === 'string') {
-            src = s`${path.resolve(rootDir, fileParam)}`;
-            dest = s`${util.replaceCaseInsensitive(src, rootDir, '')}`;
+            fileParam = this.removePkgPrefix(fileParam);
+            srcPath = s`${path.resolve(rootDir, fileParam)}`;
+            pkgPath = s`${util.replaceCaseInsensitive(srcPath, rootDir, '')}`;
         } else {
-            if (fileParam.src) {
-                src = s`${fileParam.src}`;
+            let param: any = fileParam;
+
+            if (param.src) {
+                srcPath = s`${param.src}`;
             }
-            if (fileParam.dest) {
-                dest = s`${fileParam.dest}`;
+            if (param.srcPath) {
+                srcPath = s`${param.srcPath}`;
+            }
+            if (param.dest) {
+                pkgPath = s`${this.removePkgPrefix(param.dest)}`;
+            }
+            if (param.pkgPath) {
+                pkgPath = s`${this.removePkgPrefix(param.pkgPath)}`;
             }
         }
 
         //if there's no srcPath, use the pkgPath to build an absolute srcPath
-        if (!src) {
-            src = s`${rootDir}/${dest}`;
+        if (!srcPath) {
+            srcPath = s`${rootDir}/${pkgPath}`;
         }
         //coerce srcPath to an absolute path
-        if (!path.isAbsolute(src)) {
-            src = util.standardizePath(src);
+        if (!path.isAbsolute(srcPath)) {
+            srcPath = util.standardizePath(srcPath);
         }
 
         //if there's no pkgPath, compute relative path from rootDir
-        if (!dest) {
-            dest = s`${util.replaceCaseInsensitive(src, rootDir, '')}`;
+        if (!pkgPath) {
+            pkgPath = s`${util.replaceCaseInsensitive(srcPath, rootDir, '')}`;
         }
 
-        assert.ok(src, 'fileEntry.src is required');
-        assert.ok(dest, 'fileEntry.dest is required');
+        assert.ok(srcPath, 'fileEntry.src is required');
+        assert.ok(pkgPath, 'fileEntry.dest is required');
 
         return {
-            src: src,
+            srcPath: srcPath,
             //remove leading slash from pkgPath
-            dest: dest.replace(/^[\/\\]+/, '')
+            pkgPath: pkgPath.replace(/^[\/\\]+/, '')
         };
+    }
+
+    /**
+     * Remove any leading `pkg:/` found in the path
+     */
+    private removePkgPrefix(path: string) {
+        return path.replace(/^pkg:\//i, '');
     }
 
     /**


### PR DESCRIPTION
Adds support for `pkg:/` prefixed paths in `setFile`. This makes the entire process more flexible, and moves closer to the v1 approach. Also will be useful in #408 so that plugins always provide `pkg:/` paths. 