### PR TITLE
Optimize Scope.getFile(). Simplify setFile in tests.

### DIFF
--- a/src/FunctionScope.spec.ts
+++ b/src/FunctionScope.spec.ts
@@ -23,7 +23,7 @@ describe('FunctionScope', () => {
         });
 
         it('returns variables defined above the specified line number', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                     var1 = 1
                     var2 = 2

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -28,10 +28,7 @@ describe('Scope', () => {
     });
 
     it('does not mark namespace functions as collisions with stdlib', () => {
-        program.setFile({
-            src: `${rootDir}/source/main.bs`,
-            dest: `source/main.bs`
-        }, `
+        program.setFile(`source/main.bs`, `
             namespace a
                 function constructor()
                 end function
@@ -139,7 +136,7 @@ describe('Scope', () => {
         it('detects callables from all loaded files', () => {
             const sourceScope = program.getScopeByName('source');
 
-            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile(`source/main.brs`, `
                 sub Main()
 
                 end sub
@@ -147,7 +144,7 @@ describe('Scope', () => {
                 sub ActionA()
                 end sub
             `);
-            program.setFile({ src: s`${rootDir}/source/lib.brs`, dest: s`source/lib.brs` }, `
+            program.setFile(`source/lib.brs`, `
                 sub ActionB()
                 end sub
             `);
@@ -605,18 +602,18 @@ describe('Scope', () => {
         });
 
         it('marks the scope as validated after validation has occurred', () => {
-            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile(`source/main.bs`, `
                sub main()
                end sub
             `);
-            let lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            let lib = program.setFile(`source/lib.bs`, `
                sub libFunc()
                end sub
             `);
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.false;
             program.validate();
             expect(program.getScopesForFile(lib)[0].isValidated).to.be.true;
-            lib = program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: s`source/lib.bs` }, `
+            lib = program.setFile(`source/lib.bs`, `
                 sub libFunc()
                 end sub
             `);
@@ -627,7 +624,7 @@ describe('Scope', () => {
         });
 
         it('does not mark same-named-functions in different namespaces as an error', () => {
-            program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+            program.setFile(`source/main.bs`, `
                 namespace NameA
                     sub alert()
                     end sub
@@ -641,7 +638,7 @@ describe('Scope', () => {
             expectZeroDiagnostics(program);
         });
         it('resolves local-variable function calls', () => {
-            program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+            program.setFile(`source/main.brs`, `
                 sub DoSomething()
                     sayMyName = function(name as string)
                     end function
@@ -655,7 +652,7 @@ describe('Scope', () => {
 
         describe('function shadowing', () => {
             it('warns when local var function has same name as stdlib function', () => {
-                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile(`source/main.brs`, `
                     sub main()
                         str = function(p)
                             return "override"
@@ -671,7 +668,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile(`source/main.brs`, `
                     sub main()
                         str = 12345
                         print str ' prints "12345" (i.e. our local variable is allowed to shadow the built-in function name)
@@ -682,7 +679,7 @@ describe('Scope', () => {
             });
 
             it('warns when local var has same name as built-in function', () => {
-                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile(`source/main.brs`, `
                     sub main()
                         str = 6789
                         print str(12345) ' prints "12345" (i.e. our local variable did not override the callable global function)
@@ -693,7 +690,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile(`source/main.brs`, `
                     sub main()
                         getHello = function()
                             return "override"
@@ -713,7 +710,7 @@ describe('Scope', () => {
             });
 
             it('detects local function with same name as scope function', () => {
-                program.setFile({ src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }, `
+                program.setFile(`source/main.brs`, `
                     sub main()
                         getHello = "override"
                         print getHello ' prints <Function: gethello> (i.e. local variable override does NOT work for same-scope-defined methods)
@@ -984,7 +981,7 @@ describe('Scope', () => {
 
         describe('custom types', () => {
             it('detects an unknown function return type', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     function a()
                         return invalid
                     end function
@@ -1015,7 +1012,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown function parameter type', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     sub a(num as integer)
                     end sub
 
@@ -1038,7 +1035,7 @@ describe('Scope', () => {
             });
 
             it('detects an unknown field parameter type', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     class myClass
                         foo as unknownType 'error
                     end class
@@ -1057,7 +1054,7 @@ describe('Scope', () => {
             });
 
             it('supports enums and interfaces as types', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
 
                     interface MyInterface
                         title as string
@@ -1076,7 +1073,7 @@ describe('Scope', () => {
             });
 
             it('finds interface types', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         interface MyInterface
                           title as string
@@ -1094,7 +1091,7 @@ describe('Scope', () => {
             });
 
             it('finds non-namespaced interface types', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     interface MyInterface
                         title as string
                     end interface
@@ -1112,7 +1109,7 @@ describe('Scope', () => {
             });
 
             it('finds enum types', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         enum MyEnum
                           title = "t"
@@ -1130,7 +1127,7 @@ describe('Scope', () => {
             });
 
             it('finds non-namespaced enum types', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     enum MyEnum
                         title = "t"
                     end enum
@@ -1148,7 +1145,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types inside namespaces', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -1168,7 +1165,7 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other namespaces', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -1183,7 +1180,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from current namespaces', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -1200,11 +1197,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     function foo(param as MyClass) as MyClass
                     end function
                 `);
-                program.setFile({ src: s`${rootDir}/source/MyClass.bs`, dest: s`source/MyClass.bs` }, `
+                program.setFile(`source/MyClass.bs`, `
                     class MyClass
                     end class
                 `);
@@ -1214,11 +1211,11 @@ describe('Scope', () => {
             });
 
             it('finds custom types from other other files', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     function foo(param as MyNameSpace.MyClass) as MyNameSpace.MyClass
                     end function
                 `);
-                program.setFile({ src: s`${rootDir}/source/MyNameSpace.bs`, dest: s`source/MyNameSpace.bs` }, `
+                program.setFile(`source/MyNameSpace.bs`, `
                     namespace MyNameSpace
                       class MyClass
                       end class
@@ -1230,7 +1227,7 @@ describe('Scope', () => {
             });
 
             it('detects missing custom types from another namespaces', () => {
-                program.setFile({ src: s`${rootDir}/source/main.bs`, dest: s`source/main.bs` }, `
+                program.setFile(`source/main.bs`, `
                     namespace MyNamespace
                         class MyClass
                         end class
@@ -1351,7 +1348,7 @@ describe('Scope', () => {
 
     describe('getDefinition', () => {
         it('returns empty list when there are no files', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, '');
+            let file = program.setFile('source/main.brs', '');
             let scope = program.getScopeByName('source');
             expect(scope.getDefinition(file, Position.create(0, 0))).to.be.lengthOf(0);
         });

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,7 @@ import { BsClassValidator } from './validators/ClassValidator';
 import type { NamespaceStatement, FunctionStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement } from './parser/Statement';
 import type { NewExpression } from './parser/Expression';
 import { ParseMode } from './parser/Parser';
-import { standardizePath as s, util } from './util';
+import { util } from './util';
 import { globalCallableMap } from './globalCallables';
 import { Cache } from './Cache';
 import { URI } from 'vscode-uri';
@@ -361,16 +361,26 @@ export class Scope {
     }
 
     /**
-     * Get the file with the specified pkgPath
+     * Get the file from this scope with the given path.
+     * @param filePath can be a srcPath or pkgPath
+     * @param normalizePath should this function repair and standardize the path? Passing false should have a performance boost if you can guarantee your path is already sanitized
      */
-    public getFile(getFile: string) {
-        getFile = s`${getFile}`;
-        let files = this.getAllFiles();
-        for (let file of files) {
-            if (file.srcPath === getFile) {
-                return file;
-            }
+    public getFile<TFile extends BscFile>(filePath: string, normalizePath = true) {
+        if (typeof filePath !== 'string') {
+            return undefined;
         }
+
+        const key = path.isAbsolute(filePath) ? 'srcPath' : 'pkgPath';
+        let map = this.cache.getOrAdd('fileMaps-srcPath', () => {
+            const result = new Map<string, BscFile>();
+            for (const file of this.getAllFiles()) {
+                result.set(file[key].toLowerCase(), file);
+            }
+            return result;
+        });
+        return map.get(
+            (normalizePath ? util.standardizePath(filePath) : filePath).toLowerCase()
+        ) as TFile;
     }
 
     /**
@@ -398,7 +408,7 @@ export class Scope {
                         result.push(comp.file);
                     }
                 } else {
-                    let file = this.program.getFileByPkgPath(dependency);
+                    let file = this.program.getFile(dependency);
                     if (file) {
                         result.push(file);
                     }

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -61,12 +61,12 @@ describe('XmlScope', () => {
 
     describe('getDefinition', () => {
         it('finds parent file', () => {
-            let parentXmlFile = program.setFile({ src: `${rootDir}/components/parent.xml`, dest: 'components/parent.xml' }, trim`
+            let parentXmlFile = program.setFile('components/parent.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentComponent">
                 </component>
             `);
-            let childXmlFile = program.setFile({ src: `${rootDir}/components/child.xml`, dest: 'components/child.xml' }, trim`
+            let childXmlFile = program.setFile('components/child.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildComponent" extends="ParentComponent">
                 </component>

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -57,7 +57,7 @@ describe('HoverProcessor', () => {
 
         //ignore this for now...it's not a huge deal
         it('does not match on keywords or data types', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main(name as string)
                 end sub
                 sub as()
@@ -70,7 +70,7 @@ describe('HoverProcessor', () => {
         });
 
         it('finds declared function', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 function Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -86,7 +86,7 @@ describe('HoverProcessor', () => {
         });
 
         it('finds variable function hover in same scope', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName = sub(name as string)
                     end sub
@@ -102,7 +102,7 @@ describe('HoverProcessor', () => {
         });
 
         it('finds function hover in file scope', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName()
                 end sub
@@ -124,13 +124,13 @@ describe('HoverProcessor', () => {
                 rootDir: rootDir
             });
 
-            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName()
                 end sub
             `);
 
-            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile('source/lib.brs', `
                 sub sayMyName(name as string)
 
                 end sub

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -776,7 +776,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects using `new` keyword on non-classes', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile('source/main.bs', `
             sub quack()
             end sub
             sub main()
@@ -790,7 +790,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects missing call to super', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 sub new()
                 end sub
@@ -807,7 +807,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it.skip('detects calls to unknown m methods', () => {
-        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 sub new()
                     m.methodThatDoesNotExist()
@@ -914,7 +914,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects duplicate member names', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 public name
                 public name
@@ -944,7 +944,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects mismatched member type in child class', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 public name
             end class
@@ -961,7 +961,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows untyped overridden field in child class', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 public name
             end class
@@ -1009,7 +1009,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods without override keyword', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.brs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 sub speak()
                 end sub
@@ -1026,7 +1026,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('detects overridden methods with different visibility', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -1053,7 +1053,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('allows overridden methods with matching visibility', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
                 sub speakInPublic()
                 end sub
@@ -1190,7 +1190,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports newable class namespace inference', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Duck
                 end class
@@ -1204,7 +1204,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches extending unknown namespaced class', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1219,7 +1219,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('supports omitting namespace prefix for items in same namespace', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1232,7 +1232,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate root-level class declarations', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             class Animal
             end class
             class Animal
@@ -1245,7 +1245,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches duplicate namespace-level class declarations', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Animal
                 end class
@@ -1260,7 +1260,7 @@ describe('BrsFile BrighterScript classes', () => {
     });
 
     it('catches namespaced class name which is the same as a global class', () => {
-        program.setFile({ src: `${rootDir}/source/main.bs`, dest: 'source/main.bs' }, `
+        program.setFile('source/main.bs', `
             namespace NameA.NameB
                 class Animal
                 end class

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -288,7 +288,7 @@ describe('BrsFile', () => {
 
         it('always includes `m`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main()
 
                 end sub
@@ -309,7 +309,7 @@ describe('BrsFile', () => {
 
         it('includes all keywords`', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main()
 
                 end sub
@@ -334,7 +334,7 @@ describe('BrsFile', () => {
 
         it('does not provide completions within a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main()
                     'some comment
                 end sub
@@ -347,7 +347,7 @@ describe('BrsFile', () => {
 
         it('does not provide duplicate entries for variables', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main()
                     name = "bob"
                     age = 12
@@ -365,7 +365,7 @@ describe('BrsFile', () => {
 
         it('does not include `as` and `string` text options when used in function params', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main(name as string)
 
                 end sub
@@ -378,7 +378,7 @@ describe('BrsFile', () => {
 
         it('does not provide intellisense results when inside a comment', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main(name as string)
                     'this is a comment
                 end sub
@@ -390,7 +390,7 @@ describe('BrsFile', () => {
 
         it('does provide intellisence for labels only after a goto keyword', () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
-            program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            program.setFile('source/main.brs', `
                 sub Main(name as string)
                     something:
                     goto \nend sub
@@ -502,7 +502,7 @@ describe('BrsFile', () => {
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {
-                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile('source/main.brs', `
                     sub main()
                         print "hi" 'bs:disable-line: 123456 999999   aaaab
                     end sub
@@ -539,7 +539,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile('source/main.brs', `
                     sub main()
                         'should not have any errors
                         DoSomething(1) 'bs:disable-line:1002
@@ -561,7 +561,7 @@ describe('BrsFile', () => {
                 //the current version of BRS causes parse errors after the `parse` keyword, showing error in comments
                 //the program should ignore all diagnostics found in brs:* comment lines EXCEPT
                 //for the diagnostics about using unknown error codes
-                program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                program.setFile('source/main.brs', `
                     sub main()
                         stop 'bs:disable-line
                         print "need a valid line to fix stop error"
@@ -642,7 +642,7 @@ describe('BrsFile', () => {
         });
 
         it('supports labels and goto statements', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                     'multiple goto statements on one line
                     goto myLabel : goto myLabel
@@ -653,7 +653,7 @@ describe('BrsFile', () => {
         });
 
         it('supports empty print statements', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                    print
                 end sub
@@ -684,7 +684,7 @@ describe('BrsFile', () => {
             });
 
             it('works for upper case keywords', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #CONST someFlag = true
                         #IF someFlag
@@ -700,7 +700,7 @@ describe('BrsFile', () => {
             });
 
             it('supports single-word #elseif and #endif', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -714,7 +714,7 @@ describe('BrsFile', () => {
             });
 
             it('supports multi-word #else if and #end if', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #const someFlag = true
                         #if someFlag
@@ -728,7 +728,7 @@ describe('BrsFile', () => {
             });
 
             it('does not choke on invalid code inside a false conditional compile', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #if false
                             non-commented code here should not cause parse errors
@@ -739,7 +739,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #if', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #if true1
                             print "true"
@@ -752,7 +752,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #if %
                             print "true"
@@ -766,7 +766,7 @@ describe('BrsFile', () => {
             });
 
             it('detects #const name using reserved word', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #const function = true
                     end sub
@@ -778,7 +778,7 @@ describe('BrsFile', () => {
             });
 
             it('detects syntax error in #const', () => {
-                let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                let file = program.setFile('source/main.brs', `
                     sub main()
                         #const someConst = 123
                     end sub
@@ -790,7 +790,7 @@ describe('BrsFile', () => {
         });
 
         it('supports stop statement', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                    stop
                 end sub
@@ -799,7 +799,7 @@ describe('BrsFile', () => {
         });
 
         it('supports single-line if statements', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub main()
                     if 1 < 2: return true: end if
                     if 1 < 2: return true
@@ -1709,7 +1709,7 @@ describe('BrsFile', () => {
     });
 
     it('handles mixed case `then` partions of conditionals', () => {
-        let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        let mainFile = program.setFile('source/main.brs', `
             sub Main()
                 if true then
                     print "works"
@@ -1718,7 +1718,7 @@ describe('BrsFile', () => {
         `);
 
         expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
-        mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        mainFile = program.setFile('source/main.brs', `
             sub Main()
                 if true Then
                     print "works"
@@ -1727,7 +1727,7 @@ describe('BrsFile', () => {
         `);
         expect(mainFile.getDiagnostics()).to.be.lengthOf(0);
 
-        mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        mainFile = program.setFile('source/main.brs', `
             sub Main()
                 if true THEN
                     print "works"
@@ -1739,7 +1739,7 @@ describe('BrsFile', () => {
 
     describe('getHover', () => {
         it('works for param types', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub DoSomething(name as string)
                     name = 1
                     sayMyName = function(name as string)
@@ -1760,7 +1760,7 @@ describe('BrsFile', () => {
 
         //ignore this for now...it's not a huge deal
         it('does not match on keywords or data types', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main(name as string)
                 end sub
                 sub as()
@@ -1773,7 +1773,7 @@ describe('BrsFile', () => {
         });
 
         it('finds declared function', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 function Main(count = 1)
                     firstName = "bob"
                     age = 21
@@ -1793,7 +1793,7 @@ describe('BrsFile', () => {
         });
 
         it('finds declared namespace function', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
             namespace mySpace
                 function Main(count = 1)
                     firstName = "bob"
@@ -1815,7 +1815,7 @@ describe('BrsFile', () => {
         });
 
         it('finds variable function hover in same scope', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName = sub(name as string)
                     end sub
@@ -1868,7 +1868,7 @@ describe('BrsFile', () => {
         });
 
         it('finds function hover in file scope', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName()
                 end sub
@@ -1889,7 +1889,7 @@ describe('BrsFile', () => {
         });
 
         it('finds namespace function hover in file scope', () => {
-            let file = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let file = program.setFile('source/main.brs', `
                 namespace mySpace
                 sub Main()
                     sayMyName()
@@ -1917,13 +1917,13 @@ describe('BrsFile', () => {
                 rootDir: rootDir
             });
 
-            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     sayMyName()
                 end sub
             `);
 
-            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile('source/lib.brs', `
                 sub sayMyName(name as string)
 
                 end sub
@@ -1946,13 +1946,13 @@ describe('BrsFile', () => {
                 rootDir: rootDir
             });
 
-            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     mySpace.sayMyName()
                 end sub
             `);
 
-            program.setFile({ src: `${rootDir}/source/lib.brs`, dest: 'source/lib.brs' }, `
+            program.setFile('source/lib.brs', `
                 namespace mySpace
                     sub sayMyName(name as string)
                     end sub
@@ -2024,7 +2024,7 @@ describe('BrsFile', () => {
         });
 
         it('handles mixed case `then` partions of conditionals', () => {
-            let mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            let mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     if true then
                         print "works"
@@ -2033,7 +2033,7 @@ describe('BrsFile', () => {
             `);
 
             expectZeroDiagnostics(mainFile);
-            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     if true Then
                         print "works"
@@ -2042,7 +2042,7 @@ describe('BrsFile', () => {
             `);
             expectZeroDiagnostics(mainFile);
 
-            mainFile = program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+            mainFile = program.setFile('source/main.brs', `
                 sub Main()
                     if true THEN
                         print "works"
@@ -2054,7 +2054,7 @@ describe('BrsFile', () => {
     });
 
     it('does not throw when encountering incomplete import statement', () => {
-        program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+        program.setFile('source/main.brs', `
             import
             sub main()
             end sub
@@ -2854,7 +2854,7 @@ describe('BrsFile', () => {
                 name: 'transform callback',
                 afterFileParse: onParsed
             });
-            file = program.setFile({ src: `absolute_path/file${ext}`, dest: `relative_path/file${ext}` }, `
+            file = program.setFile(`source/file${ext}`, `
                 sub Sum()
                     print "hello world"
                 end sub

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -88,7 +88,7 @@ describe('XmlFile', () => {
         });
 
         it('supports importing BrighterScript files', () => {
-            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile('components/custom.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.bs" />
@@ -99,7 +99,7 @@ describe('XmlFile', () => {
             );
         });
         it('does not include commented-out script imports', () => {
-            file = program.setFile({ src: `${rootDir}/components/custom.xml`, dest: 'components/custom.xml' }, trim`
+            file = program.setFile('components/custom.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ChildScene" extends="Scene">
                     <script type="text/brightscript" uri="ChildScene.brs" />
@@ -262,10 +262,7 @@ describe('XmlFile', () => {
         });
 
         it('resolves relative paths', () => {
-            file = program.setFile({
-                src: `${rootDir}/components/comp1.xml`,
-                dest: 'components/comp1.xml'
-            }, trim`
+            file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Cmp1" extends="Scene">
                     <script type="text/brightscript" uri="cmp1.brs" />
@@ -279,10 +276,7 @@ describe('XmlFile', () => {
         });
 
         it('finds correct position for empty uri in script tag', () => {
-            file = program.setFile({
-                src: `${rootDir}/components/comp1.xml`,
-                dest: 'components/comp1.xml'
-            }, trim`
+            file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Cmp1" extends="Scene">
                     <script type="text/brightscript" uri="" />
@@ -297,38 +291,32 @@ describe('XmlFile', () => {
 
     describe('doesReferenceFile', () => {
         it('compares case insensitive', () => {
-            let xmlFile = program.setFile({
-                src: `${rootDir}/components/comp1.xml`,
-                dest: 'components/comp1.xml'
-            }, trim`
+            let xmlFile = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Cmp1" extends="Scene">
                     <script type="text/brightscript" uri="HeroGrid.brs" />
                 </component>
             `);
-            let brsFile = program.setFile({
-                src: `${rootDir}/components/HEROGRID.brs`,
-                dest: `components/HEROGRID.brs`
-            }, ``);
+            let brsFile = program.setFile(`components/HEROGRID.brs`, ``);
             expect((xmlFile as XmlFile).doesReferenceFile(brsFile)).to.be.true;
         });
     });
 
     describe('autoImportComponentScript', () => {
         it('is not enabled by default', () => {
-            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile('components/lib.brs', `
                 function libFunc()
                 end function
             `);
 
-            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile('components/comp1.bs', `
                 function init()
                     libFunc()
                 end function
@@ -345,19 +333,19 @@ describe('XmlFile', () => {
                 rootDir: rootDir,
                 autoImportComponentScript: true
             });
-            program.setFile({ src: `${rootDir}/components/comp1.xml`, dest: 'components/comp1.xml' }, trim`
+            program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./lib.brs" />
                 </component>
             `);
 
-            program.setFile({ src: `${rootDir}/components/lib.brs`, dest: 'components/lib.brs' }, `
+            program.setFile('components/lib.brs', `
                 function libFunc()
                 end function
             `);
 
-            program.setFile({ src: `${rootDir}/components/comp1.bs`, dest: 'components/comp1.bs' }, `
+            program.setFile('components/comp1.bs', `
                 function init()
                     libFunc()
                 end function
@@ -394,15 +382,15 @@ describe('XmlFile', () => {
         });
 
         it('returns empty set when out of range', () => {
-            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile('components/component1.brs', ``);
             expect(file.getCompletions(Position.create(99, 99))).to.be.empty;
         });
 
         //TODO - refine this test once cdata scripts are supported
         it('prevents scope completions entirely', () => {
-            program.setFile({ src: `${rootDir}/components/Component1.brs`, dest: 'components/component1.brs' }, ``);
+            program.setFile('components/component1.brs', ``);
 
-            let xmlFile = program.setFile({ src: `${rootDir}/components/Component1.xml`, dest: 'components/component1.xml' }, trim`
+            let xmlFile = program.setFile('components/component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="ParentScene" extends="GrandparentScene">
                     <script type="text/brightscript" uri="./Component1.brs" />
@@ -444,20 +432,14 @@ describe('XmlFile', () => {
         expect(scope.isValidated);
 
         //add lib1
-        program.setFile({
-            src: `${rootDir}/source/lib.bs`,
-            dest: `source/lib.bs`
-        }, ``);
+        program.setFile(`source/lib.bs`, ``);
         //adding a dependent file should have invalidated the scope
         expect(scope.isValidated).to.be.false;
         program.validate();
         expect(scope.isValidated).to.be.true;
 
         //update lib1 to include an import
-        program.setFile({
-            src: `${rootDir}/source/lib.bs`,
-            dest: `source/lib.bs`
-        }, `
+        program.setFile(`source/lib.bs`, `
             import "lib2.bs"
         `);
 
@@ -467,10 +449,7 @@ describe('XmlFile', () => {
         expect(scope.isValidated).to.be.true;
 
         //add the lib2 imported from lib
-        program.setFile({
-            src: `${rootDir}/source/lib2.bs`,
-            dest: `source/lib2.bs`
-        }, ``);
+        program.setFile(`source/lib2.bs`, ``);
 
         //scope should have been invalidated again because of chained dependency
         expect(scope.isValidated).to.be.false;
@@ -507,10 +486,7 @@ describe('XmlFile', () => {
         expect(program.getScopesForFile(xmlFile2)[0].isValidated).to.be.true;
 
         //add the lib file
-        program.setFile({
-            src: `${rootDir}/source/lib.brs`,
-            dest: `source/lib.brs`
-        }, ``);
+        program.setFile(`source/lib.brs`, ``);
         expect(program.getScopesForFile(xmlFile1)[0].isValidated).to.be.false;
         expect(program.getScopesForFile(xmlFile2)[0].isValidated).to.be.true;
     });
@@ -596,14 +572,8 @@ describe('XmlFile', () => {
             autoImportComponentScript: true,
             rootDir: rootDir
         });
-        program.setFile({
-            src: `${rootDir}/components/SimpleScene.bs`,
-            dest: `components/SimpleScene.bs`
-        }, '');
-        program.setFile({
-            src: `${rootDir}/components/SimpleScene.xml`,
-            dest: `components/SimpleScene.xml`
-        }, trim`
+        program.setFile(`components/SimpleScene.bs`, '');
+        program.setFile(`components/SimpleScene.xml`, trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="SimpleScene" extends="Scene">
                 <script type="text/brighterscript" uri="SimpleScene.bs" />
@@ -866,8 +836,7 @@ describe('XmlFile', () => {
         });
 
         it('returns the XML unmodified if needsTranspiled is false', () => {
-            let file = program.setFile(
-                { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
+            let file = program.setFile('components/SimpleScene.xml',
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <!-- should stay as-is -->
@@ -887,8 +856,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is false by default', () => {
-            let file = program.setFile(
-                { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
+            let file = program.setFile('components/SimpleScene.xml',
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene" >
@@ -898,8 +866,7 @@ describe('XmlFile', () => {
         });
 
         it('needsTranspiled is true if an import is brighterscript', () => {
-            let file = program.setFile(
-                { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
+            let file = program.setFile('components/SimpleScene.xml',
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene" >
@@ -911,8 +878,7 @@ describe('XmlFile', () => {
 
         it('simple source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.setFile(
-                { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
+            let file = program.setFile('components/SimpleScene.xml',
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">
@@ -926,8 +892,7 @@ describe('XmlFile', () => {
 
         it('AST-based source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
-            let file = program.setFile(
-                { src: s`${rootDir}/components/SimpleScene.xml`, dest: 'components/SimpleScene.xml' },
+            let file = program.setFile('components/SimpleScene.xml',
                 trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="SimpleScene" extends="Scene">

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -177,19 +177,19 @@ describe('import statements', () => {
 
     it('adds brs imports to xml file during transpile', () => {
         //create child component
-        let component = program.setFile({ src: s`${rootDir}/components/ChildScene.xml`, dest: 'components/ChildScene.xml' }, trim`
+        let component = program.setFile('components/ChildScene.xml', trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="pkg:/source/lib.bs" />
             </component>
         `);
-        program.setFile({ src: s`${rootDir}/source/lib.bs`, dest: 'source/lib.bs' }, `
+        program.setFile('source/lib.bs', `
             import "stringOps.brs"
             function toLower(strVal as string)
                 return StringToLower(strVal)
             end function
         `);
-        program.setFile({ src: s`${rootDir}/source/stringOps.brs`, dest: 'source/stringOps.brs' }, `
+        program.setFile('source/stringOps.brs', `
             function StringToLower(strVal as string)
                 return isInt(strVal)
             end function


### PR DESCRIPTION
- Eliminate the `{src;dest}` object structure in most unit tests since the `src` and `dest` never change. Instead, favor passing in the relative-to-rootdir path (i.e. the `pkgPath`). 
- improve the performance and flexibility of `Scope.getFile()`. (All the benchmarks seem to show no improvement, but it was still a good refactor)

