### PR TITLE
Unit test cleanup

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -15,11 +15,10 @@ import * as assert from 'assert';
 import { expectZeroDiagnostics, trim } from './testHelpers.spec';
 import { isBrsFile, isLiteralString } from './astUtils/reflection';
 import { createVisitor, WalkMode } from './astUtils/visitors';
+import { tempDir, rootDir } from './testHelpers.spec';
 
 const sinon = createSandbox();
 
-const tempDir = s`${__dirname}/../.tmp`;
-const rootDir = s`${tempDir}/TestApp`;
 const workspacePath = rootDir;
 
 describe('LanguageServer', () => {
@@ -138,7 +137,7 @@ describe('LanguageServer', () => {
 
     describe('createStandaloneFileProject', () => {
         it('never returns undefined', async () => {
-            let filePath = `${rootDir}/.tmp/main.brs`;
+            let filePath = `${rootDir}/main.brs`;
             writeToFs(filePath, `sub main(): return: end sub`);
             let firstProject = await server['createStandaloneFileProject'](filePath);
             let secondProject = await server['createStandaloneFileProject'](filePath);
@@ -146,7 +145,7 @@ describe('LanguageServer', () => {
         });
 
         it('filters out certain diagnostics', async () => {
-            let filePath = `${rootDir}/.tmp/main.brs`;
+            let filePath = `${rootDir}/main.brs`;
             writeToFs(filePath, `sub main(): return: end sub`);
             let firstProject: Project = await server['createStandaloneFileProject'](filePath);
             expectZeroDiagnostics(firstProject.builder.program);

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -13,21 +13,18 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import { BrsFile } from './files/BrsFile';
 import { expectZeroDiagnostics } from './testHelpers.spec';
 import type { BsConfig } from './BsConfig';
+import { tempDir, rootDir, stagingDir } from './testHelpers.spec';
 
 describe('ProgramBuilder', () => {
 
-    let tmpPath = s`${process.cwd()}/.tmp`;
-    let rootDir = s`${tmpPath}/rootDir`;
-    let stagingFolderPath = s`${tmpPath}/staging`;
-
     beforeEach(() => {
         fsExtra.ensureDirSync(rootDir);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.emptyDirSync(tempDir);
     });
     afterEach(() => {
         sinon.restore();
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
     });
 
     let builder: ProgramBuilder;
@@ -167,13 +164,13 @@ describe('ProgramBuilder', () => {
             builder1.run({
                 logLevel: LogLevel.info,
                 rootDir: rootDir,
-                stagingFolderPath: stagingFolderPath,
+                stagingFolderPath: stagingDir,
                 watch: false
             }),
             builder2.run({
                 logLevel: LogLevel.error,
                 rootDir: rootDir,
-                stagingFolderPath: stagingFolderPath,
+                stagingFolderPath: stagingDir,
                 watch: false
             })
         ]);
@@ -284,9 +281,9 @@ describe('ProgramBuilder', () => {
 
     describe('require', () => {
         it('loads relative and absolute items', async () => {
-            const workingDir = s`${tmpPath}/require-test`;
-            const relativeOutputPath = `${tmpPath}/relative.txt`.replace(/\\+/g, '/');
-            const moduleOutputPath = `${tmpPath}/brighterscript-require-test.txt`.replace(/\\+/g, '/');
+            const workingDir = s`${tempDir}/require-test`;
+            const relativeOutputPath = `${tempDir}/relative.txt`.replace(/\\+/g, '/');
+            const moduleOutputPath = `${tempDir}/brighterscript-require-test.txt`.replace(/\\+/g, '/');
 
             //create roku project files
             fsExtra.outputFileSync(s`${workingDir}/src/manifest`, '');

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -5,8 +5,8 @@ import type { BscFile } from '../../interfaces';
 import { Program } from '../../Program';
 import { expectCodeActions, trim } from '../../testHelpers.spec';
 import { standardizePath as s, util } from '../../util';
+import { rootDir } from '../../testHelpers.spec';
 
-const rootDir = s`${process.cwd()}/.tmp/rootDir`;
 describe('CodeActionsProcessor', () => {
     let program: Program;
     beforeEach(() => {

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { Program } from '../../Program';
-import util, { standardizePath as s } from '../../util';
+import { util } from '../../util';
 import { createSandbox } from 'sinon';
+import { rootDir } from '../../testHelpers.spec';
 let sinon = createSandbox();
 
-let rootDir = s`${process.cwd()}/.tmp/rootDir`;
 const fence = (code: string) => util.mdFence(code, 'brightscript');
 
 describe('HoverProcessor', () => {

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -4,9 +4,9 @@ import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, SemanticToken } from '../../interfaces';
 import { Program } from '../../Program';
 import { expectZeroDiagnostics } from '../../testHelpers.spec';
-import { standardizePath as s, util } from '../../util';
+import { util } from '../../util';
+import { rootDir } from '../../testHelpers.spec';
 
-const rootDir = s`${process.cwd()}/.tmp/rootDir`;
 
 describe('BrsFileSemanticTokensProcessor', () => {
     let program: Program;

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.spec.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.spec.ts
@@ -2,11 +2,11 @@ import { createSandbox } from 'sinon';
 import * as fsExtra from 'fs-extra';
 import { Program } from '../../Program';
 import { standardizePath as s } from '../../util';
+import { tempDir, rootDir } from '../../testHelpers.spec';
 const sinon = createSandbox();
 
 describe('BrsFile', () => {
-    const tempDir = s`${process.cwd()}/.tmp`;
-    const rootDir = s`${tempDir}/rootDir`;
+
     let program: Program;
 
     beforeEach(() => {

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -12,27 +12,24 @@ import * as fsExtra from 'fs-extra';
 import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { doesNotThrow } from 'assert';
 import type { MethodStatement } from '../parser/Statement';
+import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
 
 describe('BrsFile BrighterScript classes', () => {
-    let tmpPath = s`${process.cwd()}/.tmp`;
-    let rootDir = s`${tmpPath}/rootDir`;
-    const stagingDir = s`${tmpPath}/staging`;
-
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
         fsExtra.ensureDirSync(rootDir);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.emptyDirSync(tempDir);
         program = new Program({ rootDir: rootDir, stagingFolderPath: stagingDir });
     });
     afterEach(() => {
         sinon.restore();
         program.dispose();
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
     });
 
     function addFile(relativePath: string, text: string) {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -24,12 +24,11 @@ import { createToken } from '../astUtils/creators';
 import * as fsExtra from 'fs-extra';
 import { URI } from 'vscode-uri';
 import undent from 'undent';
+import { tempDir, rootDir } from '../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
 
 describe('BrsFile', () => {
-    let tempDir = s`${process.cwd()}/.tmp`;
-    let rootDir = s`${tempDir}/rootDir`;
     let program: Program;
     let srcPath = s`${rootDir}/source/main.brs`;
     let destPath = 'source/main.brs';

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -14,11 +14,9 @@ import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimM
 import { ProgramBuilder } from '../ProgramBuilder';
 import { LogLevel } from '../Logger';
 import { isXmlFile } from '../astUtils/reflection';
+import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
 
 describe('XmlFile', () => {
-    const tempDir = s`${process.cwd()}/.tmp`;
-    const rootDir = s`${tempDir}/rootDir`;
-    const stagingDir = s`${tempDir}/stagingDir`;
 
     let program: Program;
     let sinon = sinonImport.createSandbox();
@@ -26,7 +24,6 @@ describe('XmlFile', () => {
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
-        fsExtra.ensureDirSync(tempDir);
         fsExtra.emptyDirSync(tempDir);
         fsExtra.ensureDirSync(rootDir);
         fsExtra.ensureDirSync(stagingDir);

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -7,28 +7,26 @@ import { standardizePath as s } from '../../util';
 import type { XmlFile } from '../XmlFile';
 import type { BrsFile } from '../BrsFile';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../../testHelpers.spec';
+import { tempDir, rootDir, stagingDir } from '../../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
-let tmpPath = s`${process.cwd()}/.tmp`;
-let rootDir = s`${tmpPath}/rootDir`;
-let stagingFolderPath = s`${tmpPath}/staging`;
 
 describe('import statements', () => {
     let program: Program;
     const testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingFolderPath
+            stagingFolderPath: stagingDir
         });
     });
     afterEach(() => {
         sinon.restore();
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
         program.dispose();
     });
 
@@ -59,9 +57,9 @@ describe('import statements', () => {
                 dest: x.pkgPath
             };
         });
-        await program.transpile(files, stagingFolderPath);
+        await program.transpile(files, stagingDir);
         expect(
-            trimMap(fsExtra.readFileSync(`${stagingFolderPath}/components/ChildScene.xml`).toString())
+            trimMap(fsExtra.readFileSync(`${stagingDir}/components/ChildScene.xml`).toString())
         ).to.equal(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="Scene">

--- a/src/files/tests/optionalChaning.spec.ts
+++ b/src/files/tests/optionalChaning.spec.ts
@@ -1,30 +1,27 @@
 import * as sinonImport from 'sinon';
 import * as fsExtra from 'fs-extra';
 import { Program } from '../../Program';
-import { standardizePath as s } from '../../util';
 import { getTestTranspile } from '../../testHelpers.spec';
+import { tempDir, rootDir, stagingDir } from '../../testHelpers.spec';
 
 let sinon = sinonImport.createSandbox();
-let tmpPath = s`${process.cwd()}/.tmp`;
-let rootDir = s`${tmpPath}/rootDir`;
-let stagingFolderPath = s`${tmpPath}/staging`;
 
 describe('optional chaining', () => {
     let program: Program;
     const testTranspile = getTestTranspile(() => [program, rootDir]);
 
     beforeEach(() => {
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingFolderPath
+            stagingFolderPath: stagingDir
         });
     });
     afterEach(() => {
         sinon.restore();
-        fsExtra.ensureDirSync(tmpPath);
-        fsExtra.emptyDirSync(tmpPath);
+        fsExtra.ensureDirSync(tempDir);
+        fsExtra.emptyDirSync(tempDir);
         program.dispose();
     });
 

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -1,19 +1,15 @@
-import util, { standardizePath as s } from './util';
+import { util } from './util';
 import { Program } from './Program';
-import { expectDiagnostics, expectZeroDiagnostics } from './testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics, rootDir, stagingDir } from './testHelpers.spec';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { expect } from 'chai';
-
-let tmpPath = s`${process.cwd()}/.tmp`;
-let rootDir = s`${tmpPath}/rootDir`;
-let stagingFolderPath = s`${tmpPath}/staging`;
 
 describe('globalCallables', () => {
     let program: Program;
     beforeEach(() => {
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingFolderPath
+            stagingFolderPath: stagingDir
         });
     });
     afterEach(() => {

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -1,14 +1,11 @@
-import { standardizePath as s, util } from '../util';
+import { util } from '../util';
 import * as fsExtra from 'fs-extra';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
 import { expect } from 'chai';
 import type { DottedGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
-
-let tempDir = s`${process.cwd()}/.tmp`;
-let rootDir = s`${tempDir}/rootDir`;
-let stagingDir = s`${tempDir}/staging`;
+import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
 
 describe('Program', () => {
     let program: Program;

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -3,15 +3,14 @@ import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { expectZeroDiagnostics, trim } from '../testHelpers.spec';
 import SGParser from './SGParser';
-import { standardizePath as s } from '../util';
 import { createSandbox } from 'sinon';
 import { Program } from '../Program';
 import type { XmlFile } from '../files/XmlFile';
+import { rootDir } from '../testHelpers.spec';
 
 let sinon = createSandbox();
 describe('SGParser', () => {
 
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
 
     beforeEach(() => {

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -5,11 +5,10 @@ import { ParseMode, Parser } from './Parser';
 import { WalkMode } from '../astUtils/visitors';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { Program } from '../Program';
-import * as path from 'path';
 import { trim } from '../testHelpers.spec';
 import type { BrsFile } from '../files/BrsFile';
+import { tempDir } from '../testHelpers.spec';
 
-const tempDir = path.join(process.cwd(), '.tmp');
 describe('Statement', () => {
     let program: Program;
     beforeEach(() => {

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -1,5 +1,5 @@
 import { expectCompletionsIncludes, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
-import util, { standardizePath as s } from '../../../util';
+import { util } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
 import { ParseMode, Parser } from '../../Parser';
@@ -8,11 +8,11 @@ import type { ConstStatement } from '../../Statement';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { LiteralExpression } from '../../Expression';
 import { CompletionItemKind } from 'vscode-languageserver-protocol';
+import { rootDir } from '../../../testHelpers.spec';
 
 const sinon = createSandbox();
 
 describe('ConstStatement', () => {
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
     let parser: Parser;
     let testTranspile = getTestTranspile(() => [program, rootDir]);

--- a/src/parser/tests/statement/Continue.spec.ts
+++ b/src/parser/tests/statement/Continue.spec.ts
@@ -5,12 +5,11 @@ import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { Program } from '../../../Program';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
-import { standardizePath as s } from '../../../util';
+import { rootDir } from '../../../testHelpers.spec';
 import type { BrsFile } from '../../../files/BrsFile';
 const sinon = createSandbox();
 
 describe('parser continue statements', () => {
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -12,11 +12,11 @@ import { CancellationTokenSource, CompletionItemKind } from 'vscode-languageserv
 import { WalkMode } from '../../../astUtils/visitors';
 import { isEnumStatement } from '../../../astUtils/reflection';
 import { URI } from 'vscode-uri';
+import { rootDir } from '../../../testHelpers.spec';
 
 const sinon = createSandbox();
 
 describe('EnumStatement', () => {
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 

--- a/src/parser/tests/statement/For.spec.ts
+++ b/src/parser/tests/statement/For.spec.ts
@@ -1,13 +1,11 @@
-
-import { standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
 import { getTestTranspile } from '../../../testHelpers.spec';
+import { rootDir } from '../../../testHelpers.spec';
 
 const sinon = createSandbox();
 
 describe('ForStatement', () => {
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 

--- a/src/parser/tests/statement/ForEach.spec.ts
+++ b/src/parser/tests/statement/ForEach.spec.ts
@@ -1,5 +1,5 @@
 
-import { standardizePath as s } from '../../../util';
+import { rootDir } from '../../../testHelpers.spec';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
 import { getTestTranspile } from '../../../testHelpers.spec';
@@ -7,7 +7,6 @@ import { getTestTranspile } from '../../../testHelpers.spec';
 const sinon = createSandbox();
 
 describe('ForEachStatement', () => {
-    let rootDir = s`${process.cwd()}/.tmp/rootDir`;
     let program: Program;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
 

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -1,8 +1,6 @@
 import { expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
-import { standardizePath as s } from '../../../util';
+import { rootDir } from '../../../testHelpers.spec';
 import { Program } from '../../../Program';
-
-const rootDir = s`${process.cwd()}/.tmp/rootDir`;
 
 describe('InterfaceStatement', () => {
     let program: Program;

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -4,10 +4,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { Program } from '../../../Program';
-import { standardizePath as s } from '../../../util';
+import { rootDir } from '../../../testHelpers.spec';
 import { getTestTranspile } from '../../../testHelpers.spec';
-
-const rootDir = s`${process.cwd()}/.tmp/rootDir`;
 
 describe('parser print statements', () => {
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -14,6 +14,10 @@ import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';
 import undent from 'undent';
 
+export const tempDir = s`${__dirname}/../.tmp`;
+export const rootDir = s`${tempDir}/rootDir`;
+export const stagingDir = s`${tempDir}/stagingDir`;
+
 export const trim = undent;
 
 type DiagnosticCollection = { getDiagnostics(): Array<Diagnostic> } | { diagnostics: Diagnostic[] } | Diagnostic[];

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -6,9 +6,10 @@ import type { BsConfig } from './BsConfig';
 import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { DiagnosticMessages } from './DiagnosticMessages';
+import { tempDir, rootDir } from './testHelpers.spec';
+
 const sinon = createSandbox();
-let tempDir = s`${process.cwd()}/.tmp`;
-let rootDir = s`${tempDir}/rootDir`;
+
 let cwd = process.cwd();
 
 describe('util', () => {


### PR DESCRIPTION
Centralize all unit test paths.
Rename tmpDir to tempDir in tests.
Rename stagingFolderPath to stagingDir in tests.