### PR TITLE
Migrate to `stagingDir` away from `stagingFolder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ These are the options available in the `bsconfig.json` file.
 
  - **rootDir**: `string` - The root directory of your roku project. Defaults to current directory
 
- - **stagingFolderPath**: `string` - the folder where the transpiled files are placed. Defaults to `./out/.roku-deploy-staging`
+ - **stagingDir**: `string` - the folder where the transpiled files are placed. Defaults to `./out/.roku-deploy-staging`
+
+ - **retainStagingDir**: `boolean` - Prevent the staging folder from being deleted after creating the package. Defaults to `false` meaning the dir is deleted every time.
 
  - **files**: ` (string | string[] | { src: string | string[]; dest?: string })[]` - The list file globs used to find all files for the project. If using the {src;dest;} format, you can specify a different destination directory for the matched files in src.
 

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -105,13 +105,24 @@
             "description": " The password to use when deploying to a Roku device",
             "type": "string"
         },
-        "retainStagingFolder": {
+        "retainStagingDir": {
             "type": "boolean",
             "description": "Prevent the staging folder from being deleted after the deployment package is created.  This is helpful for troubleshooting why your package isn't being created the way you expected.",
             "default": false
         },
+        "retainStagingFolder": {
+            "type": "boolean",
+            "deprecated": true,
+            "description": "Prevent the staging folder from being deleted after the deployment package is created.  This is helpful for troubleshooting why your package isn't being created the way you expected.",
+            "default": false
+        },
+        "stagingDir": {
+            "type": "string",
+            "description": "The path to the staging folder (where all files are copied before creating the zip package)"
+        },
         "stagingFolderPath": {
             "type": "string",
+            "deprecated": true,
             "description": "The path to the staging folder (where all files are copied before creating the zip package)"
         },
         "ignoreErrorCodes": {

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -81,10 +81,23 @@ export interface BsConfig {
      * Prevent the staging folder from being deleted after creating the package
      * @default false
      */
+    retainStagingDir?: boolean;
+
+    /**
+     * Prevent the staging folder from being deleted after creating the package
+     * @default false
+     * @deprecated use `retainStagingDir` instead
+     */
     retainStagingFolder?: boolean;
 
     /**
+     * The path to the staging directory (wehre the output files are copied immediately before creating the zip)
+     */
+    stagingDir?: string;
+
+    /**
      * The path to the staging folder (where all files are copied to right before creating the zip package)
+     * @deprecated use `stagingDir` instead
      */
     stagingFolderPath?: string;
 

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -34,7 +34,7 @@ describe('Program', () => {
         fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingDir
+            stagingDir: stagingDir
         });
         program.createSourceScope(); //ensure source scope is created
     });
@@ -1710,19 +1710,19 @@ describe('Program', () => {
     });
 
     it('does not create map by default', async () => {
-        fsExtra.ensureDirSync(program.options.stagingFolderPath);
+        fsExtra.ensureDirSync(program.options.stagingDir);
         program.setFile('source/main.brs', `
             sub main()
             end sub
         `);
         program.validate();
-        await program.transpile([], program.options.stagingFolderPath);
+        await program.transpile([], program.options.stagingDir);
         expect(fsExtra.pathExistsSync(s`${stagingDir}/source/main.brs`)).is.true;
         expect(fsExtra.pathExistsSync(s`${stagingDir}/source/main.brs.map`)).is.false;
     });
 
     it('creates sourcemap for brs and xml files', async () => {
-        fsExtra.ensureDirSync(program.options.stagingFolderPath);
+        fsExtra.ensureDirSync(program.options.stagingDir);
         program.setFile('source/main.brs', `
             sub main()
             end sub
@@ -1745,17 +1745,17 @@ describe('Program', () => {
             dest: s`components/comp1.xml`
         }];
         program.options.sourceMap = true;
-        await program.transpile(filePaths, program.options.stagingFolderPath);
+        await program.transpile(filePaths, program.options.stagingDir);
 
         expect(fsExtra.pathExistsSync(s`${stagingDir}/source/main.brs.map`)).is.true;
         expect(fsExtra.pathExistsSync(s`${stagingDir}/components/comp1.xml.map`)).is.true;
     });
 
     it('copies the bslib.brs file', async () => {
-        fsExtra.ensureDirSync(program.options.stagingFolderPath);
+        fsExtra.ensureDirSync(program.options.stagingDir);
         program.validate();
 
-        await program.transpile([], program.options.stagingFolderPath);
+        await program.transpile([], program.options.stagingDir);
 
         expect(fsExtra.pathExistsSync(s`${stagingDir}/source/bslib.brs`)).is.true;
     });
@@ -1981,7 +1981,7 @@ describe('Program', () => {
                     print SOURCE_LINE_NUM
                 end sub
             `);
-            await program.transpile([], program.options.stagingFolderPath);
+            await program.transpile([], program.options.stagingDir);
             expect(trimMap(
                 fsExtra.readFileSync(s`${stagingDir}/source/logger.brs`).toString()
             )).to.eql(trim`
@@ -1997,7 +1997,7 @@ describe('Program', () => {
                     print "logInfo"
                 end sub
             `);
-            await program.transpile([], program.options.stagingFolderPath);
+            await program.transpile([], program.options.stagingDir);
             expect(trimMap(
                 fsExtra.readFileSync(s`${stagingDir}/source/logger.brs`).toString()
             )).to.eql(trim`
@@ -2013,7 +2013,7 @@ describe('Program', () => {
                 <component name="Component1" extends="Scene">
                 </component>
             `);
-            await program.transpile([], program.options.stagingFolderPath);
+            await program.transpile([], program.options.stagingDir);
             expect(trimMap(
                 fsExtra.readFileSync(s`${stagingDir}/components/Component1.xml`).toString()
             )).to.eql(trim`
@@ -2028,7 +2028,7 @@ describe('Program', () => {
             let sourceRoot = s`${tempDir}/sourceRootFolder`;
             program = new Program({
                 rootDir: rootDir,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });
@@ -2054,7 +2054,7 @@ describe('Program', () => {
             let sourceRoot = s`${tempDir}/sourceRootFolder`;
             program = new Program({
                 rootDir: rootDir,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 sourceRoot: sourceRoot,
                 sourceMap: true
             });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1337,7 +1337,7 @@ export class Program {
                 filteredFileMap.push(fileEntry);
             }
         }
-        const { entries, astEditor } = this.beforeProgramTranspile(fileMap, this.options.stagingFolderPath);
+        const { entries, astEditor } = this.beforeProgramTranspile(fileMap, this.options.stagingDir);
         const result = this._getTranspiledFileContents(
             this.getFile(filePath)
         );
@@ -1397,7 +1397,7 @@ export class Program {
         };
     }
 
-    private beforeProgramTranspile(fileEntries: FileObj[], stagingFolderPath: string) {
+    private beforeProgramTranspile(fileEntries: FileObj[], stagingDir: string) {
         // map fileEntries using their path as key, to avoid excessive "find()" operations
         const mappedFileEntries = fileEntries.reduce<Record<string, FileObj>>((collection, entry) => {
             collection[s`${entry.src}`] = entry;
@@ -1417,7 +1417,7 @@ export class Program {
             //replace the file extension
             let outputPath = filePathObj.dest.replace(/\.bs$/gi, '.brs');
             //prepend the staging folder path
-            outputPath = s`${stagingFolderPath}/${outputPath}`;
+            outputPath = s`${stagingDir}/${outputPath}`;
             return outputPath;
         };
 
@@ -1438,8 +1438,8 @@ export class Program {
         };
     }
 
-    public async transpile(fileEntries: FileObj[], stagingFolderPath: string) {
-        const { entries, getOutputPath, astEditor } = this.beforeProgramTranspile(fileEntries, stagingFolderPath);
+    public async transpile(fileEntries: FileObj[], stagingDir: string) {
+        const { entries, getOutputPath, astEditor } = this.beforeProgramTranspile(fileEntries, stagingDir);
 
         const processedFiles = new Set<string>();
 
@@ -1480,7 +1480,7 @@ export class Program {
 
         //if there's no bslib file already loaded into the program, copy it to the staging directory
         if (!this.getFile(bslibAliasedRokuModulesPkgPath) && !this.getFile(s`source/bslib.brs`)) {
-            promises.push(util.copyBslibToStaging(stagingFolderPath));
+            promises.push(util.copyBslibToStaging(stagingDir));
         }
         await Promise.all(promises);
 

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -164,13 +164,13 @@ describe('ProgramBuilder', () => {
             builder1.run({
                 logLevel: LogLevel.info,
                 rootDir: rootDir,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 watch: false
             }),
             builder2.run({
                 logLevel: LogLevel.error,
                 rootDir: rootDir,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 watch: false
             })
         ]);
@@ -180,10 +180,10 @@ describe('ProgramBuilder', () => {
         expect(builder2.logger.logLevel).to.equal(LogLevel.error);
     });
 
-    it('does not error when loading stagingFolderPath from bsconfig.json', async () => {
+    it('does not error when loading stagingDir from bsconfig.json', async () => {
         fsExtra.ensureDirSync(rootDir);
         fsExtra.writeFileSync(`${rootDir}/bsconfig.json`, `{
-            "stagingFolderPath": "./out"
+            "stagingDir": "./out"
         }`);
         let builder = new ProgramBuilder();
         await builder.run({

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -424,7 +424,7 @@ export class ProgramBuilder {
 
         await this.logger.time(LogLevel.log, ['Transpiling'], async () => {
             //transpile any brighterscript files
-            await this.program.transpile(fileMap, options.stagingFolderPath);
+            await this.program.transpile(fileMap, options.stagingDir);
         });
 
         this.plugins.emit('afterPublish', this, fileMap);

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -23,7 +23,7 @@ describe('BrsFile BrighterScript classes', () => {
     beforeEach(() => {
         fsExtra.ensureDirSync(rootDir);
         fsExtra.emptyDirSync(tempDir);
-        program = new Program({ rootDir: rootDir, stagingFolderPath: stagingDir });
+        program = new Program({ rootDir: rootDir, stagingDir: stagingDir });
     });
     afterEach(() => {
         sinon.restore();

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -619,8 +619,8 @@ describe('XmlFile', () => {
             const builder = new ProgramBuilder();
             await builder.run({
                 cwd: rootDir,
-                retainStagingFolder: true,
-                stagingFolderPath: stagingDir,
+                retainStagingDir: true,
+                stagingDir: stagingDir,
                 logLevel: LogLevel.off
             });
             expect(

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -20,7 +20,7 @@ describe('import statements', () => {
         fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingDir
+            stagingDir: stagingDir
         });
     });
     afterEach(() => {

--- a/src/files/tests/optionalChaning.spec.ts
+++ b/src/files/tests/optionalChaning.spec.ts
@@ -15,7 +15,7 @@ describe('optional chaining', () => {
         fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingDir
+            stagingDir: stagingDir
         });
     });
     afterEach(() => {

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -9,7 +9,7 @@ describe('globalCallables', () => {
     beforeEach(() => {
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingDir
+            stagingDir: stagingDir
         });
     });
     afterEach(() => {

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -14,7 +14,7 @@ describe('Program', () => {
         fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir,
-            stagingFolderPath: stagingDir
+            stagingDir: stagingDir
         });
         program.createSourceScope(); //ensure source scope is created
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -335,7 +335,8 @@ export class Util {
         config.username = config.username ?? 'rokudev';
         config.watch = config.watch === true ? true : false;
         config.emitFullPaths = config.emitFullPaths === true ? true : false;
-        config.retainStagingFolder = config.retainStagingFolder === true ? true : false;
+        config.retainStagingDir = (config.retainStagingDir ?? config.retainStagingFolder) === true ? true : false;
+        config.retainStagingFolder = config.retainStagingDir;
         config.copyToStaging = config.copyToStaging === false ? false : true;
         config.ignoreErrorCodes = config.ignoreErrorCodes ?? [];
         config.diagnosticFilters = config.diagnosticFilters ?? [];


### PR DESCRIPTION
roku-deploy added new `stagingDir` and `retainStagingDir` options that more closely align with the other property names. This PR aligns BrighterScript with those new names as well