### PR TITLE
Tests: disable object truncation

### DIFF
--- a/src/Cache.spec.ts
+++ b/src/Cache.spec.ts
@@ -1,5 +1,5 @@
 import { Cache } from './Cache';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 describe('Cache', () => {
     let cache: Cache;

--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { Range } from 'vscode-languageserver';
 import { CommentFlagProcessor } from './CommentFlagProcessor';
 import { Lexer } from './lexer/Lexer';

--- a/src/DependencyGraph.spec.ts
+++ b/src/DependencyGraph.spec.ts
@@ -1,6 +1,6 @@
 import { DependencyGraph } from './DependencyGraph';
 import * as sinon from 'sinon';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 describe('DependencyGraph', () => {
     let graph: DependencyGraph;

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -4,7 +4,7 @@ import type { Project } from './LanguageServer';
 import type { ProgramBuilder } from './ProgramBuilder';
 import type { BscFile } from './interfaces';
 import util from './util';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 describe('DiagnosticCollection', () => {
     let collection: DiagnosticCollection;

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
 import type { BsDiagnostic } from './interfaces';
 import { standardizePath as s } from './util';

--- a/src/DiagnosticMessages.spec.ts
+++ b/src/DiagnosticMessages.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 import { DiagnosticMessages } from './DiagnosticMessages';
 

--- a/src/FunctionScope.spec.ts
+++ b/src/FunctionScope.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 import { FunctionScope } from './FunctionScope';
 import { Program } from './Program';

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import type { DidChangeWatchedFilesParams, Location } from 'vscode-languageserver';

--- a/src/Logger.spec.ts
+++ b/src/Logger.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { Logger, LogLevel, noop } from './Logger';
 import chalk from 'chalk';
 import { createSandbox } from 'sinon';

--- a/src/PluginInterface.spec.ts
+++ b/src/PluginInterface.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as sinon from 'sinon';
 import { Logger } from './Logger';
 import PluginInterface from './PluginInterface';

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { assert, expect } from './chai-config.spec';
 import * as pick from 'object.pick';
 import * as sinonImport from 'sinon';
 import { CompletionItemKind, Position, Range } from 'vscode-languageserver';

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
@@ -357,4 +357,3 @@ function createDiagnostic(
     };
     return diagnostic;
 }
-

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as sinonImport from 'sinon';
 import { Position, Range } from 'vscode-languageserver';
 import util, { standardizePath as s } from './util';

--- a/src/SemanticTokenUtils.spec.ts
+++ b/src/SemanticTokenUtils.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-protocol';
 import { encodeSemanticTokens, getModifierBitFlags, semanticTokensLegend } from './SemanticTokenUtils';
 import util from './util';

--- a/src/Stopwatch.spec.ts
+++ b/src/Stopwatch.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { Stopwatch } from './Stopwatch';
 import { util } from './util';
 

--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -1,5 +1,5 @@
 import { SymbolTable } from './SymbolTable';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { StringType } from './types/StringType';
 import { IntegerType } from './types/IntegerType';
 

--- a/src/Throttler.spec.ts
+++ b/src/Throttler.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { Throttler } from './Throttler';
 import { createSandbox, fake } from 'sinon';
 import { Deferred } from './deferred';

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import { Position, Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import type { XmlFile } from './files/XmlFile';

--- a/src/astUtils/AstEditor.spec.ts
+++ b/src/astUtils/AstEditor.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { AstEditor } from './AstEditor';
 import { util } from '../util';

--- a/src/astUtils/creators.spec.ts
+++ b/src/astUtils/creators.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { interpolatedRange } from '..';
 import { TranspileState } from '../parser/TranspileState';
 import { createStringLiteral } from './creators';

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-multi-spaces */
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { PrintStatement, Block, Body, AssignmentStatement, CommentStatement, ExitForStatement, ExitWhileStatement, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EmptyStatement, TryCatchStatement, CatchStatement, ThrowStatement } from '../parser/Statement';
 import { FunctionExpression, NamespacedVariableNameExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression } from '../parser/Expression';
 import type { Token } from '../lexer/Token';

--- a/src/astUtils/stackedVisitor.spec.ts
+++ b/src/astUtils/stackedVisitor.spec.ts
@@ -1,4 +1,4 @@
-import { expect, assert } from 'chai';
+import { expect, assert } from '../chai-config.spec';
 import { createStackedVisitor } from './stackedVisitor';
 
 describe('createStackedVisitor', () => {

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-multi-spaces */
 import type { CancellationToken } from 'vscode-languageserver';
 import { CancellationTokenSource, Range } from 'vscode-languageserver';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import { URI } from 'vscode-uri';
 import type { Range } from 'vscode-languageserver';
 import type { BscFile } from '../../interfaces';

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import { Program } from '../../Program';
 import { util } from '../../util';
 import { createSandbox } from 'sinon';

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-protocol';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, SemanticToken } from '../../interfaces';

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import type { BrsFile } from '../../files/BrsFile';
 import type { AALiteralExpression, DottedGetExpression } from '../../parser/Expression';
 import type { ClassStatement, FunctionStatement, NamespaceStatement, PrintStatement } from '../../parser/Statement';

--- a/src/chai-config.spec.ts
+++ b/src/chai-config.spec.ts
@@ -1,0 +1,9 @@
+// Our local copy of Chai, with configuration options specified.
+//
+//   import { expect } from './chai-config.spec';
+//
+
+import * as chai from 'chai';
+export = chai;
+
+chai.config.truncateThreshold = 0;

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -1,5 +1,5 @@
 
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { util } from './util';

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -2,7 +2,7 @@ import * as sinonImport from 'sinon';
 
 import { Program } from '../Program';
 import type { BrsFile } from './BrsFile';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { Range } from 'vscode-languageserver';
 import { ParseMode } from '../parser/Parser';

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { assert, expect } from '../chai-config.spec';
 import * as sinonImport from 'sinon';
 import { CompletionItemKind, Position, Range } from 'vscode-languageserver';
 import type { Callable, CommentFlag, VariableDeclaration } from '../interfaces';

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { assert, expect } from '../chai-config.spec';
 import * as path from 'path';
 import * as sinonImport from 'sinon';
 import type { CompletionItem } from 'vscode-languageserver';

--- a/src/files/tests/imports.spec.ts
+++ b/src/files/tests/imports.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import * as sinonImport from 'sinon';
 import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from '../../DiagnosticMessages';

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -2,7 +2,7 @@ import { util } from './util';
 import { Program } from './Program';
 import { expectDiagnostics, expectZeroDiagnostics, rootDir, stagingDir } from './testHelpers.spec';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 
 describe('globalCallables', () => {
     let program: Program;

--- a/src/lexer/Character.spec.ts
+++ b/src/lexer/Character.spec.ts
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from '../chai-config.spec';
 
 import * as Characters from './Characters';
 

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1,5 +1,5 @@
 /* eslint no-template-curly-in-string: 0 */
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { TokenKind } from './TokenKind';
 import { Lexer } from './Lexer';

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -2,7 +2,7 @@ import { util } from '../util';
 import * as fsExtra from 'fs-extra';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import type { DottedGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
@@ -43,4 +43,3 @@ describe('Program', () => {
         });
     });
 });
-

--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { TokenKind, AllowedLocalIdentifiers, AllowedProperties } from '../lexer/TokenKind';
 import { Lexer } from '../lexer/Lexer';

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, assert } from 'chai';
+import { expect, assert } from '../chai-config.spec';
 import { Lexer } from '../lexer/Lexer';
 import { ReservedWords, TokenKind } from '../lexer/TokenKind';
 import type { AAMemberExpression } from './Expression';

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { expectZeroDiagnostics, trim } from '../testHelpers.spec';

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import type { NamespaceStatement } from './Statement';
 import { Body, CommentStatement, EmptyStatement } from './Statement';
 import { ParseMode, Parser } from './Parser';

--- a/src/parser/tests/controlFlow/For.spec.ts
+++ b/src/parser/tests/controlFlow/For.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';

--- a/src/parser/tests/controlFlow/ForEach.spec.ts
+++ b/src/parser/tests/controlFlow/ForEach.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import * as assert from 'assert';
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/controlFlow/While.spec.ts
+++ b/src/parser/tests/controlFlow/While.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Additive.spec.ts
+++ b/src/parser/tests/expression/Additive.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/ArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/ArrayLiterals.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Boolean.spec.ts
+++ b/src/parser/tests/expression/Boolean.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Call.spec.ts
+++ b/src/parser/tests/expression/Call.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/expression/Exponential.spec.ts
+++ b/src/parser/tests/expression/Exponential.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Function.spec.ts
+++ b/src/parser/tests/expression/Function.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Indexing.spec.ts
+++ b/src/parser/tests/expression/Indexing.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Multiplicative.spec.ts
+++ b/src/parser/tests/expression/Multiplicative.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
+++ b/src/parser/tests/expression/NullCoalescenceExpression.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-for-in-array */
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Lexer } from '../../../lexer/Lexer';
 import { Parser, ParseMode } from '../../Parser';

--- a/src/parser/tests/expression/PrefixUnary.spec.ts
+++ b/src/parser/tests/expression/PrefixUnary.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Primary.spec.ts
+++ b/src/parser/tests/expression/Primary.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/Relational.spec.ts
+++ b/src/parser/tests/expression/Relational.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-for-in-array */
 /* eslint no-template-curly-in-string: 0 */
 
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Lexer } from '../../../lexer/Lexer';
 import { Parser, ParseMode } from '../../Parser';

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-for-in-array */
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { Parser, ParseMode } from '../../Parser';

--- a/src/parser/tests/statement/AssignmentOperators.spec.ts
+++ b/src/parser/tests/statement/AssignmentOperators.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -3,7 +3,7 @@ import { util } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
 import { ParseMode, Parser } from '../../Parser';
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import type { ConstStatement } from '../../Statement';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { LiteralExpression } from '../../Expression';

--- a/src/parser/tests/statement/Continue.spec.ts
+++ b/src/parser/tests/statement/Continue.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { createSandbox } from 'sinon';
 import { isContinueStatement } from '../../../astUtils/reflection';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';

--- a/src/parser/tests/statement/Declaration.spec.ts
+++ b/src/parser/tests/statement/Declaration.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/Dim.spec.ts
+++ b/src/parser/tests/statement/Dim.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import type { DimStatement } from '../../Statement';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { Parser } from '../../Parser';

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { LiteralExpression } from '../../Expression';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { expectCompletionsExcludes, expectCompletionsIncludes, expectDiagnostics, expectInstanceOf, expectZeroDiagnostics, getTestTranspile, trim } from '../../../testHelpers.spec';

--- a/src/parser/tests/statement/Function.spec.ts
+++ b/src/parser/tests/statement/Function.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/statement/Goto.spec.ts
+++ b/src/parser/tests/statement/Goto.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/statement/Increment.spec.ts
+++ b/src/parser/tests/statement/Increment.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/LibraryStatement.spec.ts
+++ b/src/parser/tests/statement/LibraryStatement.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';
 import { DisallowedLocalIdentifiersText, TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, token } from '../Parser.spec';

--- a/src/parser/tests/statement/ReturnStatement.spec.ts
+++ b/src/parser/tests/statement/ReturnStatement.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/Set.spec.ts
+++ b/src/parser/tests/statement/Set.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';

--- a/src/parser/tests/statement/Stop.spec.ts
+++ b/src/parser/tests/statement/Stop.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';

--- a/src/parser/tests/statement/Throw.spec.ts
+++ b/src/parser/tests/statement/Throw.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import type { TryCatchStatement, ThrowStatement } from '../../Statement';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { LiteralExpression } from '../../Expression';

--- a/src/parser/tests/statement/TryCatch.spec.ts
+++ b/src/parser/tests/statement/TryCatch.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../../../chai-config.spec';
 import { Parser } from '../../Parser';
 import { TryCatchStatement } from '../../Statement';
 

--- a/src/preprocessor/Manifest.spec.ts
+++ b/src/preprocessor/Manifest.spec.ts
@@ -1,5 +1,5 @@
 import * as fsExtra from 'fs';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { getManifest, getBsConst, parseManifest } from './Manifest';
 import { createSandbox } from 'sinon';
 import { expectThrows, mapToObject, objectToMap, trim } from '../testHelpers.spec';

--- a/src/preprocessor/Preprocessor.spec.ts
+++ b/src/preprocessor/Preprocessor.spec.ts
@@ -2,7 +2,7 @@ import { identifier, token, EOF } from '../parser/tests/Parser.spec';
 import { TokenKind } from '../lexer/TokenKind';
 import { Preprocessor } from './Preprocessor';
 import { BrightScriptChunk, DeclarationChunk, ErrorChunk, HashIfStatement } from './Chunk';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { createSandbox } from 'sinon';
 let sinon = createSandbox();
 

--- a/src/preprocessor/PreprocessorParser.spec.ts
+++ b/src/preprocessor/PreprocessorParser.spec.ts
@@ -1,7 +1,7 @@
 import { PreprocessorParser } from './PreprocessorParser';
 import { identifier, token } from '../parser/tests/Parser.spec';
 import { TokenKind } from '../lexer/TokenKind';
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import type { BrightScriptChunk } from './Chunk';
 
 describe('preprocessor parser', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import chalk from 'chalk';
 import type { CodeDescription, CompletionItem, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, integer, Range } from 'vscode-languageserver';
 import { createSandbox } from 'sinon';
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import type { CodeActionShorthand } from './CodeActionUtil';
 import { codeActionUtil } from './CodeActionUtil';
 import type { BrsFile } from './files/BrsFile';

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { ArrayType } from './ArrayType';
 import { DynamicType } from './DynamicType';

--- a/src/types/BooleanType.spec.ts
+++ b/src/types/BooleanType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { BooleanType } from './BooleanType';
 import { DynamicType } from './DynamicType';

--- a/src/types/DoubleType.spec.ts
+++ b/src/types/DoubleType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';

--- a/src/types/DynamicType.spec.ts
+++ b/src/types/DynamicType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { StringType } from './StringType';

--- a/src/types/FloatType.spec.ts
+++ b/src/types/FloatType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { FloatType } from './FloatType';

--- a/src/types/FunctionType.spec.ts
+++ b/src/types/FunctionType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { FunctionType } from './FunctionType';

--- a/src/types/IntegerType.spec.ts
+++ b/src/types/IntegerType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 import { assert } from 'sinon';
 import { objectToMap } from '../testHelpers.spec';
 import type { BscType } from './BscType';

--- a/src/types/InvalidType.spec.ts
+++ b/src/types/InvalidType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { InvalidType } from './InvalidType';

--- a/src/types/LongIntegerType.spec.ts
+++ b/src/types/LongIntegerType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { LongIntegerType } from './LongIntegerType';

--- a/src/types/ObjectType.spec.ts
+++ b/src/types/ObjectType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { ObjectType } from './ObjectType';

--- a/src/types/StringType.spec.ts
+++ b/src/types/StringType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { StringType } from './StringType';

--- a/src/types/VoidType.spec.ts
+++ b/src/types/VoidType.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
 import { VoidType } from './VoidType';

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from './chai-config.spec';
 import * as path from 'path';
 import util, { standardizePath as s } from './util';
 import { Position, Range } from 'vscode-languageserver';


### PR DESCRIPTION
### SUMMARY

Disable object truncation in assertion failures, to ease debugging in some situations. (Fixes #710)

### DETAILS

 - Add the configuration option @TwitchBronBron discovered for Chai
 - Create a single "config" file to hold configuration options for Chai
 - Switch all imports to use the configured Chai

In some test frameworks, you would do this in a configuration file, or a special "setup helper" file, but based on the docs it looks like the pattern above is the expected pattern for configuring Chai.

### TESTS

 - Unit tests passing
 - Confirmed that `.equal` and `.include` on an array of strings prints the full diagnostic.

