### PR TITLE
Fix: else block with leading comment

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2604,6 +2604,19 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('handles else block with a leading comment', () => {
+            testTranspile(`
+                sub main()
+                    if true then
+                        print "if"
+                    else
+                        ' leading comment
+                        print "else"
+                    end if
+                end sub
+            `);
+        });
+
         it('works for function parameters', () => {
             testTranspile(`
                 function DoSomething(name, age as integer, text as string)

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -454,7 +454,7 @@ export class IfStatement extends Statement {
 
             } else {
                 //else body
-                state.lineage.unshift(this.elseBranch);
+                state.lineage.unshift(this.tokens.else);
                 let body = this.elseBranch.transpile(state);
                 state.lineage.shift();
 


### PR DESCRIPTION
### SUMMARY

Fix transpilation output for an else block with leading comment. (Fixes #555)

### DETAILS

The range of a `Block` always starts with the range of its first statement.

In the case of a simple `else`, the value of `elseBranch` is a Block, which means we can't use it as the lineage marker -- in this case we can pass the `else` token itself to distinguish between a same-line and next-line comment.

### TESTS

 - All existing unit tests pass.
 - New unit test passes.

