### PR TITLE
Add a couple named types for BsConfig

### DIFF
--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -1,5 +1,19 @@
 import type { LogLevel } from './Logger';
 
+export interface BsConfigFileEntry {
+    src: string | string[];
+    dest?: string;
+}
+
+export type BsConfigFileEntryOrShortcut = string | BsConfigFileEntry;
+
+export interface DiagnosticFilter {
+    src?: string;
+    codes?: Array<number | string>;
+}
+
+export type DiagnosticFilterOrShortcut = string | number | DiagnosticFilter;
+
 export interface BsConfig {
     /**
      * The inheritance tree for all parent configs used to generate this config. Do not set this, it is computed.
@@ -33,7 +47,7 @@ export interface BsConfig {
      * If using the {src;dest;} format, you can specify a different destination directory
      * for the matched files in src.
      */
-    files?: Array<string | { src: string | string[]; dest?: string }>;
+    files?: Array<BsConfigFileEntryOrShortcut>;
 
     /**
      * The path where the output zip file should be placed.
@@ -120,7 +134,7 @@ export interface BsConfig {
     /**
      * A list of filters used to exclude diagnostics from the output
      */
-    diagnosticFilters?: Array<number | string | { src: string; codes: (number | string)[] } | { src: string } | { codes: (number | string)[] }>;
+    diagnosticFilters?: Array<DiagnosticFilterOrShortcut>;
 
     /**
      * Specify what diagnostic types should be printed to the console. Defaults to 'warn'


### PR DESCRIPTION
### SUMMARY

 - Add some named types for BsConfig
   - `BsConfigFileEntry`
   - `BsConfigFileEntryOrShortcut`
   - `BsConfigDiagnosticFilter`
   - `BsConfigDiagnosticFilerOrShortcut`

### DETAILS

When writing a bsc plugin, it can get awkward to write functions that interface with entries that have type algebra (you're copying inline into your own plugin code).

I'm putting my thumb on the scale with these names by suggesting the "real" interface for `BsConfigFileEntry` and `BsConfigDiagnosticFilter`, but also providing a type for the shortcutting versions. You could imagine a plugin doing some transforms like so:

```typescript
import {
  BsConfig,
  BsConfigFileEntry,
  BsConfigFileEntryOrShortcut,
  ProgramBuilder
} from 'brighterscript';

function transformFiles(files: BsConfigFileEntryOrShortcut): BsConfigFileEntry[] {
  // do a bunch of stuff
}

function beforeProgramCreate(builder: ProgramBuilder): void {
  builder.options.files = transformFiles(builder.options.files || []);
}

```

(Open to a different naming scheme! Just sharing my thought process.)

### TESTING

 - Existing unit tests pass.

