### PR TITLE
Better token underline range for bs1042

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -232,7 +232,7 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     mismatchedEndCallableKeyword: (expectedCallableType: string, actualCallableType: string) => ({
-        message: `Expected 'end ${expectedCallableType}' to terminate ${expectedCallableType} block but found 'end ${actualCallableType}' instead.`,
+        message: `Expected 'end ${expectedCallableType?.replace(/^end\s*/, '')}' to terminate ${expectedCallableType} block but found 'end ${actualCallableType?.replace(/^end\s*/, '')}' instead.`,
         code: 1042,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3426,4 +3426,21 @@ describe('BrsFile', () => {
             }]);
         });
     });
+
+    it('catches mismatched `end` keywords for functions', () => {
+        program.setFile('source/main.brs', `
+            function speak()
+            end sub
+            sub walk()
+            end function
+        `);
+        program.validate();
+        expectDiagnostics(program, [{
+            ...DiagnosticMessages.mismatchedEndCallableKeyword('function', 'sub'),
+            range: util.createRange(2, 12, 2, 19)
+        }, {
+            ...DiagnosticMessages.mismatchedEndCallableKeyword('sub', 'function'),
+            range: util.createRange(4, 12, 4, 24)
+        }]);
+    });
 });

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -924,7 +924,7 @@ export class Parser {
             if (func.end.kind !== expectedEndKind) {
                 this.diagnostics.push({
                     ...DiagnosticMessages.mismatchedEndCallableKeyword(functionTypeText, func.end.text),
-                    range: this.peek().range
+                    range: func.end.range
                 });
             }
             func.callExpressions = this.callExpressions;


### PR DESCRIPTION
Improve the range highlighting for bs1042. Previously it would highlight the _next_ token. ![image](https://user-images.githubusercontent.com/2544493/196270530-7cb83a1d-888b-4bfb-90f7-f7aee2ec9e97.png)

Now it highlights the entire `end sub` or `end function` token.