### PR TITLE
Fixes issues around using classes as field types

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -350,7 +350,7 @@ export class Scope {
     }
 
     public getAncestorTypeList(className: string, functionExpression?: FunctionExpression): InheritableType[] {
-        const lowerNamespaceName = functionExpression.namespaceName?.getName().toLowerCase();
+        const lowerNamespaceName = functionExpression?.namespaceName?.getName().toLowerCase();
         const ancestors: InheritableType[] = [];
         let currentClassOrIFace = this.getInheritableFileLink(className, lowerNamespaceName)?.item;
         if (currentClassOrIFace) {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -574,9 +574,11 @@ export class BrsFile {
     }
 
     public getFunctionExpressionAtPosition(position: Position) {
-        return this.cache.getOrAdd(`functionExpressionAtPosition-${position.line}:${position.character}`, () => {
-            return this._getFunctionExpressionAtPosition(position, this.parser.references.functionExpressions);
-        });
+        if (position) {
+            return this.cache.getOrAdd(`functionExpressionAtPosition-${position.line}:${position.character}`, () => {
+                return this._getFunctionExpressionAtPosition(position, this.parser.references.functionExpressions);
+            });
+        }
     }
 
     /**

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2199,7 +2199,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
                 ' ',
                 this.name?.text,
                 ' as ',
-                type.toTypeString()
+                type.toTypeString(state.typeContext)
             );
         }
         return result;


### PR DESCRIPTION
There were 2 semi-independent issues here:
- Class assignability was not properly checked, so that a class overriding fields of its superclass with subclasses was causing an error
- getting typedefs using Classes as field types defined in another file
