### PR TITLE
better parse recover for unknown func params

### DIFF
--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -65,7 +65,7 @@ export class HoverProcessor {
             const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
 
             //find a constant with this name
-            const constant = scope.getConstFileLink(fullName, containingNamespace);
+            const constant = scope?.getConstFileLink(fullName, containingNamespace);
             if (constant) {
                 const constantValue = new SourceNode(null, null, null, constant.item.value.transpile(new BrsTranspileState(file))).toString();
                 return {

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -87,6 +87,11 @@ export class BrsFileSemanticTokensProcessor {
     private iterateExpressions() {
         const scope = this.event.scopes[0];
 
+        //if this file has no scopes, there's nothing else we can do about this
+        if (!scope) {
+            return;
+        }
+
         for (let expression of this.event.file.parser.references.expressions) {
             //lift the callee from call expressions to handle namespaced function calls
             if (isCallExpression(expression)) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -89,7 +89,7 @@ export class ScopeValidator {
             const symbolTable = info.expression.getSymbolTable();
             const firstPart = info.parts[0];
             //flag all unknown left-most variables
-            if (!symbolTable.hasSymbol(firstPart.name?.text)) {
+            if (!symbolTable?.hasSymbol(firstPart.name?.text)) {
                 this.addMultiScopeDiagnostic({
                     file: file as BscFile,
                     ...DiagnosticMessages.cannotFindName(firstPart.name?.text),

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1440,7 +1440,7 @@ export class BrsFile {
             const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
 
             //find a constant with this name
-            const constant = scope.getConstFileLink(fullName, containingNamespace);
+            const constant = scope?.getConstFileLink(fullName, containingNamespace);
             if (constant) {
                 results.push(
                     util.createLocation(

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1432,10 +1432,10 @@ export class BrsFile {
 
         const scopesForFile = this.program.getScopesForFile(this);
         const [scope] = scopesForFile;
-        scope.linkSymbolTable();
 
         const expression = this.getClosestExpression(position);
-        if (expression) {
+        if (scope && expression) {
+            scope.linkSymbolTable();
             let containingNamespace = expression.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
             const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -9,7 +9,7 @@ import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement 
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { isBlock, isCommentStatement, isFunctionStatement, isIfStatement, isIndexedGetExpression } from '../astUtils/reflection';
-import { expectZeroDiagnostics } from '../testHelpers.spec';
+import { expectDiagnostics, expectZeroDiagnostics } from '../testHelpers.spec';
 import { BrsTranspileState } from './BrsTranspileState';
 import { SourceNode } from 'source-map';
 import { BrsFile } from '../files/BrsFile';
@@ -364,6 +364,19 @@ describe('parser', () => {
                 sub main(interface as object)
                 end sub
             `, ParseMode.BrighterScript).diagnostics[0]?.message).not.to.exist;
+        });
+
+        it('does not scrap the entire function when encountering unknown parameter type', () => {
+            const parser = parse(`
+                sub test(param1 as unknownType)
+                end sub
+            `);
+            expectDiagnostics(parser, [{
+                ...DiagnosticMessages.functionParameterTypeIsInvalid('param1', 'unknownType')
+            }]);
+            expect(
+                isFunctionStatement(parser.ast.statements[0])
+            ).to.be.true;
         });
 
         describe('namespace', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -981,7 +981,6 @@ export class Parser {
                     ...DiagnosticMessages.functionParameterTypeIsInvalid(name.text, typeToken.text),
                     range: typeToken.range
                 });
-                throw this.lastDiagnosticAsError();
             }
         }
         return new FunctionParameterExpression(
@@ -2536,7 +2535,7 @@ export class Parser {
     /**
      * Tries to get the next token as a type
      * Allows for built-in types (double, string, etc.) or namespaced custom types in Brighterscript mode
-     * Will  return a token of whatever is next to be parsed (unless `advanceIfUnknown` is false, in which case undefined will be returned instead
+     * Will return a token of whatever is next to be parsed
      */
     private typeToken(): Token {
         let typeToken: Token;


### PR DESCRIPTION
The parser currently scraps an entire function when encountering a parameter having an unknown type. This is a bit too aggressive. 

This PR improves that flow by recovering more gracefully by adding a diagnostic but then just keeping the unknown token as-is. 

This PR also fixes a few small runtime exceptions when interacting with files that aren't a part of any scope. 