### PR TITLE
Add name to symbol table

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -574,7 +574,7 @@ export class Scope {
                             enumStatements: new Map(),
                             constStatements: new Map(),
                             statements: [],
-                            symbolTable: new SymbolTable(this.symbolTable)
+                            symbolTable: new SymbolTable(this.symbolTable, `Namespace ${loopName}`)
                         });
                     }
                 }
@@ -721,7 +721,7 @@ export class Scope {
 
     public get symbolTable() {
         return this.cache.getOrAdd('symbolTable', () => {
-            const result = new SymbolTable(this.getParentScope()?.symbolTable);
+            const result = new SymbolTable(this.getParentScope()?.symbolTable, `Scope ${this.name}`);
             for (let file of this.getOwnFiles()) {
                 if (isBrsFile(file)) {
                     result.mergeSymbolTable(file.parser?.symbolTable);

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -7,7 +7,8 @@ import type { BscType } from './types/BscType';
  */
 export class SymbolTable {
     constructor(
-        parent?: SymbolTable | undefined
+        parent?: SymbolTable | undefined,
+        public name = ''
     ) {
         this.pushParent(parent);
     }
@@ -112,7 +113,9 @@ export class SymbolTable {
      */
     private toJSON() {
         return {
+            name: this.name,
             parent: this.parent?.toJSON(),
+            parentStack: this.parentStack.map(p => p?.toJSON()),
             symbols: [
                 ...new Set(
                     [...this.symbolMap.entries()].map(([key, symbols]) => {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -96,9 +96,10 @@ export class BrsFileValidator {
                 node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
             },
             FunctionParameterExpression: (node) => {
-                node.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.type);
+                const paramName = node.name?.text;
+                node.getSymbolTable()?.addSymbol(paramName, node.name.range, node.type);
                 //define a symbolTable for each FunctionParameterExpression that contains `m`. TODO, add previous parameter names to this list
-                node.symbolTable = new SymbolTable(node.getSymbolTable());
+                node.symbolTable = new SymbolTable(node.getSymbolTable(), `FunctionParameterExpression ${paramName}`);
                 node.symbolTable.addSymbol('m', interpolatedRange, DynamicType.instance);
             },
             ForEachStatement: (node) => {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -131,7 +131,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
 
         //if there's a body, and it doesn't have a SymbolTable, assign one
         if (this.body && !this.body.symbolTable) {
-            this.body.symbolTable = new SymbolTable();
+            this.body.symbolTable = new SymbolTable(undefined, `Function Body`);
         }
     }
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -905,7 +905,7 @@ export class Parser {
                 //support ending the function with `end sub` OR `end function`
                 func.body = this.block();
                 //attach a new SymbolTable for this function body
-                func.body.symbolTable = new SymbolTable();
+                func.body.symbolTable = new SymbolTable(undefined, `Function Body ${name?.text ?? ''}`);
             } finally {
                 this.currentFunctionExpression = previousFunctionExpression;
             }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -49,7 +49,7 @@ export class Body extends Statement implements TypedefProvider {
         super();
     }
 
-    public symbolTable = new SymbolTable();
+    public symbolTable = new SymbolTable(undefined, 'Body');
 
     public get range() {
         return util.createRangeFromPositions(


### PR DESCRIPTION
Adds a `name` property to SymbolTable to assist with debugging them. 