### PR TITLE
Allow `continue` as local var

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1112,7 +1112,8 @@ export class Parser {
             return this.gotoStatement();
         }
 
-        if (this.check(TokenKind.Continue)) {
+        //the continue keyword (followed by `for`, `while`, or a statement separator)
+        if (this.check(TokenKind.Continue) && this.checkAnyNext(TokenKind.While, TokenKind.For, TokenKind.Newline, TokenKind.Colon, TokenKind.Comment)) {
             return this.continueStatement();
         }
 

--- a/src/parser/tests/statement/Continue.spec.ts
+++ b/src/parser/tests/statement/Continue.spec.ts
@@ -82,6 +82,20 @@ describe('parser continue statements', () => {
         ]);
     });
 
+    it('allows `continue` to be used as a local variable', () => {
+        program.setFile<BrsFile>('source/main.bs', `
+            sub main()
+                continue = true
+                print continue
+                if not continue then
+                    print continue
+                end if
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
     it('transpiles properly', () => {
         testTranspile(`
             sub main()


### PR DESCRIPTION
Allow `continue` to be used as local variable. 