### PR TITLE
Remove parentStack to prevent circular references

### DIFF
--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -115,7 +115,6 @@ export class SymbolTable {
         return {
             name: this.name,
             parent: this.parent?.toJSON(),
-            parentStack: this.parentStack.map(p => p?.toJSON()),
             symbols: [
                 ...new Set(
                     [...this.symbolMap.entries()].map(([key, symbols]) => {


### PR DESCRIPTION
Fixes a stackoverflow/circular reference issue in `SymbolTable.toJSON()` by eliminating the `parentStack` property. 