### PR TITLE
Prevent namespaces being used as variables

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -696,7 +696,7 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     detectedTooDeepFileSource: (numberOfParentDirectories: number) => ({
-        message: `Expected directory depth no larger than 7, but found ${numberOfParentDirectories}.`,
+        message: `Expected directory depth no larger than 7, but found ${numberOfParentDirectories}`,
         code: 1134,
         severity: DiagnosticSeverity.Error
     }),
@@ -708,6 +708,11 @@ export let DiagnosticMessages = {
     keywordMustBeDeclaredAtNamespaceLevel: (keyword: string) => ({
         message: `${keyword} must be declared at the root level or within a namespace`,
         code: 1136,
+        severity: DiagnosticSeverity.Error
+    }),
+    namespaceCannotBeReferencedDirectly: () => ({
+        message: `Namespace cannot be referenced directly`,
+        code: 1137,
         severity: DiagnosticSeverity.Error
     })
 };

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -119,7 +119,8 @@ describe('Scope', () => {
         program.validate();
         expectDiagnostics(program, [
             DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('namea'),
-            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('NAMEA')
+            DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('NAMEA'),
+            DiagnosticMessages.namespaceCannotBeReferencedDirectly()
         ]);
     });
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -68,6 +68,37 @@ describe('BrsFile', () => {
         });
     });
 
+    it('flags namespaces used as variables', () => {
+        program.setFile('source/main.bs', `
+            sub main()
+                alpha.beta.charlie.test()
+                print alpha
+                print alpha.beta
+                print alpha.beta.charlie
+            end sub
+
+            namespace alpha
+                namespace beta
+                    namespace charlie
+                        sub test()
+                        end sub
+                    end namespace
+                end namespace
+            end namespace
+        `);
+        program.validate();
+        expectDiagnostics(program, [{
+            ...DiagnosticMessages.namespaceCannotBeReferencedDirectly(),
+            range: util.createRange(3, 22, 3, 27)
+        }, {
+            ...DiagnosticMessages.namespaceCannotBeReferencedDirectly(),
+            range: util.createRange(4, 22, 4, 32)
+        }, {
+            ...DiagnosticMessages.namespaceCannotBeReferencedDirectly(),
+            range: util.createRange(5, 22, 5, 40)
+        }]);
+    });
+
     it('supports the third parameter in CreateObject', () => {
         program.setFile('source/main.brs', `
             sub main()


### PR DESCRIPTION
Fixes #699 by preventing namespaces from being used directly as variables, since they don't exist at runtime. 

 

![image](https://user-images.githubusercontent.com/2544493/199717757-6e284c3a-984e-4c9d-9c3c-67141e306e8c.png)


