### PR TITLE
Cache `getCallableByName`

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2011,14 +2011,14 @@ describe('BrsFile', () => {
                 ' The main function
                 '
                 sub main()
-                    log("hello")
+                    writeToLog("hello")
                 end sub
 
                 '
                 ' Prints a message to the log.
                 ' Works with *markdown* **content**
                 '
-                sub log(message as string)
+                sub writeToLog(message as string)
                     print message
                 end sub
             `);
@@ -2028,7 +2028,7 @@ describe('BrsFile', () => {
                 program.getHover(file.srcPath, Position.create(5, 22))[0].contents
             ).to.equal([
                 '```brightscript',
-                'sub log(message as string) as void',
+                'sub writeToLog(message as string) as void',
                 '```',
                 '***',
                 '',


### PR DESCRIPTION
Significant performance boost by caching callables (i.e. functions/subs) in scopes the same way we cache namespaces, enums, etc.

For an internal large project:

**before:**
```
[03:43:49:7760 PM]  Validating project finished. (5s851.115ms)
[03:43:58:0450 PM]  Validating project finished. (5s741.213ms)
```
**after:**
```
[03:43:20:6070 PM]  Validating project finished. (1s60.487ms)
[03:43:22:6610 PM]  Validating project finished. (1s214.548ms)
```