### PR TITLE
Prevent a double `super` call in subclasses

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -259,6 +259,45 @@ describe('BrsFile BrighterScript classes', () => {
             `, 'trim', 'source/main.bs');
         });
 
+        it('allows comments as first line of constructor', () => {
+            testTranspile(`
+                class Animal
+                end class
+                class Duck extends Animal
+                    sub new()
+                        'comment should not cause double super call
+                        super()
+                    end sub
+                end class
+            `, `
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = sub()
+                    end sub
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = sub()
+                        'comment should not cause double super call
+                        m.super0_new()
+                    end sub
+                    return instance
+                end function
+                function Duck()
+                    instance = __Duck_builder()
+                    instance.new()
+                    return instance
+                end function
+            `);
+        });
+
         it('handles class inheritance inferred constructor calls', () => {
             testTranspile(`
                 class Animal

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2019,8 +2019,9 @@ export class MethodStatement extends FunctionStatement {
             return;
         }
 
+        //find the first non-comment statement
+        let firstStatement = this.func.body.statements.find(x => !isCommentStatement(x));
         //if the first statement is a call to super, quit here
-        let firstStatement = this.func.body.statements[0];
         if (
             //is a call statement
             isExpressionStatement(firstStatement) && isCallExpression(firstStatement.expression) &&


### PR DESCRIPTION
Fixes a bug when transpiling classes that was causing a double `super()` call in the transpiled output. This was caused anytime there was a comment as the first statement in a class `new()` body. 

Now we look for the first _non_ comment in the `new()` body.