### PR TITLE
Let users use or discard explicit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,11 @@ Type: `boolean`
 
 Prevent the staging folder from being deleted after creating the package. Defaults to `false`, meaning that the folder is deleted every time.
 
-#### `useExplicitTypes`
+#### `removeParameterTypes`
 
 Type: `boolean`
 
-If true, adds the explicit type to function's parameters and return (using the `as type` syntax); otherwise discard this information.
+If true, removes the explicit type to function's parameters and return (i.e. the `as type` syntax); otherwise keep this information.
 
 #### `files`
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Type: `boolean`
 
 Prevent the staging folder from being deleted after creating the package. Defaults to `false`, meaning that the folder is deleted every time.
 
+#### `useExplicitTypes`
+
+Type: `boolean`
+
+If true, adds the explicit type to function's parameters and return (using the `as type` syntax); otherwise discard this information.
+
 #### `files`
 
 Type:

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -149,6 +149,11 @@
             "type": "boolean",
             "default": false
         },
+        "useExplicitTypes": {
+            "description": "Add the explicit type to function's parameters and return (using the `as type` syntax) ",
+            "type": "boolean",
+            "default": true
+        },
         "diagnosticFilters": {
             "description": "A collection of filters used to hide diagnostics for certain files",
             "type": "array",

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -149,10 +149,10 @@
             "type": "boolean",
             "default": false
         },
-        "useExplicitTypes": {
-            "description": "Add the explicit type to function's parameters and return (using the `as type` syntax) ",
+        "removeParameterTypes": {
+            "description": "Removes the explicit type to function's parameters and return (i.e. the `as type` syntax) ",
             "type": "boolean",
-            "default": true
+            "default": false
         },
         "diagnosticFilters": {
             "description": "A collection of filters used to hide diagnostics for certain files",

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -118,10 +118,10 @@ export interface BsConfig {
     emitDefinitions?: boolean;
 
     /**
-     * If true, adds the explicit type to function's parameters and return (using the `as type` syntax)
-     * @default true
+     * If true, removes the explicit type to function's parameters and return (i.e. the `as type` syntax); otherwise keep this information.
+     * @default false
      */
-    useExplicitTypes?: boolean;
+    removeParameterTypes?: boolean;
 
     /**
      * A list of filters used to exclude diagnostics from the output

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -118,6 +118,12 @@ export interface BsConfig {
     emitDefinitions?: boolean;
 
     /**
+     * If true, adds the explicit type to function's parameters and return (using the `as type` syntax)
+     * @default true
+     */
+    useExplicitTypes?: boolean;
+
+    /**
      * A list of filters used to exclude diagnostics from the output
      */
     diagnosticFilters?: Array<number | string | { src: string; codes: (number | string)[] } | { src: string } | { codes: (number | string)[] }>;

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2332,8 +2332,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('discard parameter types when useExplicitType is false', () => {
-            program.options.useExplicitTypes = false;
+        it('discard parameter types when removeParameterTypes is true', () => {
+            program.options.removeParameterTypes = true;
             testTranspile(`
                 sub one(a as integer, b = "" as string, c = invalid as dynamic)
                 end sub
@@ -2343,8 +2343,8 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('discard return type when useExplicitType is false', () => {
-            program.options.useExplicitTypes = false;
+        it('discard return type when removeParameterTypes is true', () => {
+            program.options.removeParameterTypes = true;
             testTranspile(`
                 function one() as string
                     return ""

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2332,6 +2332,30 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('discard parameter types when useExplicitType is false', () => {
+            program.options.useExplicitTypes = false;
+            testTranspile(`
+                sub one(a as integer, b = "" as string, c = invalid as dynamic)
+                end sub
+            `, `
+                sub one(a, b = "", c = invalid)
+                end sub
+            `);
+        });
+
+        it('discard return type when useExplicitType is false', () => {
+            program.options.useExplicitTypes = false;
+            testTranspile(`
+                function one() as string
+                    return ""
+                end function
+            `, `
+                function one()
+                    return ""
+                end function
+            `);
+        });
+
         it('transpiles local var assignment operators', () => {
             testTranspile(`
                 sub main()

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -232,7 +232,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
             state.transpileToken(this.rightParen)
         );
         //as [Type]
-        if (this.asToken) {
+        if (this.asToken && state.options.useExplicitTypes) {
             results.push(
                 ' ',
                 //as
@@ -317,7 +317,7 @@ export class FunctionParameterExpression extends Expression {
             result.push(this.defaultValue.transpile(state));
         }
         //type declaration
-        if (this.asToken) {
+        if (this.asToken && state.options.useExplicitTypes) {
             result.push(' ');
             result.push(state.transpileToken(this.asToken));
             result.push(' ');

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -232,7 +232,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
             state.transpileToken(this.rightParen)
         );
         //as [Type]
-        if (this.asToken && state.options.useExplicitTypes) {
+        if (this.asToken && !state.options.removeParameterTypes) {
             results.push(
                 ' ',
                 //as
@@ -317,7 +317,7 @@ export class FunctionParameterExpression extends Expression {
             result.push(this.defaultValue.transpile(state));
         }
         //type declaration
-        if (this.asToken && state.options.useExplicitTypes) {
+        if (this.asToken && !state.options.removeParameterTypes) {
             result.push(' ');
             result.push(state.transpileToken(this.asToken));
             result.push(' ');

--- a/src/util.ts
+++ b/src/util.ts
@@ -343,6 +343,7 @@ export class Util {
         config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
         config.allowBrighterScriptInBrightScript = config.allowBrighterScriptInBrightScript === true ? true : false;
         config.emitDefinitions = config.emitDefinitions === true ? true : false;
+        config.useExplicitTypes = config.useExplicitTypes === false ? false : true;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -343,7 +343,7 @@ export class Util {
         config.sourceRoot = config.sourceRoot ? standardizePath(config.sourceRoot) : undefined;
         config.allowBrighterScriptInBrightScript = config.allowBrighterScriptInBrightScript === true ? true : false;
         config.emitDefinitions = config.emitDefinitions === true ? true : false;
-        config.useExplicitTypes = config.useExplicitTypes === false ? false : true;
+        config.removeParameterTypes = config.removeParameterTypes === true ? true : false;
         if (typeof config.logLevel === 'string') {
             config.logLevel = LogLevel[(config.logLevel as string).toLowerCase()];
         }


### PR DESCRIPTION
Using the `as type` syntax for parameters and return type on function seems to have a performance impact on Roku channels. 

![image (2)](https://user-images.githubusercontent.com/818706/204000672-f25e5679-d28a-4b28-b6d4-51fa3ec05004.png)

This PR adds a `useExplicitType` configuration option to let the Brighterscript transpiler omit those to generate code that will be more efficient.