### PR TITLE
BrsFile ast toString()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "require-relative": "^0.8.7",
                 "roku-deploy": "^3.9.2",
                 "serialize-error": "^7.0.1",
-                "source-map": "^0.7.3",
+                "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
                 "vscode-languageserver-protocol": "3.16.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -6138,9 +6138,9 @@
             }
         },
         "node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
             "engines": {
                 "node": ">= 8"
             }
@@ -11659,9 +11659,9 @@
             "dev": true
         },
         "source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
         },
         "source-map-support": {
             "version": "0.5.19",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
         "require-relative": "^0.8.7",
         "roku-deploy": "^3.9.2",
         "serialize-error": "^7.0.1",
-        "source-map": "^0.7.3",
+        "source-map": "^0.7.4",
         "vscode-languageserver": "7.0.0",
         "vscode-languageserver-protocol": "3.16.0",
         "vscode-languageserver-textdocument": "^1.0.1",

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -20,6 +20,7 @@ import { DynamicType } from '../types/DynamicType';
 import type { InterfaceType } from '../types/InterfaceType';
 import type { ObjectType } from '../types/ObjectType';
 import type { AstNode, Expression, Statement } from '../parser/AstNode';
+import { Token } from '../lexer/Token';
 
 // File reflection
 
@@ -183,7 +184,7 @@ export function isThrowStatement(element: AstNode | undefined): element is Throw
  * this will work for StringLiteralExpression -> Expression,
  * but will not work CustomStringLiteralExpression -> StringLiteralExpression -> Expression
  */
-export function isExpression(element: AstNode | undefined): element is Expression {
+export function isExpression(element: AstNode | Token | undefined): element is Expression {
     // eslint-disable-next-line no-bitwise
     return !!(element && element.visitMode & InternalWalkMode.visitExpressions);
 }

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -6,6 +6,13 @@ import type { Range, Diagnostic } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import util from '../util';
 
+export const triviaKinds: ReadonlyArray<TokenKind> = [
+    TokenKind.Newline,
+    TokenKind.Whitespace,
+    TokenKind.Comment,
+    TokenKind.Colon
+];
+
 export class Lexer {
     /**
      * The zero-indexed position at which the token under consideration begins.
@@ -103,10 +110,20 @@ export class Lexer {
             isReserved: false,
             text: '',
             range: util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1),
-            leadingWhitespace: this.leadingWhitespace
+            leadingWhitespace: this.leadingWhitespace,
+            leadingTrivia: this.leadingTrivia
         });
         this.leadingWhitespace = '';
         return this;
+    }
+
+    private leadingTrivia: Token[] = [];
+
+    /**
+     * Pushes a token into the leadingTrivia list
+     */
+    private pushTrivia(token: Token) {
+        this.leadingTrivia.push(token);
     }
 
     /**
@@ -1032,6 +1049,13 @@ export class Lexer {
     }
 
     /**
+     * Determine if this token is a trivia token
+     */
+    private isTrivia(token: Token) {
+        return triviaKinds.includes(token.kind);
+    }
+
+    /**
      * Creates a `Token` and adds it to the `tokens` array.
      * @param kind the type of token to produce.
      */
@@ -1042,8 +1066,15 @@ export class Lexer {
             text: text,
             isReserved: ReservedWords.has(text.toLowerCase()),
             range: this.rangeOf(),
-            leadingWhitespace: this.leadingWhitespace
+            leadingWhitespace: this.leadingWhitespace,
+            leadingTrivia: []
         };
+        if (this.isTrivia(token)) {
+            this.pushTrivia(token);
+        } else {
+            token.leadingTrivia.push(...this.leadingTrivia);
+            this.leadingTrivia = [];
+        }
         this.leadingWhitespace = '';
         this.tokens.push(token);
         this.sync();

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -17,6 +17,10 @@ export interface Token {
      * Any leading whitespace found prior to this token. Excludes newline characters.
      */
     leadingWhitespace?: string;
+    /**
+     * Any tokens starting on the next line of the previous token, up to the start of this token
+     */
+    leadingTrivia: Token[];
 }
 
 /**

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -6,6 +6,7 @@ import { expect } from '../chai-config.spec';
 import type { DottedGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
+import { Parser } from './Parser';
 
 describe('Program', () => {
     let program: Program;
@@ -40,6 +41,47 @@ describe('Program', () => {
                 const foxtrot = file.ast.findChildAtPosition<DottedGetExpression>(util.createPosition(3, 71));
                 expect(foxtrot.name.text).to.eql('foxtrot');
             });
+        });
+    });
+
+    describe('toString', () => {
+        function testToString(text: string) {
+            expect(
+                Parser.parse(text).ast.toString()
+            ).to.eql(
+                text
+            );
+        }
+        it('retains full fidelity', () => {
+            testToString(`
+                thing = true
+
+                if true
+                    thing = true
+                end if
+
+                if true
+                    thing = true
+                else
+                    thing = true
+                end if
+
+                if true
+                    thing = true
+                else if true
+                    thing = true
+                else
+                    thing = true
+                end if
+
+                for i = 0 to 10 step 1
+                    print true,false;3
+                end for
+
+                for each item in thing
+                    print 1
+                end for
+            `);
         });
     });
 });

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -8,6 +8,8 @@ import type { BrsTranspileState } from './BrsTranspileState';
 import type { TranspileResult } from '../interfaces';
 import type { AnnotationExpression } from './Expression';
 import util from '../util';
+import type { SourceNode } from 'source-map';
+import { TranspileState } from './TranspileState';
 
 /**
  * A BrightScript AST node
@@ -104,6 +106,20 @@ export abstract class AstNode {
             walkMode: WalkMode.visitAllRecursive
         });
     }
+
+    /**
+     * Return the string value of this AstNode
+     */
+    public toString() {
+        return this
+            .toSourceNode(new TranspileState('', {}))
+            .toString();
+    }
+
+    /**
+     * Generate a SourceNode that represents the stringified value of this node (used to generate sourcemaps and transpile the code
+     */
+    public abstract toSourceNode(state: TranspileState): SourceNode;
 }
 
 export abstract class Statement extends AstNode {

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,4 +1,6 @@
 import { expect, assert } from '../chai-config.spec';
+import * as fastGlob from 'fast-glob';
+import * as fsExtra from 'fs-extra';
 import { Lexer } from '../lexer/Lexer';
 import { ReservedWords, TokenKind } from '../lexer/TokenKind';
 import type { AAMemberExpression } from './Expression';

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -901,7 +901,9 @@ export class Parser {
             try {
                 //support ending the function with `end sub` OR `end function`
                 func.body = this.block();
-                func.body.symbolTable = new SymbolTable(`Block: Function '${name?.text ?? ''}'`, () => func.getSymbolTable());
+                if (func.body) {
+                    func.body.symbolTable = new SymbolTable(`Block: Function '${name?.text ?? ''}'`, () => func.getSymbolTable());
+                }
             } finally { }
 
             if (!func.body) {
@@ -958,9 +960,10 @@ export class Parser {
 
         let typeToken: Token | undefined;
         let defaultValue;
-
+        let equalsToken: Token;
         // parse argument default value
         if (this.match(TokenKind.Equal)) {
+            equalsToken = this.previous();
             // it seems any expression is allowed here -- including ones that operate on other arguments!
             defaultValue = this.expression();
         }
@@ -982,7 +985,8 @@ export class Parser {
             name,
             typeToken,
             defaultValue,
-            asToken
+            asToken,
+            equalsToken
         );
     }
 
@@ -2551,6 +2555,7 @@ export class Parser {
      */
     private typeToken(): Token {
         let typeToken: Token;
+        const leadingTrivia = this.peek()?.leadingTrivia;
 
         if (this.checkAny(...DeclarableTypes)) {
             // Token is a built in type
@@ -2567,6 +2572,9 @@ export class Parser {
         } else {
             // just get whatever's next
             typeToken = this.advance();
+        }
+        if (typeToken) {
+            typeToken.leadingTrivia = leadingTrivia;
         }
         return typeToken;
     }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -417,7 +417,8 @@ export class FunctionStatement extends Statement implements TypedefProvider {
 
     public toSourceNode(state: TranspileState): SourceNode {
         return state.toSourceNode(
-            state.tokenToSourceNodeWithTrivia(this.name),
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            //the FunctionExpression looks upwards for its name, so we don't need to include it here
             this.func.toSourceNode(state)
         );
     }
@@ -852,7 +853,7 @@ export class ReturnStatement extends Statement {
     public toSourceNode(state: TranspileState): SourceNode {
         return state.toSourceNode(
             state.tokenToSourceNodeWithTrivia(this.tokens.return),
-            this.value.toSourceNode(state)
+            this.value?.toSourceNode(state)
         );
     }
 
@@ -2313,6 +2314,13 @@ export class MethodStatement extends FunctionStatement {
             statement.walk(visitor, walkOptions);
         }
         return this.func.transpile(state);
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.accessModifier),
+            super.toSourceNode(state)
+        );
     }
 
     getTypedef(state: BrsTranspileState) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -15,7 +15,7 @@ import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
-import type { SourceNode } from 'source-map';
+import { SourceNode } from 'source-map';
 import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
 import type { Expression } from './AstNode';
@@ -34,6 +34,10 @@ export class EmptyStatement extends Statement {
     transpile(state: BrsTranspileState) {
         return [];
     }
+
+    toSourceNode() {
+        return new SourceNode();
+    }
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
@@ -44,7 +48,11 @@ export class EmptyStatement extends Statement {
  */
 export class Body extends Statement implements TypedefProvider {
     constructor(
-        public statements: Statement[] = []
+        public statements: Statement[] = [],
+        /**
+         * If this is the top-level program body, it will have the EOF token attached
+         */
+        public eofToken?: Token
     ) {
         super();
     }
@@ -89,6 +97,13 @@ export class Body extends Statement implements TypedefProvider {
             result.push(...statement.transpile(state));
         }
         return result;
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.statements, isCommentStatement),
+            this.eofToken ? state.tokenToSourceNodeWithTrivia(this.eofToken) : ''
+        );
     }
 
     getTypedef(state: BrsTranspileState) {
@@ -148,6 +163,14 @@ export class AssignmentStatement extends Statement {
         }
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.name),
+            state.tokenToSourceNodeWithTrivia(this.equals),
+            this.value.toSourceNode(state)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
@@ -204,6 +227,10 @@ export class Block extends Statement {
         return results;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.arrayToSourceNodeWithTrivia(this.statements, isCommentStatement);
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walkArray(this.statements, visitor, options, this);
@@ -223,6 +250,10 @@ export class ExpressionStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         return this.expression.transpile(state);
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return this.expression.toSourceNode(state);
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -275,6 +306,12 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
         return this.transpile(state as BrsTranspileState);
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            ...this.comments.map(x => state.tokenToSourceNodeWithTrivia(x))
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
@@ -296,6 +333,10 @@ export class ExitForStatement extends Statement {
         return [
             state.transpileToken(this.tokens.exitFor)
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.tokenToSourceNodeWithTrivia(this.tokens.exitFor);
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -320,6 +361,10 @@ export class ExitWhileStatement extends Statement {
         return [
             state.transpileToken(this.tokens.exitWhile)
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.tokenToSourceNodeWithTrivia(this.tokens.exitWhile);
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -368,6 +413,13 @@ export class FunctionStatement extends Statement implements TypedefProvider {
         };
 
         return this.func.transpile(state, nameToken);
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.name),
+            this.func.toSourceNode(state)
+        );
     }
 
     getTypedef(state: BrsTranspileState) {
@@ -490,6 +542,25 @@ export class IfStatement extends Statement {
         return results;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            //if
+            state.tokenToSourceNodeWithTrivia(this.tokens.if),
+            //conditions
+            this.condition.toSourceNode(state),
+            //then
+            state.tokenToSourceNodeWithTrivia(this.tokens.then),
+            //then branch
+            this.thenBranch?.toSourceNode(state),
+            //else
+            state.tokenToSourceNodeWithTrivia(this.tokens.else),
+            //else branch
+            this.elseBranch?.toSourceNode(state),
+            //end if
+            state.tokenToSourceNodeWithTrivia(this.tokens.endIf)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'condition', visitor, options);
@@ -519,6 +590,13 @@ export class IncrementStatement extends Statement {
             ...this.value.transpile(state),
             state.transpileToken(this.operator)
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            this.value.toSourceNode(state),
+            state.tokenToSourceNodeWithTrivia(this.operator)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -587,6 +665,24 @@ export class PrintStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        let result = [
+            state.tokenToSourceNodeWithTrivia(this.tokens.print)
+        ];
+        for (const expression of this.expressions) {
+            if (isExpression(expression)) {
+                result.push(
+                    expression.toSourceNode(state)
+                );
+            } else {
+                result.push(
+                    state.tokenToSourceNodeWithTrivia(expression)
+                );
+            }
+        }
+        return state.toSourceNode(...result);
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             //sometimes we have semicolon Tokens in the expressions list (should probably fix that...), so only walk the actual expressions
@@ -630,6 +726,27 @@ export class DimStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        const chunks: Array<SourceNode | string> = [
+            state.tokenToSourceNodeWithTrivia(this.dimToken),
+            state.tokenToSourceNodeWithTrivia(this.identifier),
+            state.tokenToSourceNodeWithTrivia(this.openingSquare)
+        ];
+        for (let i = 0; i < this.dimensions.length; i++) {
+            if (i > 0) {
+                chunks.push(', ');
+            }
+            chunks.push(
+                this.dimensions[i].toSourceNode(state)
+            );
+        }
+        chunks.push(
+            state.tokenToSourceNodeWithTrivia(this.closingSquare)
+        );
+        return state.toSourceNode(...chunks);
+    }
+
+
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (this.dimensions?.length > 0 && options.walkMode & InternalWalkMode.walkExpressions) {
             walkArray(this.dimensions, visitor, options, this);
@@ -659,6 +776,13 @@ export class GotoStatement extends Statement {
         ];
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.goto),
+            state.tokenToSourceNodeWithTrivia(this.tokens.label)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
@@ -683,6 +807,13 @@ export class LabelStatement extends Statement {
             state.transpileToken(this.tokens.colon)
 
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.identifier),
+            state.tokenToSourceNodeWithTrivia(this.tokens.colon)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -718,6 +849,13 @@ export class ReturnStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.return),
+            this.value.toSourceNode(state)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
@@ -743,6 +881,12 @@ export class EndStatement extends Statement {
         ];
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.end)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
@@ -764,6 +908,12 @@ export class StopStatement extends Statement {
         return [
             state.transpileToken(this.tokens.stop)
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.stop)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -834,6 +984,27 @@ export class ForStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            //for
+            state.tokenToSourceNodeWithTrivia(this.forToken),
+            //i=1
+            this.counterDeclaration?.toSourceNode(state),
+            //to
+            state.tokenToSourceNodeWithTrivia(this.toToken),
+            //finalValue
+            this.finalValue?.toSourceNode(state),
+            //step
+            state.tokenToSourceNodeWithTrivia(this.stepToken),
+            //stepValue
+            this.increment?.toSourceNode(state),
+            //body
+            this.body?.toSourceNode(state),
+            //end for
+            state.tokenToSourceNodeWithTrivia(this.endForToken)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'counterDeclaration', visitor, options);
@@ -901,6 +1072,23 @@ export class ForEachStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            //for each
+            state.tokenToSourceNodeWithTrivia(this.tokens.forEach),
+            //item
+            state.tokenToSourceNodeWithTrivia(this.item),
+            //in
+            state.tokenToSourceNodeWithTrivia(this.tokens.in),
+            //target
+            this.target?.toSourceNode(state),
+            //body
+            this.body?.toSourceNode(state),
+            //end for
+            state.tokenToSourceNodeWithTrivia(this.tokens.endFor)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'target', visitor, options);
@@ -955,6 +1143,19 @@ export class WhileStatement extends Statement {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            //while
+            state.tokenToSourceNodeWithTrivia(this.tokens.while),
+            //condition
+            this.condition?.toSourceNode(state),
+            //body
+            this.body?.toSourceNode(state),
+            //end while
+            state.tokenToSourceNodeWithTrivia(this.tokens.endWhile)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'condition', visitor, options);
@@ -969,7 +1170,9 @@ export class DottedSetStatement extends Statement {
     constructor(
         readonly obj: Expression,
         readonly name: Identifier,
-        readonly value: Expression
+        readonly value: Expression,
+        readonly dot: Token,
+        readonly operator: Token
     ) {
         super();
         this.range = util.createRangeFromPositions(this.obj.range.start, this.value.range.end);
@@ -995,6 +1198,26 @@ export class DottedSetStatement extends Statement {
         }
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        //if the value is a compound assignment, don't add the obj, dot, name, or operator...the expression will handle that
+        if (CompoundAssignmentOperators.includes((this.value as BinaryExpression)?.operator?.kind)) {
+            return this.value.toSourceNode(state);
+        } else {
+            return state.toSourceNode(
+                // object
+                this.obj.toSourceNode(state),
+                // .
+                state.tokenToSourceNodeWithTrivia(this.dot),
+                // name
+                state.tokenToSourceNodeWithTrivia(this.name),
+                // =
+                state.tokenToSourceNodeWithTrivia(this.operator),
+                //right-hand-side of assignment
+                this.value?.toSourceNode(state)
+            );
+        }
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
@@ -1009,7 +1232,8 @@ export class IndexedSetStatement extends Statement {
         readonly index: Expression,
         readonly value: Expression,
         readonly openingSquare: Token,
-        readonly closingSquare: Token
+        readonly closingSquare: Token,
+        readonly operator: Token
     ) {
         super();
         this.range = util.createRangeFromPositions(this.obj.range.start, this.value.range.end);
@@ -1039,6 +1263,27 @@ export class IndexedSetStatement extends Statement {
         }
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        //if the value is a component assignment, don't add the obj, index or operator...the expression will handle that
+        if (CompoundAssignmentOperators.includes((this.value as BinaryExpression)?.operator?.kind)) {
+            return this.value.toSourceNode(state);
+        } else {
+            return state.toSourceNode(
+                //obj
+                this.obj?.toSourceNode(state),
+                //   [
+                state.tokenToSourceNodeWithTrivia(this.openingSquare),
+                //    index
+                this.index?.toSourceNode(state),
+                //         ]
+                state.tokenToSourceNodeWithTrivia(this.closingSquare),
+                //           =
+                state.tokenToSourceNodeWithTrivia(this.operator),
+                //             value
+                this.value.toSourceNode(state)
+            );
+        }
+    }
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
@@ -1081,6 +1326,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
 
     getTypedef(state: BrsTranspileState) {
         return this.transpile(state);
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.library),
+            state.tokenToSourceNodeWithTrivia(this.tokens.filePath)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -1138,6 +1390,15 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     transpile(state: BrsTranspileState) {
         //namespaces don't actually have any real content, so just transpile their bodies
         return this.body.transpile(state);
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.keyword),
+            this.nameExpression?.toSourceNode(state),
+            this.body?.toSourceNode(state),
+            state.tokenToSourceNodeWithTrivia(this.endKeyword)
+        );
     }
 
     getTypedef(state: BrsTranspileState) {
@@ -1204,6 +1465,13 @@ export class ImportStatement extends Statement implements TypedefProvider {
             ' ',
             state.transpileToken(this.filePathToken)
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.importToken),
+            state.tokenToSourceNodeWithTrivia(this.filePathToken)
+        );
     }
 
     /**
@@ -1317,6 +1585,24 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         return [];
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            // interface
+            state.tokenToSourceNodeWithTrivia(this.tokens.interface),
+            // SomeInterface
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            // extends
+            state.tokenToSourceNodeWithTrivia(this.tokens.extends),
+            // SomeParentInterface
+            this.parentInterfaceName?.toSourceNode(state),
+            //interface body
+            state.arrayToSourceNodeWithTrivia(this.body, isCommentStatement),
+            //end interface
+            state.tokenToSourceNodeWithTrivia(this.tokens.endInterface)
+        );
+    }
+
     getTypedef(state: BrsTranspileState) {
         const result = [] as TranspileResult;
         for (let annotation of this.annotations ?? []) {
@@ -1409,6 +1695,18 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
 
     public get name() {
         return this.tokens.name.text;
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            //name
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            //as
+            state.tokenToSourceNodeWithTrivia(this.tokens.as),
+            //type
+            state.tokenToSourceNodeWithTrivia(this.tokens.type)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -1531,6 +1829,26 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         }
         return result;
     }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            // function|sub
+            state.tokenToSourceNodeWithTrivia(this.tokens.functionType),
+            // name
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            // (
+            state.tokenToSourceNodeWithTrivia(this.tokens.leftParen),
+            // params
+            state.arrayToSourceNodeWithTrivia(this.params),
+            // )
+            state.tokenToSourceNodeWithTrivia(this.tokens.rightParen),
+            // as
+            state.tokenToSourceNodeWithTrivia(this.tokens.as),
+            // <returnType>
+            state.tokenToSourceNodeWithTrivia(this.tokens.returnType)
+        );
+    }
 }
 
 export class ClassStatement extends Statement implements TypedefProvider {
@@ -1605,6 +1923,18 @@ export class ClassStatement extends Statement implements TypedefProvider {
         //make the class assembler (i.e. the public-facing class creator method)
         result.push(...this.getTranspiledClassFunction(state));
         return result;
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            state.tokenToSourceNodeWithTrivia(this.classKeyword),
+            state.tokenToSourceNodeWithTrivia(this.name),
+            state.tokenToSourceNodeWithTrivia(this.extendsKeyword),
+            this.parentClassName?.toSourceNode(state),
+            state.arrayToSourceNodeWithTrivia(this.body, isCommentStatement),
+            state.tokenToSourceNodeWithTrivia(this.end)
+        );
     }
 
     getTypedef(state: BrsTranspileState) {
@@ -2040,7 +2370,8 @@ export class MethodStatement extends FunctionStatement {
                         text: 'super',
                         isReserved: false,
                         range: state.classStatement.name.range,
-                        leadingWhitespace: ''
+                        leadingWhitespace: '',
+                        leadingTrivia: []
                     }
                 ),
                 {
@@ -2048,15 +2379,18 @@ export class MethodStatement extends FunctionStatement {
                     text: '(',
                     isReserved: false,
                     range: state.classStatement.name.range,
-                    leadingWhitespace: ''
+                    leadingWhitespace: '',
+                    leadingTrivia: []
                 },
                 {
                     kind: TokenKind.RightParen,
                     text: ')',
                     isReserved: false,
                     range: state.classStatement.name.range,
-                    leadingWhitespace: ''
+                    leadingWhitespace: '',
+                    leadingTrivia: []
                 },
+                [],
                 []
             )
         );
@@ -2140,6 +2474,17 @@ export class FieldStatement extends Statement implements TypedefProvider {
         throw new Error('transpile not implemented for ' + Object.getPrototypeOf(this).constructor.name);
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.accessModifier),
+            state.tokenToSourceNodeWithTrivia(this.name),
+            state.tokenToSourceNodeWithTrivia(this.as),
+            state.tokenToSourceNodeWithTrivia(this.type),
+            state.tokenToSourceNodeWithTrivia(this.equal),
+            this.initialValue?.toSourceNode(state)
+        );
+    }
+
     getTypedef(state: BrsTranspileState) {
         const result = [];
         if (this.name) {
@@ -2217,6 +2562,15 @@ export class TryCatchStatement extends Statement {
         ];
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.try),
+            this.tryBranch?.toSourceNode(state),
+            this.catchStatement?.toSourceNode(state),
+            state.tokenToSourceNodeWithTrivia(this.tokens.endTry)
+        );
+    }
+
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (this.tryBranch && options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'tryBranch', visitor, options);
@@ -2250,6 +2604,14 @@ export class CatchStatement extends Statement {
             this.exceptionVariable?.text ?? 'e',
             ...(this.catchBranch?.transpile(state) ?? [])
         ];
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.catch),
+            state.tokenToSourceNodeWithTrivia(this.exceptionVariable),
+            this.catchBranch?.toSourceNode(state)
+        );
     }
 
     public walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -2289,6 +2651,13 @@ export class ThrowStatement extends Statement {
             result.push('"An error has occurred"');
         }
         return result;
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.throwToken),
+            this.expression?.toSourceNode(state)
+        );
     }
 
     public walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -2443,6 +2812,16 @@ export class EnumStatement extends Statement implements TypedefProvider {
         return result;
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            state.tokenToSourceNodeWithTrivia(this.tokens.enum),
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            state.arrayToSourceNodeWithTrivia(this.body, isCommentStatement),
+            state.tokenToSourceNodeWithTrivia(this.tokens.endEnum)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walkArray(this.body, visitor, options, this);
@@ -2494,6 +2873,15 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
             }
         }
         return result;
+    }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            state.tokenToSourceNodeWithTrivia(this.tokens.equal),
+            this.value?.toSourceNode(state)
+        );
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -2559,6 +2947,16 @@ export class ConstStatement extends Statement implements TypedefProvider {
         ];
     }
 
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.arrayToSourceNodeWithTrivia(this.annotations),
+            state.tokenToSourceNodeWithTrivia(this.tokens.const),
+            state.tokenToSourceNodeWithTrivia(this.tokens.name),
+            state.tokenToSourceNodeWithTrivia(this.tokens.equals),
+            this.value?.toSourceNode(state)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (this.value && options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
@@ -2587,6 +2985,14 @@ export class ContinueStatement extends Statement {
             state.sourceNode(this.tokens.continue, this.tokens.loopType?.text)
         ];
     }
+
+    public toSourceNode(state: TranspileState): SourceNode {
+        return state.toSourceNode(
+            state.tokenToSourceNodeWithTrivia(this.tokens.continue),
+            state.tokenToSourceNodeWithTrivia(this.tokens.loopType)
+        );
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -1,7 +1,7 @@
 import { SourceNode } from 'source-map';
 import type { Range } from 'vscode-languageserver';
 import type { BsConfig } from '../BsConfig';
-import { Token } from '../lexer/Token';
+import type { Token } from '../lexer/Token';
 
 /**
  * Holds the state of a transpile operation as it works its way through the transpile process
@@ -156,11 +156,13 @@ export class TranspileState {
      */
     public arrayToSourceNodeWithTrivia<TElement extends { toSourceNode: (state: TranspileState) => SourceNode }>(elements: Array<TElement>, filter?: (element: TElement) => boolean) {
         const nodes: Array<SourceNode | string> = [];
-        for (const element of elements) {
-            if (element && !filter?.(element)) {
-                nodes.push(
-                    element?.toSourceNode(this) ?? ''
-                );
+        if (Array.isArray(elements)) {
+            for (const element of elements) {
+                if (element && !filter?.(element)) {
+                    nodes.push(
+                        element?.toSourceNode(this) ?? ''
+                    );
+                }
             }
         }
         return new SourceNode(1, 0, null, nodes);

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -1,6 +1,7 @@
 import { SourceNode } from 'source-map';
 import type { Range } from 'vscode-languageserver';
 import type { BsConfig } from '../BsConfig';
+import { Token } from '../lexer/Token';
 
 /**
  * Holds the state of a transpile operation as it works its way through the transpile process
@@ -66,6 +67,20 @@ export class TranspileState {
     }
 
     /**
+     * Shorthand for creating a container SourceNode (one that doesn't have a location)
+     */
+    public toSourceNode(...chunks: Array<string | SourceNode>) {
+        return new SourceNode(
+            //convert 0-based range line to 1-based SourceNode line
+            1,
+            //range and SourceNode character are both 0-based, so no conversion necessary
+            0,
+            null,
+            chunks.filter(x => !!x)
+        );
+    }
+
+    /**
      * Create a SourceNode from a token. This is more efficient than the above `sourceNode` function
      * because the entire token is passed by reference, instead of the raw string being copied to the parameter,
      * only to then be copied again for the SourceNode constructor
@@ -79,6 +94,28 @@ export class TranspileState {
             this.srcPath,
             token.text
         );
+    }
+
+    /**
+     * Create a SourceNode from a token. This is more efficient than the above `sourceNode` function
+     * because the entire token is passed by reference, instead of the raw string being copied to the parameter,
+     * only to then be copied again for the SourceNode constructor
+     */
+    public tokenToSourceNodeWithTrivia(token: { range?: Range; text: string; leadingTrivia: Token[] }) {
+        const result: SourceNode[] = [];
+        for (const item of [...token?.leadingTrivia ?? [], token]) {
+            if (token) {
+                result.push(new SourceNode(
+                    //convert 0-based range line to 1-based SourceNode line
+                    item.range.start.line + 1,
+                    //range and SourceNode character are both 0-based, so no conversion necessary
+                    item.range.start.character,
+                    this.srcPath,
+                    item.text
+                ));
+            }
+        }
+        return new SourceNode(1, 0, null, result);
     }
 
     /**
@@ -111,5 +148,21 @@ export class TranspileState {
         } else {
             return this.tokenToSourceNode(token);
         }
+    }
+
+    /**
+     * Convert an array of `toSourceNode`-enabled objects to a single SourceNode, applying an optional filter as they are iterated
+     * @param filter a function to call to EXCLUDE an item. It's an exclude filter so you can pass in things like `isCommentStatement` directly
+     */
+    public arrayToSourceNodeWithTrivia<TElement extends { toSourceNode: (state: TranspileState) => SourceNode }>(elements: Array<TElement>, filter?: (element: TElement) => boolean) {
+        const nodes: Array<SourceNode | string> = [];
+        for (const element of elements) {
+            if (element && !filter?.(element)) {
+                nodes.push(
+                    element?.toSourceNode(this) ?? ''
+                );
+            }
+        }
+        return new SourceNode(1, 0, null, nodes);
     }
 }


### PR DESCRIPTION
Adds the ability to call .toString() on any brightscript/brighterscript AST nodes and get the current string representation of them. 

Issues to resolve before merging:
 - unary expressions are not generating properly
    ![image](https://user-images.githubusercontent.com/2544493/205340624-d47ff938-d4de-4366-b9e9-d9bd66a7dc66.png)

 - conditional compile blocks are not generating properly
    ![image](https://user-images.githubusercontent.com/2544493/205340726-70be5864-5fb0-45b5-9ab7-fbe6f00bba50.png)
