### PR TITLE
Ensure enums and interfaces persist in typedefs

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -16,7 +16,7 @@ import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
-import { expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
+import { expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile, trim } from '../testHelpers.spec';
 import { ParseMode } from '../parser/Parser';
 import { Logger } from '../Logger';
 import { ImportStatement } from '../parser/Statement';
@@ -34,6 +34,7 @@ describe('BrsFile', () => {
     let destPath = 'source/main.brs';
     let file: BrsFile;
     let testTranspile = getTestTranspile(() => [program, rootDir]);
+    let testGetTypedef = getTestGetTypedef(() => [program, rootDir]);
 
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
@@ -3018,6 +3019,32 @@ describe('BrsFile', () => {
     });
 
     describe('typedef', () => {
+        it('includes enum and interface types', () => {
+            testGetTypedef(`
+                interface Foo
+                    field as string
+                end interface
+
+                enum Bar
+                    value
+                end enum
+
+                function baz(parameter as Foo) as Bar
+                    return Bar.value
+                end function
+            `, `
+                interface Foo
+                    field as string
+                end interface
+
+                enum Bar
+                    value
+                end enum
+                function baz(parameter as Foo) as Bar
+                end function
+            `);
+        });
+
         it('sets typedef path properly', () => {
             expect((program.setFile<BrsFile>('source/main1.brs', '')).typedefKey).to.equal(s`${rootDir}/source/main1.d.bs`.toLowerCase());
             expect((program.setFile<BrsFile>('source/main2.d.bs', '')).typedefKey).to.equal(undefined);

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -381,7 +381,7 @@ export class FunctionStatement extends Statement implements TypedefProvider {
         }
 
         result.push(
-            ...this.func.getTypedef(state, this.name)
+            ...this.func.getTypedef(state)
         );
         return result;
     }
@@ -1636,8 +1636,12 @@ export class ClassStatement extends Statement implements TypedefProvider {
         let body = this.body;
         //inject an empty "new" method if missing
         if (!this.getConstructorFunction()) {
+            const constructor = createMethodStatement('new', TokenKind.Sub);
+            constructor.parent = this;
+            //walk the constructor to set up parent links
+            constructor.link();
             body = [
-                createMethodStatement('new', TokenKind.Sub),
+                constructor,
                 ...this.body
             ];
         }
@@ -1986,7 +1990,7 @@ export class MethodStatement extends FunctionStatement {
     }
 
     getTypedef(state: BrsTranspileState) {
-        const result = [] as string[];
+        const result = [] as Array<string | SourceNode>;
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -2004,7 +2008,7 @@ export class MethodStatement extends FunctionStatement {
             result.push('override ');
         }
         result.push(
-            ...this.func.getTypedef(state, this.name)
+            ...this.func.getTypedef(state)
         );
         return result;
     }


### PR DESCRIPTION
Typedefs should include enum and interface information in function parameter and function return types.

Fixes #756 