### PR TITLE
Fix test-related-projects. Reenable rooibos

### DIFF
--- a/scripts/test-related-projects.ts
+++ b/scripts/test-related-projects.ts
@@ -37,7 +37,7 @@ const projects: Project[] = [
 
 let bscTarballPath: string;
 
-async function main() {
+function main() {
     console.log('Cleaning temp directory');
     fsExtra.emptyDirSync(tempDir);
 
@@ -55,7 +55,7 @@ async function main() {
     fsExtra.moveSync(initialBscTarballPath, bscTarballPath);
     for (const project of projects) {
         try {
-            await testProject(project);
+            testProject(project);
             project.success = true;
         } catch {
             project.success = false;
@@ -83,7 +83,7 @@ async function main() {
     // fsExtra.emptyDirSync(tempDir);
 }
 
-async function testProject(project: typeof projects[0]) {
+function testProject(project: typeof projects[0]) {
     const projectDir = path.join(tempDir, project.name);
     const options = {
         cwd: path.join(projectDir, project.cwd ?? '.')
@@ -132,4 +132,4 @@ interface Project {
     success?: boolean;
 }
 
-main().catch(e => console.error(e));
+main();

--- a/scripts/test-related-projects.ts
+++ b/scripts/test-related-projects.ts
@@ -3,14 +3,18 @@ import * as child_process from 'child_process';
 import * as fsExtra from 'fs-extra';
 import { version } from '../package.json';
 import M = require('minimatch');
+import * as os from 'os';
+import chalk from 'chalk';
+const tempDir = path.join(os.tmpdir(), 'brighterscript-tmp');
+const cwd = path.dirname(__dirname);
+
 const projects = [
-    // enable once rooibos tests work on Windows devices
-    // {
-    //     name: 'rooibos',
-    //     url: 'https://github.com/georgejecook/rooibos',
-    //     cwd: './bsc-plugin',
-    //     testCommand: 'npm i && npm run preversion'
-    // },
+    {
+        name: 'rooibos',
+        url: 'https://github.com/georgejecook/rooibos',
+        cwd: './bsc-plugin',
+        testCommand: 'npm run preversion'
+    },
     {
         name: 'roku-log-bsc-plugin',
         url: 'https://github.com/georgejecook/roku-log-bsc-plugin',
@@ -24,8 +28,7 @@ const projects = [
     }
 ];
 
-const cwd = path.dirname(__dirname);
-const tempDir = path.join(cwd, '.tmp');
+
 let bscTarballPath: string;
 
 async function main() {
@@ -64,7 +67,7 @@ async function testProject(project: typeof projects[0]) {
     execSync(`git clone ${project.url} ${projectDir}`);
 
     if (project.branch) {
-        logStep(project.name, `Cloning ${project.name} (${project.url})`);
+        logStep(project.name, `Checkint out branch "${project.branch}"`);
         execSync(`git checkout ${project.branch}`, { cwd: projectDir });
     }
 
@@ -79,6 +82,8 @@ async function testProject(project: typeof projects[0]) {
 
     logStep(project.name, 'Running test command again, this time against local brighterscript');
     execSync(project.testCommand, options);
+
+    logStep(chalk.green(project.name), chalk.green('Tests passed!'));
     await Promise.resolve();
 }
 

--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -9,18 +9,32 @@ export type Arguments<T> = [T] extends [(...args: infer U) => any]
 
 export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> {
 
+    /**
+     * @deprecated use the `options` parameter pattern instead
+     */
+    constructor(
+        plugins: CompilerPlugin[],
+        logger: Logger
+    );
+    constructor(
+        plugins: CompilerPlugin[],
+        options: {
+            logger: Logger;
+            suppressErrors?: boolean;
+        }
+    );
     constructor(
         private plugins: CompilerPlugin[],
         options: {
             logger: Logger;
             suppressErrors?: boolean;
-        }
+        } | Logger
     ) {
         if (options?.constructor.name === 'Logger') {
             this.logger = options as unknown as Logger;
         } else {
-            this.logger = options?.logger;
-            this.suppressErrors = options?.suppressErrors === false ? false : true;
+            this.logger = (options as any)?.logger;
+            this.suppressErrors = (options as any)?.suppressErrors === false ? false : true;
         }
     }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -62,7 +62,8 @@ export class CallExpression extends Expression {
          */
         readonly openingParen: Token,
         readonly closingParen: Token,
-        readonly args: Expression[]
+        readonly args: Expression[],
+        unused?: any
     ) {
         super();
         this.range = util.createBoundingRange(this.callee, this.openingParen, ...args, this.closingParen);


### PR DESCRIPTION
- Use the system tempdir instead of a local .tmp folder, this prevents node from finding ancestor `node_module` folders, which can cause issues when testing certain projects.
- Reenable rooibos tests now that they're working properly.
- add maestro-bsc-plugin