### PR TITLE
Add diagnostic for passing more than 5 arguments to a callFunc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,9 +1589,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001400",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-            "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+            "version": "1.0.30001442",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
             "dev": true,
             "funding": [
                 {
@@ -8225,9 +8225,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001400",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-            "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+            "version": "1.0.30001442",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
             "dev": true
         },
         "caseless": {

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -715,7 +715,7 @@ export let DiagnosticMessages = {
         code: 1137,
         severity: DiagnosticSeverity.Error
     }),
-    callFuncHasToManyArgs: (numberOfArgs: number) => ({
+    callfuncHasToManyArgs: (numberOfArgs: number) => ({
         message: `You can not have more than 5 arguments in a callFunc. ${numberOfArgs} found.`,
         code: 1138,
         severity: DiagnosticSeverity.Error

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -714,6 +714,11 @@ export let DiagnosticMessages = {
         message: `Namespace cannot be referenced directly`,
         code: 1137,
         severity: DiagnosticSeverity.Error
+    }),
+    callFuncHasToManyArgs: (numberOfArgs: number) => ({
+        message: `You can not have more than 5 arguments in a callFunc. ${numberOfArgs} found.`,
+        code: 1138,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -203,6 +203,68 @@ describe('Scope', () => {
     });
 
     describe('validate', () => {
+        it.only('Validates not too many callFunc argument count', () => {
+            program.options.autoImportComponentScript = true;
+            program.setFile(`components/myComponent.bs`, `
+                function myFunc(a, b, c, d, e)
+                    return true
+                end function
+            `);
+            program.setFile(`components/myComponent.xml`, `
+                <component name="MyComponent" extends="Group">
+                    <interface>
+                        <function name="myFunc" />
+                    </interface>
+                </component>
+            `);
+            program.setFile(`components/main.bs`, `
+                sub init()
+                    m.mc@.callFunc(1,2,3,4,5)
+                end sub
+            `);
+            program.setFile(`components/main.xml`, `
+                <component name="MainScene" extends="Scene">
+                    <children>
+                        <MyComponent id="mc" />
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it.only('Validates too many callFunc argument count', () => {
+            program.options.autoImportComponentScript = true;
+            program.setFile(`components/myComponent.bs`, `
+                function myFunc(a, b, c, d, e, f)
+                    return true
+                end function
+            `);
+            program.setFile(`components/myComponent.xml`, `
+                <component name="MyComponent" extends="Group">
+                    <interface>
+                        <function name="myFunc" />
+                    </interface>
+                </component>
+            `);
+            program.setFile(`components/main.bs`, `
+                sub init()
+                    m.mc@.callFunc(1,2,3,4,5,6)
+                end sub
+            `);
+            program.setFile(`components/main.xml`, `
+                <component name="MainScene" extends="Scene">
+                    <children>
+                        <MyComponent id="mc" />
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.callFuncHasToManyArgs(6)
+            ]);
+        });
+
         it('diagnostics are assigned to correct child scope', () => {
             program.options.autoImportComponentScript = true;
             program.setFile('components/constants.bs', `
@@ -643,6 +705,7 @@ describe('Scope', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
         it('resolves local-variable function calls', () => {
             program.setFile(`source/main.brs`, `
                 sub DoSomething()

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -233,7 +233,7 @@ describe('Scope', () => {
             expectZeroDiagnostics(program);
         });
 
-        it('Validates too many callFunc argument count', () => {
+        it('Validates too many callfunc argument count', () => {
             program.options.autoImportComponentScript = true;
             program.setFile(`components/myComponent.bs`, `
                 function myFunc(a, b, c, d, e, f)

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -203,7 +203,7 @@ describe('Scope', () => {
     });
 
     describe('validate', () => {
-        it.only('Validates not too many callFunc argument count', () => {
+        it('Validates not too many callFunc argument count', () => {
             program.options.autoImportComponentScript = true;
             program.setFile(`components/myComponent.bs`, `
                 function myFunc(a, b, c, d, e)
@@ -233,7 +233,7 @@ describe('Scope', () => {
             expectZeroDiagnostics(program);
         });
 
-        it.only('Validates too many callFunc argument count', () => {
+        it('Validates too many callFunc argument count', () => {
             program.options.autoImportComponentScript = true;
             program.setFile(`components/myComponent.bs`, `
                 function myFunc(a, b, c, d, e, f)

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -261,7 +261,7 @@ describe('Scope', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.callFuncHasToManyArgs(6)
+                DiagnosticMessages.callfuncHasToManyArgs(6)
             ]);
         });
 

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -203,7 +203,7 @@ describe('Scope', () => {
     });
 
     describe('validate', () => {
-        it('Validates not too many callFunc argument count', () => {
+        it('Validates not too many callfunc argument count', () => {
             program.options.autoImportComponentScript = true;
             program.setFile(`components/myComponent.bs`, `
                 function myFunc(a, b, c, d, e)

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -37,6 +37,14 @@ export class BrsFileValidator {
                 //add the `super` symbol to class methods
                 node.func.body.symbolTable.addSymbol('super', undefined, DynamicType.instance);
             },
+            CallfuncExpression: (node) => {
+                if (node.args.length > 5) {
+                    this.event.file.addDiagnostic({
+                        ...DiagnosticMessages.callFuncHasToManyArgs(node.args.length),
+                        range: node.methodName.range
+                    });
+                }
+            },
             EnumStatement: (node) => {
                 this.validateDeclarationLocations(node, 'enum', () => util.createBoundingRange(node.tokens.enum, node.tokens.name));
 

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -40,7 +40,7 @@ export class BrsFileValidator {
             CallfuncExpression: (node) => {
                 if (node.args.length > 5) {
                     this.event.file.addDiagnostic({
-                        ...DiagnosticMessages.callFuncHasToManyArgs(node.args.length),
+                        ...DiagnosticMessages.callfuncHasToManyArgs(node.args.length),
                         range: node.methodName.range
                     });
                 }


### PR DESCRIPTION
Passing more than 5 arguments to a callFunc method will crash the app.
Adds a diagnostic message if more than 5 arguments are passed.