### PR TITLE
Move not-referenced check into ProgramValidator

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -313,6 +313,7 @@ describe('Program', () => {
                 DiagnosticMessages.fileNotReferencedByAnyOtherFile()
             ]);
         });
+
         it('does not throw errors on shadowed init functions in components', () => {
             program.setFile('lib.brs', `
                 function DoSomething()

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -7,6 +7,7 @@ import { HoverProcessor } from './hover/HoverProcessor';
 import { BrsFileSemanticTokensProcessor } from './semanticTokens/BrsFileSemanticTokensProcessor';
 import { BrsFilePreTranspileProcessor } from './transpile/BrsFilePreTranspileProcessor';
 import { BrsFileValidator } from './validation/BrsFileValidator';
+import { ProgramValidator } from './validation/ProgramValidator';
 import { ScopeValidator } from './validation/ScopeValidator';
 import { XmlFileValidator } from './validation/XmlFileValidator';
 
@@ -46,6 +47,7 @@ export class BscPlugin implements CompilerPlugin {
     }
 
     public afterProgramValidate(program: Program) {
+        new ProgramValidator(program).process();
         //release memory once the validation cycle has finished
         this.scopeValidator.reset();
     }

--- a/src/bscPlugin/validation/ProgramValidator.ts
+++ b/src/bscPlugin/validation/ProgramValidator.ts
@@ -1,3 +1,4 @@
+import { isBrsFile } from '../../astUtils/reflection';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { Program } from '../../Program';
 import util from '../../util';
@@ -16,9 +17,12 @@ export class ProgramValidator {
         for (const key in this.program.files) {
             const file = this.program.files[key];
 
-            //if the file is included in at least one scope, we're all good
-            const scope = this.program.getFirstScopeForFile(file);
-            if (scope) {
+            if (
+                //if this isn't a brs file, skip
+                !isBrsFile(file) ||
+                //if the file is included in at least one scope, skip
+                this.program.getFirstScopeForFile(file)
+            ) {
                 continue;
             }
 

--- a/src/bscPlugin/validation/ProgramValidator.ts
+++ b/src/bscPlugin/validation/ProgramValidator.ts
@@ -1,0 +1,32 @@
+import { DiagnosticMessages } from '../../DiagnosticMessages';
+import type { Program } from '../../Program';
+import util from '../../util';
+
+export class ProgramValidator {
+    constructor(private program: Program) { }
+
+    public process() {
+        this.flagScopelessBrsFiles();
+    }
+
+    /**
+     * Flag any files that are included in 0 scopes.
+     */
+    private flagScopelessBrsFiles() {
+        for (const key in this.program.files) {
+            const file = this.program.files[key];
+
+            //if the file is included in at least one scope, we're all good
+            const scope = this.program.getFirstScopeForFile(file);
+            if (scope) {
+                continue;
+            }
+
+            this.program.addDiagnostics([{
+                ...DiagnosticMessages.fileNotReferencedByAnyOtherFile(),
+                file: file,
+                range: util.createRange(0, 0, 0, Number.MAX_VALUE)
+            }]);
+        }
+    }
+}


### PR DESCRIPTION
Created a `ProgramValidator` class that handles before/after validation items at the program level. 
moved the `this file isn't referenced anywhere` logic into that validator.