### PR TITLE
Optional chaining assignment validation

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -719,6 +719,11 @@ export let DiagnosticMessages = {
         message: `You can not have more than 5 arguments in a callFunc. ${numberOfArgs} found.`,
         code: 1138,
         severity: DiagnosticSeverity.Error
+    }),
+    noOptionalChainingInLeftHandSideOfAssignment: () => ({
+        message: `Optional chaining may not be used in the left-hand side of an assignment`,
+        code: 1139,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/files/tests/optionalChaning.spec.ts
+++ b/src/files/tests/optionalChaning.spec.ts
@@ -93,4 +93,14 @@ describe('optional chaining', () => {
             end sub
         `);
     });
+
+    it('includes final operator in chain', () => {
+        testTranspile(`
+            sub main()
+                if m.cardFolderStack <> invalid then
+                    m?.cardFolderStack?.visible?.ither = false
+                end if
+            end sub
+        `);
+    });
 });

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2009,7 +2009,8 @@ export class Parser {
                     left.name,
                     operator.kind === TokenKind.Equal
                         ? right
-                        : new BinaryExpression(left, operator, right)
+                        : new BinaryExpression(left, operator, right),
+                    left.dot
                 );
             }
         }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -969,7 +969,8 @@ export class DottedSetStatement extends Statement {
     constructor(
         readonly obj: Expression,
         readonly name: Identifier,
-        readonly value: Expression
+        readonly value: Expression,
+        readonly dot?: Token
     ) {
         super();
         this.range = util.createRangeFromPositions(this.obj.range.start, this.value.range.end);
@@ -985,7 +986,7 @@ export class DottedSetStatement extends Statement {
             return [
                 //object
                 ...this.obj.transpile(state),
-                '.',
+                this.dot ? state.tokenToSourceNode(this.dot) : '.',
                 //name
                 state.transpileToken(this.name),
                 ' = ',


### PR DESCRIPTION
- Adds diagnostics when optional chaining is used in the left-hand-side of an `AssignmentStatment`/`DottedSetStatement`/`IndexedSetStatement`.
- fixes transpile for optional chaning to left of these statements (even if it's invalid syntax, it should output the same syntax as the source file)