### PR TITLE
Convert type tokens to TypeExpressions

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -206,7 +206,7 @@ export let DiagnosticMessages = {
         code: 1036,
         severity: DiagnosticSeverity.Error
     }),
-    invalidFunctionReturnType: (typeText: string) => ({
+    __unused: (typeText: string) => ({
         message: `Function return type '${typeText}' is invalid`,
         code: 1037,
         severity: DiagnosticSeverity.Error
@@ -241,7 +241,7 @@ export let DiagnosticMessages = {
         code: 1043,
         severity: DiagnosticSeverity.Error
     }),
-    functionParameterTypeIsInvalid: (parameterName: string, typeText: string) => ({
+    ___unused: (parameterName: string, typeText: string) => ({
         message: `Function parameter '${parameterName}' is of invalid type '${typeText}'`,
         code: 1044,
         severity: DiagnosticSeverity.Error
@@ -637,7 +637,7 @@ export let DiagnosticMessages = {
         code: 1122,
         severity: DiagnosticSeverity.Error
     }),
-    cannotFindType: (typeName: string) => ({
+    __unused2: (typeName: string) => ({
         message: `Cannot find type with name '${typeName}'`,
         code: 1123,
         severity: DiagnosticSeverity.Error

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -241,7 +241,7 @@ export let DiagnosticMessages = {
         code: 1043,
         severity: DiagnosticSeverity.Error
     }),
-    ___unused: (parameterName: string, typeText: string) => ({
+    __unused2: (parameterName: string, typeText: string) => ({
         message: `Function parameter '${parameterName}' is of invalid type '${typeText}'`,
         code: 1044,
         severity: DiagnosticSeverity.Error
@@ -637,7 +637,7 @@ export let DiagnosticMessages = {
         code: 1122,
         severity: DiagnosticSeverity.Error
     }),
-    __unused2: (typeName: string) => ({
+    __unused3: (typeName: string) => ({
         message: `Cannot find type with name '${typeName}'`,
         code: 1123,
         severity: DiagnosticSeverity.Error

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -96,7 +96,7 @@ export class Program {
         this.globalScope.attachDependencyGraph(this.dependencyGraph);
         this.scopes.global = this.globalScope;
 
-        this.populateGlobalSymbolTable()
+        this.populateGlobalSymbolTable();
 
         //hardcode the files list for global scope to only contain the global file
         this.globalScope.getAllFiles = () => [globalFile];
@@ -107,13 +107,15 @@ export class Program {
         (this.globalScope as any).isValidated = true;
     }
 
-
+    /**
+     * Do all setup required for the global symbol table.
+     */
     private populateGlobalSymbolTable() {
         //Setup primitive types in global symbolTable
         //TODO: Need to handle Array types
 
         this.globalScope.symbolTable.addSymbol('boolean', undefined, BooleanType.instance, SymbolTypeFlags.typetime);
-        this.globalScope.symbolTable.addSymbol("double", undefined, DoubleType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('double', undefined, DoubleType.instance, SymbolTypeFlags.typetime);
         this.globalScope.symbolTable.addSymbol('dynamic', undefined, DynamicType.instance, SymbolTypeFlags.typetime);
         this.globalScope.symbolTable.addSymbol('float', undefined, FloatType.instance, SymbolTypeFlags.typetime);
         this.globalScope.symbolTable.addSymbol('function', undefined, new FunctionType(DynamicType.instance), SymbolTypeFlags.typetime);
@@ -125,7 +127,7 @@ export class Program {
 
         for (let pair of globalCallableMap) {
             let [key, callable] = pair;
-            this.globalScope.symbolTable.addSymbol(key, undefined, callable.type, SymbolTypeFlags.runtime)
+            this.globalScope.symbolTable.addSymbol(key, undefined, callable.type, SymbolTypeFlags.runtime);
         }
     }
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -15,7 +15,7 @@ import { DiagnosticFilterer } from './DiagnosticFilterer';
 import { DependencyGraph } from './DependencyGraph';
 import { Logger, LogLevel } from './Logger';
 import chalk from 'chalk';
-import { globalFile } from './globalCallables';
+import { globalCallableMap, globalFile } from './globalCallables';
 import { parseManifest } from './preprocessor/Manifest';
 import { URI } from 'vscode-uri';
 import PluginInterface from './PluginInterface';
@@ -29,6 +29,17 @@ import type { Statement } from './parser/AstNode';
 import { CallExpressionInfo } from './bscPlugin/CallExpressionInfo';
 import { SignatureHelpUtil } from './bscPlugin/SignatureHelpUtil';
 import { DiagnosticSeverityAdjuster } from './DiagnosticSeverityAdjuster';
+import { IntegerType } from './types/IntegerType';
+import { StringType } from './types/StringType';
+import { SymbolTypeFlags } from './SymbolTable';
+import { BooleanType } from './types/BooleanType';
+import { DoubleType } from './types/DoubleType';
+import { DynamicType } from './types/DynamicType';
+import { FloatType } from './types/FloatType';
+import { FunctionType } from './types/FunctionType';
+import { LongIntegerType } from './types/LongIntegerType';
+import { ObjectType } from './types/ObjectType';
+import { VoidType } from './types/VoidType';
 
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
@@ -84,6 +95,9 @@ export class Program {
         this.globalScope = new Scope('global', this, 'scope:global');
         this.globalScope.attachDependencyGraph(this.dependencyGraph);
         this.scopes.global = this.globalScope;
+
+        this.populateGlobalSymbolTable()
+
         //hardcode the files list for global scope to only contain the global file
         this.globalScope.getAllFiles = () => [globalFile];
         this.globalScope.validate();
@@ -91,6 +105,28 @@ export class Program {
         this.globalScope.getDiagnostics = () => [];
         //TODO we might need to fix this because the isValidated clears stuff now
         (this.globalScope as any).isValidated = true;
+    }
+
+
+    private populateGlobalSymbolTable() {
+        //Setup primitive types in global symbolTable
+        //TODO: Need to handle Array types
+
+        this.globalScope.symbolTable.addSymbol('boolean', undefined, BooleanType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol("double", undefined, DoubleType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('dynamic', undefined, DynamicType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('float', undefined, FloatType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('function', undefined, new FunctionType(DynamicType.instance), SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('integer', undefined, IntegerType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('longinteger', undefined, LongIntegerType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('object', undefined, new ObjectType(), SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('string', undefined, StringType.instance, SymbolTypeFlags.typetime);
+        this.globalScope.symbolTable.addSymbol('void', undefined, VoidType.instance, SymbolTypeFlags.typetime);
+
+        for (let pair of globalCallableMap) {
+            let [key, callable] = pair;
+            this.globalScope.symbolTable.addSymbol(key, undefined, callable.type, SymbolTypeFlags.runtime)
+        }
     }
 
     /**

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1399,7 +1399,7 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.invalidFunctionReturnType('MyNamespace.UnknownType')
+                    DiagnosticMessages.cannotFindName('MyNamespace.UnknownType')
                 ]);
             });
 
@@ -1433,11 +1433,11 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.invalidFunctionReturnType('MyClass').message
+                    DiagnosticMessages.cannotFindName('MyClass').message
                 ]);
             });
 
-            it('can reference types from parent component', () => {
+            it.only('can reference types from parent component', () => {
                 program = new Program({ rootDir: rootDir });
 
                 program.setFile('components/parent.xml', trim`

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1166,8 +1166,8 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.invalidFunctionReturnType('unknownType').message,
-                    DiagnosticMessages.invalidFunctionReturnType('unknownType').message
+                    DiagnosticMessages.cannotFindName('unknownType').message,
+                    DiagnosticMessages.cannotFindName('unknownType').message
                 ]);
             });
 
@@ -1189,8 +1189,8 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message,
-                    DiagnosticMessages.functionParameterTypeIsInvalid('unknownParam', 'unknownType').message
+                    DiagnosticMessages.cannotFindName('unknownType').message,
+                    DiagnosticMessages.cannotFindName('unknownType').message
                 ]);
             });
 
@@ -1208,8 +1208,8 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindType('unknownType').message,
-                    DiagnosticMessages.cannotFindType('unknownType').message
+                    DiagnosticMessages.cannotFindName('unknownType').message,
+                    DiagnosticMessages.cannotFindName('unknownType').message
                 ]);
             });
 
@@ -1352,7 +1352,7 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.invalidFunctionReturnType('UnknownType').message
+                    DiagnosticMessages.cannotFindName('UnknownType').message
                 ]);
             });
 
@@ -1399,8 +1399,9 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('MyNamespace.UnknownType')
+                    DiagnosticMessages.cannotFindName('UnknownType').message
                 ]);
+                expect(program.getDiagnostics()[0]?.data?.fullName).to.eq('MyNamespace.UnknownType')
             });
 
             it('scopes types to correct scope', () => {
@@ -1437,7 +1438,7 @@ describe('Scope', () => {
                 ]);
             });
 
-            it.only('can reference types from parent component', () => {
+            it('can reference types from parent component', () => {
                 program = new Program({ rootDir: rootDir });
 
                 program.setFile('components/parent.xml', trim`

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -11,6 +11,7 @@ import { Logger } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { FunctionStatement, NamespaceStatement } from './parser/Statement';
 import type { OnScopeValidateEvent } from './interfaces';
+import { SymbolTypeFlags } from './SymbolTable';
 
 describe('Scope', () => {
     let sinon = sinonImport.createSandbox();
@@ -72,13 +73,16 @@ describe('Scope', () => {
         const symbolTable = file.parser.references.namespaceStatements[1].body.getSymbolTable();
         //the symbol table should contain the relative names for all items in this namespace across the entire scope
         expect(
-            symbolTable.hasSymbol('Beta')
+            // eslint-disable-next-line no-bitwise
+            symbolTable.hasSymbol('Beta', SymbolTypeFlags.runtime | SymbolTypeFlags.typetime)
         ).to.be.true;
         expect(
-            symbolTable.hasSymbol('Charlie')
+            // eslint-disable-next-line no-bitwise
+            symbolTable.hasSymbol('Charlie', SymbolTypeFlags.runtime | SymbolTypeFlags.typetime)
         ).to.be.true;
         expect(
-            symbolTable.hasSymbol('createBeta')
+            // eslint-disable-next-line no-bitwise
+            symbolTable.hasSymbol('createBeta', SymbolTypeFlags.runtime)
         ).to.be.true;
 
         expectZeroDiagnostics(program);

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1401,7 +1401,7 @@ describe('Scope', () => {
                 expectDiagnostics(program, [
                     DiagnosticMessages.cannotFindName('UnknownType').message
                 ]);
-                expect(program.getDiagnostics()[0]?.data?.fullName).to.eq('MyNamespace.UnknownType')
+                expect(program.getDiagnostics()[0]?.data?.fullName).to.eq('MyNamespace.UnknownType');
             });
 
             it('scopes types to correct scope', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -875,27 +875,28 @@ export class Scope {
      */
     private diagnosticDetectInvalidFunctionExpressionTypes(file: BrsFile) {
         for (let func of file.parser.references.functionExpressions) {
-            if (isCustomType(func.returnType) && func.returnTypeToken) {
+            if (isCustomType(func.returnTypeExpression) && func.getType().returnType) {
                 // check if this custom type is in our class map
-                const returnTypeName = func.returnType.name;
+                const returnTypeName = func.returnTypeExpression.name;
                 const currentNamespaceName = func.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
                 if (!this.hasClass(returnTypeName, currentNamespaceName) && !this.hasInterface(returnTypeName) && !this.hasEnum(returnTypeName)) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.invalidFunctionReturnType(returnTypeName),
-                        range: func.returnTypeToken.range,
+                        range: func.returnTypeExpression.range,
                         file: file
                     });
                 }
             }
 
             for (let param of func.parameters) {
-                if (isCustomType(param.type) && param.typeToken) {
-                    const paramTypeName = param.type.name;
+                const paramType = param.getType();
+                if (isCustomType(paramType)) {
+                    const paramTypeName = paramType.name;
                     const currentNamespaceName = func.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
                     if (!this.hasClass(paramTypeName, currentNamespaceName) && !this.hasInterface(paramTypeName) && !this.hasEnum(paramTypeName)) {
                         this.diagnostics.push({
                             ...DiagnosticMessages.functionParameterTypeIsInvalid(param.name.text, paramTypeName),
-                            range: param.typeToken.range,
+                            range: param.typeExpression.range,
                             file: file
                         });
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -734,7 +734,6 @@ export class Scope {
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
             this.detectVariableNamespaceCollisions(file);
-            //this.diagnosticDetectInvalidFunctionExpressionTypes(file);
         });
     }
 
@@ -870,41 +869,6 @@ export class Scope {
         }
     }
 
-    /**
-     * Find function parameters and function return types that are neither built-in types or known Class references
-     */
-    /*private diagnosticDetectInvalidFunctionExpressionTypes(file: BrsFile) {
-        for (let func of file.parser.references.functionExpressions) {
-            if (isCustomType(func.returnTypeExpression) && func.getType().returnType) {
-                // check if this custom type is in our class map
-                const returnTypeName = func.returnTypeExpression.name;
-                const currentNamespaceName = func.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
-                if (!this.hasClass(returnTypeName, currentNamespaceName) && !this.hasInterface(returnTypeName) && !this.hasEnum(returnTypeName)) {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.invalidFunctionReturnType(returnTypeName),
-                        range: func.returnTypeExpression.range,
-                        file: file
-                    });
-                }
-            }
-
-            for (let param of func.parameters) {
-                const paramType = param.getType();
-                if (isCustomType(paramType)) {
-                    const paramTypeName = paramType.name;
-                    const currentNamespaceName = func.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
-                    if (!this.hasClass(paramTypeName, currentNamespaceName) && !this.hasInterface(paramTypeName) && !this.hasEnum(paramTypeName)) {
-                        this.diagnostics.push({
-                            ...DiagnosticMessages.functionParameterTypeIsInvalid(param.name.text, paramTypeName),
-                            range: param.typeExpression.range,
-                            file: file
-                        });
-
-                    }
-                }
-            }
-        }
-    }*/
 
     public getNewExpressions() {
         let result = [] as AugmentedNewExpression[];

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -17,7 +17,7 @@ import { URI } from 'vscode-uri';
 import { LogLevel } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
-import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isEnumMemberStatement } from './astUtils/reflection';
+import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isEnumMemberStatement, isNamespaceStatement } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
 import type { Statement } from './parser/AstNode';
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -17,7 +17,7 @@ import { URI } from 'vscode-uri';
 import { LogLevel } from './Logger';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
-import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isNamespaceStatement, isEnumMemberStatement } from './astUtils/reflection';
+import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isEnumMemberStatement } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
 import type { Statement } from './parser/AstNode';
 
@@ -734,7 +734,7 @@ export class Scope {
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
             this.detectVariableNamespaceCollisions(file);
-            this.diagnosticDetectInvalidFunctionExpressionTypes(file);
+            //this.diagnosticDetectInvalidFunctionExpressionTypes(file);
         });
     }
 
@@ -873,7 +873,7 @@ export class Scope {
     /**
      * Find function parameters and function return types that are neither built-in types or known Class references
      */
-    private diagnosticDetectInvalidFunctionExpressionTypes(file: BrsFile) {
+    /*private diagnosticDetectInvalidFunctionExpressionTypes(file: BrsFile) {
         for (let func of file.parser.references.functionExpressions) {
             if (isCustomType(func.returnTypeExpression) && func.getType().returnType) {
                 // check if this custom type is in our class map
@@ -904,7 +904,7 @@ export class Scope {
                 }
             }
         }
-    }
+    }*/
 
     public getNewExpressions() {
         let result = [] as AugmentedNewExpression[];

--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -60,8 +60,6 @@ describe('SymbolTable', () => {
         expect(table.hasSymbol('bar', SymbolTypeFlags.typetime)).to.be.true;
     });
 
-
-
     describe('mergeSymbolTable', () => {
 
         it('adds each symbol to the table', () => {

--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -1,4 +1,4 @@
-import { SymbolTable } from './SymbolTable';
+import { SymbolTable, SymbolTypeFlags } from './SymbolTable';
 import { expect } from './chai-config.spec';
 import { StringType } from './types/StringType';
 import { IntegerType } from './types/IntegerType';
@@ -49,6 +49,18 @@ describe('SymbolTable', () => {
         expect(child.hasSymbol('bar')).to.be.true;
         expect(child.hasSymbol('buz')).to.be.false;
     });
+
+    it('matches bitflags given', () => {
+        const table = new SymbolTable('Child', () => parent);
+        table.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        table.addSymbol('bar', null, new IntegerType(), SymbolTypeFlags.typetime);
+        expect(table.hasSymbol('foo', SymbolTypeFlags.runtime)).to.be.true;
+        expect(table.hasSymbol('bar', SymbolTypeFlags.runtime)).to.be.false;
+        expect(table.hasSymbol('foo', SymbolTypeFlags.typetime)).to.be.false;
+        expect(table.hasSymbol('bar', SymbolTypeFlags.typetime)).to.be.true;
+    });
+
+
 
     describe('mergeSymbolTable', () => {
 

--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -13,41 +13,41 @@ describe('SymbolTable', () => {
 
     it('is case insensitive', () => {
         const st = new SymbolTable('Child');
-        st.addSymbol('foo', null, new StringType());
-        expect(st.getSymbol('FOO').length).eq(1);
-        expect(st.getSymbol('FOO')[0].type.toString()).eq('string');
+        st.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        expect(st.getSymbol('FOO', SymbolTypeFlags.runtime).length).eq(1);
+        expect(st.getSymbol('FOO', SymbolTypeFlags.runtime)[0].type.toString()).eq('string');
     });
 
     it('stores all previous symbols', () => {
         const st = new SymbolTable('Child');
-        st.addSymbol('foo', null, new StringType());
-        st.addSymbol('foo', null, new IntegerType());
-        expect(st.getSymbol('FOO').length).eq(2);
+        st.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        st.addSymbol('foo', null, new IntegerType(), SymbolTypeFlags.runtime);
+        expect(st.getSymbol('FOO', SymbolTypeFlags.runtime).length).eq(2);
     });
 
 
     it('reads from parent symbol table if not found in current', () => {
         const st = new SymbolTable('Child', () => parent);
-        parent.addSymbol('foo', null, new StringType());
-        expect(st.getSymbol('foo')[0].type.toString()).eq('string');
+        parent.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        expect(st.getSymbol('foo', SymbolTypeFlags.runtime)[0].type.toString()).eq('string');
     });
 
     it('reads from current table if it exists', () => {
         const st = new SymbolTable('Child', () => parent);
-        parent.addSymbol('foo', null, new StringType());
-        st.addSymbol('foo', null, new IntegerType());
-        expect(st.getSymbol('foo')[0].type.toString()).eq('integer');
+        parent.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        st.addSymbol('foo', null, new IntegerType(), SymbolTypeFlags.runtime);
+        expect(st.getSymbol('foo', SymbolTypeFlags.runtime)[0].type.toString()).eq('integer');
     });
 
     it('correct checks if a symbol is in the table using hasSymbol', () => {
         const child = new SymbolTable('Child', () => parent);
-        parent.addSymbol('foo', null, new StringType());
-        child.addSymbol('bar', null, new IntegerType());
-        expect(parent.hasSymbol('foo')).to.be.true;
-        expect(parent.hasSymbol('bar')).to.be.false;
-        expect(child.hasSymbol('foo')).to.be.true;
-        expect(child.hasSymbol('bar')).to.be.true;
-        expect(child.hasSymbol('buz')).to.be.false;
+        parent.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
+        child.addSymbol('bar', null, new IntegerType(), SymbolTypeFlags.runtime);
+        expect(parent.hasSymbol('foo', SymbolTypeFlags.runtime)).to.be.true;
+        expect(parent.hasSymbol('bar', SymbolTypeFlags.runtime)).to.be.false;
+        expect(child.hasSymbol('foo', SymbolTypeFlags.runtime)).to.be.true;
+        expect(child.hasSymbol('bar', SymbolTypeFlags.runtime)).to.be.true;
+        expect(child.hasSymbol('buz', SymbolTypeFlags.runtime)).to.be.false;
     });
 
     it('matches bitflags given', () => {
@@ -64,25 +64,25 @@ describe('SymbolTable', () => {
 
         it('adds each symbol to the table', () => {
             const st = new SymbolTable('Child');
-            st.addSymbol('foo', null, new StringType());
+            st.addSymbol('foo', null, new StringType(), SymbolTypeFlags.runtime);
             const otherTable = new SymbolTable('OtherTable');
-            otherTable.addSymbol('bar', null, new IntegerType());
-            otherTable.addSymbol('foo', null, new IntegerType());
+            otherTable.addSymbol('bar', null, new IntegerType(), SymbolTypeFlags.runtime);
+            otherTable.addSymbol('foo', null, new IntegerType(), SymbolTypeFlags.runtime);
             st.mergeSymbolTable(otherTable);
         });
     });
 
     it('searches siblings before parents', () => {
-        parent.addSymbol('alpha', null, new StringType());
+        parent.addSymbol('alpha', null, new StringType(), SymbolTypeFlags.runtime);
 
         const child = new SymbolTable('Child', () => parent);
 
         const sibling = new SymbolTable('Sibling');
         child.addSibling(sibling);
-        sibling.addSymbol('alpha', null, new BooleanType());
+        sibling.addSymbol('alpha', null, new BooleanType(), SymbolTypeFlags.runtime);
 
         expect(
-            child.getSymbol('alpha').map(x => x.type.toTypeString())
+            child.getSymbol('alpha', SymbolTypeFlags.runtime).map(x => x.type.toTypeString())
         ).to.eql([
             'boolean'
         ]);

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -71,10 +71,10 @@ export class SymbolTable {
      * If the identifier is not in this table, it will check the parent
      *
      * @param name the name to lookup
-     * @param bitFlags flags to match
+     * @param bitFlags flags to match (See SymbolTypeFlags)
      * @returns true if this symbol is in the symbol table
      */
-    hasSymbol(name: string, bitFlags = SymbolTypeFlags.runtime): boolean {
+    hasSymbol(name: string, bitFlags: number): boolean {
         return !!this.getSymbol(name, bitFlags);
     }
 
@@ -86,7 +86,7 @@ export class SymbolTable {
      * @param bitFlags flags to match
      * @returns An array of BscSymbols - one for each time this symbol had a type implicitly defined
      */
-    getSymbol(name: string, bitFlags = SymbolTypeFlags.runtime): BscSymbol[] {
+    getSymbol(name: string, bitFlags: number): BscSymbol[] {
         const key = name.toLowerCase();
         let result: BscSymbol[];
         // look in our map first
@@ -114,7 +114,7 @@ export class SymbolTable {
     /**
      * Adds a new symbol to the table
      */
-    addSymbol(name: string, range: Range, type: BscType, bitFlags = SymbolTypeFlags.runtime) {
+    addSymbol(name: string, range: Range, type: BscType, bitFlags: number) {
         const key = name.toLowerCase();
         if (!this.symbolMap.has(key)) {
             this.symbolMap.set(key, []);

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -91,7 +91,8 @@ export class SymbolTable {
         let result: BscSymbol[];
         // look in our map first
         if ((result = this.symbolMap.get(key))) {
-            result = result.filter(symbol => symbol.flags & bitFlags)
+            // eslint-disable-next-line no-bitwise
+            result = result.filter(symbol => symbol.flags & bitFlags);
             if (result.length > 0) {
                 return result;
             }
@@ -99,16 +100,15 @@ export class SymbolTable {
         //look through any sibling maps next
         for (let sibling of this.siblings) {
             if ((result = sibling.symbolMap.get(key))) {
-                result = result.filter(symbol => symbol.flags & bitFlags)
+                // eslint-disable-next-line no-bitwise
+                result = result.filter(symbol => symbol.flags & bitFlags);
                 if (result.length > 0) {
                     return result;
                 }
             }
         }
         // ask our parent for a symbol
-        if (result = this.parent?.getSymbol(key, bitFlags)) {
-            return result;
-        }
+        return this.parent?.getSymbol(key, bitFlags);
     }
 
     /**

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -1,6 +1,12 @@
 import type { Range } from 'vscode-languageserver';
 import type { BscType } from './types/BscType';
 
+
+export enum SymbolTypeFlags {
+    runtime = 1,
+    typetime = 2
+}
+
 /**
  * Stores the types associated with variables and functions in the Brighterscript code
  * Can be part of a hierarchy, so lookups can reference parent scopes
@@ -68,7 +74,7 @@ export class SymbolTable {
      * @param searchParent should we look to our parent if we don't have the symbol?
      * @returns true if this symbol is in the symbol table
      */
-    hasSymbol(name: string, searchParent = true): boolean {
+    hasSymbol(name: string,/* add flags */ searchParent = true): boolean {
         return !!this.getSymbol(name, searchParent);
     }
 
@@ -102,7 +108,7 @@ export class SymbolTable {
     /**
      * Adds a new symbol to the table
      */
-    addSymbol(name: string, range: Range, type: BscType) {
+    addSymbol(name: string, range: Range, type: BscType, flags = 0) {
         const key = name.toLowerCase();
         if (!this.symbolMap.has(key)) {
             this.symbolMap.set(key, []);
@@ -110,7 +116,8 @@ export class SymbolTable {
         this.symbolMap.get(key).push({
             name: name,
             range: range,
-            type: type
+            type: type,
+            flags: 0
         });
     }
 
@@ -124,7 +131,8 @@ export class SymbolTable {
                 this.addSymbol(
                     symbol.name,
                     symbol.range,
-                    symbol.type
+                    symbol.type,
+                    symbol.flags
                 );
             }
         }
@@ -152,6 +160,7 @@ export interface BscSymbol {
     name: string;
     range: Range;
     type: BscType;
+    flags: number;
 }
 
 /**

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression } from '../parser/Expression';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -259,6 +259,9 @@ export function isAnnotationExpression(element: AstNode | undefined): element is
 }
 export function isTypedefProvider(element: any): element is TypedefProvider {
     return 'getTypedef' in element;
+}
+export function isTypeExpression(element: any): element is TypeExpression {
+    return element?.constructor.name === 'TypeExpression';
 }
 
 // BscType reflection

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -315,14 +315,14 @@ export function isNumberType(e: any): e is IntegerType | LongIntegerType | Float
 // Literal reflection
 
 export function isLiteralInvalid(e: any): e is LiteralExpression & { type: InvalidType } {
-    return isLiteralExpression(e) && isInvalidType(e.type);
+    return isLiteralExpression(e) && isInvalidType(e.getType());
 }
 export function isLiteralBoolean(e: any): e is LiteralExpression & { type: BooleanType } {
-    return isLiteralExpression(e) && isBooleanType(e.type);
+    return isLiteralExpression(e) && isBooleanType(e.getType());
 }
 export function isLiteralString(e: any): e is LiteralExpression & { type: StringType } {
-    return isLiteralExpression(e) && isStringType(e.type);
+    return isLiteralExpression(e) && isStringType(e.getType());
 }
 export function isLiteralNumber(e: any): e is LiteralExpression & { type: IntegerType | LongIntegerType | FloatType | DoubleType } {
-    return isLiteralExpression(e) && isNumberType(e.type);
+    return isLiteralExpression(e) && isNumberType(e.getType());
 }

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -972,7 +972,11 @@ describe('astUtils visitors', () => {
             `, [
                 'ClassStatement',
                 'FieldStatement',
+                'TypeExpression',
+                'VariableExpression',
                 'FieldStatement',
+                'TypeExpression',
+                'VariableExpression',
                 'LiteralExpression',
                 'MethodStatement',
                 'FunctionExpression',

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -219,5 +219,38 @@ describe('HoverProcessor', () => {
             expect(hover?.range).to.eql(util.createRange(2, 40, 2, 50));
             expect(hover?.contents).to.eql(fence('const name.sp.a.c.e.SOME_VALUE = true'));
         });
+
+        it('finds namespaced class types', () => {
+            program.setFile('source/main.bs', `
+                sub main()
+                    myKlass = new name.Klass()
+                    runNoop(myKlass)
+                end sub
+
+                sub runNoop(myKlass as name.Klass)
+                    myKlass.noop()
+                end sub
+
+                namespace name
+                    class Klass
+                        sub noop()
+                        end sub
+                    end class
+                end namespace
+            `);
+            program.validate();
+            // run|Noop(myKlass)
+            let hover = program.getHover('source/main.bs', util.createPosition(3, 24))[0];
+            expect(hover?.range).to.eql(util.createRange(3, 20, 3, 27));
+            expect(hover?.contents).to.eql(fence('sub runNoop(myKlass as name.Klass) as void'));
+            // myKl|ass.noop()
+            hover = program.getHover('source/main.bs', util.createPosition(7, 25))[0];
+            expect(hover?.range).to.eql(util.createRange(7, 20, 7, 27));
+            expect(hover?.contents).to.eql(fence('myKlass as name.Klass'));
+            //  sub no|op()
+            hover = program.getHover('source/main.bs', util.createPosition(12, 31))[0];
+            expect(hover?.range).to.eql(util.createRange(12, 20, 12, 27));
+            expect(hover?.contents).to.eql(fence('myKlass as name.Klass'));
+        });
     });
 });

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -249,8 +249,8 @@ describe('HoverProcessor', () => {
             expect(hover?.contents).to.eql(fence('myKlass as name.Klass'));
             //  sub no|op()
             hover = program.getHover('source/main.bs', util.createPosition(12, 31))[0];
-            expect(hover?.range).to.eql(util.createRange(12, 20, 12, 27));
-            expect(hover?.contents).to.eql(fence('myKlass as name.Klass'));
+            // Unfortunately, we can't get hover details on class members yet
+            expect(hover).to.be.undefined;
         });
     });
 });

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -250,6 +250,42 @@ describe('HoverProcessor', () => {
             //  sub no|op()
             hover = program.getHover('source/main.bs', util.createPosition(12, 31))[0];
             // Unfortunately, we can't get hover details on class members yet
+            // TODO: Add hover ability on class members
+            expect(hover).to.be.undefined;
+        });
+
+        it('finds types properly', () => {
+            program.setFile('source/main.bs', `
+                class Person
+                end class
+
+                sub doWork(age as integer, name as string, guy as Person)
+                end sub
+            `);
+            program.validate();
+            // a|ge as integer
+            let hover = program.getHover('source/main.bs', util.createPosition(4, 29))[0];
+            expect(hover?.range).to.eql(util.createRange(4, 27, 4, 30));
+            expect(hover?.contents).to.eql(fence('age as integer'));
+            // age as int|eger
+            hover = program.getHover('source/main.bs', util.createPosition(4, 39))[0];
+            // no hover on base types
+            expect(hover).to.be.undefined;
+            // n|ame as string
+            hover = program.getHover('source/main.bs', util.createPosition(4, 46))[0];
+            expect(hover?.range).to.eql(util.createRange(4, 43, 4, 47));
+            expect(hover?.contents).to.eql(fence('name as string'));
+            // name as st|ring
+            hover = program.getHover('source/main.bs', util.createPosition(4, 54))[0];
+            // no hover on base types
+            expect(hover).to.be.undefined;
+            // gu|y as Person
+            hover = program.getHover('source/main.bs', util.createPosition(4, 60))[0];
+            expect(hover?.range).to.eql(util.createRange(4, 59, 4, 62));
+            expect(hover?.contents).to.eql(fence('guy as Person'));
+            // guy as Pe|rson
+            hover = program.getHover('source/main.bs', util.createPosition(4, 69))[0];
+            //TODO: Add hover on custom types (classes, interfaces, enums, etc.)
             expect(hover).to.be.undefined;
         });
     });

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -111,16 +111,16 @@ export class HoverProcessor {
             }
         }
 
-        if (!expression.findAncestor(isTypeExpression)) {
-            //look through all callables in relevant scopes
-            for (let scope of this.event.scopes) {
-                let callable = scope.getCallableByName(lowerTokenText);
-                if (callable) {
-                    return {
-                        range: token.range,
-                        contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
-                    };
-                }
+        //Potentially a problem for the function `string()` as it is a type AND a function https://developer.roku.com/en-ca/docs/references/brightscript/language/global-string-functions.md#stringn-as-integer-str-as-string--as-string
+
+        //look through all callables in relevant scopes
+        for (let scope of this.event.scopes) {
+            let callable = scope.getCallableByName(lowerTokenText);
+            if (callable) {
+                return {
+                    range: token.range,
+                    contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
+                };
             }
         }
     }

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,5 +1,5 @@
 import { SourceNode } from 'source-map';
-import { isBrsFile, isFunctionType, isTypeExpression, isXmlFile } from '../../astUtils/reflection';
+import { isBrsFile, isFunctionType, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { Hover, ProvideHoverEvent } from '../../interfaces';

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -88,7 +88,7 @@ export class HoverProcessor {
                     if (varDeclaration.name.toLowerCase() === lowerTokenText) {
                         let typeText: string;
                         if (isFunctionType(varDeclaration.type)) {
-                            varDeclaration.type.setName(varDeclaration.name)
+                            varDeclaration.type.setName(varDeclaration.name);
                             typeText = varDeclaration.type.toString();
                         } else {
                             typeText = `${varDeclaration.name} as ${varDeclaration.type.toString()}`;

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,5 +1,5 @@
 import { SourceNode } from 'source-map';
-import { isBrsFile, isFunctionType, isXmlFile } from '../../astUtils/reflection';
+import { isBrsFile, isFunctionType, isTypeExpression, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { Hover, ProvideHoverEvent } from '../../interfaces';
@@ -88,6 +88,7 @@ export class HoverProcessor {
                     if (varDeclaration.name.toLowerCase() === lowerTokenText) {
                         let typeText: string;
                         if (isFunctionType(varDeclaration.type)) {
+                            varDeclaration.type.setName(varDeclaration.name)
                             typeText = varDeclaration.type.toString();
                         } else {
                             typeText = `${varDeclaration.name} as ${varDeclaration.type.toString()}`;
@@ -110,14 +111,16 @@ export class HoverProcessor {
             }
         }
 
-        //look through all callables in relevant scopes
-        for (let scope of this.event.scopes) {
-            let callable = scope.getCallableByName(lowerTokenText);
-            if (callable) {
-                return {
-                    range: token.range,
-                    contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
-                };
+        if (!expression.findAncestor(isTypeExpression)) {
+            //look through all callables in relevant scopes
+            for (let scope of this.event.scopes) {
+                let callable = scope.getCallableByName(lowerTokenText);
+                if (callable) {
+                    return {
+                        range: token.range,
+                        contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
+                    };
+                }
             }
         }
     }

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -35,12 +35,12 @@ export class BrsFileSemanticTokensProcessor {
         //classes used in function param types
         for (const func of this.event.file.parser.references.functionExpressions) {
             for (const parm of func.parameters) {
-                if (isCustomType(parm.type)) {
+                if (isCustomType(parm.getType())) {
                     const namespace = parm.findAncestor<NamespaceStatement>(isNamespaceStatement);
                     classes.push({
-                        className: parm.typeToken.text,
+                        className: util.getAllDottedGetParts(parm.typeExpression.expression).map(x => x.text).join('.'),
                         namespaceName: namespace?.getName(ParseMode.BrighterScript),
-                        range: parm.typeToken.range
+                        range: parm.typeExpression.range
                     });
                 }
             }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -53,13 +53,15 @@ export class BrsFileValidator {
                 this.validateEnumDeclaration(node);
 
                 //register this enum declaration
-                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.typetime);
+                // eslint-disable-next-line no-bitwise
+                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
             },
             ClassStatement: (node) => {
                 this.validateDeclarationLocations(node, 'class', () => util.createBoundingRange(node.classKeyword, node.name));
 
                 //register this class
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, new CustomType(node.name.text), SymbolTypeFlags.typetime);
+                // eslint-disable-next-line no-bitwise
+                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, new CustomType(node.name.text), SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
             },
             AssignmentStatement: (node) => {
                 //register this variable

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -98,7 +98,7 @@ export class BrsFileValidator {
                 if (namespace) {
                     //add the transpiled name for namespaced functions to the root symbol table
                     const transpiledNamespaceFunctionName = node.getName(ParseMode.BrightScript);
-                    const funcType = node.func.getFunctionType();
+                    const funcType = node.func.getType();
                     funcType.setName(transpiledNamespaceFunctionName);
 
                     this.event.file.parser.ast.symbolTable.addSymbol(
@@ -116,7 +116,7 @@ export class BrsFileValidator {
             FunctionParameterExpression: (node) => {
                 const paramName = node.name?.text;
                 const symbolTable = node.getSymbolTable();
-                symbolTable?.addSymbol(paramName, node.name.range, node.type);
+                symbolTable?.addSymbol(paramName, node.name.range, node.getType());
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -8,6 +8,8 @@ import type { AstNode, Expression, Statement } from '../../parser/AstNode';
 import type { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
+import { SymbolTypeFlags } from '../../SymbolTable';
+import { CustomType } from '../../types/CustomType';
 import { DynamicType } from '../../types/DynamicType';
 import util from '../../util';
 import type { Range } from 'vscode-languageserver';
@@ -51,13 +53,13 @@ export class BrsFileValidator {
                 this.validateEnumDeclaration(node);
 
                 //register this enum declaration
-                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.typetime);
             },
             ClassStatement: (node) => {
                 this.validateDeclarationLocations(node, 'class', () => util.createBoundingRange(node.classKeyword, node.name));
 
                 //register this class
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, new CustomType(node.name.text), SymbolTypeFlags.typetime);
             },
             AssignmentStatement: (node) => {
                 //register this variable
@@ -79,7 +81,8 @@ export class BrsFileValidator {
                 node.parent.getSymbolTable().addSymbol(
                     node.name.split('.')[0],
                     node.nameExpression.range,
-                    DynamicType.instance
+                    DynamicType.instance,
+                    SymbolTypeFlags.typetime
                 );
             },
             FunctionStatement: (node) => {
@@ -120,7 +123,7 @@ export class BrsFileValidator {
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.typetime);
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -120,6 +120,7 @@ export class BrsFileValidator {
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -37,7 +37,7 @@ export class BrsFileValidator {
         const visitor = createVisitor({
             MethodStatement: (node) => {
                 //add the `super` symbol to class methods
-                node.func.body.symbolTable.addSymbol('super', undefined, DynamicType.instance);
+                node.func.body.symbolTable.addSymbol('super', undefined, DynamicType.instance, SymbolTypeFlags.runtime);
             },
             CallfuncExpression: (node) => {
                 if (node.args.length > 5) {
@@ -65,7 +65,7 @@ export class BrsFileValidator {
             },
             AssignmentStatement: (node) => {
                 //register this variable
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance, SymbolTypeFlags.runtime);
             },
             DottedSetStatement: (node) => {
                 this.validateNoOptionalChainingInVarSet(node, [node.obj]);
@@ -75,7 +75,7 @@ export class BrsFileValidator {
             },
             ForEachStatement: (node) => {
                 //register the for loop variable
-                node.parent.getSymbolTable()?.addSymbol(node.item.text, node.item.range, DynamicType.instance);
+                node.parent.getSymbolTable()?.addSymbol(node.item.text, node.item.range, DynamicType.instance, SymbolTypeFlags.runtime);
             },
             NamespaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'namespace', () => util.createBoundingRange(node.keyword, node.nameExpression));
@@ -94,7 +94,8 @@ export class BrsFileValidator {
                     node.parent.getSymbolTable().addSymbol(
                         node.name.text,
                         node.name.range,
-                        DynamicType.instance
+                        DynamicType.instance,
+                        SymbolTypeFlags.runtime
                     );
                 }
 
@@ -109,19 +110,20 @@ export class BrsFileValidator {
                     this.event.file.parser.ast.symbolTable.addSymbol(
                         transpiledNamespaceFunctionName,
                         node.name.range,
-                        funcType
+                        funcType,
+                        SymbolTypeFlags.runtime
                     );
                 }
             },
             FunctionExpression: (node) => {
-                if (!node.symbolTable.hasSymbol('m')) {
-                    node.symbolTable.addSymbol('m', undefined, DynamicType.instance);
+                if (!node.symbolTable.hasSymbol('m', SymbolTypeFlags.runtime)) {
+                    node.symbolTable.addSymbol('m', undefined, DynamicType.instance, SymbolTypeFlags.runtime);
                 }
             },
             FunctionParameterExpression: (node) => {
                 const paramName = node.name?.text;
                 const symbolTable = node.getSymbolTable();
-                symbolTable?.addSymbol(paramName, node.name.range, node.getType());
+                symbolTable?.addSymbol(paramName, node.name.range, node.getType(), SymbolTypeFlags.runtime);
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
@@ -130,14 +132,14 @@ export class BrsFileValidator {
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));
 
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.runtime);
             },
             CatchStatement: (node) => {
-                node.parent.getSymbolTable().addSymbol(node.exceptionVariable.text, node.exceptionVariable.range, DynamicType.instance);
+                node.parent.getSymbolTable().addSymbol(node.exceptionVariable.text, node.exceptionVariable.range, DynamicType.instance, SymbolTypeFlags.runtime);
             },
             DimStatement: (node) => {
                 if (node.identifier) {
-                    node.parent.getSymbolTable().addSymbol(node.identifier.text, node.identifier.range, DynamicType.instance);
+                    node.parent.getSymbolTable().addSymbol(node.identifier.text, node.identifier.range, DynamicType.instance, SymbolTypeFlags.runtime);
                 }
             },
             ContinueStatement: (node) => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { isBrsFile, isLiteralExpression, isNamespaceStatement, isXmlScope } from '../../astUtils/reflection';
+import { isBrsFile, isLiteralExpression, isNamespaceStatement, isTypeExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -14,6 +14,7 @@ import type { DiagnosticRelatedInformation } from 'vscode-languageserver';
 import type { Expression } from '../../parser/AstNode';
 import type { VariableExpression, DottedGetExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
+import { SymbolTypeFlags } from '../../SymbolTable';
 
 /**
  * The lower-case names of all platform-included scenegraph nodes
@@ -94,10 +95,16 @@ export class ScopeValidator {
             const firstNamespacePartLower = firstNamespacePart?.toLowerCase();
             //get the namespace container (accounting for namespace-relative as well)
             const namespaceContainer = scope.getNamespace(firstNamespacePartLower, info.enclosingNamespaceNameLower);
+            let symbolType = SymbolTypeFlags.runtime;
+            const isUsedAsType = info.expression.findAncestor(isTypeExpression);
+            if (isUsedAsType) {
+                // This is used in a TypeExpression - only look up types from SymbolTable
+                symbolType = SymbolTypeFlags.typetime;
+            }
 
             //flag all unknown left-most variables
             if (
-                !symbolTable?.hasSymbol(firstPart.name?.text) &&
+                !symbolTable?.hasSymbol(firstPart.name?.text, symbolType) &&
                 !namespaceContainer
             ) {
                 this.addMultiScopeDiagnostic({
@@ -163,6 +170,15 @@ export class ScopeValidator {
                     continue outer;
                 }
             }
+            //if the full expression is just an enum name, this is an illegal statement because enums don't exist at runtime
+            if (!isUsedAsType && enumStatement && info.parts.length === 1) {
+                this.addMultiScopeDiagnostic({
+                    ...DiagnosticMessages.itemCannotBeUsedAsVariable('enum'),
+                    range: info.expression.range,
+                    file: file
+                }, 'When used in scope');
+            }
+
             //if the full expression is a namespace path, this is an illegal statement because namespaces don't exist at runtme
             if (scope.getNamespace(entityNameLower, info.enclosingNamespaceNameLower)) {
                 this.addMultiScopeDiagnostic({

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -132,6 +132,7 @@ export class ScopeValidator {
                 if (
                     !scope.getEnumMap().has(entityNameLower) &&
                     !scope.getClassMap().has(entityNameLower) &&
+                    !scope.getInterfaceMap().has(entityNameLower) &&
                     !scope.getConstMap().has(entityNameLower) &&
                     !scope.getCallableByName(entityNameLower) &&
                     !scope.getNamespace(entityNameLower, info.enclosingNamespaceNameLower)

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1037,10 +1037,9 @@ describe('BrsFile BrighterScript classes', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.cannotFindType('Person'),
+            DiagnosticMessages.cannotFindName('Person'),
             DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer'),
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string'),
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person')
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string')
         ]);
     });
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1039,7 +1039,8 @@ describe('BrsFile BrighterScript classes', () => {
         expectDiagnostics(program, [
             DiagnosticMessages.cannotFindName('Person'),
             DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer'),
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string')
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string'),
+            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person')
         ]);
     });
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1524,15 +1524,15 @@ describe('BrsFile', () => {
                 return { type: arg.type, range: arg.range, text: arg.text };
             });
             expect(argsMap).to.eql([{
-                type: new StringType(),
+                type: StringType.instance,
                 range: util.createRange(2, 32, 2, 38),
                 text: '"name"'
             }, {
-                type: new IntegerType(),
+                type: IntegerType.instance,
                 range: util.createRange(2, 40, 2, 42),
                 text: '12'
             }, {
-                type: new BooleanType(),
+                type: BooleanType.instance,
                 range: util.createRange(2, 44, 2, 48),
                 text: 'true'
             }]);
@@ -2854,11 +2854,11 @@ describe('BrsFile', () => {
                 sub bar(obj as SomeKlass)
                 end sub
             `, `
-                function foo() as object
+                function foo() as dynamic
                     return SomeKlass()
                 end function
 
-                sub bar(obj as object)
+                sub bar(obj as dynamic)
                 end sub
             `);
         });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -100,6 +100,30 @@ describe('BrsFile', () => {
         }]);
     });
 
+    it('flags enums used as variables', () => {
+        program.setFile('source/main.bs', `
+            enum Foo
+                bar
+                baz
+            end enum
+
+            sub main()
+                print getFooValue()
+                print getFoo()
+            end sub
+
+            function getFoo() as Foo
+                return Foo ' Error - cannot return an enum, just an enum value
+            end function
+
+            function getFooValue() as Foo
+                return Foo.bar
+            end function
+        `);
+        program.validate();
+        expectDiagnostics(program, [DiagnosticMessages.itemCannotBeUsedAsVariable('enum').message]);
+    });
+
     it('supports the third parameter in CreateObject', () => {
         program.setFile('source/main.brs', `
             sub main()
@@ -1403,6 +1427,21 @@ describe('BrsFile', () => {
                 end function
             `);
             expectZeroDiagnostics(file);
+        });
+
+        it('supports parameter types in functions in AA literals', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    aa = {
+                        name: "test"
+                        addInts: function(a as integer, b as integer) as integer
+                            return a + b
+                        end function
+                    }
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
         });
     });
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2893,11 +2893,11 @@ describe('BrsFile', () => {
                 sub bar(obj as SomeKlass)
                 end sub
             `, `
-                function foo() as dynamic
+                function foo() as object
                     return SomeKlass()
                 end function
 
-                sub bar(obj as dynamic)
+                sub bar(obj as object)
                 end sub
             `);
         });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -464,7 +464,7 @@ export class BrsFile {
                     nameRange: param.name.range,
                     lineIndex: param.name.range.start.line,
                     name: param.name.text,
-                    type: param.type
+                    type: param.getType()
                 });
             }
 
@@ -520,23 +520,11 @@ export class BrsFile {
         try {
             //function
             if (isFunctionExpression(assignment.value)) {
-                let functionType = new FunctionType(assignment.value.returnType);
-                functionType.isSub = assignment.value.functionType.text === 'sub';
-                if (functionType.isSub) {
-                    functionType.returnType = new VoidType();
-                }
-
-                functionType.setName(assignment.name.text);
-                for (let param of assignment.value.parameters) {
-                    let isOptional = !!param.defaultValue;
-                    //TODO compute optional parameters
-                    functionType.addParameter(param.name.text, param.type, isOptional);
-                }
-                return functionType;
+                return assignment.value.getType();
 
                 //literal
             } else if (isLiteralExpression(assignment.value)) {
-                return assignment.value.type;
+                return assignment.value.getType();
 
                 //function call
             } else if (isCallExpression(assignment.value)) {
@@ -547,6 +535,8 @@ export class BrsFile {
                         return func.type.returnType;
                     }
                 }
+
+                //variable
             } else if (isVariableExpression(assignment.value)) {
                 let variableName = assignment.value?.name?.text;
                 let variable = scope.getVariableByName(variableName);
@@ -574,7 +564,7 @@ export class BrsFile {
     private findCallables() {
         for (let statement of this.parser.references.functionStatements ?? []) {
 
-            let functionType = new FunctionType(statement.func.returnType);
+            let functionType = new FunctionType(statement.func.getType().returnType);
             functionType.setName(statement.name.text);
             functionType.isSub = statement.func.functionType.text.toLowerCase() === 'sub';
             if (functionType.isSub) {
@@ -586,7 +576,7 @@ export class BrsFile {
             for (let param of statement.func.parameters) {
                 let callableParam = {
                     name: param.name.text,
-                    type: param.type,
+                    type: param.getType(),
                     isOptional: !!param.defaultValue,
                     isRestArgument: false
                 };
@@ -642,7 +632,7 @@ export class BrsFile {
                     if (isLiteralExpression(arg)) {
                         args.push({
                             range: arg.range,
-                            type: arg.type,
+                            type: arg.getType(),
                             text: arg.token.text,
                             expression: arg,
                             typeToken: undefined

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -475,7 +475,7 @@ export class BrsFile {
                         nameRange: stmt.item.range,
                         lineIndex: stmt.item.range.start.line,
                         name: stmt.item.text,
-                        type: new DynamicType()
+                        type: new DynamicType() //TODO: Infer types from array
                     });
                 },
                 LabelStatement: (stmt) => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -517,6 +517,11 @@ export class BrsFile {
     }
 
     private getBscTypeFromAssignment(assignment: AssignmentStatement, scope: FunctionScope): BscType {
+        //TODO:
+        // This should be as simple as
+        // return assignment.value.getType()
+        // However, that requires scopes and symbol tables to be linked
+
         try {
             //function
             if (isFunctionExpression(assignment.value)) {

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -1,3 +1,4 @@
+import { SymbolTypeFlags } from './SymbolTable';
 import { BrsFile } from './files/BrsFile';
 import type { Callable } from './interfaces';
 import { ArrayType } from './types/ArrayType';
@@ -1016,7 +1017,7 @@ for (let callable of globalCallables) {
 }
 globalFile.callables = globalCallables as Callable[];
 for (const callable of globalCallables) {
-    globalFile.parser.symbolTable.addSymbol(callable.name, undefined, callable.type);
+    globalFile.parser.symbolTable.addSymbol(callable.name, undefined, callable.type, SymbolTypeFlags.runtime);
 }
 
 /**

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -616,6 +616,12 @@ export const DeclarableTypes = [
     TokenKind.Function
 ];
 
+/** List of TokenKind that will not break parsing a TypeExpression in Brighterscript*/
+export const AllowedTypeIdentifiers = [
+    ...AllowedProperties
+];
+
+
 /**
  * The tokens that might preceed a regex literal
  */

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -8,6 +8,7 @@ import type { BrsTranspileState } from './BrsTranspileState';
 import type { TranspileResult } from '../interfaces';
 import type { AnnotationExpression } from './Expression';
 import util from '../util';
+import { DynamicType } from '../types/DynamicType';
 
 /**
  * A BrightScript AST node
@@ -93,6 +94,13 @@ export abstract class AstNode {
                 return node.findChildAtPosition(position, options) ?? node;
             }
         }, options);
+    }
+
+    /**
+     * Get the BscType of this node.
+     */
+    public getType() {
+        return new DynamicType();
     }
 
     /**

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1621,6 +1621,8 @@ export class TypeExpression extends Expression implements TypedefProvider {
             return symbols[0].type;
         } else {
             //this is digging into nested objects (or namespaces, etc...)
+            //TODO: This is wrong -- it should be digging through the symbol tables.
+            //However, in the context of `callables` there is no symbol table because they are set at parse time
             return new CustomType(parts.map(part => part.text).join('.'));
         }
     }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -117,6 +117,10 @@ export class CallExpression extends Expression {
             walkArray(this.args, visitor, options, this);
         }
     }
+
+    getType(): BscType {
+        return this.callee.getType();
+    }
 }
 
 export class FunctionExpression extends Expression implements TypedefProvider {
@@ -1629,7 +1633,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
 
     getTypedef(state: TranspileState): (string | SourceNode)[] {
         // TypeDefs should pass through any valid type names
-        return [util.getAllDottedGetParts(this.expression).map(part => part.text).join('.')];
+        return this.expression.transpile(state as BrsTranspileState);
     }
 
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -15,12 +15,13 @@ import type { TranspileResult, TypedefProvider } from '../interfaces';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
 import { Expression } from './AstNode';
-import { SymbolTable } from '../SymbolTable';
+import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
 import { SourceNode } from 'source-map';
 import type { TranspileState } from './TranspileState';
 import { StringType } from '../types/StringType';
 import { DynamicType } from '../types/DynamicType';
 import { VoidType } from '../types/VoidType';
+import { CustomType } from '../types/CustomType';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -1615,12 +1616,12 @@ export class TypeExpression extends Expression implements TypedefProvider {
         const symbolTable = this.getSymbolTable();
         //get the leftmost variable, then walk into the type
         const parts = util.getAllDottedGetParts(this.expression);
-        const symbols = symbolTable?.getSymbol(parts[0].text) ?? [];
+        const symbols = symbolTable?.getSymbol(parts[0].text, SymbolTypeFlags.typetime) ?? [];
         if (symbols.length > 0 && parts.length === 1) {
             return symbols[0].type;
         } else {
-            //this is digging into nested objects (or namespaces, etc...) and we don't understand them yet. just return DynamicType
-            return DynamicType.instance;
+            //this is digging into nested objects (or namespaces, etc...)
+            return new CustomType(parts.map(part => part.text).join('.'));
         }
     }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -289,7 +289,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walkArray(this.parameters, visitor, options, this);
-            walk(this, 'returnTypeExpression', visitor, options)
+            walk(this, 'returnTypeExpression', visitor, options);
             //This is the core of full-program walking...it allows us to step into sub functions
             if (options.walkMode & InternalWalkMode.recurseChildFunctions) {
                 walk(this, 'body', visitor, options);
@@ -374,7 +374,7 @@ export class FunctionParameterExpression extends Expression {
             //type declaration
             ...(this.asToken ? [
                 ' as ',
-                ...this.typeExpression?.getTypedef(state)
+                ...(this.typeExpression?.getTypedef(state) ?? [''])
             ] : [])
         ];
     }
@@ -1608,7 +1608,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
             }
         }
         if (isLiteralExpression(this.expression)) {
-            return this.expression.getType()
+            return this.expression.getType();
         }
 
         //TODO eventually support more complex types

--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -6,6 +6,8 @@ import { Parser, ParseMode } from './Parser';
 import type { FunctionStatement, AssignmentStatement, FieldStatement } from './Statement';
 import { ClassStatement } from './Statement';
 import { NewExpression } from './Expression';
+import { StringType } from '../types/StringType';
+import { expectDiagnosticsIncludes } from '../testHelpers.spec';
 
 describe('parser class', () => {
     it('throws exception when used in brightscript scope', () => {
@@ -197,7 +199,7 @@ describe('parser class', () => {
             expect(field.accessModifier.kind).to.equal(TokenKind.Public);
             expect(field.name.text).to.equal('firstName');
             expect(field.as.text).to.equal('as');
-            expect(field.type.text).to.equal('string');
+            expect(field.getType()).to.be.instanceOf(StringType);
         });
 
         it('can be solely an identifier', () => {
@@ -228,15 +230,15 @@ describe('parser class', () => {
 
         it(`detects missing type after 'as' keyword`, () => {
             let { tokens } = Lexer.scan(`
-                    class Person
-                        middleName as
-                    end class
-                `);
+                class Person
+                    middleName as
+                end class
+            `);
             let { diagnostics, statements } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });
             expect(diagnostics.length).to.be.greaterThan(0);
             let cls = statements[0] as ClassStatement;
             expect(cls.fields[0].name.text).to.equal('middleName');
-            expect(diagnostics[0].code).to.equal(DiagnosticMessages.expectedIdentifierAfterKeyword('as').code);
+            expectDiagnosticsIncludes(diagnostics, DiagnosticMessages.unexpectedToken('as'));
         });
 
         it('field access modifier defaults to undefined when omitted', () => {

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -9,7 +9,7 @@ import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement 
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { isBlock, isCommentStatement, isFunctionStatement, isIfStatement, isIndexedGetExpression } from '../astUtils/reflection';
-import { expectDiagnostics, expectZeroDiagnostics } from '../testHelpers.spec';
+import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { BrsTranspileState } from './BrsTranspileState';
 import { SourceNode } from 'source-map';
 import { BrsFile } from '../files/BrsFile';

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -371,9 +371,8 @@ describe('parser', () => {
                 sub test(param1 as unknownType)
                 end sub
             `);
-            expectDiagnostics(parser, [{
-                ...DiagnosticMessages.functionParameterTypeIsInvalid('param1', 'unknownType')
-            }]);
+            // type validation happens at scope validation, not at the parser
+            expectZeroDiagnostics(parser);
             expect(
                 isFunctionStatement(parser.ast.statements[0])
             ).to.be.true;
@@ -532,7 +531,7 @@ describe('parser', () => {
                 function log() as UNKNOWN_TYPE
                 end function
             `, ParseMode.BrightScript);
-            expect(diagnostics.length).to.be.greaterThan(0);
+            expectZeroDiagnostics(diagnostics); // type validation happens at scope validation step
             expect(statements[0]).to.exist;
         });
         it('unknown function type is not a problem in Brighterscript mode', () => {
@@ -559,12 +558,12 @@ describe('parser', () => {
             expect(diagnostics.length).to.equal(0);
             expect(statements[0]).to.exist;
         });
-        it('does not allow custom parameter types in Brightscript Mode', () => {
+        it('does not cause any diagnostics when custom parameter types are used in Brightscript Mode', () => {
             let { diagnostics } = parse(`
                 sub foo(value as UNKNOWN_TYPE)
                 end sub
             `, ParseMode.BrightScript);
-            expect(diagnostics.length).not.to.equal(0);
+            expect(diagnostics.length).to.equal(0);
         });
         it('allows custom namespaced parameter types in BrighterscriptMode', () => {
             let { statements, diagnostics } = parse(`

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1,9 +1,11 @@
 import type { Token, Identifier } from '../lexer/Token';
 import { isToken } from '../lexer/Token';
-import { AllowedTypeIdentifiers, BlockTerminator, DeclarableTypes } from '../lexer/TokenKind';
+import type { BlockTerminator } from '../lexer/TokenKind';
 import { Lexer } from '../lexer/Lexer';
 import {
     AllowedLocalIdentifiers,
+    AllowedTypeIdentifiers,
+    DeclarableTypes,
     AllowedProperties,
     AssignmentOperators,
     BrighterScriptSourceLiterals,
@@ -2507,7 +2509,7 @@ export class Parser {
 
         if (this.checkAny(...AllowedTypeIdentifiers)) {
             // Since the next token is allowed as a type identifier, change the kind
-            nextToken = this.peek()
+            nextToken = this.peek();
             oldKind = nextToken.kind;
             nextToken.kind = TokenKind.Identifier;
         }
@@ -2516,8 +2518,7 @@ export class Parser {
             return new TypeExpression(
                 expr
             );
-        }
-        catch (error) {
+        } catch (error) {
             // Something went wrong - reset the kind to what it was previously
             nextToken.kind = oldKind;
             throw error;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -150,6 +150,7 @@ export class AssignmentStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
+            //TODO: Walk TypeExpression. We need to decide how to implement types on assignments
             walk(this, 'value', visitor, options);
         }
     }
@@ -1451,7 +1452,9 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
-        //nothing to walk
+        if (options.walkMode & InternalWalkMode.walkExpressions) {
+            walk(this, 'typeExpression', visitor, options);
+        }
     }
 
     getTypedef(state: BrsTranspileState): (string | SourceNode)[] {
@@ -1520,7 +1523,9 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
     };
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
-        //nothing to walk
+        if (options.walkMode & InternalWalkMode.walkExpressions) {
+            walk(this, 'returnTypeExpression', visitor, options);
+        }
     }
 
     getTypedef(state: BrsTranspileState) {
@@ -2174,7 +2179,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
      * Defaults to `DynamicType`
      */
     getType() {
-        return this.typeExpression.getType();
+        return this.typeExpression?.getType() || DynamicType.instance;
     }
 
     public readonly range: Range;
@@ -2211,7 +2216,8 @@ export class FieldStatement extends Statement implements TypedefProvider {
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
-        if (this.initialValue && options.walkMode & InternalWalkMode.walkExpressions) {
+        if (options.walkMode & InternalWalkMode.walkExpressions) {
+            walk(this, 'typeExpression', visitor, options);
             walk(this, 'initialValue', visitor, options);
         }
     }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer/TokenKind';
-import type { BinaryExpression, NamespacedVariableNameExpression, FunctionExpression, FunctionParameterExpression, LiteralExpression } from './Expression';
+import type { BinaryExpression, NamespacedVariableNameExpression, FunctionExpression, FunctionParameterExpression, LiteralExpression, TypeExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
 import type { Range } from 'vscode-languageserver';
@@ -13,7 +13,6 @@ import { isCallExpression, isCommentStatement, isEnumMemberStatement, isExpressi
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
-import type { BscType } from '../types/BscType';
 import type { SourceNode } from 'source-map';
 import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
@@ -114,9 +113,11 @@ export class Body extends Statement implements TypedefProvider {
 
 export class AssignmentStatement extends Statement {
     constructor(
-        readonly equals: Token,
-        readonly name: Identifier,
-        readonly value: Expression
+        public equals: Token,
+        public name: Identifier,
+        public value: Expression,
+        public asToken?: Token,
+        public typeExpression?: TypeExpression
     ) {
         super();
         this.range = util.createBoundingRange(name, equals, value);
@@ -1426,17 +1427,15 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     constructor(
         nameToken: Identifier,
         asToken: Token,
-        typeToken: Token,
-        public type: BscType
+        public typeExpression: TypeExpression
     ) {
         super();
         this.tokens.name = nameToken;
         this.tokens.as = asToken;
-        this.tokens.type = typeToken;
         this.range = util.createBoundingRange(
-            nameToken,
-            asToken,
-            typeToken
+            this.tokens.name,
+            this.tokens.as,
+            this.typeExpression
         );
     }
 
@@ -1445,7 +1444,6 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     public tokens = {} as {
         name: Identifier;
         as: Token;
-        type: Token;
     };
 
     public get name() {
@@ -1469,10 +1467,10 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
         result.push(
             this.tokens.name.text
         );
-        if (this.tokens.type?.text?.length > 0) {
+        if (this.typeExpression) {
             result.push(
                 ' as ',
-                this.tokens.type.text
+                ...this.typeExpression.getTypedef(state)
             );
         }
         return result;
@@ -1491,8 +1489,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         public params: FunctionParameterExpression[],
         rightParen: Token,
         asToken?: Token,
-        returnTypeToken?: Token,
-        public returnType?: BscType
+        public returnTypeExpression?: TypeExpression
     ) {
         super();
         this.tokens.functionType = functionTypeToken;
@@ -1500,7 +1497,6 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         this.tokens.leftParen = leftParen;
         this.tokens.rightParen = rightParen;
         this.tokens.as = asToken;
-        this.tokens.returnType = returnTypeToken;
     }
 
     public get range() {
@@ -1511,7 +1507,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
             ...(this.params ?? []),
             this.tokens.rightParen,
             this.tokens.as,
-            this.tokens.returnType
+            this.returnTypeExpression
         );
     }
 
@@ -1521,7 +1517,6 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         leftParen: Token;
         rightParen: Token;
         as: Token;
-        returnType: Token;
     };
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -1551,20 +1546,20 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
             }
             const param = params[i];
             result.push(param.name.text);
-            if (param.typeToken?.text?.length > 0) {
+            if (param.typeExpression) {
                 result.push(
                     ' as ',
-                    param.typeToken.text
+                    ...param.typeExpression.getTypedef(state)
                 );
             }
         }
         result.push(
             ')'
         );
-        if (this.tokens.returnType?.text.length > 0) {
+        if (this.returnTypeExpression) {
             result.push(
                 ' as ',
-                this.tokens.returnType.text
+                ...this.returnTypeExpression.getTypedef(state)
             );
         }
         return result;
@@ -2159,7 +2154,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
         readonly accessModifier?: Token,
         readonly name?: Identifier,
         readonly as?: Token,
-        readonly type?: Token,
+        readonly typeExpression?: TypeExpression,
         readonly equal?: Token,
         readonly initialValue?: Expression
     ) {
@@ -2168,7 +2163,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
             accessModifier,
             name,
             as,
-            type,
+            typeExpression,
             equal,
             initialValue
         );
@@ -2179,13 +2174,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
      * Defaults to `DynamicType`
      */
     getType() {
-        if (this.type) {
-            return util.tokenToBscType(this.type);
-        } else if (isLiteralExpression(this.initialValue)) {
-            return this.initialValue.type;
-        } else {
-            return new DynamicType();
-        }
+        return this.typeExpression.getType();
     }
 
     public readonly range: Range;

--- a/src/parser/TypeExpressions.ts
+++ b/src/parser/TypeExpressions.ts
@@ -1,5 +1,0 @@
-import { Expression } from './AstNode';
-
-export abstract class TypeExpression {
-
-}

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -137,10 +137,11 @@ export function expectDiagnostics(arg: DiagnosticCollection, expected: Array<Par
  * @param arg - any object that contains diagnostics (such as `Program`, `Scope`, or even an array of diagnostics)
  * @param expected an array of expected diagnostics. if it's a string, assume that's a diagnostic error message
  */
-export function expectDiagnosticsIncludes(arg: DiagnosticCollection, expected: Array<PartialDiagnostic | string | number>) {
+export function expectDiagnosticsIncludes(arg: DiagnosticCollection, expected: PartialDiagnostic | string | number | Array<PartialDiagnostic | string | number>) {
+    let actualExpected = Array.isArray(expected) ? expected : [expected];
     const actualDiagnostics = getDiagnostics(arg);
     const expectedDiagnostics =
-        expected.map(x => {
+        actualExpected.map(x => {
             let result = x;
             if (typeof x === 'string') {
                 result = { message: x };

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -6,6 +6,8 @@ export class BooleanType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new BooleanType('boolean');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof BooleanType ||

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -9,6 +9,8 @@ export class DoubleType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new DoubleType('double');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof DoubleType ||

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -9,6 +9,8 @@ export class FloatType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new FloatType('float');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof FloatType ||

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -9,6 +9,8 @@ export class IntegerType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new IntegerType('integer');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof IntegerType ||

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -9,6 +9,8 @@ export class LongIntegerType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new LongIntegerType('longinteger');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof LongIntegerType ||

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -6,6 +6,11 @@ export class StringType implements BscType {
         public typeText?: string
     ) { }
 
+    /**
+     * A static instance that can be used to reduce memory and constructor costs, since there's nothing unique about this
+     */
+    public static instance = new StringType('string');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof StringType ||

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,0 +1,26 @@
+import type { BscType } from './BscType';
+
+export class UnionType implements BscType {
+    constructor(
+        public types: BscType[]
+    ) {
+    }
+
+    public addType(type: BscType) {
+        this.types.push(type);
+    }
+
+    isAssignableTo(targetType: BscType): boolean {
+        throw new Error('Method not implemented.');
+    }
+    isConvertibleTo(targetType: BscType): boolean {
+        throw new Error('Method not implemented.');
+    }
+    toString(): string {
+        throw new Error('Method not implemented.');
+    }
+    toTypeString(): string {
+        throw new Error('Method not implemented.');
+    }
+
+}

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -6,6 +6,8 @@ export class VoidType implements BscType {
         public typeText?: string
     ) { }
 
+    public static instance = new VoidType('void');
+
     public isAssignableTo(targetType: BscType) {
         return (
             targetType instanceof VoidType ||

--- a/src/util.ts
+++ b/src/util.ts
@@ -1011,30 +1011,30 @@ export class Util {
                 return new BooleanType(token.text);
             case TokenKind.True:
             case TokenKind.False:
-                return new BooleanType();
+                return BooleanType.instance;
             case TokenKind.Double:
                 return new DoubleType(token.text);
             case TokenKind.DoubleLiteral:
-                return new DoubleType();
+                return DoubleType.instance;
             case TokenKind.Dynamic:
                 return new DynamicType(token.text);
             case TokenKind.Float:
                 return new FloatType(token.text);
             case TokenKind.FloatLiteral:
-                return new FloatType();
+                return FloatType.instance;
             case TokenKind.Function:
                 //TODO should there be a more generic function type without a signature that's assignable to all other function types?
                 return new FunctionType(new DynamicType(token.text));
             case TokenKind.Integer:
                 return new IntegerType(token.text);
             case TokenKind.IntegerLiteral:
-                return new IntegerType();
+                return IntegerType.instance;
             case TokenKind.Invalid:
                 return new InvalidType(token.text);
             case TokenKind.LongInteger:
                 return new LongIntegerType(token.text);
             case TokenKind.LongIntegerLiteral:
-                return new LongIntegerType();
+                return LongIntegerType.instance;
             case TokenKind.Object:
                 return new ObjectType(token.text);
             case TokenKind.String:
@@ -1043,7 +1043,7 @@ export class Util {
             case TokenKind.TemplateStringExpressionBegin:
             case TokenKind.TemplateStringExpressionEnd:
             case TokenKind.TemplateStringQuasi:
-                return new StringType();
+                return StringType.instance;
             case TokenKind.Void:
                 return new VoidType(token.text);
             case TokenKind.Identifier:

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -6,7 +6,7 @@ import type { ClassStatement, MethodStatement, NamespaceStatement } from '../par
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import util from '../util';
-import { isCallExpression, isFieldStatement, isMethodStatement, isCustomType, isNamespaceStatement } from '../astUtils/reflection';
+import { isCallExpression, isFieldStatement, isMethodStatement, isNamespaceStatement } from '../astUtils/reflection';
 import type { BscFile, BsDiagnostic } from '../interfaces';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { BrsFile } from '../files/BrsFile';
@@ -32,7 +32,7 @@ export class BsClassValidator {
         this.validateMemberCollisions();
         this.verifyChildConstructor();
         this.verifyNewExpressions();
-        this.validateFieldTypes();
+        //this.validateFieldTypes();
 
         this.cleanUp();
     }
@@ -295,7 +295,7 @@ export class BsClassValidator {
     /**
      * Check the types for fields, and validate they are valid types
      */
-    private validateFieldTypes() {
+    /*private validateFieldTypes() {
         for (const [, classStatement] of this.classes) {
             for (let statement of classStatement.body) {
                 if (isFieldStatement(statement)) {
@@ -320,7 +320,7 @@ export class BsClassValidator {
                 }
             }
         }
-    }
+    }*/
 
     /**
      * Get the closest member with the specified name (case-insensitive)

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -32,7 +32,6 @@ export class BsClassValidator {
         this.validateMemberCollisions();
         this.verifyChildConstructor();
         this.verifyNewExpressions();
-        //this.validateFieldTypes();
 
         this.cleanUp();
     }
@@ -291,36 +290,6 @@ export class BsClassValidator {
         }
     }
 
-
-    /**
-     * Check the types for fields, and validate they are valid types
-     */
-    /*private validateFieldTypes() {
-        for (const [, classStatement] of this.classes) {
-            for (let statement of classStatement.body) {
-                if (isFieldStatement(statement)) {
-                    let fieldType = statement.getType();
-
-                    if (isCustomType(fieldType)) {
-                        const fieldTypeName = fieldType.name;
-                        const lowerFieldTypeName = fieldTypeName?.toLowerCase();
-                        if (lowerFieldTypeName) {
-                            const namespace = classStatement.findAncestor<NamespaceStatement>(isNamespaceStatement);
-                            const currentNamespaceName = namespace?.getName(ParseMode.BrighterScript);
-                            //check if this custom type is in our class map
-                            if (!this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName)) {
-                                this.diagnostics.push({
-                                    ...DiagnosticMessages.cannotFindType(fieldTypeName),
-                                    range: statement.typeExpression.range,
-                                    file: classStatement.file
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }*/
 
     /**
      * Get the closest member with the specified name (case-insensitive)

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -223,7 +223,7 @@ export class BsClassValidator {
                             if (isFieldStatement(ancestorAndMember.member)) {
                                 ancestorMemberType = ancestorAndMember.member.getType();
                             } else if (isMethodStatement(ancestorAndMember.member)) {
-                                ancestorMemberType = ancestorAndMember.member.func.getFunctionType();
+                                ancestorMemberType = ancestorAndMember.member.func.getType();
                             }
                             const childFieldType = member.getType();
                             if (!childFieldType.isAssignableTo(ancestorMemberType)) {
@@ -311,7 +311,7 @@ export class BsClassValidator {
                             if (!this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName)) {
                                 this.diagnostics.push({
                                     ...DiagnosticMessages.cannotFindType(fieldTypeName),
-                                    range: statement.type.range,
+                                    range: statement.typeExpression.range,
                                     file: classStatement.file
                                 });
                             }


### PR DESCRIPTION
Converts all type related AST properties into `TypeExpression`. These include:
- function parameters (i.e. `p1 as SomeType`)
- interface / class fields (i.e. `field as SomeType`)
- function return types (i.e. `function SomeFunction() as SomeType`)

This is a work-in-progress, and is the first of many PRs #783 