### PR TITLE
Wrap transpiled template strings in parens

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1133,7 +1133,7 @@ export class TemplateStringExpression extends Expression {
         if (this.quasis.length === 1 && this.expressions.length === 0) {
             return this.quasis[0].transpile(state);
         }
-        let result = [];
+        let result = ['('];
         let plus = '';
         //helper function to figure out when to include the plus
         function add(...items) {
@@ -1176,6 +1176,8 @@ export class TemplateStringExpression extends Expression {
                 }
             }
         }
+        //the expression should be wrapped in parens so it can be used line a single expression at runtime
+        result.push(')');
 
         return result;
     }

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -82,7 +82,7 @@ describe('TemplateStringExpression', () => {
                 end sub
             `, `
                 sub main()
-                    a = rokucommunity_bslib_toString(LINE_NUM) + "," + rokucommunity_bslib_toString(LINE_NUM)
+                    a = (rokucommunity_bslib_toString(LINE_NUM) + "," + rokucommunity_bslib_toString(LINE_NUM))
                 end sub
             `);
         });
@@ -94,7 +94,7 @@ describe('TemplateStringExpression', () => {
                     end sub
                 `, `
                     sub main()
-                        a = bslib_toString(LINE_NUM) + "," + bslib_toString(LINE_NUM)
+                        a = (bslib_toString(LINE_NUM) + "," + bslib_toString(LINE_NUM))
                     end sub
                 `
             );
@@ -119,7 +119,7 @@ describe('TemplateStringExpression', () => {
                 end sub
             `, `
                 sub main()
-                    a = "hello " + bslib_toString(LINE_NUM.text) + " world " + bslib_toString("template" + "".getChars()) + " test"
+                    a = ("hello " + bslib_toString(LINE_NUM.text) + " world " + bslib_toString("template" + "".getChars()) + " test")
                 end sub
             `);
         });
@@ -191,7 +191,7 @@ describe('TemplateStringExpression', () => {
                 end sub
             `, `
                 sub main()
-                    a = "I am multiline" + chr(10) + bslib_toString(a.isRunning()) + chr(10) + "more"
+                    a = ("I am multiline" + chr(10) + bslib_toString(a.isRunning()) + chr(10) + "more")
                 end sub
             `);
         });
@@ -210,11 +210,11 @@ describe('TemplateStringExpression', () => {
                     a = [
                         "one"
                         "two"
-                        "I am a complex example" + bslib_toString(a.isRunning([
+                        ("I am a complex example" + bslib_toString(a.isRunning([
                             "a"
                             "b"
                             "c"
-                        ]))
+                        ])))
                     ]
                 end sub
             `);
@@ -239,25 +239,25 @@ describe('TemplateStringExpression', () => {
                     a = [
                         "one"
                         "two"
-                        "I am a complex example " + bslib_toString(a.isRunning([
+                        ("I am a complex example " + bslib_toString(a.isRunning([
                             "a"
                             "b"
                             "c"
-                            "d_open " + bslib_toString("inside" + m.items[1]) + " d_close"
-                        ]))
+                            ("d_open " + bslib_toString("inside" + m.items[1]) + " d_close")
+                        ])))
                     ]
                 end sub
             `);
         });
 
-        it('properly transpiles two template strings side-by-side', () => {
+        it('properly transpiles two expressions side-by-side', () => {
             testTranspile(`
                 sub main()
                     a = \`\${"hello"}\${"world"}\`
                 end sub
             `, `
                 sub main()
-                    a = "hello" + "world"
+                    a = ("hello" + "world")
                 end sub
             `);
         });
@@ -269,7 +269,7 @@ describe('TemplateStringExpression', () => {
                 end sub
             `, `
                 sub main()
-                    text = "Hello " + "world"
+                    text = ("Hello " + "world")
                 end sub
             `);
         });


### PR DESCRIPTION
Wraps transpiled template strings in parentheses so they can be interacted with as a single expression. 

Fixes #787 