### PR TITLE
Removes Parsetime Static Type Setting

### DIFF
--- a/src/FunctionScope.ts
+++ b/src/FunctionScope.ts
@@ -26,6 +26,10 @@ export class FunctionScope {
     public variableDeclarations = [] as VariableDeclaration[];
     public labelStatements = [] as LabelDeclaration[];
 
+    public get symbolTable() {
+        return this.func?.body?.getSymbolTable();
+    }
+
     /**
      * Find all variable declarations above the given line index
      * @param lineIndex the 0-based line number

--- a/src/FunctionScope.ts
+++ b/src/FunctionScope.ts
@@ -26,10 +26,6 @@ export class FunctionScope {
     public variableDeclarations = [] as VariableDeclaration[];
     public labelStatements = [] as LabelDeclaration[];
 
-    public get symbolTable() {
-        return this.func?.body?.getSymbolTable();
-    }
-
     /**
      * Find all variable declarations above the given line index
      * @param lineIndex the 0-based line number

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -938,7 +938,7 @@ export class Scope {
                 const lowerVarName = varName.toLowerCase();
 
                 //if the var is a function
-                if (isFunctionType(varDeclaration.type)) {
+                if (isFunctionType(varDeclaration.getType())) {
                     //local var function with same name as stdlib function
                     if (
                         //has same name as stdlib

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -87,11 +87,12 @@ export class HoverProcessor {
                     //we found a variable declaration with this token text!
                     if (varDeclaration.name.toLowerCase() === lowerTokenText) {
                         let typeText: string;
-                        if (isFunctionType(varDeclaration.type)) {
-                            varDeclaration.type.setName(varDeclaration.name);
-                            typeText = varDeclaration.type.toString();
+                        const varDeclarationType = varDeclaration.getType();
+                        if (isFunctionType(varDeclarationType)) {
+                            varDeclarationType.setName(varDeclaration.name);
+                            typeText = varDeclarationType.toString();
                         } else {
-                            typeText = `${varDeclaration.name} as ${varDeclaration.type.toString()}`;
+                            typeText = `${varDeclaration.name} as ${varDeclarationType.toString()}`;
                         }
                         return {
                             range: token.range,

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -65,7 +65,7 @@ export class BrsFileValidator {
             },
             AssignmentStatement: (node) => {
                 //register this variable
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance, SymbolTypeFlags.runtime);
+                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.getType(), SymbolTypeFlags.runtime);
             },
             DottedSetStatement: (node) => {
                 this.validateNoOptionalChainingInVarSet(node, [node.obj]);
@@ -94,7 +94,7 @@ export class BrsFileValidator {
                     node.parent.getSymbolTable().addSymbol(
                         node.name.text,
                         node.name.range,
-                        DynamicType.instance,
+                        node.func.getType(),
                         SymbolTypeFlags.runtime
                     );
                 }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -65,6 +65,7 @@ export class BrsFileValidator {
             },
             AssignmentStatement: (node) => {
                 //register this variable
+                // TODO: the type of the LHS may not be known yet!
                 node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.getType(), SymbolTypeFlags.runtime);
             },
             DottedSetStatement: (node) => {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1698,21 +1698,21 @@ describe('BrsFile', () => {
                 lineIndex: 2,
                 name: 'sayHi'
             });
-            expect(file.functionScopes[0].variableDeclarations[0].type).instanceof(FunctionType);
+            expect(file.functionScopes[0].variableDeclarations[0].getType()).instanceof(FunctionType);
 
             expect(file.functionScopes[1].variableDeclarations).to.be.length(1);
             expect(file.functionScopes[1].variableDeclarations[0]).to.deep.include(<VariableDeclaration>{
                 lineIndex: 3,
                 name: 'age'
             });
-            expect(file.functionScopes[1].variableDeclarations[0].type).instanceof(IntegerType);
+            expect(file.functionScopes[1].variableDeclarations[0].getType()).instanceof(IntegerType);
 
             expect(file.functionScopes[2].variableDeclarations).to.be.length(1);
             expect(file.functionScopes[2].variableDeclarations[0]).to.deep.include(<VariableDeclaration>{
                 lineIndex: 7,
                 name: 'name'
             });
-            expect(file.functionScopes[2].variableDeclarations[0].type).instanceof(StringType);
+            expect(file.functionScopes[2].variableDeclarations[0].getType()).instanceof(StringType);
         });
 
         it('finds variable declarations inside of if statements', () => {
@@ -1738,29 +1738,34 @@ describe('BrsFile', () => {
                     return "bob"
                 end function
             `);
+            // Types are only guaranteed after validation
+            program.validate();
+            expectZeroDiagnostics(program);
 
             expect(file.functionScopes[0].variableDeclarations).to.be.length(1);
             expect(file.functionScopes[0].variableDeclarations[0]).to.deep.include(<VariableDeclaration>{
                 lineIndex: 2,
                 name: 'myName'
             });
-            expect(file.functionScopes[0].variableDeclarations[0].type).instanceof(StringType);
+            expect(file.functionScopes[0].variableDeclarations[0].getType()).instanceof(StringType);
         });
 
         it('finds variable type from other variable', () => {
-            file.parse(`
+            let file = program.setFile('source/main.brs', `
                 sub Main()
                    name = "bob"
                    nameCopy = name
                 end sub
             `);
+            // Types are only guaranteed after validation
+            program.validate();
 
             expect(file.functionScopes[0].variableDeclarations).to.be.length(2);
             expect(file.functionScopes[0].variableDeclarations[1]).to.deep.include(<VariableDeclaration>{
                 lineIndex: 3,
                 name: 'nameCopy'
             });
-            expect(file.functionScopes[0].variableDeclarations[1].type).instanceof(StringType);
+            expect(file.functionScopes[0].variableDeclarations[1].getType()).instanceof(StringType);
         });
 
         it('sets proper range for functions', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -14,7 +14,7 @@ import { Lexer } from '../lexer/Lexer';
 import { TokenKind, AllowedLocalIdentifiers, Keywords } from '../lexer/TokenKind';
 import { Parser, ParseMode } from '../parser/Parser';
 import type { FunctionExpression, VariableExpression } from '../parser/Expression';
-import type { ClassStatement, FunctionStatement, NamespaceStatement, AssignmentStatement, MethodStatement, FieldStatement } from '../parser/Statement';
+import type { ClassStatement, FunctionStatement, NamespaceStatement, MethodStatement, FieldStatement } from '../parser/Statement';
 import type { Program } from '../Program';
 import { DynamicType } from '../types/DynamicType';
 import { FunctionType } from '../types/FunctionType';
@@ -24,8 +24,7 @@ import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { LogLevel } from '../Logger';
 import { serializeError } from 'serialize-error';
-import { isCallExpression, isMethodStatement, isClassStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isFieldStatement, isEnumStatement, isConstStatement } from '../astUtils/reflection';
-import type { BscType } from '../types/BscType';
+import { isMethodStatement, isClassStatement, isDottedGetExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isXmlFile, isImportStatement, isFieldStatement, isEnumStatement, isConstStatement } from '../astUtils/reflection';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
@@ -512,19 +511,6 @@ export class BrsFile {
                     name: statement.name.text,
                     getType: () => statement.value.getType()
                 });
-            }
-        }
-    }
-
-
-    private getCallableByName(name: string) {
-        name = name ? name.toLowerCase() : undefined;
-        if (!name) {
-            return;
-        }
-        for (let func of this.callables) {
-            if (func.name.toLowerCase() === name) {
-                return func;
             }
         }
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ import type { FunctionType } from './types/FunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program, SourceObj, TranspileObj } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { FunctionStatement } from './parser/Statement';
+import type { AssignmentStatement, FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
@@ -136,7 +136,7 @@ export interface File {
 
 export interface VariableDeclaration {
     name: string;
-    type: BscType;
+    getType: () => BscType;
     /**
      * The range for the variable name
      */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ import type { FunctionType } from './types/FunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program, SourceObj, TranspileObj } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { AssignmentStatement, FunctionStatement } from './parser/Statement';
+import type { FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
@@ -119,7 +119,8 @@ export class CallExpression extends Expression {
     }
 
     getType(): BscType {
-        return this.callee.getType();
+        const callType = this.callee.getType();
+        return isFunctionType(callType) ? callType.returnType : DynamicType.instance;
     }
 }
 
@@ -883,6 +884,10 @@ export class VariableExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public getType(): BscType {
+        return this.getSymbolTable()?.getSymbol(this.name.text, SymbolTypeFlags.runtime)?.[0]?.type ?? DynamicType.instance;
     }
 }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -157,6 +157,7 @@ export class AssignmentStatement extends Statement {
     }
 
     getType(): BscType {
+        // TODO: the type of the LHS may not be known yet!
         return this.value.getType();
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -18,6 +18,7 @@ import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
 import type { Expression } from './AstNode';
 import { Statement } from './AstNode';
+import type { BscType } from '../types/BscType';
 
 export class EmptyStatement extends Statement {
     constructor(
@@ -153,6 +154,10 @@ export class AssignmentStatement extends Statement {
             //TODO: Walk TypeExpression. We need to decide how to implement types on assignments
             walk(this, 'value', visitor, options);
         }
+    }
+
+    getType(): BscType {
+        return this.value.getType();
     }
 }
 


### PR DESCRIPTION
- Changes `FunctionScope.variableDeclarations` to use the `getType()` function instead of a statically-set `type`.
- `VariableDeclaration.getType()` reaches into the underlying expression/statement to derive the type 

Note:
We can probably refactor to remove `VariableDeclarations` AND `FunctionScopes` altogether, but I'm going for SMALL PRs. haha
