### PR TITLE
Adds ReferenceType

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1538,6 +1538,25 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
 
             });
+
+            it('finds correctly types a variable with type from different file', () => {
+                program.setFile(`source/main.bs`, `
+                    sub main()
+                        thing = new MyKlass()
+                        useKlass(thing)
+                    end sub
+
+                    sub useKlass(thing as MyKlass)
+                        print thing
+                    end sub
+                `);
+                program.setFile(`source/MyKlass.bs`, `
+                    class MyKlass
+                    end class
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
         });
     });
 

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -20,6 +20,7 @@ import { DynamicType } from '../types/DynamicType';
 import type { InterfaceType } from '../types/InterfaceType';
 import type { ObjectType } from '../types/ObjectType';
 import type { AstNode, Expression, Statement } from '../parser/AstNode';
+import type { ReferenceType } from '../types/ReferenceType';
 
 // File reflection
 
@@ -303,6 +304,9 @@ export function isInterfaceType(e: any): e is InterfaceType {
 }
 export function isObjectType(e: any): e is ObjectType {
     return e?.constructor.name === 'ObjectType';
+}
+export function isReferenceType(e: any): e is ReferenceType {
+    return e?.constructor.name === 'ReferenceType';
 }
 
 const numberConstructorNames = [

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -306,7 +306,7 @@ export function isObjectType(e: any): e is ObjectType {
     return e?.constructor.name === 'ObjectType';
 }
 export function isReferenceType(e: any): e is ReferenceType {
-    return e?.constructor.name === 'ReferenceType';
+    return e?.__reflection.name === 'ReferenceType';
 }
 
 const numberConstructorNames = [

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -289,7 +289,7 @@ describe('HoverProcessor', () => {
             expect(hover).to.be.undefined;
         });
 
-        it.only('finds types defined in different file', () => {
+        it('finds types defined in different file', () => {
             program.setFile(`source/main.bs`, `
                 sub main()
                     thing = new MyKlass()
@@ -319,7 +319,7 @@ describe('HoverProcessor', () => {
             expect(hover?.contents).to.eql(fence('thing as MyKlass'));
             //print some|Val
             hover = program.getHover('source/main.bs', util.createPosition(5, 31))[0];
-            expect(hover?.range).to.eql(util.createRange(5, 27, 2, 33));
+            expect(hover?.range).to.eql(util.createRange(5, 26, 5, 33));
             expect(hover?.contents).to.eql(fence('someVal as string'));
         });
     });

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -42,87 +42,94 @@ export class HoverProcessor {
 
     private getBrsFileHover(file: BrsFile): Hover {
         const scope = this.event.scopes[0];
-        const fence = (code: string) => util.mdFence(code, 'brightscript');
-        //get the token at the position
-        let token = file.getTokenAt(this.event.position);
+        try {
+            scope.linkSymbolTable();
+            const fence = (code: string) => util.mdFence(code, 'brightscript');
+            //get the token at the position
+            let token = file.getTokenAt(this.event.position);
 
-        let hoverTokenTypes = [
-            TokenKind.Identifier,
-            TokenKind.Function,
-            TokenKind.EndFunction,
-            TokenKind.Sub,
-            TokenKind.EndSub
-        ];
+            let hoverTokenTypes = [
+                TokenKind.Identifier,
+                TokenKind.Function,
+                TokenKind.EndFunction,
+                TokenKind.Sub,
+                TokenKind.EndSub
+            ];
 
-        //throw out invalid tokens and the wrong kind of tokens
-        if (!token || !hoverTokenTypes.includes(token.kind)) {
-            return null;
-        }
-
-        const expression = file.getClosestExpression(this.event.position);
-        if (expression) {
-            let containingNamespace = file.getNamespaceStatementForPosition(expression.range.start)?.getName(ParseMode.BrighterScript);
-            const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
-
-            //find a constant with this name
-            const constant = scope?.getConstFileLink(fullName, containingNamespace);
-            if (constant) {
-                const constantValue = new SourceNode(null, null, null, constant.item.value.transpile(new BrsTranspileState(file))).toString();
-                return {
-                    contents: this.buildContentsWithDocs(fence(`const ${constant.item.fullName} = ${constantValue}`), constant.item.tokens.const),
-                    range: token.range
-                };
+            //throw out invalid tokens and the wrong kind of tokens
+            if (!token || !hoverTokenTypes.includes(token.kind)) {
+                return null;
             }
-        }
 
-        let lowerTokenText = token.text.toLowerCase();
+            const expression = file.getClosestExpression(this.event.position);
+            if (expression) {
+                let containingNamespace = file.getNamespaceStatementForPosition(expression.range.start)?.getName(ParseMode.BrighterScript);
+                const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
 
-        //look through local variables first
-        {
-            //get the function scope for this position (if exists)
-            let functionScope = file.getFunctionScopeAtPosition(this.event.position);
-            if (functionScope) {
-                //find any variable with this name
-                for (const varDeclaration of functionScope.variableDeclarations) {
-                    //we found a variable declaration with this token text!
-                    if (varDeclaration.name.toLowerCase() === lowerTokenText) {
-                        let typeText: string;
-                        const varDeclarationType = varDeclaration.getType();
-                        if (isFunctionType(varDeclarationType)) {
-                            varDeclarationType.setName(varDeclaration.name);
-                            typeText = varDeclarationType.toString();
-                        } else {
-                            typeText = `${varDeclaration.name} as ${varDeclarationType.toString()}`;
+                //find a constant with this name
+                const constant = scope?.getConstFileLink(fullName, containingNamespace);
+                if (constant) {
+                    const constantValue = new SourceNode(null, null, null, constant.item.value.transpile(new BrsTranspileState(file))).toString();
+                    return {
+                        contents: this.buildContentsWithDocs(fence(`const ${constant.item.fullName} = ${constantValue}`), constant.item.tokens.const),
+                        range: token.range
+                    };
+                }
+            }
+
+            let lowerTokenText = token.text.toLowerCase();
+
+            //look through local variables first
+            {
+                //get the function scope for this position (if exists)
+                let functionScope = file.getFunctionScopeAtPosition(this.event.position);
+                if (functionScope) {
+                    //find any variable with this name
+                    for (const varDeclaration of functionScope.variableDeclarations) {
+                        //we found a variable declaration with this token text!
+                        if (varDeclaration.name.toLowerCase() === lowerTokenText) {
+                            let typeText: string;
+                            const varDeclarationType = varDeclaration.getType();
+                            if (isFunctionType(varDeclarationType)) {
+                                varDeclarationType.setName(varDeclaration.name);
+                                typeText = varDeclarationType.toString();
+                            } else {
+                                typeText = `${varDeclaration.name} as ${varDeclarationType.toString()}`;
+                            }
+                            return {
+                                range: token.range,
+                                //append the variable name to the front for scope
+                                contents: fence(typeText)
+                            };
                         }
-                        return {
-                            range: token.range,
-                            //append the variable name to the front for scope
-                            contents: fence(typeText)
-                        };
                     }
-                }
-                for (const labelStatement of functionScope.labelStatements) {
-                    if (labelStatement.name.toLocaleLowerCase() === lowerTokenText) {
-                        return {
-                            range: token.range,
-                            contents: fence(`${labelStatement.name}: label`)
-                        };
+                    for (const labelStatement of functionScope.labelStatements) {
+                        if (labelStatement.name.toLocaleLowerCase() === lowerTokenText) {
+                            return {
+                                range: token.range,
+                                contents: fence(`${labelStatement.name}: label`)
+                            };
+                        }
                     }
                 }
             }
-        }
 
-        //Potentially a problem for the function `string()` as it is a type AND a function https://developer.roku.com/en-ca/docs/references/brightscript/language/global-string-functions.md#stringn-as-integer-str-as-string--as-string
+            //Potentially a problem for the function `string()` as it is a type AND a function https://developer.roku.com/en-ca/docs/references/brightscript/language/global-string-functions.md#stringn-as-integer-str-as-string--as-string
 
-        //look through all callables in relevant scopes
-        for (let scope of this.event.scopes) {
-            let callable = scope.getCallableByName(lowerTokenText);
-            if (callable) {
-                return {
-                    range: token.range,
-                    contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
-                };
+            //look through all callables in relevant scopes
+            for (let scope of this.event.scopes) {
+                let callable = scope.getCallableByName(lowerTokenText);
+                if (callable) {
+                    return {
+                        range: token.range,
+                        contents: this.buildContentsWithDocs(fence(callable.type.toString()), callable.functionStatement?.func?.functionType)
+                    };
+                }
             }
+        } catch (e) {
+            // nothing
+        } finally {
+            scope?.unlinkSymbolTable();
         }
     }
 

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -126,8 +126,6 @@ export class HoverProcessor {
                     };
                 }
             }
-        } catch (e) {
-            // nothing
         } finally {
             scope?.unlinkSymbolTable();
         }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -65,7 +65,6 @@ export class BrsFileValidator {
             },
             AssignmentStatement: (node) => {
                 //register this variable
-                // TODO: the type of the LHS may not be known yet!
                 node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.getType(), SymbolTypeFlags.runtime);
             },
             DottedSetStatement: (node) => {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -16,7 +16,7 @@ import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import util, { standardizePath as s } from '../util';
 import PluginInterface from '../PluginInterface';
-import { expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile, trim } from '../testHelpers.spec';
+import { expectCompletionsIncludes, expectDiagnostics, expectHasDiagnostics, expectTypeToBe, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile, trim } from '../testHelpers.spec';
 import { ParseMode } from '../parser/Parser';
 import { Logger } from '../Logger';
 import { ImportStatement } from '../parser/Statement';
@@ -1747,7 +1747,7 @@ describe('BrsFile', () => {
                 lineIndex: 2,
                 name: 'myName'
             });
-            expect(file.functionScopes[0].variableDeclarations[0].getType()).instanceof(StringType);
+            expectTypeToBe(file.functionScopes[0].variableDeclarations[0].getType(), StringType);
         });
 
         it('finds variable type from other variable', () => {
@@ -1765,7 +1765,7 @@ describe('BrsFile', () => {
                 lineIndex: 3,
                 name: 'nameCopy'
             });
-            expect(file.functionScopes[0].variableDeclarations[1].getType()).instanceof(StringType);
+            expectTypeToBe(file.functionScopes[0].variableDeclarations[1].getType(), StringType);
         });
 
         it('sets proper range for functions', () => {

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -107,7 +107,7 @@ export abstract class AstNode {
      * Links all child nodes to their parent AstNode, and the same with symbol tables. This performs a full AST walk, so you should use this sparingly
      */
     public link() {
-        //the cat of walking causes the nodes to be linked
+        //the act of walking causes the nodes to be linked
         this.walk(() => { }, {
             walkMode: WalkMode.visitAllRecursive
         });

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -9,6 +9,7 @@ import type { TranspileResult } from '../interfaces';
 import type { AnnotationExpression } from './Expression';
 import util from '../util';
 import { DynamicType } from '../types/DynamicType';
+import type { BscType } from '../types/BscType';
 
 /**
  * A BrightScript AST node
@@ -99,7 +100,7 @@ export abstract class AstNode {
     /**
      * Get the BscType of this node.
      */
-    public getType() {
+    public getType(): BscType {
         return new DynamicType();
     }
 

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -107,7 +107,7 @@ export abstract class AstNode {
      * Links all child nodes to their parent AstNode, and the same with symbol tables. This performs a full AST walk, so you should use this sparingly
      */
     public link() {
-        //the act of walking causes the nodes to be linked
+        //the cat of walking causes the nodes to be linked
         this.walk(() => { }, {
             walkMode: WalkMode.visitAllRecursive
         });

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isReferenceType, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -124,7 +124,7 @@ export class CallExpression extends Expression {
         if (isReferenceType(callType)) {
             callType = callType.resolve();
         }
-        return isFunctionType(callType) ? callType.returnType : DynamicType.instance;
+        return isFunctionType(callType) ? callType.returnType : callType;
     }
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -895,7 +895,7 @@ export class VariableExpression extends Expression {
     }
 
     public getType(): BscType {
-        return new ReferenceType(this.name.text, () => this.getSymbolTable()); //SymbolTableProvider  ////this.getSymbolTable()?.getSymbol(this.name.text, SymbolTypeFlags.runtime)?.[0]?.type ?? DynamicType.instance;
+        return new ReferenceType(this.name.text, () => this.getSymbolTable());
     }
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -119,11 +119,8 @@ export class CallExpression extends Expression {
         }
     }
 
-    getType(): BscType {
+    getType() {
         let callType = this.callee.getType();
-        if (isReferenceType(callType)) {
-            callType = callType.resolve();
-        }
         return isFunctionType(callType) ? callType.returnType : callType;
     }
 }
@@ -894,7 +891,7 @@ export class VariableExpression extends Expression {
         //nothing to walk
     }
 
-    public getType(): BscType {
+    public getType() {
         return new ReferenceType(this.name.text, () => this.getSymbolTable());
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -18,7 +18,6 @@ import type { TranspileState } from './TranspileState';
 import { SymbolTable } from '../SymbolTable';
 import type { Expression } from './AstNode';
 import { Statement } from './AstNode';
-import type { BscType } from '../types/BscType';
 
 export class EmptyStatement extends Statement {
     constructor(
@@ -156,8 +155,7 @@ export class AssignmentStatement extends Statement {
         }
     }
 
-    getType(): BscType {
-        // TODO: the type of the LHS may not be known yet!
+    getType() {
         return this.value.getType();
     }
 }

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -13,6 +13,8 @@ import type { CodeWithSourceMap } from 'source-map';
 import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';
 import undent from 'undent';
+import type { BscType } from './types/BscType';
+import { isReferenceType } from './astUtils/reflection';
 
 export const tempDir = s`${__dirname}/../.tmp`;
 export const rootDir = s`${tempDir}/rootDir`;
@@ -362,4 +364,14 @@ export function mapToObject<T>(map: Map<any, T>) {
         result[key] = value;
     }
     return result;
+}
+
+/**
+ * Test that a type is what was expected
+ */
+export function expectTypeToBe(someType: BscType, expectedTypeClass: any) {
+    if (isReferenceType(someType)) {
+        someType = someType.resolve();
+    }
+    expect(someType).instanceof(expectedTypeClass);
 }

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -14,7 +14,6 @@ import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';
 import undent from 'undent';
 import type { BscType } from './types/BscType';
-import { isReferenceType } from './astUtils/reflection';
 
 export const tempDir = s`${__dirname}/../.tmp`;
 export const rootDir = s`${tempDir}/rootDir`;
@@ -370,8 +369,5 @@ export function mapToObject<T>(map: Map<any, T>) {
  * Test that a type is what was expected
  */
 export function expectTypeToBe(someType: BscType, expectedTypeClass: any) {
-    if (isReferenceType(someType)) {
-        someType = someType.resolve();
-    }
-    expect(someType).instanceof(expectedTypeClass);
+    expect(someType.constructor.name).to.eq(expectedTypeClass.name);
 }

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
+import { expectTypeToBe } from '../testHelpers.spec';
+import { DynamicType } from './DynamicType';
+import { IntegerType } from './IntegerType';
+import { ReferenceType } from './ReferenceType';
+import { StringType } from './StringType';
+import { FloatType } from './FloatType';
+import { CustomType } from './CustomType';
+
+describe('ReferenceType', () => {
+    it('defaults to dynamic type if it can not resolve', () => {
+        expectTypeToBe(new ReferenceType('test', () => undefined), DynamicType);
+        const table = new SymbolTable('testTable');
+        expectTypeToBe(new ReferenceType('test', () => table), DynamicType);
+        table.addSymbol('someVar', null, StringType.instance, SymbolTypeFlags.runtime);
+        expectTypeToBe(new ReferenceType('test', () => table), DynamicType);
+    });
+
+    it('can resolve based on a symbol table', () => {
+        const table = new SymbolTable('test');
+        const ref = new ReferenceType('someVar', () => table);
+        table.addSymbol('someVar', null, StringType.instance, SymbolTypeFlags.runtime);
+        expectTypeToBe(ref, StringType);
+    });
+
+    it('resolves before checking assigning and convertible', () => {
+        const table = new SymbolTable('test');
+        const ref = new ReferenceType('someVar', () => table);
+        table.addSymbol('someVar', null, IntegerType.instance, SymbolTypeFlags.runtime);
+        expect(ref.isAssignableTo(IntegerType.instance)).to.be.true;
+        expect(ref.isConvertibleTo(FloatType.instance)).to.be.true;
+    });
+
+    it('resolves before stringifying', () => {
+        const table = new SymbolTable('test');
+        const ref = new ReferenceType('someKlass', () => table);
+        table.addSymbol('someKlass', null, new CustomType('SomeKlass'), SymbolTypeFlags.runtime);
+        expect(ref.toTypeString()).to.eq('object');
+        expect(ref.toString()).to.eq('SomeKlass');
+    });
+});

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -39,4 +39,24 @@ describe('ReferenceType', () => {
         expect(ref.toTypeString()).to.eq('object');
         expect(ref.toString()).to.eq('SomeKlass');
     });
+
+    it('catches circular references', () => {
+        const table = new SymbolTable('test');
+        const ref = new ReferenceType('someVar', () => table);
+        table.addSymbol('someVar', null, ref, SymbolTypeFlags.runtime);
+        expectTypeToBe(ref, DynamicType);
+    });
+
+
+    it('catches circular references of many levels', () => {
+        const table = new SymbolTable('test');
+        const ref1 = new ReferenceType('someVar1', () => table);
+        const ref2 = new ReferenceType('someVar2', () => table);
+        const ref3 = new ReferenceType('someVar3', () => table);
+        table.addSymbol('someVar0', null, ref1, SymbolTypeFlags.runtime);
+        table.addSymbol('someVar1', null, ref2, SymbolTypeFlags.runtime);
+        table.addSymbol('someVar2', null, ref3, SymbolTypeFlags.runtime);
+        table.addSymbol('someVar3', null, ref1, SymbolTypeFlags.runtime);
+        expectTypeToBe(table.getSymbol('someVar0', SymbolTypeFlags.runtime)[0].type, DynamicType);
+    });
 });

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -7,8 +7,16 @@ import { ReferenceType } from './ReferenceType';
 import { StringType } from './StringType';
 import { FloatType } from './FloatType';
 import { CustomType } from './CustomType';
+import { isReferenceType } from '../astUtils/reflection';
 
 describe('ReferenceType', () => {
+    it('can be checked with reflection', () => {
+        const table = new SymbolTable('test');
+        const ref = new ReferenceType('someVar', () => table);
+        expect(isReferenceType(ref)).to.be.true;
+    });
+
+
     it('defaults to dynamic type if it can not resolve', () => {
         expectTypeToBe(new ReferenceType('test', () => undefined), DynamicType);
         const table = new SymbolTable('testTable');

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -1,0 +1,36 @@
+import type { SymbolTableProvider } from '../SymbolTable';
+import { SymbolTypeFlags } from '../SymbolTable';
+import type { BscType } from './BscType';
+import { DynamicType } from './DynamicType';
+
+export class ReferenceType implements BscType {
+    constructor(
+        public name: string,
+        private tableProvider: SymbolTableProvider
+    ) { }
+
+    public isAssignableTo(targetType: BscType) {
+        return this.resolve()?.isAssignableTo(targetType);
+    }
+
+    public isConvertibleTo(targetType: BscType) {
+        return this.resolve()?.isConvertibleTo(targetType);
+    }
+
+    public toString() {
+        return this.resolve()?.toString();
+    }
+
+    public toTypeString(): string {
+        return this.resolve()?.toTypeString();
+    }
+
+    /**
+     * Resolves the type based on the original name and the table provider
+     * Is public because there are situation when we may want to know if the resolved type is a function/class, etc.
+     */
+    public resolve(): BscType {
+        // eslint-disable-next-line no-bitwise
+        return this.tableProvider()?.getSymbol(this.name, SymbolTypeFlags.runtime | SymbolTypeFlags.typetime)?.[0]?.type ?? DynamicType.instance;
+    }
+}

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -8,6 +8,11 @@ export class ReferenceType implements BscType {
         // eslint-disable-next-line no-constructor-return
         return new Proxy(this, {
             get: (target, propName, receiver) => {
+
+                if (propName === '__reflection') {
+                    // Cheeky way to get `isReferenceType` reflection to work
+                    return { name: 'ReferenceType' };
+                }
                 //There may be some need to specifically get members on ReferenceType in the future
                 // eg: if (Reflect.has(target, name)) {
                 //   return Reflect.get(target, propName, receiver);


### PR DESCRIPTION
Adds `ReferenceType`

A `ReferenceType` is a `BscType` that is given a `SymbolTableProvider`, so that it can do lookups in a symbol table.
This is useful for when a type is unknown at parse time - eg. when a function is defined in a different file (or even just further down a file)

An additional change here is to make sure SymbolTables are linked for the appropriate scope when doing a hover.
