### PR TITLE
Improves performance in symbol table fetching

### DIFF
--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -39,13 +39,15 @@ export abstract class AstNode {
     public symbolTable?: SymbolTable;
 
     /**
-     * Get the closest symbol table for this node. Should be overridden in children that directly contain a symbol table
+     * Get the closest symbol table for this node
      */
     public getSymbolTable(): SymbolTable {
-        if (this.symbolTable) {
-            return this.symbolTable;
-        } else {
-            return this.parent?.getSymbolTable();
+        let node: AstNode = this;
+        while (node) {
+            if (node.symbolTable) {
+                return node.symbolTable;
+            }
+            node = node.parent;
         }
     }
 


### PR DESCRIPTION
Small performance boost by optimizing the `AstNode.getSymbolTable()` method. 

Before: 
![image](https://user-images.githubusercontent.com/2544493/233732854-1577e2c5-e2eb-489b-b49e-9c5464b97e04.png)

After (i.e. this change) 
![image](https://user-images.githubusercontent.com/2544493/233732843-42f08221-45de-49ea-99b7-1707567ac1f8.png)
