### PR TITLE
ClassType and InterfaceType refactor and Inheritance

### DIFF
--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "benchmark": "^2.1.4",
-                "brighterscript1": "file:.tmp/brighterscript-0.64.21682439243564.tgz",
+                "brighterscript1": "file:.tmp/brighterscript-0.64.21682614318535.tgz",
                 "brighterscript2": "npm:brighterscript@^0.64.2",
                 "chalk": "^4.1.2",
                 "fast-glob": "^3.2.12",
@@ -533,8 +533,8 @@
         "node_modules/brighterscript1": {
             "name": "brighterscript",
             "version": "0.64.2",
-            "resolved": "file:.tmp/brighterscript-0.64.21682439243564.tgz",
-            "integrity": "sha512-PtlbxF76azFNjUHzWRJFpST5M9D0NDoe/1mOAMsy7pBbuQf75xvxFjMmfxiEgyTxfHf8Cq8oNvHyBfTfUzw0mA==",
+            "resolved": "file:.tmp/brighterscript-0.64.21682614318535.tgz",
+            "integrity": "sha512-lnOB10vo8afUYbl6EE0gwKT6b4GASK+CeAbC3JtesUJTYNepuzR37hMdWiTYs1uR0CJu6aRiOom8NaMNWNM3Bw==",
             "license": "MIT",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
@@ -3876,8 +3876,8 @@
             }
         },
         "brighterscript1": {
-            "version": "file:.tmp/brighterscript-0.64.21682439243564.tgz",
-            "integrity": "sha512-PtlbxF76azFNjUHzWRJFpST5M9D0NDoe/1mOAMsy7pBbuQf75xvxFjMmfxiEgyTxfHf8Cq8oNvHyBfTfUzw0mA==",
+            "version": "file:.tmp/brighterscript-0.64.21682614318535.tgz",
+            "integrity": "sha512-lnOB10vo8afUYbl6EE0gwKT6b4GASK+CeAbC3JtesUJTYNepuzR37hMdWiTYs1uR0CJu6aRiOom8NaMNWNM3Bw==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1787,6 +1787,69 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
             });
         });
+
+        describe('interfaces', () => {
+            it('allows using interfaces as types', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFace as iFace)
+                    end sub
+
+                    interface iFace
+                        name as string
+                    end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('disallows using interface members as types', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFaceName as iFace.name)
+                    end sub
+
+                    interface iFace
+                        name as string
+                    end interface
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.itemCannotBeUsedAsType('iFace.name').message
+                ]);
+            });
+
+            it('allows accessing interface members in code', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFace as iFace)
+                        print myFace.name
+                    end sub
+
+                    interface iFace
+                        name as string
+                    end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows accessing an interface member from a super interface', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFace as iFace)
+                        print myFace.coin
+                    end sub
+
+                    interface iFace extends twoFace
+                        name as string
+                    end interface
+
+                    interface twoFace
+                        coin as string
+                    end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+        });
     });
 
     describe('inheritance', () => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -13,7 +13,7 @@ import type { FunctionStatement, NamespaceStatement } from './parser/Statement';
 import type { OnScopeValidateEvent } from './interfaces';
 import { SymbolTypeFlags } from './SymbolTable';
 import { EnumMemberType } from './types/EnumType';
-import { CustomType } from './types/CustomType';
+import { ClassType } from './types/ClassType';
 import { BooleanType } from './types/BooleanType';
 import { StringType } from './types/StringType';
 import { IntegerType } from './types/IntegerType';
@@ -1987,7 +1987,7 @@ describe('Scope', () => {
             expect(sourceScope).to.exist;
             expect(mainFnScope).to.exist;
             sourceScope.linkSymbolTable();
-            expectTypeToBe(mainFnScope.symbolTable.getSymbol('fooInstance', SymbolTypeFlags.runtime)[0].type, CustomType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('fooInstance', SymbolTypeFlags.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('fooInstance', SymbolTypeFlags.runtime)[0].type.toString()).to.eq('Foo');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('myNum', SymbolTypeFlags.runtime)[0].type, IntegerType);
         });
@@ -2054,11 +2054,11 @@ describe('Scope', () => {
             expect(mainFnScope).to.exist;
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('skin', SymbolTypeFlags.runtime)[0].type, EnumMemberType);
 
-            expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoy', SymbolTypeFlags.runtime)[0].type, CustomType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoy', SymbolTypeFlags.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('flyBoy', SymbolTypeFlags.runtime)[0].type.toString()).to.eq('Animals.Bird');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoysWings', SymbolTypeFlags.runtime)[0].type, BooleanType);
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoysSkin', SymbolTypeFlags.runtime)[0].type, EnumMemberType);
-            expectTypeToBe(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlags.runtime)[0].type, CustomType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlags.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlags.runtime)[0].type.toString()).to.eq('Animals.Dog');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('fidoBark', SymbolTypeFlags.runtime)[0].type, StringType);
         });

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1630,6 +1630,27 @@ describe('Scope', () => {
                 ]);
             });
 
+            it('allows a class to extend from a class in another namespace and file', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFace as Villain)
+                        print myFace.coin
+                    end sub
+
+                    class Villain extends MyKlasses.twoFace
+                        name as string
+                    end class
+                `);
+                program.setFile(`source/extra.bs`, `
+                    namespace MyKlasses
+                        class twoFace
+                            coin as string
+                        end class
+                    end namespace
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
 
             it('resolves a const in a namespace', () => {
                 program.setFile(`source/main.bs`, `
@@ -1844,6 +1865,27 @@ describe('Scope', () => {
                     interface twoFace
                         coin as string
                     end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows an interface to extend from an interface in another namespace and file', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(myFace as iFace)
+                        print myFace.coin
+                    end sub
+
+                    interface iFace extends MyInterfaces.twoFace
+                        name as string
+                    end interface
+                `);
+                program.setFile(`source/interfaces.bs`, `
+                    namespace MyInterfaces
+                        interface twoFace
+                            coin as string
+                        end interface
+                    end namespace
                 `);
                 program.validate();
                 expectZeroDiagnostics(program);

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1919,6 +1919,9 @@ describe('Scope', () => {
                 fido = new Animals.Dog()
                 fidoBark = fido.bark()
                 chimp = new Animals.Ape()
+                chimpHasLegs = chimp.hasLegs
+                chimpSpeed = chimp.getRunSpeed()
+                fidoSpeed = fido.getRunSpeed()
                 skin = Animals.SkinType.fur
             end sub
          `;
@@ -2061,6 +2064,24 @@ describe('Scope', () => {
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlags.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlags.runtime)[0].type.toString()).to.eq('Animals.Dog');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('fidoBark', SymbolTypeFlags.runtime)[0].type, StringType);
+        });
+
+        it('finds correct type for members of classes with super classes', () => {
+            const mainFile = program.setFile('source/main.bs', mainFileContents);
+            program.setFile('source/animals.bs', animalFileContents);
+            program.validate();
+            expectZeroDiagnostics(program);
+            const mainFnScope = mainFile.getFunctionScopeAtPosition(util.createPosition(7, 23));
+            const sourceScope = program.getScopeByName('source');
+            expect(sourceScope).to.exist;
+            sourceScope.linkSymbolTable();
+            expect(mainFnScope).to.exist;
+            const chimpType = mainFnScope.symbolTable.getSymbol('chimp', SymbolTypeFlags.runtime)[0].type;
+            expectTypeToBe(chimpType, ClassType);
+            expectTypeToBe((chimpType as ClassType).superClass, ClassType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('chimpHasLegs', SymbolTypeFlags.runtime)[0].type, BooleanType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('chimpSpeed', SymbolTypeFlags.runtime)[0].type, IntegerType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('fidoSpeed', SymbolTypeFlags.runtime)[0].type, IntegerType);
         });
 
         it('finds correct types for method calls', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -1221,7 +1221,7 @@ export class Scope {
         let link = this.getClassFileLink(className, callsiteNamespace);
         while (link) {
             items.push(link);
-            link = this.getClassFileLink(link.item.parentClassName?.getName(ParseMode.BrighterScript)?.toLowerCase(), callsiteNamespace);
+            link = this.getClassFileLink(link.item.parentClassName?.getName()?.toLowerCase(), callsiteNamespace);
         }
         return items;
     }

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -13,7 +13,7 @@ import { IntegerType } from '../types/IntegerType';
 import { LongIntegerType } from '../types/LongIntegerType';
 import { FloatType } from '../types/FloatType';
 import { DoubleType } from '../types/DoubleType';
-import { CustomType } from '../types/CustomType';
+import { ClassType } from '../types/ClassType';
 import type { Scope } from '../Scope';
 import type { XmlScope } from '../XmlScope';
 import { DynamicType } from '../types/DynamicType';
@@ -295,8 +295,8 @@ export function isInvalidType(e: any): e is InvalidType {
 export function isVoidType(e: any): e is VoidType {
     return e?.constructor.name === VoidType.name;
 }
-export function isCustomType(e: any): e is CustomType {
-    return e?.constructor.name === CustomType.name;
+export function isClassType(e: any): e is ClassType {
+    return e?.constructor.name === ClassType.name;
 }
 export function isDynamicType(e: any): e is DynamicType {
     return e?.constructor.name === DynamicType.name;

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -1,7 +1,7 @@
 import type { Range } from 'vscode-languageserver-protocol';
 import { SemanticTokenModifiers } from 'vscode-languageserver-protocol';
 import { SemanticTokenTypes } from 'vscode-languageserver-protocol';
-import { isCallExpression, isCustomType, isNamespaceStatement, isNewExpression } from '../../astUtils/reflection';
+import { isCallExpression, isClassType, isNamespaceStatement, isNewExpression } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { OnGetSemanticTokensEvent } from '../../interfaces';
 import type { Locatable } from '../../lexer/Token';
@@ -36,7 +36,7 @@ export class BrsFileSemanticTokensProcessor {
         //classes used in function param types
         for (const func of this.event.file.parser.references.functionExpressions) {
             for (const parm of func.parameters) {
-                if (isCustomType(parm.getType(SymbolTypeFlags.typetime))) {
+                if (isClassType(parm.getType(SymbolTypeFlags.typetime))) {
                     const namespace = parm.findAncestor<NamespaceStatement>(isNamespaceStatement);
                     classes.push({
                         className: util.getAllDottedGetParts(parm.typeExpression.expression).map(x => x.text).join('.'),

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -131,7 +131,7 @@ export class BrsFileValidator {
                     node.parent.getSymbolTable().addSymbol(
                         node.name.text,
                         node.name.range,
-                        node.getType(SymbolTypeFlags.runtime),
+                        node.getType(SymbolTypeFlags.typetime),
                         SymbolTypeFlags.runtime
                     );
                 }
@@ -170,7 +170,8 @@ export class BrsFileValidator {
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.typetime);
+                // eslint-disable-next-line no-bitwise
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.runtime | SymbolTypeFlags.typetime);
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -170,7 +170,7 @@ export class BrsFileValidator {
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance, SymbolTypeFlags.typetime);
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.typetime);
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -63,9 +63,9 @@ export class ScopeValidator {
             const expressions = [
                 ...file.parser.references.expressions,
                 //all class "extends <whatever>" expressions
-                ...file.parser.references.classStatements.map(x => x.parentClassName?.expression),
+                ...file.parser.references.classStatements.map(x => x.parentClassName),
                 //all interface "extends <whatever>" expressions
-                ...file.parser.references.interfaceStatements.map(x => x.parentInterfaceName?.expression)
+                ...file.parser.references.interfaceStatements.map(x => x.parentInterfaceName)
             ];
             for (let expression of expressions) {
                 if (!expression) {

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1199,12 +1199,9 @@ describe('BrsFile BrighterScript classes', () => {
                 end namespace
             `);
             program.validate();
-            expectDiagnostics(program, [{
-                ...DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird'),
-                relatedInformation: [{
-                    message: `Not defined in scope 'source'`
-                }]
-            }]);
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird').message
+            ]);
         });
     });
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1178,9 +1178,12 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             `);
             program.validate();
-            expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird')
-            ]);
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird'),
+                relatedInformation: [{
+                    message: `Not defined in scope 'source'`
+                }]
+            }]);
         });
 
         it('namespaced parent class from inside namespace', () => {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -502,13 +502,13 @@ export class DottedGetExpression extends Expression {
         this.typeChain = [];
         const objType = this.obj?.getType(flags);
         const result = objType?.getMemberType(this.name?.text, flags);
-        const typeChainEntry = { name: this.name.text, resolved: !isReferenceType(result) };
+        const typeChainEntry = { name: this.name.text, resolved: !!result && !isReferenceType(result) };
 
         if (isDottedGetExpression(this.obj)) {
             this.typeChain.push(...this.obj.typeChain, typeChainEntry);
         } else {
             const parentName = (this.obj as any)?.name ? (this.obj as any)?.name.text : 'unknown';
-            const parentEntry = { name: parentName, resolved: !isReferenceType(objType) || objType.isResolvable() };
+            const parentEntry = { name: parentName, resolved: !!objType && (!isReferenceType(objType) || objType.isResolvable()) };
             this.typeChain.push(parentEntry, typeChainEntry);
         }
         if (result || flags & SymbolTypeFlags.typetime) {
@@ -1677,6 +1677,16 @@ export class TypeExpression extends Expression implements TypedefProvider {
     getTypedef(state: TranspileState): (string | SourceNode)[] {
         // TypeDefs should pass through any valid type names
         return this.expression.transpile(state as BrsTranspileState);
+    }
+
+    getName(): string {
+        //TODO: this may not support Complex Types, eg. generics or Unions
+        return util.getAllDottedGetParts(this.expression).map(x => x.text).join('.');
+    }
+
+    getNameParts(): string[] {
+        //TODO: really, this code is only used to get Namespaces. It could be more clear.
+        return util.getAllDottedGetParts(this.expression).map(x => x.text);
     }
 
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -309,12 +309,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
     }
 
-    protected _type: FunctionType;
-
     public getType(flags: SymbolTypeFlags): FunctionType {
-        if (this._type) {
-            return this._type;
-        }
         //if there's a defined return type, use that
         let returnType = this.returnTypeExpression?.getType(flags);
         const isSub = this.functionType.kind === TokenKind.Sub;
@@ -323,12 +318,12 @@ export class FunctionExpression extends Expression implements TypedefProvider {
             returnType = isSub ? VoidType.instance : DynamicType.instance;
         }
 
-        this._type = new FunctionType(returnType);
-        this._type.isSub = isSub;
+        const resultType = new FunctionType(returnType);
+        resultType.isSub = isSub;
         for (let param of this.parameters) {
-            this._type.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
+            resultType.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
         }
-        return this._type;
+        return resultType;
     }
 }
 
@@ -933,17 +928,13 @@ export class VariableExpression extends Expression {
         //nothing to walk
     }
 
-    private _type: BscType;
 
     getType(flags: SymbolTypeFlags) {
         const standardType = util.tokenToBscType(this.name);
         if (standardType) {
             return standardType;
         }
-        if (!this._type) {
-            this._type = new ReferenceType(this.name.text, flags, () => this.getSymbolTable());
-        }
-        return this._type;
+        return new ReferenceType(this.name.text, flags, () => this.getSymbolTable());
     }
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -309,7 +309,12 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
     }
 
+    protected _type: FunctionType;
+
     public getType(flags: SymbolTypeFlags): FunctionType {
+        if (this._type) {
+            return this._type;
+        }
         //if there's a defined return type, use that
         let returnType = this.returnTypeExpression?.getType(flags);
         const isSub = this.functionType.kind === TokenKind.Sub;
@@ -318,12 +323,12 @@ export class FunctionExpression extends Expression implements TypedefProvider {
             returnType = isSub ? VoidType.instance : DynamicType.instance;
         }
 
-        let functionType = new FunctionType(returnType);
-        functionType.isSub = isSub;
+        this._type = new FunctionType(returnType);
+        this._type.isSub = isSub;
         for (let param of this.parameters) {
-            functionType.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
+            this._type.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
         }
-        return functionType;
+        return this._type;
     }
 }
 

--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -238,7 +238,7 @@ describe('parser class', () => {
             expect(diagnostics.length).to.be.greaterThan(0);
             let cls = statements[0] as ClassStatement;
             expect(cls.fields[0].name.text).to.equal('middleName');
-            expectDiagnosticsIncludes(diagnostics, DiagnosticMessages.unexpectedToken('as'));
+            expectDiagnosticsIncludes(diagnostics, DiagnosticMessages.expectedIdentifierAfterKeyword('as'));
         });
 
         it('field access modifier defaults to undefined when omitted', () => {
@@ -367,7 +367,7 @@ describe('parser class', () => {
         expect(diagnostics[0]?.message).to.not.exist;
         let stmt = (statements[1] as ClassStatement);
         expect(stmt.extendsKeyword.text).to.equal('extends');
-        expect(stmt.parentClassName.getName(ParseMode.BrighterScript)).to.equal('Person');
+        expect(stmt.parentClassName.getName()).to.equal('Person');
     });
 
     it('catches missing identifier after "extends" keyword', () => {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1228,15 +1228,10 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
         }
     }
 
-    protected _type: NamespaceType;
-
     getType() {
-        if (this._type) {
-            return this._type;
-        }
-        this._type = new NamespaceType(this.name);
-        this._type.pushMemberProvider(() => this.body.getSymbolTable());
-        return this._type;
+        const resultType = new NamespaceType(this.name);
+        resultType.pushMemberProvider(() => this.body.getSymbolTable());
+        return resultType;
     }
 
 }
@@ -1455,24 +1450,18 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         }
     }
 
-    private _type: InterfaceType;
-
-
     getType(flags: SymbolTypeFlags) {
-        if (this._type) {
-            return this._type;
-        }
-        let superIface = this.parentInterfaceName?.getType(flags) as InterfaceType;
+        const superIface = this.parentInterfaceName?.getType(flags) as InterfaceType;
 
-        this._type = new InterfaceType(this.getName(ParseMode.BrighterScript), superIface);
+        const resultType = new InterfaceType(this.getName(ParseMode.BrighterScript), superIface);
 
         for (const statement of this.methods) {
-            this._type.addMember(statement?.tokens.name?.text, statement?.range, statement?.getType(flags), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement?.getType(flags), SymbolTypeFlags.runtime);
         }
         for (const statement of this.fields) {
-            this._type.addMember(statement?.tokens.name?.text, statement?.range, statement.getType(flags), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement.getType(flags), SymbolTypeFlags.runtime);
         }
-        return this._type;
+        return resultType;
     }
 }
 
@@ -1631,13 +1620,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         return result;
     }
 
-    private _type: FunctionType;
-
     public getType(flags: SymbolTypeFlags): FunctionType {
-        if (this._type) {
-            return this._type;
-        }
-
         //if there's a defined return type, use that
         let returnType = this.returnTypeExpression?.getType(flags);
         const isSub = this.tokens.functionType.kind === TokenKind.Sub;
@@ -1646,12 +1629,12 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
             returnType = isSub ? VoidType.instance : DynamicType.instance;
         }
 
-        this._type = new FunctionType(returnType);
-        this._type.isSub = isSub;
+        const resultType = new FunctionType(returnType);
+        resultType.isSub = isSub;
         for (let param of this.params) {
-            this._type.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
+            resultType.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
         }
-        return this._type;
+        return resultType;
     }
 }
 
@@ -2044,24 +2027,19 @@ export class ClassStatement extends Statement implements TypedefProvider {
         }
     }
 
-    protected _type: ClassType;
-
     getType(flags: SymbolTypeFlags) {
-        if (this._type) {
-            return this._type;
-        }
-        let superClass = this.parentClassName?.getType(flags) as ClassType;
+        const superClass = this.parentClassName?.getType(flags) as ClassType;
 
-        this._type = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
+        const resultType = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
 
         for (const statement of this.methods) {
             const funcType = statement?.func.getType(flags);
-            this._type.addMember(statement?.name?.text, statement?.range, funcType, SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.name?.text, statement?.range, funcType, SymbolTypeFlags.runtime);
         }
         for (const statement of this.fields) {
-            this._type.addMember(statement?.name?.text, statement?.range, statement.getType(), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.name?.text, statement?.range, statement.getType(), SymbolTypeFlags.runtime);
         }
-        return this._type;
+        return resultType;
     }
 }
 
@@ -2609,19 +2587,14 @@ export class EnumStatement extends Statement implements TypedefProvider {
         }
     }
 
-    protected _type: EnumType;
-
     getType() {
-        if (this._type) {
-            return this._type;
-        }
-        this._type = new EnumType(this.fullName);
-        this._type.pushMemberProvider(() => this.getSymbolTable());
+        const resultType = new EnumType(this.fullName);
+        resultType.pushMemberProvider(() => this.getSymbolTable());
         for (const statement of this.getMembers()) {
-            this._type.addMember(statement?.tokens?.name?.text, statement?.range, statement.getType(), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.tokens?.name?.text, statement?.range, statement.getType(), SymbolTypeFlags.runtime);
         }
 
-        return this._type;
+        return resultType;
     }
 }
 
@@ -2677,15 +2650,8 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
         }
     }
 
-
-    protected _type: EnumMemberType;
-
     getType() {
-        if (this._type) {
-            return this._type;
-        }
-        this._type = new EnumMemberType((this.parent as EnumStatement)?.fullName, this.tokens?.name?.text);
-        return this._type;
+        return new EnumMemberType((this.parent as EnumStatement)?.fullName, this.tokens?.name?.text);
     }
 }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -21,6 +21,7 @@ import { Statement } from './AstNode';
 import { ClassType } from '../types/ClassType';
 import { EnumMemberType, EnumType } from '../types/EnumType';
 import { NamespaceType } from '../types/NameSpaceType';
+import { ReferenceType } from '../types/ReferenceType';
 
 export class EmptyStatement extends Statement {
     constructor(
@@ -1991,10 +1992,9 @@ export class ClassStatement extends Statement implements TypedefProvider {
         if (this._type) {
             return this._type;
         }
-        this._type = new ClassType(this.getName(ParseMode.BrighterScript));
-        if (this.hasParentClass()) {
-            // TODO figure out setting the type's member table parentage
-        }
+        let superClass = this.hasParentClass() ? new ReferenceType(this.parentClassName.getName(ParseMode.BrighterScript), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
+
+        this._type = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
 
         for (const statement of this.methods) {
             const funcType = statement?.func.getType(flags);

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1300,7 +1300,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         interfaceToken: Token,
         name: Identifier,
         extendsToken: Token,
-        public parentInterfaceName: NamespacedVariableNameExpression,
+        public parentInterfaceName: TypeExpression,
         public body: Statement[],
         endInterfaceToken: Token
     ) {
@@ -1409,7 +1409,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
             ' ',
             this.tokens.name.text
         );
-        const parentInterfaceName = this.parentInterfaceName?.getName(ParseMode.BrighterScript);
+        const parentInterfaceName = this.parentInterfaceName?.getName();
         if (parentInterfaceName) {
             result.push(
                 ' extends ',
@@ -1463,7 +1463,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         if (this._type) {
             return this._type;
         }
-        let superIface = this.hasParentInterface() ? new ReferenceType(this.parentInterfaceName.getName(ParseMode.BrighterScript), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
+        let superIface = this.hasParentInterface() ? new ReferenceType(this.parentInterfaceName.getName(), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
 
         this._type = new InterfaceType(this.getName(ParseMode.BrighterScript), superIface);
 
@@ -1667,7 +1667,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         public body: Statement[],
         readonly end: Token,
         readonly extendsKeyword?: Token,
-        readonly parentClassName?: NamespacedVariableNameExpression
+        readonly parentClassName?: TypeExpression
     ) {
         super();
         this.body = this.body ?? [];
@@ -1753,7 +1753,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         if (this.extendsKeyword && this.parentClassName) {
             const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
             const fqName = util.getFullyQualifiedClassName(
-                this.parentClassName.getName(ParseMode.BrighterScript),
+                this.parentClassName.getName(),
                 namespace?.getName(ParseMode.BrighterScript)
             );
             result.push(
@@ -1806,7 +1806,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
                 //find the parent class
                 stmt = state.file.getClassFileLink(
-                    stmt.parentClassName.getName(ParseMode.BrighterScript),
+                    stmt.parentClassName.getName(),
                     namespace?.getName(ParseMode.BrighterScript)
                 )?.item;
                 myIndex++;
@@ -1837,7 +1837,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
             if (stmt.parentClassName) {
                 const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
                 stmt = state.file.getClassFileLink(
-                    stmt.parentClassName.getName(ParseMode.BrighterScript),
+                    stmt.parentClassName.getName(),
                     namespace?.getName(ParseMode.BrighterScript)
                 )?.item;
                 ancestors.push(stmt);
@@ -2051,7 +2051,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         if (this._type) {
             return this._type;
         }
-        let superClass = this.hasParentClass() ? new ReferenceType(this.parentClassName.getName(ParseMode.BrighterScript), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
+        let superClass = this.hasParentClass() ? new ReferenceType(this.parentClassName.getName(), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
 
         this._type = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -18,7 +18,7 @@ import type { TranspileState } from './TranspileState';
 import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
 import type { Expression } from './AstNode';
 import { Statement } from './AstNode';
-import { CustomType } from '../types/CustomType';
+import { ClassType } from '../types/ClassType';
 import { EnumMemberType, EnumType } from '../types/EnumType';
 import { NamespaceType } from '../types/NameSpaceType';
 
@@ -1985,13 +1985,13 @@ export class ClassStatement extends Statement implements TypedefProvider {
         }
     }
 
-    protected _type: CustomType;
+    protected _type: ClassType;
 
     getType(flags: SymbolTypeFlags) {
         if (this._type) {
             return this._type;
         }
-        this._type = new CustomType(this.getName(ParseMode.BrighterScript));
+        this._type = new ClassType(this.getName(ParseMode.BrighterScript));
         if (this.hasParentClass()) {
             // TODO figure out setting the type's member table parentage
         }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -21,7 +21,6 @@ import { Statement } from './AstNode';
 import { ClassType } from '../types/ClassType';
 import { EnumMemberType, EnumType } from '../types/EnumType';
 import { NamespaceType } from '../types/NameSpaceType';
-import { ReferenceType } from '../types/ReferenceType';
 import { InterfaceType } from '../types/InterfaceType';
 import type { BscType } from '../types/BscType';
 import { VoidType } from '../types/VoidType';
@@ -1463,7 +1462,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         if (this._type) {
             return this._type;
         }
-        let superIface = this.hasParentInterface() ? new ReferenceType(this.parentInterfaceName.getName(), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
+        let superIface = this.parentInterfaceName?.getType(flags) as InterfaceType;
 
         this._type = new InterfaceType(this.getName(ParseMode.BrighterScript), superIface);
 
@@ -2051,7 +2050,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         if (this._type) {
             return this._type;
         }
-        let superClass = this.hasParentClass() ? new ReferenceType(this.parentClassName.getName(), SymbolTypeFlags.typetime, () => this.parent.getSymbolTable()) : undefined;
+        let superClass = this.parentClassName?.getType(flags) as ClassType;
 
         this._type = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
 

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -44,4 +44,8 @@ export abstract class BscType {
     toTypeString(): string {
         throw new Error('Method not implemented.');
     }
+
+    equals(targetType: BscType): boolean {
+        return targetType.constructor.name === this.constructor.name;
+    }
 }

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -44,8 +44,4 @@ export abstract class BscType {
     toTypeString(): string {
         throw new Error('Method not implemented.');
     }
-
-    equals(targetType: BscType): boolean {
-        return targetType.constructor.name === this.constructor.name;
-    }
 }

--- a/src/types/ClassType.spec.ts
+++ b/src/types/ClassType.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { ClassType } from './ClassType';
+import { StringType } from './StringType';
+import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
+import { expectTypeToBe } from '../testHelpers.spec';
+import { ReferenceType } from './ReferenceType';
+import { isReferenceType } from '../astUtils/reflection';
+
+describe('ClassType', () => {
+
+    it('can have a super class', () => {
+        const superKlass = new ClassType('SuperKlass');
+        const subKlass = new ClassType('SubKlass', superKlass);
+
+        expect(subKlass.superClass).to.exist;
+        expect(subKlass.superClass.toString()).to.equal('SuperKlass');
+    });
+
+    it('should be assignable to a super klass, or higher ancestor', () => {
+        const grandSuperKlass = new ClassType('GrandSuperKlass');
+        const superKlass = new ClassType('SuperKlass', grandSuperKlass);
+        const subKlass = new ClassType('SubKlass', superKlass);
+
+        expect(subKlass.isAssignableTo(subKlass)).to.be.true;
+        expect(subKlass.isAssignableTo(superKlass)).to.be.true;
+        expect(subKlass.isAssignableTo(grandSuperKlass)).to.be.true;
+    });
+
+    it('should not be assignable to a class that is not an ancestor', () => {
+        const otherKlass = new ClassType('OtherKlass');
+
+        const superKlass = new ClassType('SuperKlass');
+        const subKlass = new ClassType('SubKlass', superKlass);
+
+        expect(subKlass.isAssignableTo(superKlass)).to.be.true;
+        expect(subKlass.isAssignableTo(otherKlass)).to.be.false;
+    });
+
+    it('will look in super classes for members', () => {
+        const superKlass = new ClassType('SuperKlass');
+        superKlass.addMember('title', null, StringType.instance, SymbolTypeFlags.runtime);
+        const subKlass = new ClassType('SubKlass', superKlass);
+        expectTypeToBe(subKlass.getMemberType('title', SymbolTypeFlags.runtime), StringType);
+    });
+
+    it('allow ReferenceTypes as super classes', () => {
+        const myTable = new SymbolTable('test');
+        const futureSuperKlass = new ReferenceType('SuperKlass', SymbolTypeFlags.typetime, () => myTable);
+        const subKlass = new ClassType('SubKlass', futureSuperKlass);
+        expect(subKlass.isResolvable()).to.be.false;
+        const superKlass = new ClassType('SuperKlass');
+        myTable.addSymbol('SuperKlass', null, superKlass, SymbolTypeFlags.typetime);
+        expect(subKlass.isResolvable()).to.be.true;
+    });
+
+    it('allows members of future super classes to be resolved', () => {
+        const myTable = new SymbolTable('test');
+        const futureSuperKlass = new ReferenceType('SuperKlass', SymbolTypeFlags.typetime, () => myTable);
+        const subKlass = new ClassType('SubKlass', futureSuperKlass);
+        expect(subKlass.isResolvable()).to.be.false;
+        const futureTitleType = subKlass.getMemberType('title', SymbolTypeFlags.runtime);
+        expect(isReferenceType(futureTitleType)).to.be.true;
+        expect(futureTitleType.isResolvable()).to.be.false;
+        const superKlass = new ClassType('SuperKlass');
+        superKlass.addMember('title', null, StringType.instance, SymbolTypeFlags.runtime);
+        // eslint-disable-next-line no-bitwise
+        myTable.addSymbol('SuperKlass', null, superKlass, SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
+        expect(futureTitleType.isResolvable()).to.be.true;
+        expectTypeToBe(futureTitleType, StringType);
+    });
+
+});

--- a/src/types/ClassType.spec.ts
+++ b/src/types/ClassType.spec.ts
@@ -77,8 +77,8 @@ describe('ClassType', () => {
             superKlass.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
             superKlass.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
 
-            expect(subKlass.toJSString).to.exist;
-            expect(subKlass.toJSString()).to.equal('{ age: integer; name: string; }');
+            expect((subKlass as any).toJSString).to.exist;
+            expect((subKlass as any).toJSString()).to.equal('{ age: integer; name: string; }');
         });
     });
 

--- a/src/types/ClassType.spec.ts
+++ b/src/types/ClassType.spec.ts
@@ -5,6 +5,7 @@ import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
 import { expectTypeToBe } from '../testHelpers.spec';
 import { ReferenceType } from './ReferenceType';
 import { isReferenceType } from '../astUtils/reflection';
+import { IntegerType } from './IntegerType';
 
 describe('ClassType', () => {
 
@@ -67,6 +68,18 @@ describe('ClassType', () => {
         myTable.addSymbol('SuperKlass', null, superKlass, SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
         expect(futureTitleType.isResolvable()).to.be.true;
         expectTypeToBe(futureTitleType, StringType);
+    });
+
+    describe('toJSString', () => {
+        it('includes superclass members', () => {
+            const superKlass = new ClassType('SuperKlass');
+            const subKlass = new ClassType('SubKlass', superKlass);
+            superKlass.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
+            superKlass.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
+
+            expect(subKlass.toJSString).to.exist;
+            expect(subKlass.toJSString()).to.equal('{ age: integer; name: string; }');
+        });
     });
 
 });

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -7,11 +7,13 @@ export class ClassType extends BscType {
 
     constructor(public name: string, public readonly superClass?: ClassType | ReferenceType) {
         super(name);
-
+        if (superClass) {
+            this.memberTable.pushParentProvider(() => this.superClass.memberTable);
+        }
     }
 
     getMemberType(name: string, flags: SymbolTypeFlags) {
-        return super.getMemberType(name, flags) ?? this.superClass?.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
+        return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
     }
 
     public toString() {

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -1,9 +1,9 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
-import { isCustomType, isDynamicType } from '../astUtils/reflection';
+import { isClassType, isDynamicType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 
-export class CustomType extends BscType {
+export class ClassType extends BscType {
 
     constructor(public name: string) {
         super(name);
@@ -23,7 +23,7 @@ export class CustomType extends BscType {
 
     public isAssignableTo(targetType: BscType) {
         //TODO for now, if the custom types have the same name, assume they're the same thing
-        if (isCustomType(targetType) && targetType.name === this.name) {
+        if (isClassType(targetType) && targetType.name === this.name) {
             return true;
         } else if (isDynamicType(targetType)) {
             return true;

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -2,26 +2,13 @@ import { SymbolTypeFlags } from '../SymbolTable';
 import { isClassType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType } from './InheritableType';
-import { ReferenceType } from './ReferenceType';
+import type { ReferenceType } from './ReferenceType';
 
 export class ClassType extends InheritableType {
 
     constructor(public name: string, public readonly superClass?: ClassType | ReferenceType) {
         super(name, superClass);
     }
-
-    getMemberType(name: string, flags: SymbolTypeFlags) {
-        return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
-    }
-
-    public toString() {
-        return this.name;
-    }
-
-    public toTypeString(): string {
-        return 'dynamic';
-    }
-
 
     public isAssignableTo(targetType: BscType) {
         if (isClassType(targetType) && targetType.name === this.name) {

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -2,31 +2,27 @@ import { SymbolTypeFlags } from '../SymbolTable';
 import { isClassType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType } from './InheritableType';
-import type { ReferenceType } from './ReferenceType';
 
 export class ClassType extends InheritableType {
 
-    constructor(public name: string, public readonly superClass?: ClassType | ReferenceType) {
+    constructor(public name: string, public readonly superClass?: BscType) {
         super(name, superClass);
     }
 
     public isAssignableTo(targetType: BscType) {
-        if (isClassType(targetType) && targetType.name === this.name) {
+        //TODO: We need to make sure that things don't get assigned to built-in types
+        if (this === targetType) {
             return true;
         } else if (isDynamicType(targetType) || isObjectType(targetType)) {
             return true;
-        } else if (isInterfaceType(targetType)) {
-            return this.checkAssignabilityToInterface(targetType, SymbolTypeFlags.runtime);
-        } else {
+        } else if (isClassType(targetType)) {
             const ancestorTypes = this.getAncestorTypeList();
-            if (ancestorTypes?.find(ancestorType => ancestorType.equals(targetType))) {
+            if (ancestorTypes?.find(ancestorType => ancestorType === targetType)) {
                 return true;
             }
-            return false;
+        } else if (isInterfaceType(targetType)) {
+            return this.checkAssignabilityToInterface(targetType, SymbolTypeFlags.runtime);
         }
-    }
-
-    public equals(targetType: BscType): boolean {
-        return isClassType(targetType) && this.toString() === targetType?.toString();
+        return false;
     }
 }

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -27,7 +27,7 @@ export class EnumType extends BscType {
         return 'dynamic';
     }
 
-    public equals(targetType: BscType): boolean {
+    protected equals(targetType: BscType): boolean {
         return isEnumType(targetType) && targetType?.name.toLowerCase() === this.name.toLowerCase();
     }
 }
@@ -62,7 +62,7 @@ export class EnumMemberType extends BscType {
         return 'dynamic';
     }
 
-    public equals(targetType: BscType): boolean {
+    protected equals(targetType: BscType): boolean {
         return isEnumMemberType(targetType) &&
             targetType?.enumName.toLowerCase() === this.enumName.toLowerCase() &&
             targetType?.memberName.toLowerCase() === this.memberName.toLowerCase();

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -1,0 +1,67 @@
+import type { SymbolTypeFlags } from '../SymbolTable';
+import { isClassType, isInterfaceType } from '../astUtils/reflection';
+import { BscType } from './BscType';
+import { ReferenceType } from './ReferenceType';
+
+export abstract class InheritableType extends BscType {
+
+    constructor(public name: string, public readonly parentType?: InheritableType | ReferenceType) {
+        super(name);
+        if (parentType) {
+            this.memberTable.pushParentProvider(() => this.parentType.memberTable);
+        }
+    }
+
+    getMemberType(name: string, flags: SymbolTypeFlags) {
+        return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
+    }
+
+    public toString() {
+        return this.name;
+    }
+
+    public toTypeString(): string {
+        return 'dynamic';
+    }
+
+    isResolvable(): boolean {
+        return this.parentType ? this.parentType.isResolvable() : true;
+    }
+
+    public isConvertibleTo(targetType: BscType) {
+        return this.isAssignableTo(targetType);
+    }
+
+    public equals(targetType: BscType): boolean {
+        return isClassType(targetType) && this.toString() === targetType?.toString();
+    }
+
+    protected getAncestorTypeList(): InheritableType[] {
+        const ancestors = [];
+        let currentParentType = this.parentType;
+        while (currentParentType) {
+            if (isClassType(currentParentType) || isInterfaceType(currentParentType)) {
+                ancestors.push(currentParentType);
+                currentParentType = currentParentType.parentType;
+            } else {
+                break;
+            }
+        }
+        return ancestors;
+    }
+
+    checkAssignabilityToInterface(targetType: BscType, flags: SymbolTypeFlags) {
+        if (!isInterfaceType(targetType)) {
+            return false;
+        }
+        let isSuperSet = true;
+        const targetSymbols = targetType.memberTable?.getAllSymbols(flags);
+        for (const targetSymbol of targetSymbols) {
+            // TODO TYPES: this ignores union types
+
+            const mySymbolsWithName = this.memberTable.getSymbol(targetSymbol.name, flags);
+            isSuperSet = isSuperSet && mySymbolsWithName && mySymbolsWithName.length > 0 && mySymbolsWithName[0].type.isAssignableTo(targetSymbol.type);
+        }
+        return isSuperSet;
+    }
+}

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -5,7 +5,7 @@ import { ReferenceType } from './ReferenceType';
 
 export abstract class InheritableType extends BscType {
 
-    constructor(public name: string, public readonly parentType?: InheritableType | ReferenceType) {
+    constructor(public name: string, public readonly parentType?: BscType) {
         super(name);
         if (parentType) {
             this.memberTable.pushParentProvider(() => this.parentType.memberTable);
@@ -32,8 +32,8 @@ export abstract class InheritableType extends BscType {
         return this.isAssignableTo(targetType);
     }
 
-    public equals(targetType: BscType): boolean {
-        return isClassType(targetType) && this.toString() === targetType?.toString();
+    equals(targetType: BscType) {
+        return this === targetType;
     }
 
     protected getAncestorTypeList(): InheritableType[] {
@@ -50,7 +50,7 @@ export abstract class InheritableType extends BscType {
         return ancestors;
     }
 
-    checkAssignabilityToInterface(targetType: BscType, flags: SymbolTypeFlags) {
+    protected checkAssignabilityToInterface(targetType: BscType, flags: SymbolTypeFlags) {
         if (!isInterfaceType(targetType)) {
             return false;
         }
@@ -70,7 +70,7 @@ export abstract class InheritableType extends BscType {
      * Gets a string representation of the Interface that looks like javascript
      * Useful for debugging
      */
-    public toJSString() {
+    private toJSString() {
         // eslint-disable-next-line no-bitwise
         const flags = SymbolTypeFlags.runtime | SymbolTypeFlags.typetime;
         let result = '{';

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -1,4 +1,4 @@
-import type { SymbolTypeFlags } from '../SymbolTable';
+import { SymbolTypeFlags } from '../SymbolTable';
 import { isClassType, isInterfaceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
@@ -40,7 +40,7 @@ export abstract class InheritableType extends BscType {
         const ancestors = [];
         let currentParentType = this.parentType;
         while (currentParentType) {
-            if (isClassType(currentParentType) || isInterfaceType(currentParentType)) {
+            if (isInheritableType(currentParentType)) {
                 ancestors.push(currentParentType);
                 currentParentType = currentParentType.parentType;
             } else {
@@ -64,4 +64,31 @@ export abstract class InheritableType extends BscType {
         }
         return isSuperSet;
     }
+
+
+    /**
+     * Gets a string representation of the Interface that looks like javascript
+     * Useful for debugging
+     */
+    public toJSString() {
+        // eslint-disable-next-line no-bitwise
+        const flags = SymbolTypeFlags.runtime | SymbolTypeFlags.typetime;
+        let result = '{';
+        const memberSymbols = (this.memberTable?.getAllSymbols(flags) || []).sort((a, b) => a.name.localeCompare(b.name));
+        for (const symbol of memberSymbols) {
+            let symbolTypeString = symbol.type.toString();
+            if (isInheritableType(symbol.type)) {
+                symbolTypeString = symbol.type.toJSString();
+            }
+            result += ' ' + symbol.name + ': ' + symbolTypeString + ';';
+        }
+        if (memberSymbols.length > 0) {
+            result += ' ';
+        }
+        return result + '}';
+    }
+}
+
+export function isInheritableType(target): target is InheritableType {
+    return isClassType(target) || isInterfaceType(target);
 }

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -1,21 +1,22 @@
 import { expect } from '../chai-config.spec';
 import { assert } from 'sinon';
-import { objectToMap } from '../testHelpers.spec';
 import type { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
 import { InterfaceType } from './InterfaceType';
 import { ObjectType } from './ObjectType';
 import { StringType } from './StringType';
+import type { ReferenceType } from './ReferenceType';
+import { SymbolTypeFlags } from '../SymbolTable';
 
 describe('InterfaceType', () => {
-    describe('toString', () => {
+    describe('toJSString', () => {
         it('returns empty curly braces when no members', () => {
-            expect(iface({}).toString()).to.eql('{}');
+            expect(iface({}).toJSString()).to.eql('{}');
         });
 
         it('includes member types', () => {
-            expect(iface({ name: new StringType() }).toString()).to.eql('{ name: string; }');
+            expect(iface({ name: new StringType() }).toJSString()).to.eql('{ name: string; }');
         });
 
         it('includes nested object types', () => {
@@ -26,7 +27,7 @@ describe('InterfaceType', () => {
                         age: new IntegerType()
                     })
                 }
-                ).toString()
+                ).toJSString()
             ).to.eql('{ name: string; parent: { age: integer; }; }');
         });
     });
@@ -91,15 +92,17 @@ describe('InterfaceType', () => {
         });
 
         it('matches properties in mismatched order', () => {
-            expect(
-                new InterfaceType('', new Map([
-                    ['name', new StringType()],
-                    ['age', new IntegerType()]
-                ])).isAssignableTo(new InterfaceType('', new Map([
-                    ['age', new IntegerType()],
-                    ['name', new StringType()]
-                ])))
-            ).to.be.true;
+            const ifaceOne = iface({
+                name: new StringType(),
+                age: new IntegerType()
+            });
+            const ifaceTwo = iface({
+                age: new IntegerType(),
+                name: new StringType()
+            });
+
+            expect(ifaceOne.isAssignableTo(ifaceTwo)).to.be.true;
+            expect(ifaceTwo.isAssignableTo(ifaceOne)).to.be.true;
         });
 
         it('rejects with member having mismatched type', () => {
@@ -184,18 +187,24 @@ describe('InterfaceType', () => {
     });
 });
 
-function iface(members: Record<string, BscType>) {
-    return new InterfaceType(
-        '',
-        objectToMap(members)
-    );
+let ifaceCount = 0;
+
+function iface(members: Record<string, BscType>, name?: string, parentType?: InterfaceType | ReferenceType) {
+    name = name ?? 'SomeIFace' + ifaceCount;
+    ifaceCount++;
+    const ifaceType = new InterfaceType(name, parentType);
+
+    for (const key in members) {
+        ifaceType.addMember(key, null, members[key], SymbolTypeFlags.runtime);
+    }
+    return ifaceType;
 }
 
 function expectAssignable(targetMembers: Record<string, BscType>, sourceMembers: Record<string, BscType>) {
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
     if (!sourceIface.isAssignableTo(targetIface)) {
-        assert.fail(`expected type ${targetIface.toString()} to be assignable to type ${sourceIface.toString()}`);
+        assert.fail(`expected type ${targetIface.toJSString()} to be assignable to type ${sourceIface.toJSString()}`);
     }
 }
 
@@ -203,6 +212,6 @@ function expectNotAssignable(targetMembers: Record<string, BscType>, sourceMembe
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
     if (sourceIface.isAssignableTo(targetIface)) {
-        assert.fail(`expected type ${targetIface.toString()} to not be assignable to type ${sourceIface.toString()}`);
+        assert.fail(`expected type ${targetIface.toJSString()} to not be assignable to type ${sourceIface.toJSString()}`);
     }
 }

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -12,22 +12,22 @@ import { SymbolTypeFlags } from '../SymbolTable';
 describe('InterfaceType', () => {
     describe('toJSString', () => {
         it('returns empty curly braces when no members', () => {
-            expect(iface({}).toJSString()).to.eql('{}');
+            expect((iface({}) as any).toJSString()).to.eql('{}');
         });
 
         it('includes member types', () => {
-            expect(iface({ name: new StringType() }).toJSString()).to.eql('{ name: string; }');
+            expect((iface({ name: new StringType() }) as any).toJSString()).to.eql('{ name: string; }');
         });
 
         it('includes nested object types', () => {
             expect(
-                iface({
+                (iface({
                     name: new StringType(),
                     parent: iface({
                         age: new IntegerType()
                     })
                 }
-                ).toJSString()
+                ) as any).toJSString()
             ).to.eql('{ name: string; parent: { age: integer; }; }');
         });
     });
@@ -204,7 +204,7 @@ function expectAssignable(targetMembers: Record<string, BscType>, sourceMembers:
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
     if (!sourceIface.isAssignableTo(targetIface)) {
-        assert.fail(`expected type ${targetIface.toJSString()} to be assignable to type ${sourceIface.toJSString()}`);
+        assert.fail(`expected type ${(targetIface as any).toJSString()} to be assignable to type ${(sourceIface as any).toJSString()}`);
     }
 }
 
@@ -212,6 +212,6 @@ function expectNotAssignable(targetMembers: Record<string, BscType>, sourceMembe
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
     if (sourceIface.isAssignableTo(targetIface)) {
-        assert.fail(`expected type ${targetIface.toJSString()} to not be assignable to type ${sourceIface.toJSString()}`);
+        assert.fail(`expected type ${(targetIface as any).toJSString()} to not be assignable to type ${(sourceIface as any).toJSString()}`);
     }
 }

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -29,29 +29,6 @@ export class InterfaceType extends InheritableType {
         return false;
     }
 
-    /**
-     * Gets a string representation of the Interface that looks like javascript
-     * Useful for debugging
-     * @returns {string}
-     */
-    public toJSString() {
-        // eslint-disable-next-line no-bitwise
-        const flags = SymbolTypeFlags.runtime | SymbolTypeFlags.typetime;
-        let result = '{';
-        const memberSymbols = (this.memberTable?.getAllSymbols(flags) || []).sort((a, b) => a.name.localeCompare(b.name));
-        for (const symbol of memberSymbols) {
-            let symbolTypeString = symbol.type.toString();
-            if (isInterfaceType(symbol.type)) {
-                symbolTypeString = symbol.type.toJSString();
-            }
-            result += ' ' + symbol.name + ': ' + symbolTypeString + ';';
-        }
-        if (memberSymbols.length > 0) {
-            result += ' ';
-        }
-        return result + '}';
-    }
-
     public equals(targetType: BscType): boolean {
 
         if (isInterfaceType(targetType)) {
@@ -60,4 +37,3 @@ export class InterfaceType extends InheritableType {
         return false;
     }
 }
-

--- a/src/types/NameSpaceType.ts
+++ b/src/types/NameSpaceType.ts
@@ -1,4 +1,5 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
+import { isNamespaceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 
@@ -15,4 +16,9 @@ export class NamespaceType extends BscType {
     getMemberType(name: string, flags: SymbolTypeFlags) {
         return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
     }
+
+    public equals(targetType: BscType): boolean {
+        return isNamespaceType(targetType) && this.toString() === targetType?.toString();
+    }
+
 }

--- a/src/types/NameSpaceType.ts
+++ b/src/types/NameSpaceType.ts
@@ -1,5 +1,4 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
-import { isNamespaceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 
@@ -15,10 +14,6 @@ export class NamespaceType extends BscType {
 
     getMemberType(name: string, flags: SymbolTypeFlags) {
         return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
-    }
-
-    public equals(targetType: BscType): boolean {
-        return isNamespaceType(targetType) && this.toString() === targetType?.toString();
     }
 
 }

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -1,4 +1,5 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
+import { isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -32,5 +33,9 @@ export class ObjectType extends BscType {
         // TODO: How should we handle accessing properties of an object?
         // For example, we could add fields as properties to m.top, but there could be other members added programmatically
         return super.getMemberType(name, flags) ?? DynamicType.instance;
+    }
+
+    public equals(targetType: BscType): boolean {
+        return isObjectType(targetType) && this.isAssignableTo(targetType);
     }
 }

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -1,5 +1,4 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
-import { isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -33,9 +32,5 @@ export class ObjectType extends BscType {
         // TODO: How should we handle accessing properties of an object?
         // For example, we could add fields as properties to m.top, but there could be other members added programmatically
         return super.getMemberType(name, flags) ?? DynamicType.instance;
-    }
-
-    public equals(targetType: BscType): boolean {
-        return isObjectType(targetType) && this.isAssignableTo(targetType);
     }
 }

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -6,7 +6,7 @@ import { IntegerType } from './IntegerType';
 import { TypePropertyReferenceType, ReferenceType } from './ReferenceType';
 import { StringType } from './StringType';
 import { FloatType } from './FloatType';
-import { CustomType } from './CustomType';
+import { ClassType } from './ClassType';
 import { isTypePropertyReferenceType, isReferenceType } from '../astUtils/reflection';
 import { FunctionType } from './FunctionType';
 
@@ -46,7 +46,7 @@ describe('ReferenceType', () => {
     it('resolves before stringifying', () => {
         const table = new SymbolTable('test');
         const ref = new ReferenceType('someKlass', runtimeFlag, () => table);
-        table.addSymbol('someKlass', null, new CustomType('SomeKlass'), SymbolTypeFlags.runtime);
+        table.addSymbol('someKlass', null, new ClassType('SomeKlass'), SymbolTypeFlags.runtime);
         expect(ref.toString()).to.eq('SomeKlass');
     });
 
@@ -106,13 +106,13 @@ describe('PropertyReferenceType', () => {
         expectTypeToBe(returnPropRef, DynamicType);
 
         // Set fnRef to resolve to a function that returns a complex type
-        const klassType = new CustomType('Klass');
+        const klassType = new ClassType('Klass');
         klassType.addMember('myNum', null, IntegerType.instance, SymbolTypeFlags.runtime);
         table.addSymbol('someFunc', null, new FunctionType(klassType), SymbolTypeFlags.runtime);
 
         // returnPropRef = someFunc().myNum
         expectTypeToBe(fnRef, FunctionType);
-        expectTypeToBe(returnRef, CustomType);
+        expectTypeToBe(returnRef, ClassType);
         expectTypeToBe(returnPropRef, IntegerType);
     });
 

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -116,5 +116,4 @@ describe('PropertyReferenceType', () => {
         expectTypeToBe(returnPropRef, IntegerType);
     });
 
-
 });

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -59,6 +59,8 @@ export class ReferenceType extends BscType {
                         return () => 'dynamic';
                     } else if (propName === 'returnType') {
                         return new TypePropertyReferenceType(this, propName);
+                    } else if (propName === 'memberTable') {
+                        return this.tableProvider();
                     }
                 }
 

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -46,7 +46,7 @@ export class ReferenceType extends BscType {
                         // We're looking for a member of a reference type
                         // Since we don't know what type this is, yet, return ReferenceType
                         return (memberName: string, flags: SymbolTypeFlags) => {
-                            return new ReferenceType(memberName, this.flags, () => {
+                            return new ReferenceType(memberName, flags, () => {
                                 return (this.resolve() as any)?.memberTable;
                             });
                         };

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -360,7 +360,7 @@ export class BsClassValidator {
     private linkClassesWithParents() {
         //link all classes with their parents
         for (const [, classStatement] of this.classes) {
-            let parentClassName = classStatement.parentClassName?.getName(ParseMode.BrighterScript);
+            let parentClassName = classStatement.parentClassName?.getName();
             if (parentClassName) {
                 let relativeName: string;
                 let absoluteName: string;


### PR DESCRIPTION
- Changes `CustomType` to `ClassType`
- Refactors `InterfaceType` to behave more like other types
- Introduces abstract `InheritableType` that wraps code common to InterfaceType and ClassType
- Allows inheritable properties to be accessed from an interface or class instance
- Modifies InterfaceStatement & ClassStatement so that parents are TypeExpressions
- Changes diagnostic when no identifier is after `as` to be 'Identifier Expected after "as"...' instead of "unexpected token 'as' "