### PR TITLE
Type chain refactor

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1808,7 +1808,6 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
             });
 
-
             it('finds unknown members of primitive types', () => {
                 program.setFile(`source/main.bs`, `
                     sub fn(input as SomeKlass)
@@ -1824,6 +1823,33 @@ describe('Scope', () => {
                 program.validate();
                 //TODO: ideally, if this is a primitive type, we should know all the possible members
                 // This *SHOULD* be an error, but currently, during Runtime, an unknown member (from DottedtGetExpression) is returned as Dynamic.instance
+                expectZeroDiagnostics(program);
+            });
+
+
+            it('finds members of arrays', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(input as SomeKlass)
+                        numValue = input.getOtherKlasses()[2].num
+                        print numValue
+                    end sub
+
+                    class OtherKlass
+                      num = 1
+                    end class
+
+                    class SomeKlass
+                        function getPi() as float
+                            return 3.14
+                        end function
+
+                        function getOtherKlasses()
+                            return [new OtherKlass(), new OtherKlass(), new OtherKlass()]
+                        end function
+                    end class
+                `);
+                program.validate();
+                //TODO: When array types are available, check that `numValue` is an integer
                 expectZeroDiagnostics(program);
             });
 

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1788,7 +1788,7 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
             });
 
-            it('allows dot-references to properties on results of global callables ', () => {
+            it('allows dot-references to properties on results of global callables', () => {
                 program.setFile(`source/main.bs`, `
                     sub fn()
                         print CreateObject("roSgNode", "Node").id
@@ -1798,7 +1798,7 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
             });
 
-            it('allows dot-references to functions on results of global callables ', () => {
+            it('allows dot-references to functions on results of global callables', () => {
                 program.setFile(`source/main.bs`, `
                     sub fn()
                         print CreateObject("roDateTime").asSeconds()
@@ -1807,6 +1807,26 @@ describe('Scope', () => {
                 program.validate();
                 expectZeroDiagnostics(program);
             });
+
+
+            it('finds unknown members of primitive types', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(input as SomeKlass)
+                        piValue = input.getPi().noMethod()
+                    end sub
+
+                    class SomeKlass
+                        function getPi() as float
+                            return 3.14
+                        end function
+                    end class
+                `);
+                program.validate();
+                //TODO: ideally, if this is a primitive type, we should know all the possible members
+                // This *SHOULD* be an error, but currently, during Runtime, an unknown member (from DottedtGetExpression) is returned as Dynamic.instance
+                expectZeroDiagnostics(program);
+            });
+
         });
 
         describe('interfaces', () => {

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -35,13 +35,13 @@ export class BrsFileSemanticTokensProcessor {
 
         //classes used in function param types
         for (const func of this.event.file.parser.references.functionExpressions) {
-            for (const parm of func.parameters) {
-                if (isClassType(parm.getType(SymbolTypeFlags.typetime))) {
-                    const namespace = parm.findAncestor<NamespaceStatement>(isNamespaceStatement);
+            for (const param of func.parameters) {
+                if (isClassType(param.getType({ flags: SymbolTypeFlags.typetime }))) {
+                    const namespace = param.findAncestor<NamespaceStatement>(isNamespaceStatement);
                     classes.push({
-                        className: util.getAllDottedGetParts(parm.typeExpression.expression).map(x => x.text).join('.'),
+                        className: util.getAllDottedGetParts(param.typeExpression.expression).map(x => x.text).join('.'),
                         namespaceName: namespace?.getName(ParseMode.BrighterScript),
-                        range: parm.typeExpression.range
+                        range: param.typeExpression.range
                     });
                 }
             }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -63,12 +63,12 @@ export class BrsFileValidator {
 
                 //register this class
                 // eslint-disable-next-line no-bitwise
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
+                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, node.getType({ flags: SymbolTypeFlags.typetime }), SymbolTypeFlags.typetime | SymbolTypeFlags.runtime);
             },
             AssignmentStatement: (node) => {
                 //register this variable
 
-                const nodeType = node.getType(SymbolTypeFlags.runtime);
+                const nodeType = node.getType({ flags: SymbolTypeFlags.runtime });
                 node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, nodeType, SymbolTypeFlags.runtime);
             },
             DottedSetStatement: (node) => {
@@ -131,7 +131,7 @@ export class BrsFileValidator {
                     node.parent.getSymbolTable().addSymbol(
                         node.name.text,
                         node.name.range,
-                        node.getType(SymbolTypeFlags.typetime),
+                        node.getType({ flags: SymbolTypeFlags.typetime }),
                         SymbolTypeFlags.runtime
                     );
                 }
@@ -142,12 +142,12 @@ export class BrsFileValidator {
                     namespace.getSymbolTable().addSymbol(
                         node.name.text,
                         node.name.range,
-                        node.getType(SymbolTypeFlags.typetime),
+                        node.getType({ flags: SymbolTypeFlags.typetime }),
                         SymbolTypeFlags.runtime
                     );
                     //add the transpiled name for namespaced functions to the root symbol table
                     const transpiledNamespaceFunctionName = node.getName(ParseMode.BrightScript);
-                    const funcType = node.func.getType(SymbolTypeFlags.typetime);
+                    const funcType = node.func.getType({ flags: SymbolTypeFlags.typetime });
                     funcType.setName(transpiledNamespaceFunctionName);
 
                     this.event.file.parser.ast.symbolTable.addSymbol(
@@ -166,17 +166,17 @@ export class BrsFileValidator {
             FunctionParameterExpression: (node) => {
                 const paramName = node.name?.text;
                 const symbolTable = node.getSymbolTable();
-                symbolTable?.addSymbol(paramName, node.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.runtime);
+                symbolTable?.addSymbol(paramName, node.name.range, node.getType({ flags: SymbolTypeFlags.typetime }), SymbolTypeFlags.runtime);
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
                 // eslint-disable-next-line no-bitwise
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.runtime | SymbolTypeFlags.typetime);
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType({ flags: SymbolTypeFlags.typetime }), SymbolTypeFlags.runtime | SymbolTypeFlags.typetime);
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));
 
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType(SymbolTypeFlags.typetime), SymbolTypeFlags.runtime);
+                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, node.getType({ flags: SymbolTypeFlags.typetime }), SymbolTypeFlags.runtime);
             },
             CatchStatement: (node) => {
                 node.parent.getSymbolTable().addSymbol(node.exceptionVariable.text, node.exceptionVariable.range, DynamicType.instance, SymbolTypeFlags.runtime);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { isBrsFile, isDottedGetExpression, isLiteralExpression, isNamespaceStatement, isTypeExpression, isXmlScope } from '../../astUtils/reflection';
+import { isBrsFile, isLiteralExpression, isNamespaceStatement, isTypeExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -126,10 +126,9 @@ export class ScopeValidator {
                 }
 
                 const typeChainScan = util.processTypeChain(typeChain);
-
                 this.addMultiScopeDiagnostic({
                     file: file as BscFile,
-                    ...DiagnosticMessages.cannotFindName(typeChainScan.cannotFindName, typeChainScan.fullErrorName),
+                    ...DiagnosticMessages.cannotFindName(typeChainScan.missingItemName, typeChainScan.fullNameOfMissingItem),
                     range: typeChainScan.range
                 });
                 //skip to the next expression

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -103,10 +103,11 @@ export class ScopeValidator {
                 symbolType = SymbolTypeFlags.typetime;
                 oppositeSymbolType = SymbolTypeFlags.runtime;
             }
-            let exprType = info.expression.getType(symbolType);
+            const typeChain = [];
+            let exprType = info.expression.getType({ flags: symbolType, typeChain: typeChain });
             if (!exprType || !exprType.isResolvable()) {
-                if (info.expression.getType(oppositeSymbolType)?.isResolvable()) {
-                    const invalidlyUsedResolvedTypeName = info.expression.getType(oppositeSymbolType).toString();
+                if (info.expression.getType({ flags: oppositeSymbolType })?.isResolvable()) {
+                    const invalidlyUsedResolvedTypeName = info.expression.getType({ flags: oppositeSymbolType }).toString();
                     if (isUsedAsType) {
 
                         this.addMultiScopeDiagnostic({
@@ -127,10 +128,10 @@ export class ScopeValidator {
                 let fullErrorName = fullName;
                 let lastName = info.parts[info.parts.length - 1].name.text;
                 if (isDottedGetExpression(info.expression)) {
-                    //TODO: Wrap deciphering a typeChain in a function, so that it cna handle multiple kinds of expressions
+                    //TODO: Wrap deciphering a typeChain in a function, so that it can handle multiple kinds of expressions
                     fullErrorName = '';
-                    for (let i = 0; i < info.expression.typeChain.length; i++) {
-                        const chainItem = info.expression.typeChain[i];
+                    for (let i = 0; i < typeChain.length; i++) {
+                        const chainItem = typeChain[i];
                         if (i > 0) {
                             fullErrorName += '.';
                         }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -462,7 +462,7 @@ export class BrsFile {
                     nameRange: param.name.range,
                     lineIndex: param.name.range.start.line,
                     name: param.name.text,
-                    getType: () => param.getType(SymbolTypeFlags.runtime)
+                    getType: () => param.getType({ flags: SymbolTypeFlags.runtime })
                 });
             }
 
@@ -508,7 +508,7 @@ export class BrsFile {
                     nameRange: statement.name.range,
                     lineIndex: statement.name.range.start.line,
                     name: statement.name.text,
-                    getType: () => statement.value.getType(SymbolTypeFlags.runtime)
+                    getType: () => statement.value.getType({ flags: SymbolTypeFlags.runtime })
                 });
             }
         }
@@ -522,7 +522,7 @@ export class BrsFile {
             for (let param of statement.func.parameters) {
                 let callableParam = {
                     name: param.name.text,
-                    type: param.getType(SymbolTypeFlags.typetime),
+                    type: param.getType({ flags: SymbolTypeFlags.typetime }),
                     isOptional: !!param.defaultValue,
                     isRestArgument: false
                 };
@@ -536,7 +536,7 @@ export class BrsFile {
                 file: this,
                 params: params,
                 range: statement.func.range,
-                type: statement.getType(SymbolTypeFlags.typetime),
+                type: statement.getType({ flags: SymbolTypeFlags.typetime }),
                 getName: statement.getName.bind(statement),
                 hasNamespace: !!statement.findAncestor<NamespaceStatement>(isNamespaceStatement),
                 functionStatement: statement

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,6 +14,7 @@ import type { SourceMapGenerator, SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 import type { Token } from './lexer/Token';
+import type { SymbolTypeFlags } from './SymbolTable';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -410,4 +411,10 @@ export interface FileLink<T> {
 export interface TypeResolution {
     name: string;
     resolved: boolean;
+}
+
+export interface GetTypeOptions {
+    flags: SymbolTypeFlags;
+    typeChain?: { name: string; resolved: boolean }[];
+    //TODO: Add a TypeCache that can be used to look up and store types to short circuit reference type look ups
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -423,7 +423,7 @@ export class TypeChainEntry {
     }
 }
 
-export interface TypeChainProcessResults {
+export interface TypeChainProcessResult {
     missingItemName: string;
     missingItemParentTypeName: string;
     fullNameOfMissingItem: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ import type { FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
-import type { BscType } from './types/BscType';
+import type { BscType, TypeResolution } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 import type { Token } from './lexer/Token';
 import type { SymbolTypeFlags } from './SymbolTable';
@@ -408,13 +408,9 @@ export interface FileLink<T> {
     file: BrsFile;
 }
 
-export interface TypeResolution {
-    name: string;
-    resolved: boolean;
-}
 
 export interface GetTypeOptions {
     flags: SymbolTypeFlags;
-    typeChain?: { name: string; resolved: boolean }[];
+    typeChain?: TypeResolution[];
     //TODO: Add a TypeCache that can be used to look up and store types to short circuit reference type look ups
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ import type { FunctionStatement } from './parser/Statement';
 import type { Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceMapGenerator, SourceNode } from 'source-map';
-import type { BscType, TypeResolution } from './types/BscType';
+import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 import type { Token } from './lexer/Token';
 import type { SymbolTypeFlags } from './SymbolTable';
@@ -411,6 +411,22 @@ export interface FileLink<T> {
 
 export interface GetTypeOptions {
     flags: SymbolTypeFlags;
-    typeChain?: TypeResolution[];
+    typeChain?: TypeChainEntry[];
     //TODO: Add a TypeCache that can be used to look up and store types to short circuit reference type look ups
+}
+
+export class TypeChainEntry {
+    constructor(public name: string, public type: BscType, public range: Range) {
+    }
+    get isResolved() {
+        return this.type?.isResolvable();
+    }
+}
+
+export interface TypeChainProcessResults {
+    missingItemName: string;
+    missingItemParentTypeName: string;
+    fullNameOfMissingItem: string;
+    fullChainName: string;
+    range: Range;
 }

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -3,9 +3,9 @@ import { WalkMode } from '../astUtils/visitors';
 import type { Position, Range } from 'vscode-languageserver';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { InternalWalkMode } from '../astUtils/visitors';
-import type { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
+import type { SymbolTable } from '../SymbolTable';
 import type { BrsTranspileState } from './BrsTranspileState';
-import type { TranspileResult } from '../interfaces';
+import type { GetTypeOptions, TranspileResult } from '../interfaces';
 import type { AnnotationExpression } from './Expression';
 import util from '../util';
 import { DynamicType } from '../types/DynamicType';
@@ -102,7 +102,7 @@ export abstract class AstNode {
     /**
      * Get the BscType of this node.
      */
-    public getType(flags: SymbolTypeFlags): BscType {
+    public getType(options: GetTypeOptions): BscType {
         return DynamicType.instance;
     }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -506,33 +506,6 @@ export class DottedGetExpression extends Expression {
 
 }
 
-class SomeKlass {
-
-    getDiffClass(): NameA.OtherKlass {
-        return new NameA.OtherKlass();
-    }
-
-    getClassArr() {
-        return [new SomeKlass(), new SomeKlass()];
-    }
-
-}
-
-// eslint-disable-next-line @typescript-eslint/no-namespace
-namespace NameA {
-    export class OtherKlass {
-
-        getStr() {
-            return 'hello';
-        }
-
-    }
-}
-
-function returnsAClass(): SomeKlass {
-    return new SomeKlass();
-}
-
 export class XmlAttributeGetExpression extends Expression {
     constructor(
         readonly obj: Expression,

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -13,7 +13,7 @@ import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
 import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isReferenceType, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import type { BscType } from '../types/BscType';
-import { TypeResolution } from '../types/BscType';
+import { TypeChainEntry } from '../interfaces';
 import { FunctionType } from '../types/FunctionType';
 import { Expression } from './AstNode';
 import { SymbolTable, SymbolTypeFlags } from '../SymbolTable';
@@ -493,7 +493,7 @@ export class DottedGetExpression extends Expression {
     getType(options: GetTypeOptions) {
         const objType = this.obj?.getType(options);
         const result = objType?.getMemberType(this.name?.text, options.flags);
-        const typeChainEntry = new TypeResolution(this.name?.text, result, this.range);
+        const typeChainEntry = new TypeChainEntry(this.name?.text, result, this.range);
         options.typeChain?.push(typeChainEntry);
         if (result || options.flags & SymbolTypeFlags.typetime) {
             // All types should be known at typetime
@@ -920,7 +920,7 @@ export class VariableExpression extends Expression {
 
     getType(options: GetTypeOptions) {
         const resultType = util.tokenToBscType(this.name) ?? new ReferenceType(this.name.text, options.flags, () => this.getSymbolTable());
-        options.typeChain?.push(new TypeResolution(this.name.text, resultType, this.range));
+        options.typeChain?.push(new TypeChainEntry(this.name.text, resultType, this.range));
         return resultType;
     }
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -11,7 +11,7 @@ import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
 import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isReferenceType, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
-import type { TranspileResult, TypedefProvider } from '../interfaces';
+import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
 import { Expression } from './AstNode';
@@ -118,8 +118,8 @@ export class CallExpression extends Expression {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        const calleeType = this.callee.getType(flags);
+    getType(options: GetTypeOptions) {
+        const calleeType = this.callee.getType(options);
         if (isNewExpression(this.parent)) {
             return calleeType;
         }
@@ -309,9 +309,9 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
     }
 
-    public getType(flags: SymbolTypeFlags): FunctionType {
+    public getType(options: GetTypeOptions): FunctionType {
         //if there's a defined return type, use that
-        let returnType = this.returnTypeExpression?.getType(flags);
+        let returnType = this.returnTypeExpression?.getType(options);
         const isSub = this.functionType.kind === TokenKind.Sub;
         //if we don't have a return type and this is a sub, set the return type to `void`. else use `dynamic`
         if (!returnType) {
@@ -321,7 +321,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         const resultType = new FunctionType(returnType);
         resultType.isSub = isSub;
         for (let param of this.parameters) {
-            resultType.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
+            resultType.addParameter(param.name.text, param.getType(options), !!param.defaultValue);
         }
         return resultType;
     }
@@ -338,8 +338,10 @@ export class FunctionParameterExpression extends Expression {
         super();
     }
 
-    public getType(_flags: SymbolTypeFlags) {
-        return this.typeExpression?.getType(SymbolTypeFlags.typetime) ?? this.defaultValue?.getType(SymbolTypeFlags.runtime) ?? DynamicType.instance;
+    public getType(options: GetTypeOptions) {
+        return this.typeExpression?.getType({ ...options, flags: SymbolTypeFlags.typetime }) ??
+            this.defaultValue?.getType({ ...options, flags: SymbolTypeFlags.runtime }) ??
+            DynamicType.instance;
     }
 
     public get range(): Range {
@@ -448,8 +450,8 @@ export class NamespacedVariableNameExpression extends Expression {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        return this.expression.getType(flags);
+    getType(options: GetTypeOptions) {
+        return this.expression.getType(options);
     }
 }
 
@@ -465,11 +467,6 @@ export class DottedGetExpression extends Expression {
         super();
         this.range = util.createBoundingRange(this.obj, this.dot, this.name);
     }
-
-    // TODO: remove typeChain, instead, allow an array passed into `getType()` to be filled with the
-    // types found
-    // The typechain needs to be agnostic of use, and some other function will be used for changing it into a human-readable format
-    public typeChain: { name: string; resolved: boolean }[] = [];
 
     public readonly range: Range;
 
@@ -492,21 +489,21 @@ export class DottedGetExpression extends Expression {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
+    getType(options: GetTypeOptions) {
         //reset
-        this.typeChain = [];
-        const objType = this.obj?.getType(flags);
-        const result = objType?.getMemberType(this.name?.text, flags);
+
+        const objType = this.obj?.getType(options);
+        const result = objType?.getMemberType(this.name?.text, options.flags);
         const typeChainEntry = { name: this.name.text, resolved: !!result && !isReferenceType(result) };
 
         if (isDottedGetExpression(this.obj)) {
-            this.typeChain.push(...this.obj.typeChain, typeChainEntry);
+            options.typeChain?.push(typeChainEntry);
         } else {
             const parentName = (this.obj as any)?.name ? (this.obj as any)?.name.text : 'unknown';
             const parentEntry = { name: parentName, resolved: !!objType && (!isReferenceType(objType) || objType.isResolvable()) };
-            this.typeChain.push(parentEntry, typeChainEntry);
+            options.typeChain?.push(parentEntry, typeChainEntry);
         }
-        if (result || flags & SymbolTypeFlags.typetime) {
+        if (result || options.flags & SymbolTypeFlags.typetime) {
             // All types should be known at typetime
             return result;
         }
@@ -610,8 +607,8 @@ export class GroupingExpression extends Expression {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        return this.expression.getType(flags);
+    getType(options: GetTypeOptions) {
+        return this.expression.getType(options);
     }
 }
 
@@ -622,7 +619,7 @@ export class LiteralExpression extends Expression {
         super();
     }
 
-    public getType(_flags: SymbolTypeFlags = SymbolTypeFlags.runtime | SymbolTypeFlags.typetime) {
+    public getType(options?: GetTypeOptions) {
         return util.tokenToBscType(this.token);
     }
 
@@ -929,12 +926,12 @@ export class VariableExpression extends Expression {
     }
 
 
-    getType(flags: SymbolTypeFlags) {
+    getType(options: GetTypeOptions) {
         const standardType = util.tokenToBscType(this.name);
         if (standardType) {
             return standardType;
         }
-        return new ReferenceType(this.name.text, flags, () => this.getSymbolTable());
+        return new ReferenceType(this.name.text, options.flags, () => this.getSymbolTable());
     }
 }
 
@@ -1056,8 +1053,8 @@ export class NewExpression extends Expression {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        return this.call.getType(flags);
+    getType(options: GetTypeOptions) {
+        return this.call.getType(options);
     }
 }
 
@@ -1187,7 +1184,7 @@ export class TemplateStringExpression extends Expression {
 
     public readonly range: Range;
 
-    public getType(flags: SymbolTypeFlags) {
+    public getType(options: GetTypeOptions) {
         return StringType.instance;
     }
 
@@ -1653,7 +1650,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
     public range: Range;
 
     public transpile(state: BrsTranspileState): TranspileResult {
-        return [this.getType().toTypeString()];
+        return [this.getType({ flags: SymbolTypeFlags.typetime }).toTypeString()];
     }
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
@@ -1661,8 +1658,8 @@ export class TypeExpression extends Expression implements TypedefProvider {
         }
     }
 
-    public getType(_flags: SymbolTypeFlags = SymbolTypeFlags.typetime): BscType {
-        return this.expression.getType(SymbolTypeFlags.typetime);
+    public getType(options: GetTypeOptions): BscType {
+        return this.expression.getType({ ...options, flags: SymbolTypeFlags.typetime });
     }
 
     getTypedef(state: TranspileState): (string | SourceNode)[] {

--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -8,6 +8,7 @@ import { ClassStatement } from './Statement';
 import { NewExpression } from './Expression';
 import { StringType } from '../types/StringType';
 import { expectDiagnosticsIncludes } from '../testHelpers.spec';
+import { SymbolTypeFlags } from '../SymbolTable';
 
 describe('parser class', () => {
     it('throws exception when used in brightscript scope', () => {
@@ -199,7 +200,7 @@ describe('parser class', () => {
             expect(field.accessModifier.kind).to.equal(TokenKind.Public);
             expect(field.name.text).to.equal('firstName');
             expect(field.as.text).to.equal('as');
-            expect(field.getType()).to.be.instanceOf(StringType);
+            expect(field.getType({ flags: SymbolTypeFlags.typetime })).to.be.instanceOf(StringType);
         });
 
         it('can be solely an identifier', () => {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -10,7 +10,7 @@ import { ParseMode } from './Parser';
 import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { InternalWalkMode, walk, createVisitor, WalkMode, walkArray } from '../astUtils/visitors';
 import { isCallExpression, isCommentStatement, isEnumMemberStatement, isExpression, isExpressionStatement, isFieldStatement, isFunctionExpression, isFunctionStatement, isIfStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInvalidType, isLiteralExpression, isMethodStatement, isNamespaceStatement, isTypedefProvider, isUnaryExpression, isVoidType } from '../astUtils/reflection';
-import type { TranspileResult, TypedefProvider } from '../interfaces';
+import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
 import type { SourceNode } from 'source-map';
@@ -162,8 +162,8 @@ export class AssignmentStatement extends Statement {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        return this.value.getType(flags);
+    getType(options: GetTypeOptions) {
+        return this.value.getType(options);
     }
 }
 
@@ -400,8 +400,8 @@ export class FunctionStatement extends Statement implements TypedefProvider {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        const funcExprType = this.func.getType(flags);
+    getType(options: GetTypeOptions) {
+        const funcExprType = this.func.getType(options);
         funcExprType.setName(this.name.text);
         return funcExprType;
     }
@@ -1450,16 +1450,16 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        const superIface = this.parentInterfaceName?.getType(flags) as InterfaceType;
+    getType(options: GetTypeOptions) {
+        const superIface = this.parentInterfaceName?.getType(options) as InterfaceType;
 
         const resultType = new InterfaceType(this.getName(ParseMode.BrighterScript), superIface);
 
         for (const statement of this.methods) {
-            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement?.getType(flags), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement?.getType(options), SymbolTypeFlags.runtime);
         }
         for (const statement of this.fields) {
-            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement.getType(flags), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.tokens.name?.text, statement?.range, statement.getType(options), SymbolTypeFlags.runtime);
         }
         return resultType;
     }
@@ -1523,8 +1523,8 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
         return result;
     }
 
-    public getType(flags: SymbolTypeFlags): BscType {
-        return this.typeExpression?.getType(flags) ?? DynamicType.instance;
+    public getType(options: GetTypeOptions): BscType {
+        return this.typeExpression?.getType(options) ?? DynamicType.instance;
     }
 
 }
@@ -1620,9 +1620,9 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         return result;
     }
 
-    public getType(flags: SymbolTypeFlags): FunctionType {
+    public getType(options): FunctionType {
         //if there's a defined return type, use that
-        let returnType = this.returnTypeExpression?.getType(flags);
+        let returnType = this.returnTypeExpression?.getType(options);
         const isSub = this.tokens.functionType.kind === TokenKind.Sub;
         //if we don't have a return type and this is a sub, set the return type to `void`. else use `dynamic`
         if (!returnType) {
@@ -1632,7 +1632,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         const resultType = new FunctionType(returnType);
         resultType.isSub = isSub;
         for (let param of this.params) {
-            resultType.addParameter(param.name.text, param.getType(flags), !!param.defaultValue);
+            resultType.addParameter(param.name.text, param.getType(options), !!param.defaultValue);
         }
         return resultType;
     }
@@ -2027,17 +2027,17 @@ export class ClassStatement extends Statement implements TypedefProvider {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        const superClass = this.parentClassName?.getType(flags) as ClassType;
+    getType(options: GetTypeOptions) {
+        const superClass = this.parentClassName?.getType(options) as ClassType;
 
         const resultType = new ClassType(this.getName(ParseMode.BrighterScript), superClass);
 
         for (const statement of this.methods) {
-            const funcType = statement?.func.getType(flags);
+            const funcType = statement?.func.getType(options);
             resultType.addMember(statement?.name?.text, statement?.range, funcType, SymbolTypeFlags.runtime);
         }
         for (const statement of this.fields) {
-            resultType.addMember(statement?.name?.text, statement?.range, statement.getType(), SymbolTypeFlags.runtime);
+            resultType.addMember(statement?.name?.text, statement?.range, statement.getType(options), SymbolTypeFlags.runtime);
         }
         return resultType;
     }
@@ -2260,8 +2260,9 @@ export class FieldStatement extends Statement implements TypedefProvider {
      * Derive a ValueKind from the type token, or the initial value.
      * Defaults to `DynamicType`
      */
-    getType() {
-        return this.typeExpression?.getType(SymbolTypeFlags.typetime) ?? this.initialValue?.getType(SymbolTypeFlags.runtime) ?? DynamicType.instance;
+    getType(options: GetTypeOptions) {
+        return this.typeExpression?.getType({ ...options, flags: SymbolTypeFlags.typetime }) ??
+            this.initialValue?.getType({ ...options, flags: SymbolTypeFlags.runtime }) ?? DynamicType.instance;
     }
 
     public readonly range: Range;
@@ -2281,7 +2282,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
                 );
             }
 
-            let type = this.getType();
+            let type = this.getType({ flags: SymbolTypeFlags.typetime });
             if (isInvalidType(type) || isVoidType(type)) {
                 type = new DynamicType();
             }
@@ -2717,8 +2718,8 @@ export class ConstStatement extends Statement implements TypedefProvider {
         }
     }
 
-    getType(flags: SymbolTypeFlags) {
-        return this.value.getType(flags);
+    getType(options: GetTypeOptions) {
+        return this.value.getType(options);
     }
 }
 

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -47,10 +47,3 @@ export abstract class BscType {
 }
 
 
-export class TypeResolution {
-    constructor(public name: string, public type: BscType, public range: Range) {
-    }
-    get resolved() {
-        return this.type?.isResolvable();
-    }
-}

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -45,3 +45,12 @@ export abstract class BscType {
         throw new Error('Method not implemented.');
     }
 }
+
+
+export class TypeResolution {
+    constructor(public name: string, public type: BscType, public range: Range) {
+    }
+    get resolved() {
+        return this.type?.isResolvable();
+    }
+}

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -7,7 +7,7 @@ import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { tempDir, rootDir } from './testHelpers.spec';
-import { TypeResolution } from './types/BscType';
+import { TypeChainEntry } from './interfaces';
 import { ClassType } from './types/ClassType';
 import { NamespaceType } from './types/NameSpaceType';
 import { ReferenceType } from './types/ReferenceType';
@@ -813,15 +813,16 @@ describe('util', () => {
     describe('processTypeChain', () => {
         it('should  find the correct details in a list of type resolutions', () => {
             const chain = [
-                new TypeResolution('AlphaNamespace', new NamespaceType('Alpha'), util.createRange(1, 1, 2, 2)),
-                new TypeResolution('BetaProp', new ClassType('Beta'), util.createRange(2, 2, 3, 3)),
-                new TypeResolution('CharlieProp', new ReferenceType('Charlie', SymbolTypeFlags.runtime, () => null), util.createRange(3, 3, 4, 4))
+                new TypeChainEntry('AlphaNamespace', new NamespaceType('Alpha'), util.createRange(1, 1, 2, 2)),
+                new TypeChainEntry('BetaProp', new ClassType('Beta'), util.createRange(2, 2, 3, 3)),
+                new TypeChainEntry('CharlieProp', new ReferenceType('Charlie', SymbolTypeFlags.runtime, () => null), util.createRange(3, 3, 4, 4))
             ];
 
             const result = util.processTypeChain(chain);
-            expect(result.cannotFindName).to.eql('CharlieProp');
+            expect(result.missingItemName).to.eql('CharlieProp');
             expect(result.fullChainName).to.eql('AlphaNamespace.BetaProp.CharlieProp');
-            expect(result.fullErrorName).to.eql('Beta.CharlieProp');
+            expect(result.missingItemParentTypeName).to.eql('Beta');
+            expect(result.fullNameOfMissingItem).to.eql('Beta.CharlieProp');
             expect(result.range).to.eql(util.createRange(3, 3, 4, 4));
         });
     });

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -7,6 +7,11 @@ import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { tempDir, rootDir } from './testHelpers.spec';
+import { TypeResolution } from './types/BscType';
+import { ClassType } from './types/ClassType';
+import { NamespaceType } from './types/NameSpaceType';
+import { ReferenceType } from './types/ReferenceType';
+import { SymbolTypeFlags } from './SymbolTable';
 
 const sinon = createSandbox();
 
@@ -803,6 +808,21 @@ describe('util', () => {
                     'uri', util.createRange(2, 3, 4, 5)
                 )
             }]);
+        });
+    });
+    describe('processTypeChain', () => {
+        it('should  find the correct details in a list of type resolutions', () => {
+            const chain = [
+                new TypeResolution('AlphaNamespace', new NamespaceType('Alpha'), util.createRange(1, 1, 2, 2)),
+                new TypeResolution('BetaProp', new ClassType('Beta'), util.createRange(2, 2, 3, 3)),
+                new TypeResolution('CharlieProp', new ReferenceType('Charlie', SymbolTypeFlags.runtime, () => null), util.createRange(3, 3, 4, 4))
+            ];
+
+            const result = util.processTypeChain(chain);
+            expect(result.cannotFindName).to.eql('CharlieProp');
+            expect(result.fullChainName).to.eql('AlphaNamespace.BetaProp.CharlieProp');
+            expect(result.fullErrorName).to.eql('Beta.CharlieProp');
+            expect(result.range).to.eql(util.createRange(3, 3, 4, 4));
         });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,7 @@ import { URI } from 'vscode-uri';
 import * as xml2js from 'xml2js';
 import type { BsConfig } from './BsConfig';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo, TypeChainEntry, TypeChainProcessResults } from './interfaces';
+import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo, TypeChainEntry, TypeChainProcessResult } from './interfaces';
 import { BooleanType } from './types/BooleanType';
 import { DoubleType } from './types/DoubleType';
 import { DynamicType } from './types/DynamicType';
@@ -1473,7 +1473,7 @@ export class Util {
         }
     }
 
-    public processTypeChain(typeChain: TypeChainEntry[]): TypeChainProcessResults {
+    public processTypeChain(typeChain: TypeChainEntry[]): TypeChainProcessResult {
         let fullChainName = '';
         let fullErrorName = '';
         let missingItemName = '';

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,7 @@ import * as xml2js from 'xml2js';
 import type { BsConfig } from './BsConfig';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo } from './interfaces';
+import type { TypeResolution } from './types/BscType';
 import { BooleanType } from './types/BooleanType';
 import { DoubleType } from './types/DoubleType';
 import { DynamicType } from './types/DynamicType';
@@ -1471,6 +1472,35 @@ export class Util {
                 range: this.createRange(0, 0, 0, Number.MAX_VALUE)
             }]);
         }
+    }
+
+    public processTypeChain(typeChain: TypeResolution[]): { cannotFindName: string; fullErrorName: string; fullChainName: string; range: Range } {
+        let fullChainName = '';
+        let fullErrorName = '';
+        let cannotFindName = '';
+        let previousTypeName = '';
+        let errorRange: Range;
+        for (let i = 0; i < typeChain.length; i++) {
+            const chainItem = typeChain[i];
+            if (i > 0) {
+                fullChainName += '.';
+            }
+            fullChainName += chainItem.name;
+            fullErrorName = previousTypeName ? `${previousTypeName}.${chainItem.name}` : chainItem.name;
+            previousTypeName = chainItem.type.toString();
+            cannotFindName = chainItem.name;
+            if (!chainItem.resolved) {
+                errorRange = chainItem.range;
+                break;
+            }
+        }
+        return {
+            cannotFindName: cannotFindName,
+            fullErrorName: fullErrorName,
+            fullChainName: fullChainName,
+            range: errorRange
+
+        };
     }
 }
 

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -222,11 +222,11 @@ export class BsClassValidator {
                         if (isFieldStatement(member)) {
                             let ancestorMemberType: BscType = new DynamicType();
                             if (isFieldStatement(ancestorAndMember.member)) {
-                                ancestorMemberType = ancestorAndMember.member.getType();
+                                ancestorMemberType = ancestorAndMember.member.getType({ flags: SymbolTypeFlags.typetime });
                             } else if (isMethodStatement(ancestorAndMember.member)) {
-                                ancestorMemberType = ancestorAndMember.member.func.getType(SymbolTypeFlags.typetime);
+                                ancestorMemberType = ancestorAndMember.member.func.getType({ flags: SymbolTypeFlags.typetime });
                             }
-                            const childFieldType = member.getType();
+                            const childFieldType = member.getType({ flags: SymbolTypeFlags.typetime });
                             if (!childFieldType.isAssignableTo(ancestorMemberType)) {
                                 //flag incompatible child field type to ancestor field type
                                 this.diagnostics.push({


### PR DESCRIPTION
- Adds options to all `AstNode.getType()` calls
- Each AstNode is Responsible for adding to the the passed-in type chain
- Added Utility function to process a type chain

- [ ] Add typechain pushing to indexedGet