### PR TITLE
Adds Union types

### DIFF
--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -140,30 +140,29 @@ export class SymbolTable {
         //Need to take the intersection of siblings...
         const key = name.toLowerCase();
         let result: BscSymbol[];
-        let resultSoFar = [];
+        let resultSoFar: BscSymbol[] = [];
         // look in our map first
         if ((result = this.symbolMap.get(key))) {
             // eslint-disable-next-line no-bitwise
             const resultMe = result.filter(symbol => symbol.flags & bitFlags);
-            if (resultMe.length > 0) {
-                return result;
-            }
+            resultSoFar.push(...resultMe);
         }
 
         //look through any sibling maps next
         for (let sibling of this.siblings) {
             if ((result = sibling.symbolMap.get(key))) {
                 // eslint-disable-next-line no-bitwise
-                result = result.filter(symbol => symbol.flags & bitFlags);
-                if (result.length > 0) {
-                    return result;
-                }
+                const resultMe = result.filter(symbol => symbol.flags & bitFlags);
+                resultSoFar.push(...resultMe);
             }
         }
-        // ask our parent for a symbol
-        return this.parent?.getSymbol(key, bitFlags);
 
-        return [];
+        const typeResults = resultSoFar.map(result => result.type);
+        if (typeResults.length > 0) {
+            return typeResults;
+        }
+        // ask our parent for a symbol
+        return this.parent?.getSymbolTypes(key, bitFlags);
     }
 
     /**
@@ -238,5 +237,3 @@ export interface BscSymbol {
  * A function that returns a symbol table.
  */
 export type SymbolTableProvider = () => SymbolTable;
-
-

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -140,7 +140,7 @@ export class SymbolTable {
         //Need to take the intersection of siblings...
         const key = name.toLowerCase();
         let result: BscSymbol[];
-        let resultMe = [];
+        let resultSoFar = [];
         // look in our map first
         if ((result = this.symbolMap.get(key))) {
             // eslint-disable-next-line no-bitwise
@@ -149,6 +149,7 @@ export class SymbolTable {
                 return result;
             }
         }
+
         //look through any sibling maps next
         for (let sibling of this.siblings) {
             if ((result = sibling.symbolMap.get(key))) {

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -127,6 +127,14 @@ export class SymbolTable {
         });
     }
 
+    getSymbolTypes(name: string, bitFlags: number): BscType[] {
+        const symbolArray = this.getSymbol(name, bitFlags);
+        if (!symbolArray) {
+            return undefined;
+        }
+        return symbolArray.map(symbol => symbol.type);
+    }
+
     /**
      * Adds all the symbols from another table to this one
      * It will overwrite any existing symbols in this table
@@ -199,3 +207,5 @@ export interface BscSymbol {
  * A function that returns a symbol table.
  */
 export type SymbolTableProvider = () => SymbolTable;
+
+

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -23,6 +23,7 @@ import type { AstNode, Expression, Statement } from '../parser/AstNode';
 import type { TypePropertyReferenceType, ReferenceType } from '../types/ReferenceType';
 import type { EnumMemberType, EnumType } from '../types/EnumType';
 import type { NamespaceType } from '../types/NameSpaceType';
+import type { UnionType } from '../types/UnionType';
 
 // File reflection
 
@@ -321,6 +322,9 @@ export function isTypePropertyReferenceType(e: any): e is TypePropertyReferenceT
 }
 export function isNamespaceType(e: any): e is NamespaceType {
     return e?.constructor.name === 'NamespaceType';
+}
+export function isUnionType(e: any): e is UnionType {
+    return e?.constructor.name === 'UnionType';
 }
 
 const numberConstructorNames = [

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -24,6 +24,8 @@ import type { TypePropertyReferenceType, ReferenceType } from '../types/Referenc
 import type { EnumMemberType, EnumType } from '../types/EnumType';
 import type { NamespaceType } from '../types/NameSpaceType';
 import type { UnionType } from '../types/UnionType';
+import type { UninitializedType } from '../types/UninitializedType';
+import type { ArrayType } from '../types/ArrayType';
 
 // File reflection
 
@@ -325,6 +327,12 @@ export function isNamespaceType(e: any): e is NamespaceType {
 }
 export function isUnionType(e: any): e is UnionType {
     return e?.constructor.name === 'UnionType';
+}
+export function isUninitializedType(e: any): e is UninitializedType {
+    return e?.constructor.name === 'UninitializedType';
+}
+export function isArrayType(e: any): e is ArrayType {
+    return e?.constructor.name === 'ArrayType';
 }
 
 const numberConstructorNames = [

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -67,7 +67,6 @@ export class BrsFileValidator {
             },
             AssignmentStatement: (node) => {
                 //register this variable
-
                 const nodeType = node.getType(SymbolTypeFlags.runtime);
                 node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, nodeType, SymbolTypeFlags.runtime);
             },

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1030,7 +1030,7 @@ describe('BrsFile BrighterScript classes', () => {
                 public owner as Person
             end class
             class Duck extends Bird
-                public age = 12.2 'should be integer but is float
+                public age = 12.2 'should be integer, but a float can be assigned to an int
                 public name = 12 'should be string but is integer
                 public owner as string
             end class
@@ -1038,7 +1038,6 @@ describe('BrsFile BrighterScript classes', () => {
         program.validate();
         expectDiagnostics(program, [
             DiagnosticMessages.cannotFindName('Person'),
-            DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'age', 'float', 'integer'),
             DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'name', 'integer', 'string'),
             DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty('Duck', 'Bird', 'owner', 'string', 'Person')
         ]);

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -22,6 +22,7 @@ import { StringType } from '../types/StringType';
 import { DynamicType } from '../types/DynamicType';
 import { VoidType } from '../types/VoidType';
 import { TypePropertyReferenceType, ReferenceType } from '../types/ReferenceType';
+import { getUniqueType } from '../types/helpers';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -496,7 +497,7 @@ export class DottedGetExpression extends Expression {
         //reset
         this.typeChain = [];
         const objType = this.obj?.getType(flags);
-        const result = objType?.getMemberType(this.name?.text, flags);
+        const result = getUniqueType(objType?.getMemberTypes(this.name?.text, flags));
         const typeChainEntry = { name: this.name.text, resolved: !!result && !isReferenceType(result) };
 
         if (isDottedGetExpression(this.obj)) {

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -7,22 +7,22 @@ import { StringType } from './StringType';
 
 describe('ArrayType', () => {
     it('is equivalent to array types', () => {
-        expect(new ArrayType().isAssignableTo(new ArrayType())).to.be.true;
-        expect(new ArrayType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new ArrayType().isTypeCompatible(new ArrayType())).to.be.true;
+        expect(new ArrayType().isTypeCompatible(new DynamicType())).to.be.true;
     });
 
     it('catches arrays containing different inner types', () => {
-        expect(new ArrayType(new BooleanType()).isAssignableTo(new ArrayType(new BooleanType()))).to.be.true;
-        expect(new ArrayType(new BooleanType()).isAssignableTo(new ArrayType(new StringType()))).to.be.false;
+        expect(new ArrayType(new BooleanType()).isTypeCompatible(new ArrayType(new BooleanType()))).to.be.true;
+        expect(new ArrayType(new BooleanType()).isTypeCompatible(new ArrayType(new StringType()))).to.be.false;
     });
 
     it('is not equivalent to other types', () => {
-        expect(new ArrayType().isAssignableTo(new BooleanType())).to.be.false;
+        expect(new ArrayType().isEqual(new BooleanType())).to.be.false;
     });
 
-    describe('isConveribleTo', () => {
-        expect(new ArrayType().isConvertibleTo(new BooleanType())).to.be.false;
-        expect(new ArrayType().isConvertibleTo(new ArrayType())).to.be.true;
+    describe('isTypeCompatible', () => {
+        expect(new ArrayType().isTypeCompatible(new BooleanType())).to.be.false;
+        expect(new ArrayType().isTypeCompatible(new ArrayType())).to.be.true;
     });
 
     describe('toString', () => {

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,5 @@
+import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 export class ArrayType extends BscType {
     constructor(...innerTypes: BscType[]) {
@@ -8,34 +8,19 @@ export class ArrayType extends BscType {
     }
     public innerTypes: BscType[] = [];
 
-    public isAssignableTo(targetType: BscType) {
-        if (targetType instanceof DynamicType) {
+    public isTypeCompatible(targetType: BscType) {
+
+        if (isDynamicType(targetType)) {
             return true;
-        } else if (!(targetType instanceof ArrayType)) {
+        } else if (isObjectType(targetType)) {
+            return true;
+        } else if (!isArrayType(targetType)) {
             return false;
         }
-        //this array type is assignable to the target IF
-        //1. all of the types in this array are present in the target
-        outer: for (let innerType of this.innerTypes) {
-            //find this inner type in the target
-
-            // eslint-disable-next-line no-unreachable-loop
-            for (let targetInnerType of targetType.innerTypes) {
-                //TODO is this loop correct? It ends after 1 iteration but we might need to do more iterations
-
-                if (innerType.isAssignableTo(targetInnerType)) {
-                    continue outer;
-                }
-
-                //our array contains a type that the target array does not...so these arrays are different
-                return false;
-            }
+        if (this.isEqual(targetType)) {
+            return true;
         }
-        return true;
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
+        return false;
     }
 
     public toString() {
@@ -44,5 +29,21 @@ export class ArrayType extends BscType {
 
     public toTypeString(): string {
         return 'object';
+    }
+
+    public isEqual(targetType: BscType): boolean {
+        //TODO: figure out array type equality later
+        if (isArrayType(targetType)) {
+            if (targetType.innerTypes.length !== this.innerTypes.length) {
+                return false;
+            }
+            for (let i = 0; i < this.innerTypes.length; i++) {
+                if (!this.innerTypes[i].isEqual(targetType.innerTypes[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/types/BooleanType.spec.ts
+++ b/src/types/BooleanType.spec.ts
@@ -1,18 +1,18 @@
 import { expect } from '../chai-config.spec';
 
 import { BooleanType } from './BooleanType';
-import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
-import { StringType } from './StringType';
-import { UnionType } from './UnionType';
+import { IntegerType } from './IntegerType';
 
 describe('BooleanType', () => {
-    it('is equivalent to boolean types', () => {
-        expect(new BooleanType().isAssignableTo(new BooleanType())).to.be.true;
-        expect(new BooleanType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is equal to boolean type', () => {
+        expect(new BooleanType().isEqual(new BooleanType())).to.be.true;
+        expect(new BooleanType().isEqual(new DynamicType())).to.be.false;
     });
 
-    it('can be assigned to a Union that includes this type', () => {
-        expect(BooleanType.instance.isAssignableTo(new UnionType([DoubleType.instance, StringType.instance, BooleanType.instance]))).to.be.true;
+    it('is compatible with only correct types', () => {
+        expect(new BooleanType().isTypeCompatible(new BooleanType())).to.be.true;
+        expect(new BooleanType().isTypeCompatible(new DynamicType())).to.be.true;
+        expect(new BooleanType().isTypeCompatible(IntegerType.instance)).to.be.false;
     });
 });

--- a/src/types/BooleanType.spec.ts
+++ b/src/types/BooleanType.spec.ts
@@ -1,11 +1,18 @@
 import { expect } from '../chai-config.spec';
 
 import { BooleanType } from './BooleanType';
+import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
+import { StringType } from './StringType';
+import { UnionType } from './UnionType';
 
 describe('BooleanType', () => {
     it('is equivalent to boolean types', () => {
         expect(new BooleanType().isAssignableTo(new BooleanType())).to.be.true;
         expect(new BooleanType().isAssignableTo(new DynamicType())).to.be.true;
+    });
+
+    it('can be assigned to a Union that includes this type', () => {
+        expect(BooleanType.instance.isAssignableTo(new UnionType([DoubleType.instance, StringType.instance, BooleanType.instance]))).to.be.true;
     });
 });

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -1,4 +1,4 @@
-import { isBooleanType, isDynamicType, isUnionType } from '../astUtils/reflection';
+import { isBooleanType, isDynamicType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 
 export class BooleanType extends BscType {

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -10,19 +10,11 @@ export class BooleanType extends BscType {
 
     public static instance = new BooleanType('boolean');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
-
+    public isTypeCompatible(targetType: BscType) {
         return (
             isBooleanType(targetType) ||
             isDynamicType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
     }
 
     public toString() {
@@ -31,5 +23,9 @@ export class BooleanType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    isEqual(targetType: BscType): boolean {
+        return isBooleanType(targetType);
     }
 }

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -1,5 +1,5 @@
+import { isBooleanType, isDynamicType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 export class BooleanType extends BscType {
     constructor(
@@ -11,9 +11,13 @@ export class BooleanType extends BscType {
     public static instance = new BooleanType('boolean');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
+
         return (
-            targetType instanceof BooleanType ||
-            targetType instanceof DynamicType
+            isBooleanType(targetType) ||
+            isDynamicType(targetType)
         );
     }
 

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -24,8 +24,8 @@ export abstract class BscType {
         this.memberTable.addSymbol(name, range, type, flags);
     }
 
-    getMemberType(name: string, flags: SymbolTypeFlags) {
-        return this.memberTable.getSymbol(name, flags)?.[0]?.type;
+    getMemberTypes(name: string, flags: SymbolTypeFlags) {
+        return this.memberTable.getSymbolTypes(name, flags);
     }
 
     isResolvable(): boolean {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -32,10 +32,20 @@ export abstract class BscType {
         return true;
     }
 
-    isAssignableTo(_targetType: BscType): boolean {
-        throw new Error('Method not implemented.');
+    /**
+     * Check if this type can be assigned to the target type
+     * @param targetType the type that we're trying to assign this type to
+     * @deprecated
+     */
+    isAssignableTo(targetType: BscType): boolean {
+        return targetType.isTypeCompatible(this);
     }
-    isConvertibleTo(_targetType: BscType): boolean {
+
+    /**
+     * Check if a different type can be assigned to this type - eg. does the other type convert into this type?
+     * @param _otherType the type to check if it can be used as this type, or can automatically be converted into this type
+     */
+    isTypeCompatible(_otherType: BscType): boolean {
         throw new Error('Method not implemented.');
     }
     toString(): string {
@@ -44,6 +54,26 @@ export abstract class BscType {
     toTypeString(): string {
         throw new Error('Method not implemented.');
     }
-}
 
+    isEqual(targetType: BscType): boolean {
+        throw new Error('Method not implemented.');
+    }
+
+
+    checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlags) {
+        let isSuperSet = true;
+        const targetSymbols = targetType.memberTable?.getAllSymbols(flags);
+        for (const targetSymbol of targetSymbols) {
+            const myTypesOfTargetSymbol = this.memberTable.getSymbolTypes(targetSymbol.name, flags);
+            isSuperSet = isSuperSet && myTypesOfTargetSymbol && myTypesOfTargetSymbol.length > 0 &&
+                myTypesOfTargetSymbol.reduce((acc, myTypeOfTarget) => {
+                    return acc && myTypeOfTarget.isTypeCompatible(targetSymbol.type);
+                }, true);
+            if (!isSuperSet) {
+                return false;
+            }
+        }
+        return isSuperSet;
+    }
+}
 

--- a/src/types/ClassType.spec.ts
+++ b/src/types/ClassType.spec.ts
@@ -6,6 +6,7 @@ import { expectTypeToBe } from '../testHelpers.spec';
 import { ReferenceType } from './ReferenceType';
 import { isReferenceType } from '../astUtils/reflection';
 import { IntegerType } from './IntegerType';
+import { getUniqueType } from './helpers';
 
 describe('ClassType', () => {
 
@@ -41,7 +42,7 @@ describe('ClassType', () => {
         const superKlass = new ClassType('SuperKlass');
         superKlass.addMember('title', null, StringType.instance, SymbolTypeFlags.runtime);
         const subKlass = new ClassType('SubKlass', superKlass);
-        expectTypeToBe(subKlass.getMemberType('title', SymbolTypeFlags.runtime), StringType);
+        expectTypeToBe(getUniqueType(subKlass.getMemberTypes('title', SymbolTypeFlags.runtime)), StringType);
     });
 
     it('allow ReferenceTypes as super classes', () => {
@@ -59,7 +60,7 @@ describe('ClassType', () => {
         const futureSuperKlass = new ReferenceType('SuperKlass', SymbolTypeFlags.typetime, () => myTable);
         const subKlass = new ClassType('SubKlass', futureSuperKlass);
         expect(subKlass.isResolvable()).to.be.false;
-        const futureTitleType = subKlass.getMemberType('title', SymbolTypeFlags.runtime);
+        const futureTitleType = getUniqueType(subKlass.getMemberTypes('title', SymbolTypeFlags.runtime));
         expect(isReferenceType(futureTitleType)).to.be.true;
         expect(futureTitleType.isResolvable()).to.be.false;
         const superKlass = new ClassType('SuperKlass');

--- a/src/types/ClassType.spec.ts
+++ b/src/types/ClassType.spec.ts
@@ -23,9 +23,9 @@ describe('ClassType', () => {
         const superKlass = new ClassType('SuperKlass', grandSuperKlass);
         const subKlass = new ClassType('SubKlass', superKlass);
 
-        expect(subKlass.isAssignableTo(subKlass)).to.be.true;
-        expect(subKlass.isAssignableTo(superKlass)).to.be.true;
-        expect(subKlass.isAssignableTo(grandSuperKlass)).to.be.true;
+        expect(subKlass.isTypeCompatible(subKlass)).to.be.true;
+        expect(superKlass.isTypeCompatible(subKlass)).to.be.true;
+        expect(grandSuperKlass.isTypeCompatible(superKlass)).to.be.true;
     });
 
     it('should not be assignable to a class that is not an ancestor', () => {
@@ -34,8 +34,8 @@ describe('ClassType', () => {
         const superKlass = new ClassType('SuperKlass');
         const subKlass = new ClassType('SubKlass', superKlass);
 
-        expect(subKlass.isAssignableTo(superKlass)).to.be.true;
-        expect(subKlass.isAssignableTo(otherKlass)).to.be.false;
+        expect(superKlass.isTypeCompatible(subKlass)).to.be.true;
+        expect(otherKlass.isTypeCompatible(subKlass)).to.be.false;
     });
 
     it('will look in super classes for members', () => {

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -1,5 +1,5 @@
 import { SymbolTypeFlags } from '../SymbolTable';
-import { isClassType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
+import { isClassType, isDynamicType, isInterfaceType, isObjectType, isUnionType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType } from './InheritableType';
 
@@ -14,6 +14,8 @@ export class ClassType extends InheritableType {
         if (this === targetType) {
             return true;
         } else if (isDynamicType(targetType) || isObjectType(targetType)) {
+            return true;
+        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
             return true;
         } else if (isClassType(targetType)) {
             const ancestorTypes = this.getAncestorTypeList();

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -1,5 +1,4 @@
-import { SymbolTypeFlags } from '../SymbolTable';
-import { isClassType, isDynamicType, isInterfaceType, isObjectType, isUnionType } from '../astUtils/reflection';
+import { isClassType, isDynamicType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType } from './InheritableType';
 
@@ -9,22 +8,22 @@ export class ClassType extends InheritableType {
         super(name, superClass);
     }
 
-    public isAssignableTo(targetType: BscType) {
-        //TODO: We need to make sure that things don't get assigned to built-in types
-        if (this === targetType) {
+    public isTypeCompatible(targetType: BscType) {
+        if (this.isEqual(targetType)) {
             return true;
-        } else if (isDynamicType(targetType) || isObjectType(targetType)) {
-            return true;
-        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+        } else if (isDynamicType(targetType)) {
             return true;
         } else if (isClassType(targetType)) {
-            const ancestorTypes = this.getAncestorTypeList();
-            if (ancestorTypes?.find(ancestorType => ancestorType === targetType)) {
+            // Check if this is an ancestor of targetType
+            const targetAncestorTypes = targetType.getAncestorTypeList();
+            if (targetAncestorTypes?.find(ancestorType => ancestorType.isEqual(this))) {
                 return true;
             }
-        } else if (isInterfaceType(targetType)) {
-            return this.checkAssignabilityToInterface(targetType, SymbolTypeFlags.runtime);
         }
         return false;
+    }
+
+    isEqual(targetType: BscType): boolean {
+        return isClassType(targetType) && this.name === targetType.name;
     }
 }

--- a/src/types/DoubleType.spec.ts
+++ b/src/types/DoubleType.spec.ts
@@ -1,17 +1,21 @@
 import { expect } from '../chai-config.spec';
+import { BooleanType } from './BooleanType';
 
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
-import { StringType } from './StringType';
-import { UnionType } from './UnionType';
+import { IntegerType } from './IntegerType';
 
 describe('DoubleType', () => {
-    it('is equivalent to double types', () => {
-        expect(new DoubleType().isAssignableTo(new DoubleType())).to.be.true;
-        expect(new DoubleType().isAssignableTo(new DynamicType())).to.be.true;
+
+    it('is equal to double type', () => {
+        expect(new DoubleType().isEqual(new DoubleType())).to.be.true;
+        expect(new DoubleType().isEqual(new DynamicType())).to.be.false;
     });
 
-    it('can be assigned to a Union that includes this type', () => {
-        expect(DoubleType.instance.isAssignableTo(new UnionType([DoubleType.instance, StringType.instance]))).to.be.true;
+    it('is compatible with only correct types', () => {
+        expect(new DoubleType().isTypeCompatible(new DoubleType())).to.be.true;
+        expect(new DoubleType().isTypeCompatible(new DynamicType())).to.be.true;
+        expect(new DoubleType().isTypeCompatible(IntegerType.instance)).to.be.true;
+        expect(new DoubleType().isTypeCompatible(BooleanType.instance)).to.be.false;
     });
 });

--- a/src/types/DoubleType.spec.ts
+++ b/src/types/DoubleType.spec.ts
@@ -2,10 +2,16 @@ import { expect } from '../chai-config.spec';
 
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
+import { StringType } from './StringType';
+import { UnionType } from './UnionType';
 
 describe('DoubleType', () => {
     it('is equivalent to double types', () => {
         expect(new DoubleType().isAssignableTo(new DoubleType())).to.be.true;
         expect(new DoubleType().isAssignableTo(new DynamicType())).to.be.true;
+    });
+
+    it('can be assigned to a Union that includes this type', () => {
+        expect(DoubleType.instance.isAssignableTo(new UnionType([DoubleType.instance, StringType.instance]))).to.be.true;
     });
 });

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,9 +1,7 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
-import { FloatType } from './FloatType';
-import { IntegerType } from './IntegerType';
-import { LongIntegerType } from './LongIntegerType';
+
 
 export class DoubleType extends BscType {
     constructor(
@@ -14,28 +12,14 @@ export class DoubleType extends BscType {
 
     public static instance = new DoubleType('double');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof DoubleType ||
-            targetType instanceof DynamicType
+            isDynamicType(targetType) ||
+            isIntegerType(targetType) ||
+            isFloatType(targetType) ||
+            isDoubleType(targetType) ||
+            isLongIntegerType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        if (
-            targetType instanceof DynamicType ||
-            targetType instanceof IntegerType ||
-            targetType instanceof FloatType ||
-            targetType instanceof DoubleType ||
-            targetType instanceof LongIntegerType
-        ) {
-            return true;
-        } else {
-            return false;
-        }
     }
     public toString() {
         return this.typeText ?? 'double';
@@ -43,5 +27,9 @@ export class DoubleType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    public isEqual(targetType: BscType): boolean {
+        return isDoubleType(targetType);
     }
 }

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 import { FloatType } from './FloatType';
@@ -14,6 +15,9 @@ export class DoubleType extends BscType {
     public static instance = new DoubleType('double');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof DoubleType ||
             targetType instanceof DynamicType

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,6 +1,5 @@
-import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isUnionType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 
 export class DoubleType extends BscType {

--- a/src/types/DynamicType.spec.ts
+++ b/src/types/DynamicType.spec.ts
@@ -1,11 +1,23 @@
 import { expect } from '../chai-config.spec';
+import { BooleanType } from './BooleanType';
+import { ClassType } from './ClassType';
+import { DoubleType } from './DoubleType';
 
 import { DynamicType } from './DynamicType';
-import { StringType } from './StringType';
+import { IntegerType } from './IntegerType';
 
 describe('DynamicType', () => {
-    it('is equivalent to dynamic types', () => {
-        expect(new DynamicType().isAssignableTo(new StringType())).to.be.true;
-        expect(new DynamicType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is equal to dynamic type', () => {
+        expect(new DynamicType().isEqual(new DynamicType())).to.be.true;
+        expect(new DynamicType().isEqual(new DoubleType())).to.be.false;
+        expect(new DynamicType().isEqual(new ClassType('test'))).to.be.false;
+    });
+
+    it('is compatible with only all types', () => {
+        expect(new DynamicType().isTypeCompatible(new DoubleType())).to.be.true;
+        expect(new DynamicType().isTypeCompatible(new DynamicType())).to.be.true;
+        expect(new DynamicType().isTypeCompatible(IntegerType.instance)).to.be.true;
+        expect(new DynamicType().isTypeCompatible(BooleanType.instance)).to.be.true;
+        expect(new DynamicType().isTypeCompatible(new ClassType('test'))).to.be.true;
     });
 });

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -1,3 +1,4 @@
+import { isDynamicType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 
 export class DynamicType extends BscType {
@@ -21,7 +22,7 @@ export class DynamicType extends BscType {
     /**
      * The dynamic type is convertible to everything.
      */
-    public isConvertibleTo(targetType: BscType) {
+    public isTypeCompatible(targetType: BscType) {
         //everything can be dynamic, so as long as a type is provided, this is true
         return !!targetType;
     }
@@ -33,4 +34,9 @@ export class DynamicType extends BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public isEqual(targetType: BscType) {
+        return isDynamicType(targetType);
+    }
 }
+

--- a/src/types/EnumType.spec.ts
+++ b/src/types/EnumType.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from '../chai-config.spec';
+import { ClassType } from './ClassType';
+import { EnumMemberType, EnumType } from './EnumType';
+
+describe('EnumType', () => {
+    it('is equal to appropriate enum type', () => {
+        expect(new EnumType('hello').isEqual(new ClassType('hello'))).to.be.false;
+        expect(new EnumType('hello').isEqual(new EnumType('hello'))).to.be.true;
+        expect(new EnumType('hello').isEqual(new EnumType('notHello'))).to.be.false;
+    });
+
+    it('is compatible with enum type that is the same', () => {
+        expect(new EnumType('hello').isTypeCompatible(new ClassType('hello'))).to.be.false;
+        expect(new EnumType('hello').isTypeCompatible(new EnumType('hello'))).to.be.true;
+        expect(new EnumType('hello').isTypeCompatible(new EnumType('notHello'))).to.be.false;
+    });
+
+    it('is compatible with appropriate enum member type', () => {
+        const myEnum = new EnumType('hello');
+        expect(myEnum.isTypeCompatible(new EnumType('hello'))).to.be.true;
+        const enumMember = new EnumMemberType(myEnum.name, 'someMember');
+        const enumMember2 = new EnumMemberType('other', 'someMember');
+        expect(myEnum.isTypeCompatible(enumMember)).to.be.true;
+        expect(myEnum.isTypeCompatible(enumMember2)).to.be.false;
+    });
+});
+
+
+describe('EnumMemberType', () => {
+    it('is equal to appropriate enum member type', () => {
+        expect(new EnumMemberType('a', 'b').isEqual(new EnumMemberType('a', 'b'))).to.be.true;
+        expect(new EnumMemberType('a', 'b').isEqual(new EnumMemberType('a', 'c'))).to.be.false;
+        expect(new EnumMemberType('a', 'b').isEqual(new EnumMemberType('d', 'b'))).to.be.false;
+    });
+});

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -1,4 +1,4 @@
-import { isDynamicType, isEnumMemberType, isEnumType } from '../astUtils/reflection';
+import { isDynamicType, isEnumMemberType, isEnumType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 
 export class EnumType extends BscType {
@@ -9,6 +9,9 @@ export class EnumType extends BscType {
     }
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             this.equals(targetType) ||
             isDynamicType(targetType)

--- a/src/types/FloatType.spec.ts
+++ b/src/types/FloatType.spec.ts
@@ -4,8 +4,8 @@ import { DynamicType } from './DynamicType';
 import { FloatType } from './FloatType';
 
 describe('FloatType', () => {
-    it('is equivalent to double types', () => {
-        expect(new FloatType().isAssignableTo(new FloatType())).to.be.true;
-        expect(new FloatType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is compatible to double types', () => {
+        expect(new FloatType().isTypeCompatible(new FloatType())).to.be.true;
+        expect(new FloatType().isTypeCompatible(new DynamicType())).to.be.true;
     });
 });

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -1,9 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DoubleType } from './DoubleType';
-import { DynamicType } from './DynamicType';
-import { IntegerType } from './IntegerType';
-import { LongIntegerType } from './LongIntegerType';
 
 export class FloatType extends BscType {
     constructor(
@@ -14,28 +10,15 @@ export class FloatType extends BscType {
 
     public static instance = new FloatType('float');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof FloatType ||
-            targetType instanceof DynamicType
+            isDynamicType(targetType) ||
+            isIntegerType(targetType) ||
+            isFloatType(targetType) ||
+            isDoubleType(targetType) ||
+            isLongIntegerType(targetType)
         );
-    }
 
-    public isConvertibleTo(targetType: BscType) {
-        if (
-            targetType instanceof DynamicType ||
-            targetType instanceof IntegerType ||
-            targetType instanceof FloatType ||
-            targetType instanceof DoubleType ||
-            targetType instanceof LongIntegerType
-        ) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     public toString() {
@@ -44,5 +27,9 @@ export class FloatType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    public isEqual(targetType: BscType): boolean {
+        return isFloatType(targetType);
     }
 }

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
@@ -14,6 +15,9 @@ export class FloatType extends BscType {
     public static instance = new FloatType('float');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof FloatType ||
             targetType instanceof DynamicType

--- a/src/types/FunctionType.spec.ts
+++ b/src/types/FunctionType.spec.ts
@@ -8,29 +8,29 @@ import { VoidType } from './VoidType';
 
 describe('FunctionType', () => {
     it('is equivalent to dynamic type', () => {
-        expect(new FunctionType(new VoidType()).isAssignableTo(new DynamicType())).to.be.true;
+        expect(new FunctionType(new VoidType()).isTypeCompatible(new DynamicType())).to.be.true;
     });
 
     it('validates using param and return types', () => {
-        expect(new FunctionType(new VoidType()).isAssignableTo(new FunctionType(new VoidType()))).to.be.true;
+        expect(new FunctionType(new VoidType()).isTypeCompatible(new FunctionType(new VoidType()))).to.be.true;
 
         //different parameter count
         expect(
-            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isAssignableTo(
+            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isTypeCompatible(
                 new FunctionType(new VoidType())
             )
         ).to.be.false;
 
         //different parameter types
         expect(
-            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isAssignableTo(
+            new FunctionType(new VoidType()).addParameter('a', new IntegerType(), false).isTypeCompatible(
                 new FunctionType(new VoidType()).addParameter('a', new StringType(), false)
             )
         ).to.be.false;
 
         //different return type
         expect(
-            new FunctionType(new VoidType()).isAssignableTo(
+            new FunctionType(new VoidType()).isTypeCompatible(
                 new FunctionType(new IntegerType())
             )
         ).to.be.false;

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -1,4 +1,4 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isFunctionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -35,12 +35,28 @@ export class FunctionType extends BscType {
         return this;
     }
 
-    public isAssignableTo(targetType: BscType) {
+    public isTypeCompatible(targetType: BscType) {
         if (targetType instanceof DynamicType) {
             return true;
-        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        } else if (targetType instanceof FunctionType) {
+        }
+        return this.isEqual(targetType);
+    }
+
+    public toString() {
+        let paramTexts = [];
+        for (let param of this.params) {
+            paramTexts.push(`${param.name}${param.isOptional ? '?' : ''} as ${param.type.toString()}`);
+        }
+        return `${this.isSub ? 'sub' : 'function'} ${this.name}(${paramTexts.join(', ')}) as ${this.returnType.toString()}`;
+
+    }
+
+    public toTypeString(): string {
+        return 'Function';
+    }
+
+    isEqual(targetType: BscType) {
+        if (isFunctionType(targetType)) {
             //compare all parameters
             let len = Math.max(this.params.length, targetType.params.length);
             for (let i = 0; i < len; i++) {
@@ -58,25 +74,7 @@ export class FunctionType extends BscType {
 
             //made it here, all params and return type are equivalent
             return true;
-        } else {
-            return false;
         }
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
-    }
-
-    public toString() {
-        let paramTexts = [];
-        for (let param of this.params) {
-            paramTexts.push(`${param.name}${param.isOptional ? '?' : ''} as ${param.type.toString()}`);
-        }
-        return `${this.isSub ? 'sub' : 'function'} ${this.name}(${paramTexts.join(', ')}) as ${this.returnType.toString()}`;
-
-    }
-
-    public toTypeString(): string {
-        return 'Function';
+        return false;
     }
 }

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -36,6 +37,8 @@ export class FunctionType extends BscType {
 
     public isAssignableTo(targetType: BscType) {
         if (targetType instanceof DynamicType) {
+            return true;
+        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
             return true;
         } else if (targetType instanceof FunctionType) {
             //compare all parameters

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -12,8 +12,8 @@ export abstract class InheritableType extends BscType {
         }
     }
 
-    getMemberType(name: string, flags: SymbolTypeFlags) {
-        return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
+    getMemberTypes(name: string, flags: SymbolTypeFlags) {
+        return super.getMemberTypes(name, flags) ?? [new ReferenceType(name, flags, () => this.memberTable)];
     }
 
     public toString() {

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -28,14 +28,6 @@ export abstract class InheritableType extends BscType {
         return this.parentType ? this.parentType.isResolvable() : true;
     }
 
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
-    }
-
-    equals(targetType: BscType) {
-        return this === targetType;
-    }
-
     protected getAncestorTypeList(): InheritableType[] {
         const ancestors = [];
         let currentParentType = this.parentType;
@@ -49,22 +41,6 @@ export abstract class InheritableType extends BscType {
         }
         return ancestors;
     }
-
-    protected checkAssignabilityToInterface(targetType: BscType, flags: SymbolTypeFlags) {
-        if (!isInterfaceType(targetType)) {
-            return false;
-        }
-        let isSuperSet = true;
-        const targetSymbols = targetType.memberTable?.getAllSymbols(flags);
-        for (const targetSymbol of targetSymbols) {
-            // TODO TYPES: this ignores union types
-
-            const mySymbolsWithName = this.memberTable.getSymbol(targetSymbol.name, flags);
-            isSuperSet = isSuperSet && mySymbolsWithName && mySymbolsWithName.length > 0 && mySymbolsWithName[0].type.isAssignableTo(targetSymbol.type);
-        }
-        return isSuperSet;
-    }
-
 
     /**
      * Gets a string representation of the Interface that looks like javascript

--- a/src/types/IntegerType.spec.ts
+++ b/src/types/IntegerType.spec.ts
@@ -1,19 +1,17 @@
 import { expect } from '../chai-config.spec';
-import { BooleanType } from './BooleanType';
-import { DoubleType } from './DoubleType';
-
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
-import { StringType } from './StringType';
-import { UnionType } from './UnionType';
 
 describe('IntegerType', () => {
-    it('is equivalent to other integer types', () => {
-        expect(new IntegerType().isAssignableTo(new IntegerType())).to.be.true;
-        expect(new IntegerType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is equal to other integer types', () => {
+        expect(new IntegerType().isEqual(new IntegerType())).to.be.true;
+        expect(new IntegerType().isEqual(new DynamicType())).to.be.false;
     });
 
-    it('can be assigned to a Union that includes this type', () => {
-        expect(IntegerType.instance.isAssignableTo(new UnionType([BooleanType.instance, IntegerType.instance, DoubleType.instance, StringType.instance]))).to.be.true;
+    it('is compatible with to other integer types', () => {
+        expect(new IntegerType().isTypeCompatible(new IntegerType())).to.be.true;
+        expect(new IntegerType().isTypeCompatible(new DynamicType())).to.be.true;
     });
+
+
 });

--- a/src/types/IntegerType.spec.ts
+++ b/src/types/IntegerType.spec.ts
@@ -1,11 +1,19 @@
 import { expect } from '../chai-config.spec';
+import { BooleanType } from './BooleanType';
+import { DoubleType } from './DoubleType';
 
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
+import { StringType } from './StringType';
+import { UnionType } from './UnionType';
 
 describe('IntegerType', () => {
     it('is equivalent to other integer types', () => {
         expect(new IntegerType().isAssignableTo(new IntegerType())).to.be.true;
         expect(new IntegerType().isAssignableTo(new DynamicType())).to.be.true;
+    });
+
+    it('can be assigned to a Union that includes this type', () => {
+        expect(IntegerType.instance.isAssignableTo(new UnionType([BooleanType.instance, IntegerType.instance, DoubleType.instance, StringType.instance]))).to.be.true;
     });
 });

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
@@ -14,6 +15,9 @@ export class IntegerType extends BscType {
     public static instance = new IntegerType('integer');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof IntegerType ||
             targetType instanceof DynamicType

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -1,9 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DoubleType } from './DoubleType';
-import { DynamicType } from './DynamicType';
-import { FloatType } from './FloatType';
-import { LongIntegerType } from './LongIntegerType';
 
 export class IntegerType extends BscType {
     constructor(
@@ -14,28 +10,14 @@ export class IntegerType extends BscType {
 
     public static instance = new IntegerType('integer');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof IntegerType ||
-            targetType instanceof DynamicType
+            isDynamicType(targetType) ||
+            isIntegerType(targetType) ||
+            isFloatType(targetType) ||
+            isDoubleType(targetType) ||
+            isLongIntegerType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        if (
-            targetType instanceof DynamicType ||
-            targetType instanceof IntegerType ||
-            targetType instanceof FloatType ||
-            targetType instanceof DoubleType ||
-            targetType instanceof LongIntegerType
-        ) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     public toString() {
@@ -44,5 +26,9 @@ export class IntegerType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    isEqual(otherType: BscType) {
+        return isIntegerType(otherType);
     }
 }

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -32,9 +32,9 @@ describe('InterfaceType', () => {
         });
     });
 
-    describe('isConvertibleTo', () => {
+    describe('isTypeCompatible', () => {
         it('works', () => {
-            expectAssignable({
+            expectCompatible({
                 name: new StringType()
             }, {
                 name: new StringType()
@@ -45,28 +45,28 @@ describe('InterfaceType', () => {
     describe('equals', () => {
         it('matches equal objects', () => {
             expect(
-                iface({ name: new StringType() }).equals(iface({ name: new StringType() }))
+                iface({ name: new StringType() }).isEqual(iface({ name: new StringType() }))
             ).to.be.true;
         });
 
         it('does not match inequal objects', () => {
             expect(
-                iface({ name: new StringType() }).equals(iface({ name: new IntegerType() }))
+                iface({ name: new StringType() }).isEqual(iface({ name: new IntegerType() }))
             ).to.be.false;
         });
     });
 
-    describe('isAssignableTo', () => {
-        it('rejects being assignable to other types', () => {
+    describe('isTypeCompatible', () => {
+        it('rejects being able to assign other types to this', () => {
             expect(
                 iface({
                     name: new StringType()
-                }).isAssignableTo(new IntegerType())
+                }).isTypeCompatible(new IntegerType())
             ).to.be.false;
         });
 
         it('matches exact properties', () => {
-            expectAssignable({
+            expectCompatible({
                 name: new StringType()
             }, {
                 name: new StringType()
@@ -74,7 +74,7 @@ describe('InterfaceType', () => {
         });
 
         it('matches an object with more properties being assigned to an object with less', () => {
-            expectAssignable({
+            expectCompatible({
                 name: new StringType()
             }, {
                 name: new StringType(),
@@ -83,7 +83,7 @@ describe('InterfaceType', () => {
         });
 
         it('rejects assigning an object with less properties to one with more', () => {
-            expectNotAssignable({
+            expectNotCompatible({
                 name: new StringType(),
                 age: new IntegerType()
             }, {
@@ -101,12 +101,12 @@ describe('InterfaceType', () => {
                 name: new StringType()
             });
 
-            expect(ifaceOne.isAssignableTo(ifaceTwo)).to.be.true;
-            expect(ifaceTwo.isAssignableTo(ifaceOne)).to.be.true;
+            expect(ifaceOne.isTypeCompatible(ifaceTwo)).to.be.true;
+            expect(ifaceTwo.isTypeCompatible(ifaceOne)).to.be.true;
         });
 
         it('rejects with member having mismatched type', () => {
-            expectNotAssignable({
+            expectNotCompatible({
                 name: new StringType()
             }, {
                 name: new IntegerType()
@@ -114,7 +114,7 @@ describe('InterfaceType', () => {
         });
 
         it('rejects with object member having mismatched type', () => {
-            expectNotAssignable({
+            expectNotCompatible({
                 parent: iface({
                     name: new StringType()
                 })
@@ -126,7 +126,7 @@ describe('InterfaceType', () => {
         });
 
         it('rejects with object member having missing prop type', () => {
-            expectNotAssignable({
+            expectNotCompatible({
                 parent: iface({
                     name: new StringType(),
                     age: new IntegerType()
@@ -139,7 +139,7 @@ describe('InterfaceType', () => {
         });
 
         it('accepts with object member having same prop types', () => {
-            expectAssignable({
+            expectCompatible({
                 parent: iface({
                     name: new StringType(),
                     age: new IntegerType()
@@ -153,35 +153,35 @@ describe('InterfaceType', () => {
         });
 
         it('accepts with source member having dyanmic prop type', () => {
-            expectAssignable({
+            expectCompatible({
+                parent: new DynamicType()
+            }, {
                 parent: iface({
                     name: new StringType(),
                     age: new IntegerType()
                 })
-            }, {
-                parent: new DynamicType()
             });
         });
 
         it('accepts with target member having dyanmic prop type', () => {
-            expectAssignable({
-                parent: new DynamicType()
-            }, {
+            expectCompatible({
                 parent: iface({
                     name: new StringType(),
                     age: new IntegerType()
                 })
+            }, {
+                parent: new DynamicType()
             });
         });
 
         it('accepts with target member having "object" prop type', () => {
-            expectAssignable({
-                parent: new ObjectType()
-            }, {
+            expectCompatible({
                 parent: iface({
                     name: new StringType(),
                     age: new IntegerType()
                 })
+            }, {
+                parent: new ObjectType()
             });
         });
     });
@@ -200,18 +200,18 @@ function iface(members: Record<string, BscType>, name?: string, parentType?: Int
     return ifaceType;
 }
 
-function expectAssignable(targetMembers: Record<string, BscType>, sourceMembers: Record<string, BscType>) {
+function expectCompatible(targetMembers: Record<string, BscType>, sourceMembers: Record<string, BscType>) {
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
-    if (!sourceIface.isAssignableTo(targetIface)) {
+    if (!sourceIface.isTypeCompatible(targetIface)) {
         assert.fail(`expected type ${(targetIface as any).toJSString()} to be assignable to type ${(sourceIface as any).toJSString()}`);
     }
 }
 
-function expectNotAssignable(targetMembers: Record<string, BscType>, sourceMembers: Record<string, BscType>) {
+function expectNotCompatible(targetMembers: Record<string, BscType>, sourceMembers: Record<string, BscType>) {
     const targetIface = iface(targetMembers);
     const sourceIface = iface(sourceMembers);
-    if (sourceIface.isAssignableTo(targetIface)) {
+    if (sourceIface.isTypeCompatible(targetIface)) {
         assert.fail(`expected type ${(targetIface as any).toJSString()} to not be assignable to type ${(sourceIface as any).toJSString()}`);
     }
 }

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,5 +1,5 @@
 import { SymbolTypeFlags } from '../SymbolTable';
-import { isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isDynamicType, isObjectType, isUnionType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType, isInheritableType } from './InheritableType';
 
@@ -17,6 +17,8 @@ export class InterfaceType extends InheritableType {
             return true;
         }
         if (isObjectType(targetType) || isDynamicType(targetType)) {
+            return true;
+        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
             return true;
         }
         const ancestorTypes = this.getAncestorTypeList();

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,5 +1,5 @@
 import { SymbolTypeFlags } from '../SymbolTable';
-import { isDynamicType, isObjectType, isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isInterfaceType, isUnionType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { InheritableType, isInheritableType } from './InheritableType';
 
@@ -11,27 +11,27 @@ export class InterfaceType extends InheritableType {
         super(name, superInterface);
     }
 
-    public isAssignableTo(targetType: BscType) {
+    public isTypeCompatible(targetType: BscType) {
         //TODO: We need to make sure that things don't get assigned to built-in types
-        if (this === targetType) {
+        if (this.isEqual(targetType)) {
             return true;
         }
-        if (isObjectType(targetType) || isDynamicType(targetType)) {
-            return true;
-        } else if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+        if (isDynamicType(targetType)) {
             return true;
         }
         const ancestorTypes = this.getAncestorTypeList();
-        if (ancestorTypes?.find(ancestorType => ancestorType.equals(targetType))) {
+        if (ancestorTypes?.find(ancestorType => ancestorType.isEqual(targetType))) {
             return true;
         }
-        if (isInheritableType(targetType)) {
-            return this.checkAssignabilityToInterface(targetType, SymbolTypeFlags.runtime);
+        if (isInheritableType(targetType) || isUnionType(targetType)) {
+            return this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlags.runtime);
         }
         return false;
     }
 
-    equals(targetType: BscType): boolean {
-        return this.isAssignableTo(targetType) && targetType.isAssignableTo(this);
+    isEqual(targetType: BscType): boolean {
+        return isInterfaceType(targetType) &&
+            this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlags.runtime) &&
+            targetType.checkCompatibilityBasedOnMembers(this, SymbolTypeFlags.runtime);
     }
 }

--- a/src/types/InvalidType.spec.ts
+++ b/src/types/InvalidType.spec.ts
@@ -4,8 +4,13 @@ import { DynamicType } from './DynamicType';
 import { InvalidType } from './InvalidType';
 
 describe('InvalidType', () => {
-    it('is equivalent to invalid types', () => {
-        expect(new InvalidType().isAssignableTo(new InvalidType())).to.be.true;
-        expect(new InvalidType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is compatible to invalid types', () => {
+        expect(new InvalidType().isTypeCompatible(new InvalidType())).to.be.true;
+        expect(new InvalidType().isTypeCompatible(new DynamicType())).to.be.true;
+    });
+
+    it('is equal to invalid types', () => {
+        expect(new InvalidType().isEqual(new InvalidType())).to.be.true;
+        expect(new InvalidType().isEqual(new DynamicType())).to.be.false;
     });
 });

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -9,6 +10,9 @@ export class InvalidType extends BscType {
     }
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof InvalidType ||
             targetType instanceof DynamicType

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -1,6 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isInvalidType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 export class InvalidType extends BscType {
     constructor(
@@ -9,18 +8,11 @@ export class InvalidType extends BscType {
         super();
     }
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof InvalidType ||
-            targetType instanceof DynamicType
+            isInvalidType(targetType) ||
+            isDynamicType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
     }
 
     public toString() {
@@ -29,5 +21,9 @@ export class InvalidType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    isEqual(targetType: BscType): boolean {
+        return isInvalidType(targetType);
     }
 }

--- a/src/types/LongIntegerType.spec.ts
+++ b/src/types/LongIntegerType.spec.ts
@@ -1,11 +1,19 @@
 import { expect } from '../chai-config.spec';
 
 import { DynamicType } from './DynamicType';
+import { FloatType } from './FloatType';
 import { LongIntegerType } from './LongIntegerType';
 
 describe('LongIntegerType', () => {
-    it('is equivalent to other long integer types', () => {
-        expect(new LongIntegerType().isAssignableTo(new LongIntegerType())).to.be.true;
-        expect(new LongIntegerType().isAssignableTo(new DynamicType())).to.be.true;
+    it('is equal to other longinteger types', () => {
+        expect(new LongIntegerType().isEqual(new LongIntegerType())).to.be.true;
+        expect(new LongIntegerType().isEqual(new DynamicType())).to.be.false;
     });
+
+    it('is compatible with to other integer types', () => {
+        expect(new LongIntegerType().isTypeCompatible(new LongIntegerType())).to.be.true;
+        expect(new LongIntegerType().isTypeCompatible(new FloatType())).to.be.true;
+        expect(new LongIntegerType().isTypeCompatible(new DynamicType())).to.be.true;
+    });
+
 });

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -1,9 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DoubleType } from './DoubleType';
-import { DynamicType } from './DynamicType';
-import { FloatType } from './FloatType';
-import { IntegerType } from './IntegerType';
 
 export class LongIntegerType extends BscType {
     constructor(
@@ -14,28 +10,14 @@ export class LongIntegerType extends BscType {
 
     public static instance = new LongIntegerType('longinteger');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof LongIntegerType ||
-            targetType instanceof DynamicType
+            isDynamicType(targetType) ||
+            isIntegerType(targetType) ||
+            isFloatType(targetType) ||
+            isDoubleType(targetType) ||
+            isLongIntegerType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        if (
-            targetType instanceof DynamicType ||
-            targetType instanceof IntegerType ||
-            targetType instanceof FloatType ||
-            targetType instanceof DoubleType ||
-            targetType instanceof LongIntegerType
-        ) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     public toString() {
@@ -44,5 +26,9 @@ export class LongIntegerType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    isEqual(targetType: BscType): boolean {
+        return isLongIntegerType(targetType);
     }
 }

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DoubleType } from './DoubleType';
 import { DynamicType } from './DynamicType';
@@ -14,6 +15,9 @@ export class LongIntegerType extends BscType {
     public static instance = new LongIntegerType('longinteger');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof LongIntegerType ||
             targetType instanceof DynamicType

--- a/src/types/NameSpaceType.ts
+++ b/src/types/NameSpaceType.ts
@@ -1,4 +1,5 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
+import { isNamespaceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 
@@ -14,6 +15,10 @@ export class NamespaceType extends BscType {
 
     getMemberTypes(name: string, flags: SymbolTypeFlags) {
         return super.getMemberTypes(name, flags) ?? [new ReferenceType(name, flags, () => this.memberTable)];
+    }
+
+    isEqual(targetType: BscType): boolean {
+        return isNamespaceType(targetType) && targetType.name === this.name;
     }
 
 }

--- a/src/types/NameSpaceType.ts
+++ b/src/types/NameSpaceType.ts
@@ -12,8 +12,8 @@ export class NamespaceType extends BscType {
         return this.name;
     }
 
-    getMemberType(name: string, flags: SymbolTypeFlags) {
-        return super.getMemberType(name, flags) ?? new ReferenceType(name, flags, () => this.memberTable);
+    getMemberTypes(name: string, flags: SymbolTypeFlags) {
+        return super.getMemberTypes(name, flags) ?? [new ReferenceType(name, flags, () => this.memberTable)];
     }
 
 }

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -1,4 +1,5 @@
 import type { SymbolTypeFlags } from '../SymbolTable';
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -10,6 +11,9 @@ export class ObjectType extends BscType {
     }
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof ObjectType ||
             targetType instanceof DynamicType

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -32,9 +32,9 @@ export class ObjectType extends BscType {
         return this.toString();
     }
 
-    getMemberType(name: string, flags: SymbolTypeFlags) {
+    getMemberTypes(name: string, flags: SymbolTypeFlags) {
         // TODO: How should we handle accessing properties of an object?
         // For example, we could add fields as properties to m.top, but there could be other members added programmatically
-        return super.getMemberType(name, flags) ?? DynamicType.instance;
+        return super.getMemberTypes(name, flags) ?? [DynamicType.instance];
     }
 }

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -1,7 +1,8 @@
-import type { SymbolTypeFlags } from '../SymbolTable';
-import { isUnionType } from '../astUtils/reflection';
+import { SymbolTypeFlags } from '../SymbolTable';
+import { isDynamicType, isObjectType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
+import { isInheritableType } from './InheritableType';
 
 export class ObjectType extends BscType {
     constructor(
@@ -10,18 +11,16 @@ export class ObjectType extends BscType {
         super();
     }
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+    public isTypeCompatible(targetType: BscType) {
+        if (isUnionType(targetType)) {
+            return targetType.checkAllMemberTypes((type) => type.isTypeCompatible(this));
+        } else if (isObjectType(targetType) ||
+            isDynamicType(targetType) ||
+            isInheritableType(targetType)
+        ) {
             return true;
         }
-        return (
-            targetType instanceof ObjectType ||
-            targetType instanceof DynamicType
-        );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
+        return false;
     }
 
     public toString() {
@@ -36,5 +35,9 @@ export class ObjectType extends BscType {
         // TODO: How should we handle accessing properties of an object?
         // For example, we could add fields as properties to m.top, but there could be other members added programmatically
         return super.getMemberTypes(name, flags) ?? [DynamicType.instance];
+    }
+
+    isEqual(otherType: BscType) {
+        return isObjectType(otherType) && this.checkCompatibilityBasedOnMembers(otherType, SymbolTypeFlags.runtime);
     }
 }

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -101,9 +101,9 @@ describe('PropertyReferenceType', () => {
         const table = new SymbolTable('test');
         const fnRef = new ReferenceType('someFunc', runtimeFlag, () => table);
         const returnRef = new TypePropertyReferenceType(fnRef, 'returnType');
-        const returnPropRef = returnRef.getMemberType('myNum', SymbolTypeFlags.runtime);
+        const returnPropRef = returnRef.getMemberTypes('myNum', SymbolTypeFlags.runtime);
         // `ref` will resolve to DynamicType, and its returnType is DynamicType.Instance
-        expectTypeToBe(returnPropRef, DynamicType);
+        expectTypeToBe(returnPropRef[0], DynamicType);
 
         // Set fnRef to resolve to a function that returns a complex type
         const klassType = new ClassType('Klass');
@@ -113,7 +113,7 @@ describe('PropertyReferenceType', () => {
         // returnPropRef = someFunc().myNum
         expectTypeToBe(fnRef, FunctionType);
         expectTypeToBe(returnRef, ClassType);
-        expectTypeToBe(returnPropRef, IntegerType);
+        expectTypeToBe(returnPropRef[0], IntegerType);
     });
 
 });

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -40,7 +40,7 @@ describe('ReferenceType', () => {
         const ref = new ReferenceType('someVar', runtimeFlag, () => table);
         table.addSymbol('someVar', null, IntegerType.instance, SymbolTypeFlags.runtime);
         expect(ref.isAssignableTo(IntegerType.instance)).to.be.true;
-        expect(ref.isConvertibleTo(FloatType.instance)).to.be.true;
+        expect(ref.isTypeCompatible(FloatType.instance)).to.be.true;
     });
 
     it('resolves before stringifying', () => {

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -3,6 +3,7 @@ import type { SymbolTypeFlags } from '../SymbolTable';
 import { isReferenceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
+import { getUniqueType } from './UnionType';
 
 export class ReferenceType extends BscType {
     constructor(public name: string, public flags: SymbolTypeFlags, private tableProvider: SymbolTableProvider) {
@@ -96,7 +97,7 @@ export class ReferenceType extends BscType {
      */
     private resolve(): BscType {
         // eslint-disable-next-line no-bitwise
-        return this.tableProvider()?.getSymbol(this.name, this.flags)?.[0]?.type;
+        return getUniqueType(this.tableProvider()?.getSymbol(this.name, this.flags)?.map(symbol => symbol.type));//[0]?.type;
     }
 
     private referenceChain = new Set<BscType>();

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -1,6 +1,6 @@
 import type { SymbolTableProvider } from '../SymbolTable';
 import type { SymbolTypeFlags } from '../SymbolTable';
-import { isReferenceType } from '../astUtils/reflection';
+import { isDynamicType, isReferenceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 import { getUniqueType } from './helpers';
@@ -62,6 +62,10 @@ export class ReferenceType extends BscType {
                         return new TypePropertyReferenceType(this, propName);
                     } else if (propName === 'memberTable') {
                         return this.tableProvider();
+                    } else if (propName === 'isTypeCompatible') {
+                        return (targetType: BscType) => {
+                            return isDynamicType(targetType);
+                        };
                     }
                 }
 

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -3,7 +3,7 @@ import type { SymbolTypeFlags } from '../SymbolTable';
 import { isReferenceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
-import { getUniqueType } from './UnionType';
+import { getUniqueType } from './helpers';
 
 export class ReferenceType extends BscType {
     constructor(public name: string, public flags: SymbolTypeFlags, private tableProvider: SymbolTableProvider) {
@@ -43,13 +43,13 @@ export class ReferenceType extends BscType {
                 if (!innerType) {
                     // No real BscType found - we may need to handle some specific cases
 
-                    if (propName === 'getMemberType') {
+                    if (propName === 'getMemberTypes') {
                         // We're looking for a member of a reference type
                         // Since we don't know what type this is, yet, return ReferenceType
                         return (memberName: string, flags: SymbolTypeFlags) => {
-                            return new ReferenceType(memberName, flags, () => {
+                            return [new ReferenceType(memberName, flags, () => {
                                 return (this.resolve() as any)?.memberTable;
-                            });
+                            })];
                         };
                     } else if (propName === 'toString') {
                         // This type was never found
@@ -96,8 +96,7 @@ export class ReferenceType extends BscType {
      * Resolves the type based on the original name and the table provider
      */
     private resolve(): BscType {
-        // eslint-disable-next-line no-bitwise
-        return getUniqueType(this.tableProvider()?.getSymbol(this.name, this.flags)?.map(symbol => symbol.type));//[0]?.type;
+        return getUniqueType(this.tableProvider()?.getSymbolTypes(this.name, this.flags));
     }
 
     private referenceChain = new Set<BscType>();
@@ -127,13 +126,13 @@ export class TypePropertyReferenceType extends BscType {
                 }
 
                 if (isReferenceType(this.outerType) && !this.outerType.isResolvable()) {
-                    if (propName === 'getMemberType') {
-                        //If we're calling `getMemberType()`, we need it to proxy to using the actual symbol table
+                    if (propName === 'getMemberTypes') {
+                        //If we're calling `getMemberTypes()`, we need it to proxy to using the actual symbol table
                         //So if that symbol is ever populated, the correct type is passed through
                         return (memberName: string, flags: SymbolTypeFlags) => {
-                            return new ReferenceType(memberName, flags, () => {
+                            return [new ReferenceType(memberName, flags, () => {
                                 return (this.outerType[this.propertyName] as any)?.memberTable;
-                            });
+                            })];
                         };
                     }
                 }

--- a/src/types/StringType.spec.ts
+++ b/src/types/StringType.spec.ts
@@ -5,7 +5,7 @@ import { StringType } from './StringType';
 
 describe('StringType', () => {
     it('is equivalent to string types', () => {
-        expect(new StringType().isAssignableTo(new StringType())).to.be.true;
-        expect(new StringType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new StringType().isTypeCompatible(new StringType())).to.be.true;
+        expect(new StringType().isTypeCompatible(new DynamicType())).to.be.true;
     });
 });

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -14,6 +15,9 @@ export class StringType extends BscType {
     public static instance = new StringType('string');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof StringType ||
             targetType instanceof DynamicType

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -1,6 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isStringType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 export class StringType extends BscType {
     constructor(
@@ -14,18 +13,11 @@ export class StringType extends BscType {
      */
     public static instance = new StringType('string');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof StringType ||
-            targetType instanceof DynamicType
+            isStringType(targetType) ||
+            isDynamicType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
     }
 
     public toString() {
@@ -34,5 +26,9 @@ export class StringType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    public isEqual(targetType: BscType): boolean {
+        return isStringType(targetType);
     }
 }

--- a/src/types/UninitializedType.ts
+++ b/src/types/UninitializedType.ts
@@ -1,3 +1,4 @@
+import { isDynamicType, isUninitializedType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -9,8 +10,11 @@ export class UninitializedType extends BscType {
         );
     }
 
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
+    public isTypeCompatible(targetType: BscType) {
+        return (
+            isUninitializedType(targetType) ||
+            isDynamicType(targetType)
+        );
     }
 
     public toString() {
@@ -19,5 +23,9 @@ export class UninitializedType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    public isEqual(targetType: BscType): boolean {
+        return isUninitializedType(targetType);
     }
 }

--- a/src/types/UnionType.spec.ts
+++ b/src/types/UnionType.spec.ts
@@ -9,7 +9,7 @@ import { BooleanType } from './BooleanType';
 
 
 describe('UnionType', () => {
-    it('can be assigned to by anything that can be assigned to an included type ', () => {
+    it('can be assigned to by anything that can be assigned to an included type', () => {
         const parentIFace = new InterfaceType('IfaceParent');
         parentIFace.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
         const iFace = new InterfaceType('IfaceChild', parentIFace);
@@ -22,20 +22,18 @@ describe('UnionType', () => {
 
         const myUnion = new UnionType([FloatType.instance, iFace, StringType.instance]);
 
-        expect(myUnion.canBeAssignedFrom(FloatType.instance)).to.be.true;
-        expect(FloatType.instance.isAssignableTo(myUnion)).to.be.true;
-        expect(myUnion.canBeAssignedFrom(StringType.instance)).to.be.true;
-        expect(StringType.instance.isAssignableTo(myUnion)).to.be.true;
-        expect(myUnion.canBeAssignedFrom(otheriFaceWithSameMembers)).to.be.true;
-        expect(otheriFaceWithSameMembers.isAssignableTo(myUnion)).to.be.true;
+        expect(myUnion.isTypeCompatible(FloatType.instance)).to.be.true;
+        expect(myUnion.isTypeCompatible(StringType.instance)).to.be.true;
+        expect(myUnion.isTypeCompatible(otheriFaceWithSameMembers)).to.be.false;
+        expect(otheriFaceWithSameMembers.isTypeCompatible(myUnion)).to.be.true;
     });
 
     it('can assign to a more general Union', () => {
         const myUnion = new UnionType([StringType.instance, FloatType.instance]);
         const otherUnion = new UnionType([FloatType.instance, StringType.instance, BooleanType.instance]);
 
-        expect(myUnion.isAssignableTo(otherUnion)).to.be.true;
-        expect(otherUnion.isAssignableTo(myUnion)).to.be.false;
+        expect(myUnion.isTypeCompatible(otherUnion)).to.be.false;
+        expect(otherUnion.isTypeCompatible(myUnion)).to.be.true;
     });
 
     it('can assign to a more general Union with interfaces', () => {
@@ -44,16 +42,16 @@ describe('UnionType', () => {
         const iFace = new InterfaceType('IfaceChild', parentIFace);
         iFace.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
         iFace.addMember('height', null, FloatType.instance, SymbolTypeFlags.runtime);
-        const myUnion = new UnionType([FloatType.instance, iFace, StringType.instance]);
+        const myUnion = new UnionType([FloatType.instance, iFace, StringType.instance, BooleanType.instance]);
 
         const otheriFaceWithSameMembers = new InterfaceType('OtherIface');
         otheriFaceWithSameMembers.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
         otheriFaceWithSameMembers.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
 
-        const otherUnion = new UnionType([FloatType.instance, otheriFaceWithSameMembers, StringType.instance, BooleanType.instance]);
+        const otherUnion = new UnionType([FloatType.instance, otheriFaceWithSameMembers, StringType.instance]);
 
-        expect(myUnion.isAssignableTo(otherUnion)).to.be.true;
-        expect(otherUnion.isAssignableTo(myUnion)).to.be.false;
+        expect(myUnion.isTypeCompatible(otherUnion)).to.be.true;
+        expect(otherUnion.isTypeCompatible(myUnion)).to.be.false;
     });
 
 });

--- a/src/types/UnionType.spec.ts
+++ b/src/types/UnionType.spec.ts
@@ -1,57 +1,12 @@
 import { expect } from 'chai';
-import * as assert from 'assert';
-import { ClassType } from './ClassType';
 import { StringType } from './StringType';
-import { expectTypeToBe } from '../testHelpers.spec';
-import { isUnionType } from '../astUtils/reflection';
 import { IntegerType } from './IntegerType';
-import { UnionType, getUniqueType } from './UnionType';
-import { DynamicType } from './DynamicType';
+import { UnionType } from './UnionType';
 import { FloatType } from './FloatType';
 import { InterfaceType } from './InterfaceType';
 import { SymbolTypeFlags } from '../SymbolTable';
 import { BooleanType } from './BooleanType';
 
-describe('getUniqueType', () => {
-
-    it('should return a single type if only one is given', () => {
-        expectTypeToBe(getUniqueType([IntegerType.instance]), IntegerType);
-    });
-
-
-    it('should return a single type if all types are the same', () => {
-        expectTypeToBe(getUniqueType([IntegerType.instance, IntegerType.instance, IntegerType.instance]), IntegerType);
-    });
-
-
-    it('should return dynamic if dynamic is included', () => {
-        expectTypeToBe(getUniqueType([IntegerType.instance, DynamicType.instance, StringType.instance]), DynamicType);
-    });
-
-    it('should return the most general type of all types inputed', () => {
-        const superKlassType = new ClassType('Super');
-        const subKlassType = new ClassType('Sub', superKlassType);
-        expect(getUniqueType([subKlassType, superKlassType]).toString()).to.eq('Super');
-        expect(getUniqueType([subKlassType, subKlassType]).toString()).to.eq('Sub');
-        expect(getUniqueType([superKlassType, subKlassType]).toString()).to.eq('Super');
-        expect(getUniqueType([subKlassType, superKlassType, subKlassType]).toString()).to.eq('Super');
-    });
-
-
-    it('should return a union type of unique types', () => {
-        const resultType = getUniqueType([IntegerType.instance, StringType.instance, IntegerType.instance, FloatType.instance]);
-        expectTypeToBe(resultType, UnionType);
-        if (isUnionType(resultType)) {
-            expect(resultType.types.length).to.eq(3);
-            expect(resultType.types).to.include(IntegerType.instance);
-            expect(resultType.types).to.include(StringType.instance);
-            expect(resultType.types).to.include(FloatType.instance);
-
-        } else {
-            assert.fail('Should be UnionType');
-        }
-    });
-});
 
 describe('UnionType', () => {
     it('can be assigned to by anything that can be assigned to an included type ', () => {

--- a/src/types/UnionType.spec.ts
+++ b/src/types/UnionType.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import * as assert from 'assert';
+import { ClassType } from './ClassType';
+import { StringType } from './StringType';
+import { expectTypeToBe } from '../testHelpers.spec';
+import { isUnionType } from '../astUtils/reflection';
+import { IntegerType } from './IntegerType';
+import { UnionType, getUniqueType } from './UnionType';
+import { DynamicType } from './DynamicType';
+import { FloatType } from './FloatType';
+import { InterfaceType } from './InterfaceType';
+import { SymbolTypeFlags } from '../SymbolTable';
+import { BooleanType } from './BooleanType';
+
+describe('getUniqueType', () => {
+
+    it('should return a single type if only one is given', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance]), IntegerType);
+    });
+
+
+    it('should return a single type if all types are the same', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance, IntegerType.instance, IntegerType.instance]), IntegerType);
+    });
+
+
+    it('should return dynamic if dynamic is included', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance, DynamicType.instance, StringType.instance]), DynamicType);
+    });
+
+    it('should return the most general type of all types inputed', () => {
+        const superKlassType = new ClassType('Super');
+        const subKlassType = new ClassType('Sub', superKlassType);
+        expect(getUniqueType([subKlassType, superKlassType]).toString()).to.eq('Super');
+        expect(getUniqueType([subKlassType, subKlassType]).toString()).to.eq('Sub');
+        expect(getUniqueType([superKlassType, subKlassType]).toString()).to.eq('Super');
+        expect(getUniqueType([subKlassType, superKlassType, subKlassType]).toString()).to.eq('Super');
+    });
+
+
+    it('should return a union type of unique types', () => {
+        const resultType = getUniqueType([IntegerType.instance, StringType.instance, IntegerType.instance, FloatType.instance]);
+        expectTypeToBe(resultType, UnionType);
+        if (isUnionType(resultType)) {
+            expect(resultType.types.length).to.eq(3);
+            expect(resultType.types).to.include(IntegerType.instance);
+            expect(resultType.types).to.include(StringType.instance);
+            expect(resultType.types).to.include(FloatType.instance);
+
+        } else {
+            assert.fail('Should be UnionType');
+        }
+    });
+});
+
+describe('UnionType', () => {
+    it('can be assigned to by anything that can be assigned to an included type ', () => {
+        const parentIFace = new InterfaceType('IfaceParent');
+        parentIFace.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
+        const iFace = new InterfaceType('IfaceChild', parentIFace);
+        iFace.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
+
+        const otheriFaceWithSameMembers = new InterfaceType('OtherIface');
+        otheriFaceWithSameMembers.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
+        otheriFaceWithSameMembers.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
+        otheriFaceWithSameMembers.addMember('height', null, FloatType.instance, SymbolTypeFlags.runtime);
+
+        const myUnion = new UnionType([FloatType.instance, iFace, StringType.instance]);
+
+        expect(myUnion.canBeAssignedFrom(FloatType.instance)).to.be.true;
+        expect(FloatType.instance.isAssignableTo(myUnion)).to.be.true;
+        expect(myUnion.canBeAssignedFrom(StringType.instance)).to.be.true;
+        expect(StringType.instance.isAssignableTo(myUnion)).to.be.true;
+        expect(myUnion.canBeAssignedFrom(otheriFaceWithSameMembers)).to.be.true;
+        expect(otheriFaceWithSameMembers.isAssignableTo(myUnion)).to.be.true;
+    });
+
+    it('can assign to a more general Union', () => {
+        const myUnion = new UnionType([StringType.instance, FloatType.instance]);
+        const otherUnion = new UnionType([FloatType.instance, StringType.instance, BooleanType.instance]);
+
+        expect(myUnion.isAssignableTo(otherUnion)).to.be.true;
+        expect(otherUnion.isAssignableTo(myUnion)).to.be.false;
+    });
+
+    it('can assign to a more general Union with interfaces', () => {
+        const parentIFace = new InterfaceType('IfaceParent');
+        parentIFace.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
+        const iFace = new InterfaceType('IfaceChild', parentIFace);
+        iFace.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
+        iFace.addMember('height', null, FloatType.instance, SymbolTypeFlags.runtime);
+        const myUnion = new UnionType([FloatType.instance, iFace, StringType.instance]);
+
+        const otheriFaceWithSameMembers = new InterfaceType('OtherIface');
+        otheriFaceWithSameMembers.addMember('name', null, StringType.instance, SymbolTypeFlags.runtime);
+        otheriFaceWithSameMembers.addMember('age', null, IntegerType.instance, SymbolTypeFlags.runtime);
+
+        const otherUnion = new UnionType([FloatType.instance, otheriFaceWithSameMembers, StringType.instance, BooleanType.instance]);
+
+        expect(myUnion.isAssignableTo(otherUnion)).to.be.true;
+        expect(otherUnion.isAssignableTo(myUnion)).to.be.false;
+    });
+
+});

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,3 +1,4 @@
+import type { SymbolTypeFlags } from '../SymbolTable';
 import { isDynamicType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { isInheritableType } from './InheritableType';
@@ -15,6 +16,10 @@ export class UnionType extends BscType {
     public addType(type: BscType) {
         this.types.push(type);
         this.memberTable.addSibling(type.memberTable);
+    }
+
+    getMemberTypes(name: string, flags: SymbolTypeFlags) {
+        return [];
     }
 
     isAssignableTo(targetType: BscType): boolean {
@@ -61,7 +66,6 @@ export class UnionType extends BscType {
     canBeAssignedFrom(targetType: BscType) {
         return !!this.types.find(t => targetType?.isAssignableTo(t));
     }
-
 }
 
 

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,6 +1,5 @@
 import { isDynamicType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 import { isInheritableType } from './InheritableType';
 
 export class UnionType extends BscType {
@@ -68,65 +67,5 @@ export class UnionType extends BscType {
 
 function joinTypesString(types: BscType[]) {
     return types.map(t => t.toString()).join(' | ');
-}
-
-/**
- * Gets a Unique type from a list of types
- * If all types are the same - just that type is returned
- * If one of the types is Dynamic, then Dynamic.instance is returned
- * If any types are assignable to another type, the more general type is returned
- * If there are multiple types that cannot be assigned, then a UnionType is returned
- * @param types array of types
- * @returns either the singular most general type, if there is one, otherwise a UnionType of the most general types
- */
-export function getUniqueType(types: BscType[]): BscType {
-    if (!types || types?.length === 0) {
-        return undefined;
-    }
-    const uniqueTypes = Array.from(new Set(types)).map(t => {
-        return { type: t, ignore: false };
-    });
-
-    if (uniqueTypes.length === 1) {
-        // only one type
-        return uniqueTypes[0].type;
-    } else if (uniqueTypes.find(t => isDynamicType(t.type))) {
-        // If it includes dynamic, then the result is dynamic
-        return DynamicType.instance;
-    }
-    const generalizedTypes = [];
-    //check assignability:
-    for (let i = 0; i < uniqueTypes.length; i++) {
-        const currentType = uniqueTypes[i];
-        if (i === uniqueTypes.length - 1) {
-            if (!currentType.ignore) {
-                //this type was not convertible to anything else... it is as general as possible
-                generalizedTypes.push(currentType.type);
-            }
-            break;
-        }
-        for (let j = i + 1; j < uniqueTypes.length; j++) {
-            if (uniqueTypes[j].ignore) {
-                continue;
-            }
-            if (currentType.type.isAssignableTo(uniqueTypes[j].type)) {
-                // the currentType can be assigned to some other type - it won't be in the final set
-                break;
-            }
-            if (uniqueTypes[j].type.isAssignableTo(currentType.type)) {
-                //the type we're checking is less general than the current type... it can be ignored
-                uniqueTypes[j].ignore = true;
-            }
-            if (j === uniqueTypes.length - 1) {
-                //this type was not convertible to anything else... it is as general as possible
-                generalizedTypes.push(currentType.type);
-            }
-        }
-    }
-    if (generalizedTypes.length === 1) {
-        // only one type
-        return generalizedTypes[0];
-    }
-    return new UnionType(generalizedTypes);
 }
 

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -4,11 +4,15 @@ export class UnionType extends BscType {
     constructor(
         public types: BscType[]
     ) {
-        super();
+        super(joinTypesString(types));
+        for (const type of this.types) {
+            this.memberTable.addSibling(type.memberTable);
+        }
     }
 
     public addType(type: BscType) {
         this.types.push(type);
+        this.memberTable.addSibling(type.memberTable);
     }
 
     isAssignableTo(targetType: BscType): boolean {
@@ -18,10 +22,15 @@ export class UnionType extends BscType {
         throw new Error('Method not implemented.');
     }
     toString(): string {
-        throw new Error('Method not implemented.');
+        return joinTypesString(this.types);
     }
     toTypeString(): string {
-        throw new Error('Method not implemented.');
+        return 'dynamic';
     }
 
+}
+
+
+function joinTypesString(types: BscType[]) {
+    return types.map(t => t.toString()).join(' | ');
 }

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,4 +1,7 @@
+import { isDynamicType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
+import { DynamicType } from './DynamicType';
+import { isInheritableType } from './InheritableType';
 
 export class UnionType extends BscType {
     constructor(
@@ -16,10 +19,38 @@ export class UnionType extends BscType {
     }
 
     isAssignableTo(targetType: BscType): boolean {
-        throw new Error('Method not implemented.');
+        if (isDynamicType(targetType)) {
+            return true;
+        }
+        if (isInheritableType(targetType)) {
+            let isAssignable = true;
+            for (const currentType of this.types) {
+                // assignable to target if each of these types can assign to target
+                if (!currentType.isAssignableTo(targetType)) {
+                    isAssignable = false;
+                    break;
+                }
+            }
+            return isAssignable;
+        }
+        if (isUnionType(targetType)) {
+            let isAssignable = true;
+            for (const currentType of this.types) {
+                // assignable to target if each of these types can assign to target
+                if (!targetType.canBeAssignedFrom(currentType)) {
+                    isAssignable = false;
+                    break;
+                }
+            }
+            return isAssignable;
+        }
+
+        return false;
     }
+
+
     isConvertibleTo(targetType: BscType): boolean {
-        throw new Error('Method not implemented.');
+        return this.isAssignableTo(targetType);
     }
     toString(): string {
         return joinTypesString(this.types);
@@ -28,9 +59,74 @@ export class UnionType extends BscType {
         return 'dynamic';
     }
 
+    canBeAssignedFrom(targetType: BscType) {
+        return !!this.types.find(t => targetType?.isAssignableTo(t));
+    }
+
 }
 
 
 function joinTypesString(types: BscType[]) {
     return types.map(t => t.toString()).join(' | ');
 }
+
+/**
+ * Gets a Unique type from a list of types
+ * If all types are the same - just that type is returned
+ * If one of the types is Dynamic, then Dynamic.instance is returned
+ * If any types are assignable to another type, the more general type is returned
+ * If there are multiple types that cannot be assigned, then a UnionType is returned
+ * @param types array of types
+ * @returns either the singular most general type, if there is one, otherwise a UnionType of the most general types
+ */
+export function getUniqueType(types: BscType[]): BscType {
+    if (!types || types?.length === 0) {
+        return undefined;
+    }
+    const uniqueTypes = Array.from(new Set(types)).map(t => {
+        return { type: t, ignore: false };
+    });
+
+    if (uniqueTypes.length === 1) {
+        // only one type
+        return uniqueTypes[0].type;
+    } else if (uniqueTypes.find(t => isDynamicType(t.type))) {
+        // If it includes dynamic, then the result is dynamic
+        return DynamicType.instance;
+    }
+    const generalizedTypes = [];
+    //check assignability:
+    for (let i = 0; i < uniqueTypes.length; i++) {
+        const currentType = uniqueTypes[i];
+        if (i === uniqueTypes.length - 1) {
+            if (!currentType.ignore) {
+                //this type was not convertible to anything else... it is as general as possible
+                generalizedTypes.push(currentType.type);
+            }
+            break;
+        }
+        for (let j = i + 1; j < uniqueTypes.length; j++) {
+            if (uniqueTypes[j].ignore) {
+                continue;
+            }
+            if (currentType.type.isAssignableTo(uniqueTypes[j].type)) {
+                // the currentType can be assigned to some other type - it won't be in the final set
+                break;
+            }
+            if (uniqueTypes[j].type.isAssignableTo(currentType.type)) {
+                //the type we're checking is less general than the current type... it can be ignored
+                uniqueTypes[j].ignore = true;
+            }
+            if (j === uniqueTypes.length - 1) {
+                //this type was not convertible to anything else... it is as general as possible
+                generalizedTypes.push(currentType.type);
+            }
+        }
+    }
+    if (generalizedTypes.length === 1) {
+        // only one type
+        return generalizedTypes[0];
+    }
+    return new UnionType(generalizedTypes);
+}
+

--- a/src/types/VoidType.spec.ts
+++ b/src/types/VoidType.spec.ts
@@ -5,7 +5,7 @@ import { VoidType } from './VoidType';
 
 describe('VoidType', () => {
     it('is equivalent to dynamic types', () => {
-        expect(new VoidType().isAssignableTo(new VoidType())).to.be.true;
-        expect(new VoidType().isAssignableTo(new DynamicType())).to.be.true;
+        expect(new VoidType().isTypeCompatible(new VoidType())).to.be.true;
+        expect(new VoidType().isTypeCompatible(new DynamicType())).to.be.true;
     });
 });

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -1,3 +1,4 @@
+import { isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 
@@ -11,6 +12,9 @@ export class VoidType extends BscType {
     public static instance = new VoidType('void');
 
     public isAssignableTo(targetType: BscType) {
+        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
+            return true;
+        }
         return (
             targetType instanceof VoidType ||
             targetType instanceof DynamicType

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -1,6 +1,5 @@
-import { isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isVoidType } from '../astUtils/reflection';
 import { BscType } from './BscType';
-import { DynamicType } from './DynamicType';
 
 export class VoidType extends BscType {
     constructor(
@@ -11,18 +10,11 @@ export class VoidType extends BscType {
 
     public static instance = new VoidType('void');
 
-    public isAssignableTo(targetType: BscType) {
-        if (isUnionType(targetType) && targetType.canBeAssignedFrom(this)) {
-            return true;
-        }
+    public isTypeCompatible(targetType: BscType) {
         return (
-            targetType instanceof VoidType ||
-            targetType instanceof DynamicType
+            isVoidType(targetType) ||
+            isDynamicType(targetType)
         );
-    }
-
-    public isConvertibleTo(targetType: BscType) {
-        return this.isAssignableTo(targetType);
     }
 
     public toString() {
@@ -31,5 +23,9 @@ export class VoidType extends BscType {
 
     public toTypeString(): string {
         return this.toString();
+    }
+
+    public isEqual(targetType: BscType) {
+        return isVoidType(targetType);
     }
 }

--- a/src/types/helper.spec.ts
+++ b/src/types/helper.spec.ts
@@ -1,0 +1,51 @@
+import { expect, assert } from 'chai';
+import { isUnionType } from '../astUtils/reflection';
+import { expectTypeToBe } from '../testHelpers.spec';
+import { ClassType } from './ClassType';
+import { DynamicType } from './DynamicType';
+import { FloatType } from './FloatType';
+import { IntegerType } from './IntegerType';
+import { StringType } from './StringType';
+import { UnionType } from './UnionType';
+import { getUniqueType } from './helpers';
+
+describe('getUniqueType', () => {
+
+    it('should return a single type if only one is given', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance]), IntegerType);
+    });
+
+
+    it('should return a single type if all types are the same', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance, IntegerType.instance, IntegerType.instance]), IntegerType);
+    });
+
+
+    it('should return dynamic if dynamic is included', () => {
+        expectTypeToBe(getUniqueType([IntegerType.instance, DynamicType.instance, StringType.instance]), DynamicType);
+    });
+
+    it('should return the most general type of all types inputed', () => {
+        const superKlassType = new ClassType('Super');
+        const subKlassType = new ClassType('Sub', superKlassType);
+        expect(getUniqueType([subKlassType, superKlassType]).toString()).to.eq('Super');
+        expect(getUniqueType([subKlassType, subKlassType]).toString()).to.eq('Sub');
+        expect(getUniqueType([superKlassType, subKlassType]).toString()).to.eq('Super');
+        expect(getUniqueType([subKlassType, superKlassType, subKlassType]).toString()).to.eq('Super');
+    });
+
+
+    it('should return a union type of unique types', () => {
+        const resultType = getUniqueType([IntegerType.instance, StringType.instance, IntegerType.instance, FloatType.instance]);
+        expectTypeToBe(resultType, UnionType);
+        if (isUnionType(resultType)) {
+            expect(resultType.types.length).to.eq(3);
+            expect(resultType.types).to.include(IntegerType.instance);
+            expect(resultType.types).to.include(StringType.instance);
+            expect(resultType.types).to.include(FloatType.instance);
+
+        } else {
+            assert.fail('Should be UnionType');
+        }
+    });
+});

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,6 @@
 import { isDynamicType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
+import { isInheritableType } from './InheritableType';
 import { UnionType } from './UnionType';
 
 /**
@@ -43,13 +44,18 @@ export function getUniqueType(types: BscType[]): BscType {
             if (uniqueTypes[j].ignore) {
                 continue;
             }
-            if (currentType.type.isAssignableTo(uniqueTypes[j].type)) {
-                // the currentType can be assigned to some other type - it won't be in the final set
-                break;
-            }
-            if (uniqueTypes[j].type.isAssignableTo(currentType.type)) {
-                //the type we're checking is less general than the current type... it can be ignored
+
+            if (currentType.type.isEqual(uniqueTypes[j].type)) {
                 uniqueTypes[j].ignore = true;
+            } else if (isInheritableType(uniqueTypes[j].type)) {
+                if (currentType.type.isTypeCompatible(uniqueTypes[j].type)) {
+                    //the type we're checking is less general than the current type... it can be ignored
+                    uniqueTypes[j].ignore = true;
+                }
+                if (uniqueTypes[j].type.isTypeCompatible(currentType.type)) {
+                    // the currentType can be assigned to some other type - it won't be in the final set
+                    break;
+                }
             }
             if (j === uniqueTypes.length - 1) {
                 //this type was not convertible to anything else... it is as general as possible

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,0 +1,65 @@
+import { isDynamicType } from '../astUtils/reflection';
+import type { BscType } from './BscType';
+import { UnionType } from './UnionType';
+
+/**
+ * Gets a Unique type from a list of types
+ * If all types are the same - just that type is returned
+ * If one of the types is Dynamic, then Dynamic.instance is returned
+ * If any types are assignable to another type, the more general type is returned
+ * If there are multiple types that cannot be assigned, then a UnionType is returned
+ * @param types array of types
+ * @returns either the singular most general type, if there is one, otherwise a UnionType of the most general types
+ */
+export function getUniqueType(types: BscType[]): BscType {
+    if (!types || types?.length === 0) {
+        return undefined;
+    }
+    const uniqueTypes = Array.from(new Set(types)).map(t => {
+        return { type: t, ignore: false };
+    });
+
+    if (uniqueTypes.length === 1) {
+        // only one type
+        return uniqueTypes[0].type;
+    }
+    const existingDynamicType = uniqueTypes.find(t => isDynamicType(t.type));
+    if (existingDynamicType) {
+        // If it includes dynamic, then the result is dynamic
+        return existingDynamicType.type;
+    }
+    const generalizedTypes = [];
+    //check assignability:
+    for (let i = 0; i < uniqueTypes.length; i++) {
+        const currentType = uniqueTypes[i];
+        if (i === uniqueTypes.length - 1) {
+            if (!currentType.ignore) {
+                //this type was not convertible to anything else... it is as general as possible
+                generalizedTypes.push(currentType.type);
+            }
+            break;
+        }
+        for (let j = i + 1; j < uniqueTypes.length; j++) {
+            if (uniqueTypes[j].ignore) {
+                continue;
+            }
+            if (currentType.type.isAssignableTo(uniqueTypes[j].type)) {
+                // the currentType can be assigned to some other type - it won't be in the final set
+                break;
+            }
+            if (uniqueTypes[j].type.isAssignableTo(currentType.type)) {
+                //the type we're checking is less general than the current type... it can be ignored
+                uniqueTypes[j].ignore = true;
+            }
+            if (j === uniqueTypes.length - 1) {
+                //this type was not convertible to anything else... it is as general as possible
+                generalizedTypes.push(currentType.type);
+            }
+        }
+    }
+    if (generalizedTypes.length === 1) {
+        // only one type
+        return generalizedTypes[0];
+    }
+    return new UnionType(generalizedTypes);
+}

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -227,7 +227,7 @@ export class BsClassValidator {
                                 ancestorMemberType = ancestorAndMember.member.func.getType({ flags: SymbolTypeFlags.typetime });
                             }
                             const childFieldType = member.getType({ flags: SymbolTypeFlags.typetime });
-                            if (!childFieldType.isAssignableTo(ancestorMemberType)) {
+                            if (!ancestorMemberType.isTypeCompatible(childFieldType)) {
                                 //flag incompatible child field type to ancestor field type
                                 this.diagnostics.push({
                                     ...DiagnosticMessages.childFieldTypeNotAssignableToBaseProperty(


### PR DESCRIPTION
- Union Types can be made of any other other types
- Added a utility function that finds the most general type that will fit an array of types
- Refactored `BscType.getMemberType` to `getMemberTypes`... it would be nice to make that all use the helper function, but I had some circular reference issues

- [x] Refactor `isAssignableTo` to be `isTypeCompatible`

These next two will be in a different PR:

- [ ]  ~Add way to actually declare a Union Type in code:~

```
function intValue(num as string | integer) as integer
   if type(num) = "Integer"
     return num
   end if
   return Val(num, 10)
end function 
```

- [ ]  ~Make `UnionType.getMemberTypes` look at the intersection of member types of all the UnionTypes' types. And since this will require coding, I will probably also need to type it (with a keyboard!)~