### PR TITLE
Fixes issue with multiple namespace symbol tables

### DIFF
--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -73,7 +73,9 @@ export class SymbolTable implements SymbolTypeGetter {
      * Add a sibling symbol table (which will be inspected first before walking upward to the parent
      */
     public addSibling(sibling: SymbolTable) {
-        this.siblings.add(sibling);
+        if (!this.siblings.has(sibling)) {
+            this.siblings.add(sibling);
+        }
     }
 
     /**


### PR DESCRIPTION
There was an issue with namespaces having multiple symbol tables for each time they were created. This fixes that by building a SINGLE namespacetype at the scope level and adding the aggregate namespace symbol table as a sibling.
