### PR TITLE
Fixes some issues related to Classes as Properties and Consts validation

### DIFF
--- a/src/CacheVerifier.ts
+++ b/src/CacheVerifier.ts
@@ -20,6 +20,3 @@ export class CacheVerifier {
         return token === this.currentToken;
     }
 }
-
-
-export type CacheVerifierProvider = () => CacheVerifier;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -689,9 +689,7 @@ export class Program {
             this.logger.time(LogLevel.info, ['Validate all scopes'], () => {
                 for (let scopeName in this.scopes) {
                     let scope = this.scopes[scopeName];
-                    scope.linkSymbolTable();
                     scope.validate();
-                    scope.unlinkSymbolTable();
                 }
             });
 

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -196,6 +196,13 @@ export class SymbolTable implements SymbolTypeGetter {
         return resolvedType;
     }
 
+    setSymbolTypeCache(name: string, resolvedType: BscType, options: GetSymbolTypeOptions) {
+        if (resolvedType) {
+            this.setCachedType(name, resolvedType, options);
+        }
+        return resolvedType;
+    }
+
 
     /**
      * Adds all the symbols from another table to this one
@@ -277,6 +284,11 @@ export class SymbolTable implements SymbolTypeGetter {
             // no cache verifier
             return;
         }
+        let existingCachedValue = this.typeCache[options.flags]?.get(name.toLowerCase());
+        if (isReferenceType(type) && !isReferenceType(existingCachedValue)) {
+            // No need to overwrite a non-referenceType with a referenceType
+            return;
+        }
         return this.typeCache[options.flags]?.set(name.toLowerCase(), type);
     }
 
@@ -310,6 +322,7 @@ export interface BscSymbol {
 
 export interface SymbolTypeGetter {
     getSymbolType(name: string, options: GetSymbolTypeOptions): BscType;
+    setCachedType(name: string, resolvedType: BscType, options: GetSymbolTypeOptions);
 }
 
 /**

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -149,7 +149,7 @@ export class BrsFileValidator {
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));
-                const nodeType = this.getTypeFromNode(node, { flags: SymbolTypeFlag.typetime });
+                const nodeType = this.getTypeFromNode(node, { flags: SymbolTypeFlag.runtime });
                 node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, nodeType, SymbolTypeFlag.runtime);
             },
             CatchStatement: (node) => {

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -44,6 +44,9 @@ export class UnionType extends BscType {
                 return {
                     getSymbolType: (innerName: string, innerOptions: GetTypeOptions) => {
                         return getUniqueType(findTypeUnion(this.getMemberTypeFromInnerTypes(name, options)), unionTypeFactory);
+                    },
+                    setCachedType: (innerName: string, innerType: BscType, innerOptions: GetTypeOptions) => {
+                        // TODO: is this even cachable? This is a NO-OP for now, and it shouldn't hurt anything
                     }
                 };
             });


### PR DESCRIPTION
- Fixes when a Class is a Property of another class, and being unable to resolve it
- Fixes issue with Consts value looking at a `typetime` value of the RHS
- Does a better job of caching symbol lookups on memberTables