### PR TITLE
Prevent crashing when diagnostic is missing range.

### DIFF
--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -33,6 +33,14 @@ describe('DiagnosticCollection', () => {
         expect(actual).to.eql(expected);
     }
 
+    it('does not crash for diagnostics with missing locations', () => {
+        const [d1] = addDiagnostics('file1.brs', ['I have no location']);
+        delete d1.range;
+        testPatch({
+            'file1.brs': ['I have no location']
+        });
+    });
+
     it('returns full list of diagnostics on first call, and nothing on second call', () => {
         addDiagnostics('file1.brs', ['message1', 'message2']);
         addDiagnostics('file2.brs', ['message3', 'message4']);
@@ -96,8 +104,9 @@ describe('DiagnosticCollection', () => {
     }
 
     function addDiagnostics(srcPath: string, messages: string[]) {
+        const newDiagnostics = [];
         for (const message of messages) {
-            diagnostics.push({
+            newDiagnostics.push({
                 file: {
                     srcPath: srcPath
                 } as BscFile,
@@ -107,5 +116,7 @@ describe('DiagnosticCollection', () => {
                 message: message
             });
         }
+        diagnostics.push(...newDiagnostics);
+        return newDiagnostics as typeof diagnostics;
     }
 });

--- a/src/DiagnosticCollection.ts
+++ b/src/DiagnosticCollection.ts
@@ -1,5 +1,6 @@
 import type { BsDiagnostic } from './interfaces';
 import type { Project } from './LanguageServer';
+import { util } from './util';
 
 export class DiagnosticCollection {
     private previousDiagnosticsByFile = {} as Record<string, KeyedDiagnostic[]>;
@@ -36,13 +37,16 @@ export class DiagnosticCollection {
             }
             const diagnosticMap = result[srcPath];
 
+            //fall back to a default range if missing
+            const range = diagnostic?.range ?? util.createRange(0, 0, 0, 0);
+
             diagnostic.key =
                 srcPath.toLowerCase() + '-' +
                 diagnostic.code + '-' +
-                diagnostic.range.start.line + '-' +
-                diagnostic.range.start.character + '-' +
-                diagnostic.range.end.line + '-' +
-                diagnostic.range.end.character +
+                range.start.line + '-' +
+                range.start.character + '-' +
+                range.end.line + '-' +
+                range.end.character +
                 diagnostic.message;
 
             //don't include duplicates


### PR DESCRIPTION
Prevent another crash when diagnostics are missing the `range` property.