### PR TITLE
Adds Function Call Type Validation

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -729,6 +729,11 @@ export let DiagnosticMessages = {
         message: `'${typeText}' cannot be used as a type`,
         code: 1140,
         severity: DiagnosticSeverity.Error
+    }),
+    argumentTypeMismatch: (actualTypeString: string, expectedTypeString: string) => ({
+        message: `Argument of type '${actualTypeString}' is not compatible with parameter of type '${expectedTypeString}'`,
+        code: 1141,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -732,7 +732,10 @@ export class Scope {
 
         //do many per-file checks
         this.enumerateBrsFiles((file) => {
-            this.diagnosticDetectFunctionCallsWithWrongParamCount(file, callableContainerMap);
+            if (!this.program.options.enableTypeValidation) {
+                //TODO: this is replaced by ScopeValidator.validateFunctionCalls() when enableTypeValidation is true
+                this.diagnosticDetectFunctionCallsWithWrongParamCount(file, callableContainerMap);
+            }
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
             this.detectVariableNamespaceCollisions(file);

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -717,7 +717,8 @@ export class BrsFile {
                     name: functionName,
                     nameRange: util.createRange(callee.range.start.line, columnIndexBegin, callee.range.start.line, columnIndexEnd),
                     //TODO keep track of parameters
-                    args: args
+                    args: args,
+                    expression: expression
                 };
                 this.functionCalls.push(functionCall);
             }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,7 @@ import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 import type { Token } from './lexer/Token';
 import type { SymbolTypeFlag } from './SymbolTable';
+import type { CallExpression } from './parser/Expression';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -68,6 +69,7 @@ export interface FunctionCall {
      * The full range of this function call (from the start of the function name to its closing paren)
      */
     range: Range;
+    expression: CallExpression;
     functionScope: FunctionScope;
     file: File;
     name: string;

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -1,5 +1,5 @@
 import { SymbolTypeFlag } from '../SymbolTable';
-import { isDynamicType, isInheritableType, isObjectType, isUnionType } from '../astUtils/reflection';
+import { isObjectType } from '../astUtils/reflection';
 import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
@@ -15,15 +15,8 @@ export class ObjectType extends BscType {
     public readonly kind = BscTypeKind.ObjectType;
 
     public isTypeCompatible(targetType: BscType) {
-        if (isUnionType(targetType)) {
-            return targetType.checkAllMemberTypes((type) => type.isTypeCompatible(this));
-        } else if (isObjectType(targetType) ||
-            isDynamicType(targetType) ||
-            isInheritableType(targetType)
-        ) {
-            return true;
-        }
-        return false;
+        //Brightscript allows anything passed "as object", so as long as a type is provided, this is true
+        return !!targetType;
     }
 
     public toString() {


### PR DESCRIPTION
Adds Function Call Type Validation when `enableTypeValidation` is `true`

- new method `ScopeValidator.validateFunctionCalls()` is called when `enableTypeValidation` is `true`
- Uses `Expression.getType()` to get the types of a function's arguments
- Validates against the function's parameters using the `BscType.isTypeCompatible()` methods
- When `enableTypeValidation` is `true` parameter count mismatches are also handled in new method instead of in `Scope.ts`
- Adds new spec file `ScopeValidator.spec.ts`


<img width="861" alt="image" src="https://github.com/rokucommunity/brighterscript/assets/810290/96968101-0f43-48aa-8cbd-e6e6bd4e70d7">
