### PR TITLE
Bunch of small fixes

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1981,6 +1981,18 @@ describe('Scope', () => {
             expectZeroDiagnostics(program);
         });
 
+        it('should correctly validate formatJson', () => {
+            program.setFile(`source/main.brs`, `
+                sub main()
+                    obj = {hello: "world"}
+                    print formatJson(obj) ' 2nd param not included
+                    print formatJson(obj, 0) ' 2nd param as integer
+                    print formatJson(obj, "0") ' 2nd param as string
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
 
         describe('inheritance', () => {
             it('inherits callables from parent', () => {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -727,5 +727,39 @@ describe('ScopeValidator', () => {
                 DiagnosticMessages.argumentTypeMismatch('float', 'function').message
             ]);
         });
+
+        it('allows any variable to passed as rg to an untyped param with default type invalid', () => {
+            program.setFile('source/util.brs', `
+                sub doSomething(x = invalid)
+                    print x
+                end sub
+
+                sub tests()
+                    doSomething(1)
+                    doSomething(1.1)
+                    doSomething("Hello")
+                    doSomething(true)
+                    doSomething({test: true})
+                end sub
+            `);
+            program.validate();
+            //should have no errors
+            expectZeroDiagnostics(program);
+        });
+    });
+
+    describe('cannotFindName', () => {
+
+        it('finds variables from assignments from member functions of primitive types', () => {
+            program.setFile('source/util.brs', `
+                function lcaseTrim(str)
+                    trimmedLowerStr = lcase(str).trim()
+                    print trimmedLowerStr
+                end function
+            `);
+            program.validate();
+            //should have no errors
+            expectZeroDiagnostics(program);
+        });
     });
 });

--- a/src/globalCallables.spec.ts
+++ b/src/globalCallables.spec.ts
@@ -21,6 +21,20 @@ describe('globalCallables', () => {
             program.setFile('source/main.brs', `
                 sub main()
                     adIface = Roku_Ads()
+                    print adIface
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+    });
+
+    describe('Roku_Event_Dispatcher', () => {
+        it('exists', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    red = Roku_Event_Dispatcher()
+                    print red
                 end sub
             `);
             program.validate();

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -828,6 +828,13 @@ let programStatementFunctions = [
         type: new TypedFunctionType(new ObjectType()),
         file: globalFile,
         params: []
+        //TODO this is a temporary fix for library imported files. Eventually this should be moved into `Roku_Event_Dispatcher.brs` and handled by the `Library` statement
+    }, {
+        name: 'Roku_Event_Dispatcher',
+        shortDescription: 'Use the Roku Event Dispatcher in your channel\'s authentication workflow to send authentication events. See: https://developer.roku.com/docs/developer-program/discovery/search/prioritizing-authenticated-channels-in-roku-search.md',
+        type: new TypedFunctionType(new ObjectType()),
+        file: globalFile,
+        params: []
     }, { //TODO Same as the Roku_Ads.brs (RAF) library above, the following functions are from the 'v30/bslCore.brs' library
         name: 'bslBrightScriptErrorCodes',
         shortDescription: 'Returns an roAssociativeArray with name value pairs of the error name and corresponding integer value, for example ERR_OKAY = &hFF.',

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -11,6 +11,7 @@ import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';
 import { VoidType } from './types/VoidType';
 import util from './util';
+import { UnionType } from './types/UnionType';
 
 export let globalFile = new BrsFile('global', 'global', null);
 globalFile.parse('');
@@ -561,7 +562,7 @@ Normally non-ASCII characters are escaped in the output string as "\\uXXXX" wher
             isOptional: false
         }, {
             name: 'flags',
-            type: new StringType(),
+            type: new UnionType([IntegerType.instance, StringType.instance]),
             isOptional: true
         }]
     }, {

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -1,6 +1,8 @@
 import { isBooleanType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 export class BooleanType extends BscType {
     constructor(
@@ -31,5 +33,10 @@ export class BooleanType extends BscType {
 
     isEqual(targetType: BscType): boolean {
         return isBooleanType(targetType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,6 +1,8 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 
 export class DoubleType extends BscType {
@@ -34,5 +36,10 @@ export class DoubleType extends BscType {
 
     public isEqual(targetType: BscType): boolean {
         return isDoubleType(targetType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/EnumType.ts
+++ b/src/types/EnumType.ts
@@ -1,4 +1,5 @@
 import { isDynamicType, isEnumMemberType, isEnumType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import { DynamicType } from './DynamicType';
@@ -81,5 +82,10 @@ export class EnumMemberType extends BscType {
         return isEnumMemberType(targetType) &&
             targetType?.enumName.toLowerCase() === this.enumName.toLowerCase() &&
             targetType?.memberName.toLowerCase() === this.memberName.toLowerCase();
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -1,6 +1,8 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 export class FloatType extends BscType {
     constructor(
@@ -35,5 +37,10 @@ export class FloatType extends BscType {
 
     public isEqual(targetType: BscType): boolean {
         return isFloatType(targetType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -1,6 +1,8 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 export class IntegerType extends BscType {
     constructor(
@@ -34,5 +36,10 @@ export class IntegerType extends BscType {
 
     isEqual(otherType: BscType) {
         return isIntegerType(otherType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -1,6 +1,8 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 export class LongIntegerType extends BscType {
     constructor(
@@ -34,5 +36,10 @@ export class LongIntegerType extends BscType {
 
     isEqual(targetType: BscType): boolean {
         return isLongIntegerType(targetType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -1,6 +1,8 @@
 import { isDynamicType, isEnumMemberType, isEnumType, isObjectType, isStringType } from '../astUtils/reflection';
+import type { GetTypeOptions } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { DynamicType } from './DynamicType';
 
 export class StringType extends BscType {
     constructor(
@@ -38,5 +40,10 @@ export class StringType extends BscType {
 
     public isEqual(targetType: BscType): boolean {
         return isStringType(targetType);
+    }
+
+    getMemberType(memberName: string, options: GetTypeOptions) {
+        //TODO: this should really add the appropriate interface methods from roku-types
+        return DynamicType.instance;
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,7 @@ import type { CallExpression, CallfuncExpression, DottedGetExpression, FunctionP
 import { Logger, LogLevel } from './Logger';
 import type { Identifier, Locatable, Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
-import { isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isDottedGetExpression, isDoubleType, isExpression, isFloatType, isIndexedGetExpression, isIntegerType, isInvalidType, isLongIntegerType, isStringType, isTypeExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
+import { isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isDottedGetExpression, isDoubleType, isDynamicType, isExpression, isFloatType, isIndexedGetExpression, isIntegerType, isInvalidType, isLongIntegerType, isStringType, isTypeExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
 import { SourceNode } from 'source-map';
 import * as requireRelative from 'require-relative';
@@ -1030,7 +1030,7 @@ export class Util {
             case TokenKind.IntegerLiteral:
                 return IntegerType.instance;
             case TokenKind.Invalid:
-                return new InvalidType(token.text);
+                return DynamicType.instance; // TODO: use InvalidType better new InvalidType(token.text);
             case TokenKind.LongInteger:
                 return new LongIntegerType(token.text);
             case TokenKind.LongIntegerLiteral:
@@ -1061,7 +1061,7 @@ export class Util {
                     case 'integer':
                         return new IntegerType(token.text);
                     case 'invalid':
-                        return new InvalidType(token.text);
+                        return DynamicType.instance; // TODO: use InvalidType better new InvalidType(token.text);
                     case 'longinteger':
                         return new LongIntegerType(token.text);
                     case 'object':
@@ -1090,6 +1090,7 @@ export class Util {
         let hasFloat = isFloatType(leftType) || isFloatType(rightType);
         let hasLongInteger = isLongIntegerType(leftType) || isLongIntegerType(rightType);
         let hasInvalid = isInvalidType(leftType) || isInvalidType(rightType);
+        let hasDynamic = isDynamicType(leftType) || isDynamicType(rightType);
         let bothNumbers = this.isNumberType(leftType) && this.isNumberType(rightType);
         let bothStrings = isStringType(leftType) && isStringType(rightType);
         let eitherBooleanOrNum = (this.isNumberType(leftType) || isBooleanType(leftType)) && (this.isNumberType(rightType) || isBooleanType(rightType));
@@ -1172,8 +1173,8 @@ export class Util {
             // All comparison operators result in boolean
             case TokenKind.Equal:
             case TokenKind.LessGreater:
-                // = and <> can accept invalid
-                if (hasInvalid || bothStrings || eitherBooleanOrNum) {
+                // = and <> can accept invalid / dynamic
+                if (hasDynamic || hasInvalid || bothStrings || eitherBooleanOrNum) {
                     return BooleanType.instance;
                 }
                 break;

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,6 @@ import { DoubleType } from './types/DoubleType';
 import { DynamicType } from './types/DynamicType';
 import { FloatType } from './types/FloatType';
 import { IntegerType } from './types/IntegerType';
-import { InvalidType } from './types/InvalidType';
 import { LongIntegerType } from './types/LongIntegerType';
 import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';


### PR DESCRIPTION
Fixes:
 - assignment from return of member functions of primitive types
 - using `invalid` as a default param value (now sets type to `dynamic`)
 - adds `Roku_Event_Dispatcher()` global callable (from library `Roku_Event_Dispatcher.brs`)
 - Fixes `FormatJson()` function signature (https://developer.roku.com/docs/references/brightscript/language/global-utility-functions.md#formatjsonjson-as-object-flags--0-as-integer-as-string)