### PR TITLE
Type casts are not allowed in BrightScript

### DIFF
--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1310,6 +1310,20 @@ describe('parser', () => {
     });
 
     describe('type casts', () => {
+
+        it('is not allowed in brightscript mode', () => {
+            let parser = parse(`
+                sub main(node as dynamic)
+                    print lcase((node as string))
+                end sub
+            `, ParseMode.BrightScript);
+            expect(
+                parser.diagnostics[0]?.message
+            ).to.equal(
+                DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('type cast').message
+            );
+        });
+
         it('allows type casts after function calls', () => {
             let { statements, diagnostics } = parse(`
                 sub main()

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2218,6 +2218,7 @@ export class Parser {
         if (findTypeCast) {
             do {
                 if (this.check(TokenKind.As)) {
+                    this.warnIfNotBrighterScriptMode('type cast');
                     // Check if this expression is wrapped in any type casts
                     // allows for multiple casts:
                     // myVal = foo() as dynamic as string


### PR DESCRIPTION
![image](https://github.com/rokucommunity/brighterscript/assets/810290/7280d101-0214-4973-b961-fd727642b90a)
