### PR TITLE
Print diagnostic related information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001442",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true,
       "funding": [
         {
@@ -1636,6 +1636,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -8239,9 +8243,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001442",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true
     },
     "caseless": {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -13,6 +13,7 @@ import * as diagnosticUtils from './diagnosticUtils';
 import * as fsExtra from 'fs-extra';
 import * as requireRelative from 'require-relative';
 import { Throttler } from './Throttler';
+import { URI } from 'vscode-uri';
 
 /**
  * A runner class that handles
@@ -310,8 +311,19 @@ export class ProgramBuilder {
             for (let diagnostic of sortedDiagnostics) {
                 //default the severity to error if undefined
                 let severity = typeof diagnostic.severity === 'number' ? diagnostic.severity : DiagnosticSeverity.Error;
+                let relatedInformation = (diagnostic.relatedInformation ?? []).map(x => {
+                    let relatedInfoFilePath = URI.parse(x.location.uri).fsPath;
+                    if (!emitFullPaths) {
+                        relatedInfoFilePath = path.relative(cwd, relatedInfoFilePath);
+                    }
+                    return {
+                        filePath: relatedInfoFilePath,
+                        range: x.location.range,
+                        message: x.message
+                    };
+                });
                 //format output
-                diagnosticUtils.printDiagnostic(options, severity, filePath, lines, diagnostic);
+                diagnosticUtils.printDiagnostic(options, severity, filePath, lines, diagnostic, relatedInformation);
             }
         }
     }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -352,7 +352,7 @@ export class ScopeValidator {
         if (isXmlScope(this.event.scope) && this.event.scope.xmlFile?.srcPath) {
             info.location = util.createLocation(
                 URI.file(this.event.scope.xmlFile.srcPath).toString(),
-                util.createRange(0, 0, 0, 10)
+                this.event.scope?.xmlFile?.ast?.component?.getAttribute('name')?.value.range ?? util.createRange(0, 0, 0, 10)
             );
         } else {
             info.location = util.createLocation(

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -4,11 +4,21 @@ import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { util } from './util';
 import chalk from 'chalk';
+import { createSandbox } from 'sinon';
+import undent from 'undent';
+import type { BsDiagnostic } from './interfaces';
+import { stripConsoleColors } from './testHelpers.spec';
+const sinon = createSandbox();
 
 describe('diagnosticUtils', () => {
     let options: ReturnType<typeof diagnosticUtils.getPrintDiagnosticOptions>;
     beforeEach(() => {
+        sinon.restore();
         options = diagnosticUtils.getPrintDiagnosticOptions({});
+    });
+
+    afterEach(() => {
+        sinon.restore();
     });
 
     describe('printDiagnostic', () => {
@@ -25,9 +35,72 @@ describe('diagnosticUtils', () => {
             //print a diagnostic that doesn't have a range...it should not explode
             diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, undefined, [], {
                 message: 'Bad thing happened',
-                range: Range.create(0, 0, 2, 2), //important...this needs to be null for the test to pass,
+                range: Range.create(0, 0, 2, 2),
                 code: 1234
             } as any);
+        });
+
+        function testPrintDiagnostic(diagnostic: BsDiagnostic, code: string, expected: string) {
+            let logOutput = '';
+            sinon.stub(console, 'log').callsFake((...args: any[]) => {
+                if (logOutput.length > 0) {
+                    logOutput += '\n';
+                }
+                logOutput += stripConsoleColors(args.join(' '));
+            });
+            //print a diagnostic that doesn't have a range...it should not explode
+            diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, undefined, code.split(/\r?\n/g), diagnostic);
+
+            //remove leading and trailing newlines
+            logOutput = logOutput.replace(/^[\r\n]*/g, '').replace(/[\r\n]*$/g, '');
+            expected = undent(logOutput).replace(/^[\r\n]*/g, '').replace(/[\r\n]*$/g, '');
+
+            expect(logOutput).to.eql(expected);
+        }
+
+        it('handles mixed tabs and spaces', () => {
+            testPrintDiagnostic(
+                {
+                    message: 'Bad thing happened',
+                    range: Range.create(0, 5, 0, 18),
+                    code: 1234
+                } as any,
+                `\t  \t print "hello"`,
+                `
+                <unknown file>:1:6 - error BS1234: Bad thing happened
+                 1             print "hello"
+                 _             ~~~~~~~~~~~~~
+            `);
+        });
+
+        it('handles only tabs', () => {
+            testPrintDiagnostic(
+                {
+                    message: 'Bad thing happened',
+                    range: Range.create(0, 5, 0, 18),
+                    code: 1234
+                } as any,
+                `\tprint "hello"`,
+                `
+                <unknown file>:1:6 - error BS1234: Bad thing happened
+                 1      print "hello"
+                 _      ~~~~~~~~~~~~~
+            `);
+        });
+
+        it('handles only spaces', () => {
+            testPrintDiagnostic(
+                {
+                    message: 'Bad thing happened',
+                    range: Range.create(0, 5, 0, 18),
+                    code: 1234
+                } as any,
+                `   print "hello"`,
+                `
+                <unknown file>:1:6 - error BS1234: Bad thing happened
+                 1     print "hello"
+                 _     ~~~~~~~~~~~~~
+            `);
         });
     });
 
@@ -92,76 +165,75 @@ describe('diagnosticUtils', () => {
 
     describe('getDiagnosticSquiggly', () => {
         it('works for normal cases', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, 4)
-            }, 'asdf')).to.equal('~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('asdf', 0, 4)
+            ).to.equal('~~~~');
         });
 
         it('highlights whole line if no range', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-            }, ' asdf ')).to.equal('~~~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText(' asdf ', undefined, undefined)
+            ).to.equal('~~~~~~');
         });
 
         it('returns empty string when no line is found', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, 10)
-            }, '')).to.equal('');
+            expect(diagnosticUtils.getDiagnosticSquigglyText('', 0, 10)).to.equal('');
 
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, 10)
-            }, undefined)).to.equal('');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText(undefined, 0, 10)
+            ).to.equal('');
         });
 
         it('supports diagnostic not at start of line', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 2, 0, 6)
-            }, '  asdf')).to.equal('  ~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('  asdf', 2, 6)
+            ).to.equal('  ~~~~');
         });
 
         it('supports diagnostic that does not finish at end of line', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, 4)
-            }, 'asdf  ')).to.equal('~~~~  ');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('asdf  ', 0, 4)
+            ).to.equal('~~~~  ');
         });
 
         it('supports diagnostic with space on both sides', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 2, 0, 6)
-            }, '  asdf  ')).to.equal('  ~~~~  ');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('  asdf  ', 2, 6)
+            ).to.equal('  ~~~~  ');
         });
 
         it('handles diagnostic that starts and stops on the same position', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 2, 0, 2)
-            }, 'abcde')).to.equal('~~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('abcde', 2, 2)
+            ).to.equal('~~~~~');
         });
 
         it('handles single-character diagnostic', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 2, 0, 3)
-            }, 'abcde')).to.equal('  ~  ');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('abcde', 2, 3)
+            ).to.equal('  ~  ');
         });
 
         it('handles diagnostics that are longer than the line', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 0, 0, 10)
-            }, 'abcde')).to.equal('~~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('abcde', 0, 10)
+            ).to.equal('~~~~~');
 
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(0, 2, 0, 10)
-            }, 'abcde')).to.equal('  ~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('abcde', 2, 10)
+            ).to.equal('  ~~~');
         });
 
         it('handles Number.MAX_VALUE for end character', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: util.createRange(0, 0, 0, Number.MAX_VALUE)
-            }, 'abcde')).to.equal('~~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('abcde', 0, Number.MAX_VALUE)
+            ).to.equal('~~~~~');
         });
 
         it.skip('handles edge cases', () => {
-            expect(diagnosticUtils.getDiagnosticSquigglyText(<any>{
-                range: Range.create(5, 16, 5, 18)
-            }, 'end functionasdf')).to.equal('            ~~~~');
+            expect(
+                diagnosticUtils.getDiagnosticSquigglyText('end functionasdf', 16, 18)
+            ).to.equal('            ~~~~');
         });
     });
 

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -245,7 +245,7 @@ describe('diagnosticUtils', () => {
                 diagnosticUtils.getDiagnosticLine({ range: range } as any, '1'.repeat(lineLength), color)
             ).to.eql([
                 chalk.bgWhite(' ' + chalk.black((range.start.line + 1).toString()) + ' ') + ' ' + '1'.repeat(lineLength),
-                chalk.bgWhite(' ' + chalk.white('_'.repeat((range.start.line + 1).toString().length)) + ' ') + ' ' + squigglyText.padEnd(lineLength, ' ')
+                chalk.bgWhite(' ' + chalk.white(' '.repeat((range.start.line + 1).toString().length)) + ' ') + ' ' + squigglyText.padEnd(lineLength, ' ')
             ].join('\n'));
         }
 

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -95,10 +95,11 @@ export function printDiagnostic(
     );
 
     //print related information if present (only first few rows)
-    const relatedInfoList = relatedInformation?.slice(0, 5) ?? [];
+    const relatedInfoList = relatedInformation ?? [];
     let indent = '    ';
     for (let i = 0; i < relatedInfoList.length; i++) {
         let relatedInfo = relatedInfoList[i];
+        //only show the first 5 relatedInfo links
         if (i < 5) {
             console.log('');
             console.log(

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -362,3 +362,12 @@ export function mapToObject<T>(map: Map<any, T>) {
     }
     return result;
 }
+
+export function stripConsoleColors(inputString) {
+    // Regular expression to match ANSI escape codes for colors
+    // eslint-disable-next-line no-control-regex
+    const colorPattern = /\u001b\[(?:\d*;){0,5}\d*m/g;
+
+    // Remove all occurrences of ANSI escape codes
+    return inputString.replace(colorPattern, '');
+}


### PR DESCRIPTION
Print the `relatedInfo` portion of diagnostics. 

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/bd59ed7d-2054-4886-94dd-d25266fa548f)
