### PR TITLE
ensure consistent insertion of bslib.brs

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1843,8 +1843,38 @@ describe('Program', () => {
         });
     });
 
-    describe('transpile', () => {
+    it('beforeProgramTranspile sends entries in alphabetical order', () => {
+        program.setFile('source/main.bs', trim`
+            sub main()
+                print "hello world"
+            end sub
+        `);
 
+        program.setFile('source/common.bs', trim`
+            sub getString()
+                return "test"
+            end sub
+        `);
+
+        //send the files out of order
+        const result = program['beforeProgramTranspile']([{
+            src: s`${rootDir}/source/main.bs`,
+            dest: 'source/main.bs'
+        }, {
+            src: s`${rootDir}/source/main.bs`,
+            dest: 'source/main.bs'
+        }], program.options.stagingDir);
+
+        //entries should now be in alphabetic order
+        expect(
+            result.entries.map(x => x.outputPath)
+        ).to.eql([
+            s`${stagingDir}/source/common.brs`,
+            s`${stagingDir}/source/main.brs`
+        ]);
+    });
+
+    describe('transpile', () => {
         it('detects and transpiles files added between beforeProgramTranspile and afterProgramTranspile', async () => {
             program.setFile('source/main.bs', trim`
                 sub main()

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1188,6 +1188,7 @@ export class Program {
                 outputPath: getOutputPath(file)
             };
         });
+        entries.sort((a, b) => a.file.srcPath < b.file.srcPath ? 1 : -1)
 
         const astEditor = new AstEditor();
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1187,8 +1187,10 @@ export class Program {
                 file: file,
                 outputPath: getOutputPath(file)
             };
+            //sort the entries to make transpiling more deterministic
+        }).sort((a, b) => {
+            return a.file.srcPath < b.file.srcPath ? -1 : 1;
         });
-        entries.sort((a, b) => a.file.srcPath < b.file.srcPath ? 1 : -1)
 
         const astEditor = new AstEditor();
 


### PR DESCRIPTION
Sort files prior to transpilation to ensure consistency between builds with regards to insertion of bslib.brs reference in transpiled XML files.