### PR TITLE
Adds Return type validation

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -734,6 +734,11 @@ export let DiagnosticMessages = {
         message: `Argument of type '${actualTypeString}' is not compatible with parameter of type '${expectedTypeString}'`,
         code: 1141,
         severity: DiagnosticSeverity.Error
+    }),
+    returnTypeMismatch: (actualTypeString: string, expectedTypeString: string) => ({
+        message: `Type '${actualTypeString}' is not compatible with declared return type '${expectedTypeString}'`,
+        code: 1142,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1204,7 +1204,7 @@ describe('Scope', () => {
                     end function
                 `);
                 program.validate();
-                expectDiagnostics(program, [
+                expectDiagnosticsIncludes(program, [
                     DiagnosticMessages.cannotFindName('unknownType').message,
                     DiagnosticMessages.cannotFindName('unknownType').message
                 ]);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,11 +1,11 @@
 import { URI } from 'vscode-uri';
-import { isAssignmentStatement, isBinaryExpression, isBrsFile, isClassType, isLiteralExpression, isNamespaceStatement, isTypeExpression, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
+import { isAssignmentStatement, isBinaryExpression, isBrsFile, isClassType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isTypeExpression, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, BsDiagnostic, OnScopeValidateEvent } from '../../interfaces';
 import { SymbolTypeFlag } from '../../SymbolTable';
-import type { AssignmentStatement, EnumStatement, NamespaceStatement } from '../../parser/Statement';
+import type { AssignmentStatement, EnumStatement, NamespaceStatement, ReturnStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
@@ -58,10 +58,15 @@ export class ScopeValidator {
                 file.ast.walk(createVisitor({
                     CallExpression: (functionCall) => {
                         this.validateFunctionCall(file, functionCall);
+                    },
+                    ReturnStatement: (returnStatement) => {
+                        this.validateReturnStatement(file, returnStatement);
                     }
+
                 }), {
-                    walkMode: WalkMode.visitExpressionsRecursive
+                    walkMode: WalkMode.visitAllRecursive
                 });
+                console.log('finished walkFiles', file.srcPath);
             }
         });
     }
@@ -455,6 +460,28 @@ export class ScopeValidator {
                 paramIndex++;
             }
 
+        }
+        this.event.scope.addDiagnostics(diagnostics);
+    }
+
+
+    /**
+     * Detect return statements with incompatible types vs. declared return type
+     */
+    private validateReturnStatement(file: BrsFile, returnStmt: ReturnStatement) {
+        const diagnostics: BsDiagnostic[] = [];
+        const getTypeOptions = { flags: SymbolTypeFlag.runtime };
+        let funcType = returnStmt.findAncestor(isFunctionExpression).getType({ flags: SymbolTypeFlag.typetime });
+        if (isTypedFunctionType(funcType)) {
+            const actualReturnType = returnStmt.value?.getType(getTypeOptions);
+            if (actualReturnType && !funcType.returnType.isTypeCompatible(actualReturnType)) {
+                this.addMultiScopeDiagnostic({
+                    ...DiagnosticMessages.returnTypeMismatch(actualReturnType.toString(), funcType.returnType.toString()),
+                    range: returnStmt.value.range,
+                    file: file
+                });
+
+            }
         }
         this.event.scope.addDiagnostics(diagnostics);
     }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -66,7 +66,6 @@ export class ScopeValidator {
                 }), {
                     walkMode: WalkMode.visitAllRecursive
                 });
-                console.log('finished walkFiles', file.srcPath);
             }
         });
     }

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1625,7 +1625,7 @@ describe('BrsFile', () => {
                     else if true
                     else if true then
                         if true then
-                            return true
+                            return
                         end if
                     end if
                 end sub

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -610,7 +610,7 @@ describe('EnumStatement', () => {
                         val2
                     end enum
 
-                    function foo() as integer
+                    function foo() as MyEnum
                         return MyEnum.val1
                     end function
                 end namespace


### PR DESCRIPTION
- Validates actual return type vs. the declared return type
- Subs and void functions will have validation errors when an actual type is included
- works in Brs and Bs files


https://github.com/rokucommunity/brighterscript/assets/810290/d065c1ee-30f2-496f-ad4d-2e66182b166b

