### PR TITLE
Add missing emitDefinitions to docs and fix iface

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,12 @@ Type: `boolean`
 
 Emit full paths to files when printing diagnostics to the console. Defaults to `false`.
 
+#### `emitDefinitions`
+
+Type: `boolean`
+
+Emit type definition files (`d.bs`) during transpile. Defaults to `false`.
+
 #### `diagnosticFilters`
 
 Type: `Array<string | number | {src: string; codes: number[]}`

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -128,7 +128,7 @@ export interface BsConfig {
 
     /**
      * Emit type definition files (`d.bs`)
-     * @default true
+     * @default false
      */
     emitDefinitions?: boolean;
 


### PR DESCRIPTION
Add missing `emitDefinitions` entry in the readme.
Fix incorrect default `true` value for `emitDefinitions` in the `BsConfig` interface jsdocs comment