### PR TITLE
Fix isLiteralInvalid

### DIFF
--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -133,10 +133,16 @@ export function createIntegerLiteral(value: string, range?: Range) {
 export function createFloatLiteral(value: string, range?: Range) {
     return new LiteralExpression(createToken(TokenKind.FloatLiteral, value, range));
 }
+export function createDoubleLiteral(value: string, range?: Range) {
+    return new LiteralExpression(createToken(TokenKind.DoubleLiteral, value, range));
+}
+export function createLongIntegerLiteral(value: string, range?: Range) {
+    return new LiteralExpression(createToken(TokenKind.LongIntegerLiteral, value, range));
+}
 export function createInvalidLiteral(value?: string, range?: Range) {
     return new LiteralExpression(createToken(TokenKind.Invalid, value, range));
 }
-export function createBooleanLiteral(value: 'true' | 'false', range?: Range) {
+export function createBooleanLiteral(value: string, range?: Range) {
     return new LiteralExpression(createToken(value === 'true' ? TokenKind.True : TokenKind.False, value, range));
 }
 export function createFunctionExpression(kind: TokenKind.Sub | TokenKind.Function) {

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -4,12 +4,11 @@ import { PrintStatement, Block, Body, AssignmentStatement, CommentStatement, Exi
 import { FunctionExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression } from '../parser/Expression';
 import type { Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression, isTryCatchStatement, isCatchStatement, isThrowStatement } from './reflection';
-import { createToken, createStringLiteral, interpolatedRange as range } from './creators';
+import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression, isTryCatchStatement, isCatchStatement, isThrowStatement, isLiteralInvalid, isLiteralBoolean, isLiteralNumber, isLiteralInteger, isLiteralLongInteger, isLiteralFloat, isLiteralDouble } from './reflection';
+import { createToken, createStringLiteral, interpolatedRange as range, createInvalidLiteral, createBooleanLiteral, createIntegerLiteral, createVariableExpression, createFloatLiteral, createDoubleLiteral, createLongIntegerLiteral } from './creators';
 import { Program } from '../Program';
 import { BrsFile } from '../files/BrsFile';
 import { XmlFile } from '../files/XmlFile';
-import { createVariableExpression } from '..';
 
 describe('reflection', () => {
     describe('Files', () => {
@@ -310,6 +309,95 @@ describe('reflection', () => {
             //doesn't fail for invalid param types
             expect(isExpression(undefined)).to.be.false;
             expect(isExpression(1 as any)).to.be.false;
+        });
+    });
+
+    describe('isLiteralInvalid', () => {
+        it('handles true cases', () => {
+            expect(isLiteralInvalid(createInvalidLiteral('invalid'))).to.be.true;
+            expect(isLiteralInvalid(createInvalidLiteral('Invalid'))).to.be.true;
+            expect(isLiteralInvalid(createInvalidLiteral('INVALID'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralInvalid(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralInvalid(createIntegerLiteral('1'))).to.be.false;
+            expect(isLiteralInvalid(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralBoolean', () => {
+        it('handles true cases', () => {
+            expect(isLiteralBoolean(createBooleanLiteral('true'))).to.be.true;
+            expect(isLiteralBoolean(createBooleanLiteral('TRUE'))).to.be.true;
+            expect(isLiteralBoolean(createBooleanLiteral('false'))).to.be.true;
+            expect(isLiteralBoolean(createBooleanLiteral('FALSE'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralBoolean(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralBoolean(createIntegerLiteral('1'))).to.be.false;
+            expect(isLiteralBoolean(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralNumber', () => {
+        it('handles true cases', () => {
+            expect(isLiteralNumber(createIntegerLiteral('1'))).to.be.true;
+            expect(isLiteralNumber(createLongIntegerLiteral('1'))).to.be.true;
+            expect(isLiteralNumber(createFloatLiteral('1.2'))).to.be.true;
+            expect(isLiteralNumber(createDoubleLiteral('2.3'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralNumber(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralNumber(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralNumber(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralInteger', () => {
+        it('handles true cases', () => {
+            expect(isLiteralInteger(createIntegerLiteral('1'))).to.be.true;
+            expect(isLiteralInteger(createIntegerLiteral('100'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralInteger(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralInteger(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralInteger(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralLongInteger', () => {
+        it('handles true cases', () => {
+            expect(isLiteralLongInteger(createLongIntegerLiteral('1'))).to.be.true;
+            expect(isLiteralLongInteger(createLongIntegerLiteral('100'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralLongInteger(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralLongInteger(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralLongInteger(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralFloat', () => {
+        it('handles true cases', () => {
+            expect(isLiteralFloat(createFloatLiteral('1.2'))).to.be.true;
+            expect(isLiteralFloat(createFloatLiteral('1.234'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralFloat(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralFloat(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralFloat(createVariableExpression('cat'))).to.be.false;
+        });
+    });
+
+    describe('isLiteralDouble', () => {
+        it('handles true cases', () => {
+            expect(isLiteralDouble(createDoubleLiteral('1.2'))).to.be.true;
+            expect(isLiteralDouble(createDoubleLiteral('1.234'))).to.be.true;
+        });
+        it('handles false cases', () => {
+            expect(isLiteralDouble(createInvalidLiteral('invalid'))).to.be.false;
+            expect(isLiteralDouble(createBooleanLiteral('true'))).to.be.false;
+            expect(isLiteralDouble(createVariableExpression('cat'))).to.be.false;
         });
     });
 });

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -33,6 +33,7 @@ import type { NamespaceType } from '../types/NamespaceType';
 import type { BaseFunctionType } from '../types/BaseFunctionType';
 import type { ComponentType } from '../types/ComponentType';
 import type { AssociativeArrayType } from '../types/AssociativeArrayType';
+import { TokenKind } from '../lexer/TokenKind';
 
 // File reflection
 export function isBrsFile(file: (BscFile | File)): file is BrsFile {
@@ -377,7 +378,7 @@ export function isPrimitiveType(value: any): value is IntegerType | LongIntegerT
 // Literal reflection
 
 export function isLiteralInvalid(value: any): value is LiteralExpression & { type: InvalidType } {
-    return isLiteralExpression(value) && isInvalidType(value.getType());
+    return isLiteralExpression(value) && value.token.kind === TokenKind.Invalid;
 }
 export function isLiteralBoolean(value: any): value is LiteralExpression & { type: BooleanType } {
     return isLiteralExpression(value) && isBooleanType(value.getType());
@@ -388,3 +389,17 @@ export function isLiteralString(value: any): value is LiteralExpression & { type
 export function isLiteralNumber(value: any): value is LiteralExpression & { type: IntegerType | LongIntegerType | FloatType | DoubleType } {
     return isLiteralExpression(value) && isNumberType(value.getType());
 }
+export function isLiteralInteger(value: any): value is LiteralExpression & { type: IntegerType } {
+    return isLiteralExpression(value) && isIntegerType(value.getType());
+}
+export function isLiteralLongInteger(value: any): value is LiteralExpression & { type: LongIntegerType } {
+    return isLiteralExpression(value) && isLongIntegerType(value.getType());
+}
+export function isLiteralFloat(value: any): value is LiteralExpression & { type: FloatType } {
+    return isLiteralExpression(value) && isFloatType(value.getType());
+}
+export function isLiteralDouble(value: any): value is LiteralExpression & { type: DoubleType } {
+    return isLiteralExpression(value) && isDoubleType(value.getType());
+}
+
+


### PR DESCRIPTION
Fix `isLiteralInvalid` method to properly detect the true case. 
Add other `isLiteral*` methods.
Add unit tests for these methods.