### PR TITLE
Better multi scope messages

### DIFF
--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -323,7 +323,7 @@ export class ProgramBuilder {
             for (let diagnostic of sortedDiagnostics) {
                 //default the severity to error if undefined
                 let severity = typeof diagnostic.severity === 'number' ? diagnostic.severity : DiagnosticSeverity.Error;
-                let relatedInformation = (diagnostic.relatedInformation ?? []).map(x => {
+                let relatedInformation = (util.toDiagnostic(diagnostic, diagnostic.source)?.relatedInformation ?? []).map(x => {
                     let relatedInfoFilePath = URI.parse(x.location.uri).fsPath;
                     if (!emitFullPaths) {
                         relatedInfoFilePath = path.relative(cwd, relatedInfoFilePath);

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -343,7 +343,7 @@ describe('Scope', () => {
                         srcPath: buttonPrimary.srcPath
                     },
                     relatedInformation: [{
-                        message: `Not defined in scope '${s('components/ButtonPrimary.xml')}'`
+                        message: `In component scope 'ButtonPrimary'`
                     }]
                 }, {
                     message: DiagnosticMessages.cannotFindName('delta').message,
@@ -351,7 +351,7 @@ describe('Scope', () => {
                         srcPath: buttonSecondary.srcPath
                     },
                     relatedInformation: [{
-                        message: `Not defined in scope '${s('components/ButtonSecondary.xml')}'`
+                        message: `In component scope 'ButtonSecondary'`
                     }]
                 }
             ]);

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -5,6 +5,8 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import type { BsDiagnostic } from '.';
 import type { Range } from 'vscode-languageserver';
 
+export const MAX_RELATED_INFOS_COUNT = 3;
+
 /**
  * Prepare print diagnostic formatting options
  */
@@ -99,8 +101,8 @@ export function printDiagnostic(
     let indent = '    ';
     for (let i = 0; i < relatedInfoList.length; i++) {
         let relatedInfo = relatedInfoList[i];
-        //only show the first 5 relatedInfo links
-        if (i < 5) {
+        //only show the first MAX_RELATED_INFOS_COUNT relatedInfo links
+        if (i < MAX_RELATED_INFOS_COUNT) {
             console.log('');
             console.log(
                 indent,

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1226,7 +1226,7 @@ describe('BrsFile BrighterScript classes', () => {
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird'),
                 relatedInformation: [{
-                    message: `Not defined in scope 'source'`
+                    message: `In scope 'source'`
                 }]
             }]);
         });


### PR DESCRIPTION
Make the multi-scope diagnostic messaging for related infos more relevant (and concise). Also truncate that list since seeing 95 related infos is just noise...

Here's how it looks now: 
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1e216018-5607-4e53-bb71-8d0c5a322ada)
