### PR TITLE
Add some more details to the plugins docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -323,6 +323,8 @@ export default function () {
 };
 ```
 
+Note that creating diagnostics requires that `BscFile` objects are available. This means that diagnostics cannot be recorded in the `beforeProgramCreate` and `afterProgramCreate` steps.
+
 ## Modifying code
 Sometimes plugins will want to modify code before the project is transpiled. While you can technically edit the AST directly at any point in the file's lifecycle, this is not recommended as those changes will remain changed as long as that file exists in memory and could cause issues with file validation if the plugin is used in a language-server context (i.e. inside vscode).
 
@@ -390,6 +392,29 @@ export default function plugin() {
                     });
                 }
             }
+        }
+    } as CompilerPlugin;
+}
+```
+
+## Modifying `bsconfig.json` via a plugin
+
+In some cases you may want to modify the project's configuration via a plugin, such as to change settings based on environment variables or to dynamically modify the project's `files` array. Plugins may do so in the `beforeProgramCreate` step. For example, here's a plugin which adds an additional file to the build:
+```typescript
+import { CompilerPlugin, ProgramBuilder } from 'brighterscript';
+
+export default function plugin() {
+    return {
+        name: 'addFilesDynamically',
+        beforeProgramCreate: (builder: ProgramBuilder) => {
+            if (!builder.options.files) {
+                builder.options.files = [];
+            }
+
+            builder.options.files.push({
+                src: "path/to/plugin/file.bs",
+                dest: "some/destination/path/goes/here"
+            })
         }
     } as CompilerPlugin;
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -323,8 +323,6 @@ export default function () {
 };
 ```
 
-Note that creating diagnostics requires that `BscFile` objects are available. This means that diagnostics cannot be recorded in the `beforeProgramCreate` and `afterProgramCreate` steps.
-
 ## Modifying code
 Sometimes plugins will want to modify code before the project is transpiled. While you can technically edit the AST directly at any point in the file's lifecycle, this is not recommended as those changes will remain changed as long as that file exists in memory and could cause issues with file validation if the plugin is used in a language-server context (i.e. inside vscode).
 


### PR DESCRIPTION
This adds some additional information on plugins. If the note on the diagnostics availability in early build steps is too much detail I can remove it.