### PR TITLE
Fix incorrect quasi location in template string

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -616,7 +616,7 @@ export class Lexer {
                     this.scanToken();
                 }
                 if (this.check('}')) {
-                    this.current++;
+                    this.advance();
                     this.addToken(TokenKind.TemplateStringExpressionEnd);
                 } else {
 

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -9,7 +9,6 @@ import { AssignmentStatement } from '../../Statement';
 import { Program } from '../../../Program';
 import { expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 import { util } from '../../../util';
-import { TokenKind } from '../../../lexer/TokenKind';
 
 describe('TemplateStringExpression', () => {
     describe('parser template String', () => {

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -8,6 +8,8 @@ import { Parser, ParseMode } from '../../Parser';
 import { AssignmentStatement } from '../../Statement';
 import { Program } from '../../../Program';
 import { expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
+import { util } from '../../../util';
+import { TokenKind } from '../../../lexer/TokenKind';
 
 describe('TemplateStringExpression', () => {
     describe('parser template String', () => {
@@ -18,6 +20,41 @@ describe('TemplateStringExpression', () => {
         });
 
         describe('in assignment', () => {
+            it('generates correct locations for quasis', () => {
+                let { tokens } = Lexer.scan('print `0xAAAAAA${"0xBBBBBB"}0xCCCCCC`');
+                expect(
+                    tokens.filter(x => /"?0x/.test(x.text)).map(x => x.range)
+                ).to.eql([
+                    util.createRange(0, 7, 0, 15), // 0xAAAAAA
+                    util.createRange(0, 17, 0, 27), // "0xBBBBBB"
+                    util.createRange(0, 28, 0, 36) // 0xCCCCCC
+                ]);
+            });
+
+            it('generates correct locations for items', () => {
+                let { tokens } = Lexer.scan('print `${111}${222}${333}`');
+                //throw out the `print` token
+                tokens.shift();
+                expect(
+                    //compute the length of the token char spread
+                    tokens.filter(x => x.text !== '').map(x => [x.range.end.character - x.range.start.character, x.text])
+                ).to.eql([
+                    '`',
+                    '${',
+                    '111',
+                    '}',
+                    '${',
+                    '222',
+                    '}',
+                    '${',
+                    '333',
+                    '}',
+                    '`'
+                ].map(x => [x.length, x])
+                );
+            });
+
+
             it(`simple case`, () => {
                 let { tokens } = Lexer.scan(`a = \`hello      world\``);
                 let { statements, diagnostics } = Parser.parse(tokens, { mode: ParseMode.BrighterScript });


### PR DESCRIPTION
Fixes a token location bug in the template string lexer logic where the closing `}` had incorrect end char position. 