### PR TITLE
fix bug in --noproject flag logic

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -232,6 +232,31 @@ describe('util', () => {
     });
 
     describe('normalizeAndResolveConfig', () => {
+        it('loads project by default', () => {
+            fsExtra.outputJsonSync(`${rootDir}/bsconfig.json`, {
+                rootDir: s`${cwd}/TEST`
+            });
+            expect(
+                util.normalizeAndResolveConfig({
+                    cwd: rootDir
+                }).rootDir
+            ).to.eql(
+                s`${cwd}/TEST`
+            );
+        });
+
+        it('noproject skips loading the local bsconfig.json', () => {
+            fsExtra.outputJsonSync(`${rootDir}/bsconfig.json`, {
+                rootDir: s`${cwd}/TEST`
+            });
+            expect(
+                util.normalizeAndResolveConfig({
+                    cwd: rootDir,
+                    noProject: true
+                }).rootDir
+            ).to.be.undefined;
+        });
+
         it('throws for missing project file', () => {
             expect(() => {
                 util.normalizeAndResolveConfig({ project: 'path/does/not/exist/bsconfig.json' });

--- a/src/util.ts
+++ b/src/util.ts
@@ -301,22 +301,19 @@ export class Util {
             return result;
         }
 
-        result.project = null;
-        if (config?.project) {
-            result.project = config?.project;
+        //if no options were provided, try to find a bsconfig.json file
+        if (!config || !config.project) {
+            result.project = this.getConfigFilePath(config?.cwd);
         } else {
-            if (config?.cwd) {
-                result.project = this.getConfigFilePath(config?.cwd);
-            }
+            //use the config's project link
+            result.project = config.project;
         }
         if (result.project) {
             let configFile = this.loadConfigFile(result.project, null, config?.cwd);
             result = Object.assign(result, configFile);
         }
-
         //override the defaults with the specified options
         result = Object.assign(result, config);
-
         return result;
     }
 


### PR DESCRIPTION
fixes bug in `--noproject` logic that was skipping bsconfig loading sometimes when it shouldn't. 