### PR TITLE
Add function parameter support in interfaces

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -92,3 +92,20 @@ end interface
 
 ```
 </details>
+
+</details>
+
+## Methods
+Interfaces can describe complex methods as well
+```brighterscript
+interface Dog
+    sub barkAt(nemesis as Cat)
+end interface
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```BrightScript
+```
+</details>

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -417,7 +417,19 @@ export class Parser {
         const name = this.identifier(...AllowedProperties);
         const leftParen = this.consumeToken(TokenKind.LeftParen);
 
-        const params = [];
+        let params = [] as FunctionParameterExpression[];
+        if (!this.check(TokenKind.RightParen)) {
+            do {
+                if (params.length >= CallExpression.MaximumArguments) {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.tooManyCallableParameters(params.length, CallExpression.MaximumArguments),
+                        range: this.peek().range
+                    });
+                }
+
+                params.push(this.functionParameter());
+            } while (this.match(TokenKind.Comma));
+        }
         const rightParen = this.consumeToken(TokenKind.RightParen);
         let asToken = null as Token;
         let returnTypeToken = null as Token;

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -87,4 +87,13 @@ describe('InterfaceStatement', () => {
             'this comment was throwing exception during transpile
         `);
     });
+
+    it('allows parameters in interface method signatures', () => {
+        testGetTypedef(`
+            interface Person
+                sub someFunc(name as string, age as integer) as string
+                someField as string
+            end interface
+        `, undefined, undefined, undefined, true);
+    });
 });


### PR DESCRIPTION
Adds support for function parameters in interface declarations. I had added this to v0.66, but it really should be in mainline since it's such a simple change. 