### PR TITLE
Fixes compatibility of built in types (roArray -> typed arrays)

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -757,7 +757,7 @@ export let DiagnosticMessages = {
 };
 export const defaultMaximumTruncationLength = 160;
 
-function typeCompatibilityMessage(actualTypeString: string, expectedTypeString: string, data: TypeCompatibilityData) {
+export function typeCompatibilityMessage(actualTypeString: string, expectedTypeString: string, data: TypeCompatibilityData) {
     let message = '';
     if (data?.missingFields?.length > 0) {
         message = `\n    Type '${actualTypeString}' is missing the following members: ` + util.truncate({

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1099,6 +1099,110 @@ describe('ScopeValidator', () => {
             expectTypeToBe(data.fieldMismatches[0].expectedType, IntegerType);
             expectTypeToBe(data.fieldMismatches[0].actualType, StringType);
         });
+
+
+        describe('array compatibility', () => {
+            it('accepts dynamic when assigning to a roArray', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as roArray)
+                    end sub
+
+                    sub doStuff(someArray)
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+            it('accepts roArray when assigning to a roArray', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as roArray)
+                    end sub
+
+                    sub doStuff(someArray as roArray)
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+            it('accepts typed arrays when assigning to a roArray', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as roArray)
+                    end sub
+
+                    sub doStuff(someArray as dynamic[])
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+
+            it('accepts roArray when assigning to dynamic[]', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as dynamic[])
+                    end sub
+
+                    sub doStuff(someArray as roArray)
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+            it('accepts roArray when assigning to typed array', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as string[])
+                    end sub
+
+                    sub doStuff(someArray as roArray)
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+            it('validates when typed array types are incompatible', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as string[])
+                    end sub
+
+                    sub doStuff(someArray as integer[])
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have errors
+                expectDiagnostics(program, [
+                    DiagnosticMessages.argumentTypeMismatch('Array<integer>', 'Array<string>').message
+                ]);
+            });
+
+            it('accepts when typed array types are compatible', () => {
+                program.setFile('source/util.bs', `
+                    sub takesArray(arr as float[])
+                    end sub
+
+                    sub doStuff(someArray as integer[])
+                        takesArray(someArray)
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+        });
     });
 
     describe('cannotFindName', () => {

--- a/src/types/ArrayType.spec.ts
+++ b/src/types/ArrayType.spec.ts
@@ -24,7 +24,7 @@ describe('ArrayType', () => {
         expect(new ArrayType().isEqual(new BooleanType())).to.be.false;
     });
 
-    describe('isTypeCompatible', () => {
+    it('isTypeCompatible', () => {
         expect(new ArrayType().isTypeCompatible(new BooleanType())).to.be.false;
         expect(new ArrayType().isTypeCompatible(new ArrayType())).to.be.true;
     });

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,5 @@
-import type { TypeCompatibilityData } from '..';
-import { isArrayType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
+import { SymbolTypeFlag, type TypeCompatibilityData } from '..';
+import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import type { BuiltInInterfaceOverride } from './BuiltInInterfaceAdder';
@@ -7,7 +7,7 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
 import { unionTypeFactory } from './UnionType';
-import { getUniqueType, isUnionTypeCompatible } from './helpers';
+import { getUniqueType, isNativeInterfaceCompatible, isUnionTypeCompatible } from './helpers';
 
 export class ArrayType extends BscType {
     constructor(...innerTypes: BscType[]) {
@@ -36,10 +36,10 @@ export class ArrayType extends BscType {
             return true;
         } else if (isUnionTypeCompatible(this, targetType)) {
             return true;
-        } else if (isInterfaceType(targetType) && targetType.name.toLowerCase() === 'roarray') {
-            return true;
         } else if (isArrayType(targetType)) {
             return this.defaultType.isTypeCompatible(targetType.defaultType, data);
+        } else if (this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data)) {
+            return true;
         }
         return false;
     }

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,5 @@
 import type { TypeCompatibilityData } from '..';
-import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isArrayType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import type { BuiltInInterfaceOverride } from './BuiltInInterfaceAdder';
@@ -35,6 +35,8 @@ export class ArrayType extends BscType {
         } else if (isObjectType(targetType)) {
             return true;
         } else if (isUnionTypeCompatible(this, targetType)) {
+            return true;
+        } else if (isInterfaceType(targetType) && targetType.name.toLowerCase() === 'roarray') {
             return true;
         } else if (isArrayType(targetType)) {
             return this.defaultType.isTypeCompatible(targetType.defaultType, data);

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,5 +1,7 @@
-import { SymbolTypeFlag, type TypeCompatibilityData } from '..';
+
+import { SymbolTypeFlag } from '../SymbolTable';
 import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import type { TypeCompatibilityData } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import type { BuiltInInterfaceOverride } from './BuiltInInterfaceAdder';
@@ -7,7 +9,7 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
 import { unionTypeFactory } from './UnionType';
-import { getUniqueType, isNativeInterfaceCompatible, isUnionTypeCompatible } from './helpers';
+import { getUniqueType, isUnionTypeCompatible } from './helpers';
 
 export class ArrayType extends BscType {
     constructor(...innerTypes: BscType[]) {

--- a/src/types/AssociativeArrayType.ts
+++ b/src/types/AssociativeArrayType.ts
@@ -1,5 +1,5 @@
 import { SymbolTypeFlag } from '../SymbolTable';
-import { isAssociativeArrayType, isClassType, isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
+import { isAssociativeArrayType, isClassType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
@@ -20,7 +20,7 @@ export class AssociativeArrayType extends BscType {
             return true;
         } else if (isAssociativeArrayType(targetType)) {
             return true;
-        } else if (isInterfaceType(targetType) && targetType.name.toLowerCase() === 'roassociativearray') {
+        } else if (this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data)) {
             return true;
         } else if (isClassType(targetType)) {
             return true;

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -1,7 +1,7 @@
 import { isBooleanType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isUnionTypeCompatible } from './helpers';
+import { isNativeInterfaceCompatible, isUnionTypeCompatible } from './helpers';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
@@ -21,7 +21,8 @@ export class BooleanType extends BscType {
             isBooleanType(targetType) ||
             isDynamicType(targetType) ||
             isObjectType(targetType) ||
-            isUnionTypeCompatible(this, targetType)
+            isUnionTypeCompatible(this, targetType) ||
+            isNativeInterfaceCompatible(this, targetType, 'roboolean', data)
         );
     }
 

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -71,11 +71,12 @@ export abstract class BscType {
         throw new Error('Method not implemented.');
     }
 
-
     checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}) {
         let isSuperSet = true;
         data.missingFields ||= [];
         data.fieldMismatches ||= [];
+        this.addBuiltInInterfaces();
+        targetType.addBuiltInInterfaces();
 
         const mySymbols = this.getMemberTable()?.getAllSymbols(flags);
         for (const memberSymbol of mySymbols) {

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -1,7 +1,7 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isEnumTypeCompatible, isUnionTypeCompatible } from './helpers';
+import { isEnumTypeCompatible, isNativeInterfaceCompatibleNumber, isUnionTypeCompatible } from './helpers';
 
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
@@ -26,7 +26,8 @@ export class DoubleType extends BscType {
             isDoubleType(targetType) ||
             isLongIntegerType(targetType) ||
             isUnionTypeCompatible(this, targetType, data) ||
-            isEnumTypeCompatible(this, targetType, data)
+            isEnumTypeCompatible(this, targetType, data) ||
+            isNativeInterfaceCompatibleNumber(this, targetType, data)
         );
     }
     public toString() {

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -1,7 +1,7 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isEnumTypeCompatible, isUnionTypeCompatible } from './helpers';
+import { isEnumTypeCompatible, isNativeInterfaceCompatibleNumber, isUnionTypeCompatible } from './helpers';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
@@ -25,7 +25,8 @@ export class FloatType extends BscType {
             isDoubleType(targetType) ||
             isLongIntegerType(targetType) ||
             isUnionTypeCompatible(this, targetType, data) ||
-            isEnumTypeCompatible(this, targetType, data)
+            isEnumTypeCompatible(this, targetType, data) ||
+            isNativeInterfaceCompatibleNumber(this, targetType, data)
         );
 
     }

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -1,7 +1,7 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isEnumTypeCompatible, isUnionTypeCompatible } from './helpers';
+import { isEnumTypeCompatible, isNativeInterfaceCompatibleNumber, isUnionTypeCompatible } from './helpers';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
@@ -25,7 +25,8 @@ export class IntegerType extends BscType {
             isDoubleType(targetType) ||
             isLongIntegerType(targetType) ||
             isUnionTypeCompatible(this, targetType, data) ||
-            isEnumTypeCompatible(this, targetType, data)
+            isEnumTypeCompatible(this, targetType, data) ||
+            isNativeInterfaceCompatibleNumber(this, targetType, data)
         );
     }
 

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -8,8 +8,10 @@ import { ObjectType } from './ObjectType';
 import { StringType } from './StringType';
 import type { ReferenceType } from './ReferenceType';
 import { SymbolTypeFlag } from '../SymbolTable';
-import { ArrayType, BooleanType } from '..';
 import { AssociativeArrayType } from './AssociativeArrayType';
+import { ArrayType } from './ArrayType';
+import { BooleanType } from './BooleanType';
+import { typeCompatibilityMessage } from '../DiagnosticMessages';
 
 describe('InterfaceType', () => {
     describe('toJSString', () => {
@@ -44,7 +46,9 @@ describe('InterfaceType', () => {
         });
 
         it('roku component types are compatible with BscTypes', () => {
-            expectTypeCrossCompatible(new StringType(), new InterfaceType('roString'));
+            // TODO: Fix String type compatibility -  reason is because of overloaded members (Mid(), StartsWith(), etc)
+            // SEE: https://github.com/rokucommunity/brighterscript/issues/926
+            // expectTypeCrossCompatible(new StringType(), new InterfaceType('roString'));
             expectTypeCrossCompatible(new ArrayType(), new InterfaceType('roArray'));
             expectTypeCrossCompatible(new AssociativeArrayType(), new InterfaceType('roAssociativeArray'));
             expectTypeCrossCompatible(new BooleanType(), new InterfaceType('roBoolean'));
@@ -234,10 +238,12 @@ function expectNotCompatible(sourceMembers: Record<string, BscType>, targetMembe
 }
 
 function expectTypeCrossCompatible(source: BscType, target: BscType) {
-    if (!source.isTypeCompatible(target)) {
-        assert.fail(`expected type ${target.toString()} to be assignable to type ${(source).toString()}`);
+    let data = {};
+    if (!source.isTypeCompatible(target, data)) {
+        assert.fail(typeCompatibilityMessage(target.toString(), source.toString(), data));
     }
-    if (!target.isTypeCompatible(source)) {
-        assert.fail(`expected type ${source.toString()} to be assignable to type ${(target).toString()}`);
+    data = {};
+    if (!target.isTypeCompatible(source, data)) {
+        assert.fail(typeCompatibilityMessage(source.toString(), target.toString(), data));
     }
 }

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -8,6 +8,8 @@ import { ObjectType } from './ObjectType';
 import { StringType } from './StringType';
 import type { ReferenceType } from './ReferenceType';
 import { SymbolTypeFlag } from '../SymbolTable';
+import { ArrayType, BooleanType } from '..';
+import { AssociativeArrayType } from './AssociativeArrayType';
 
 describe('InterfaceType', () => {
     describe('toJSString', () => {
@@ -40,6 +42,16 @@ describe('InterfaceType', () => {
                 name: new StringType()
             });
         });
+
+        it('roku component types are compatible with BscTypes', () => {
+            expectTypeCrossCompatible(new StringType(), new InterfaceType('roString'));
+            expectTypeCrossCompatible(new ArrayType(), new InterfaceType('roArray'));
+            expectTypeCrossCompatible(new AssociativeArrayType(), new InterfaceType('roAssociativeArray'));
+            expectTypeCrossCompatible(new BooleanType(), new InterfaceType('roBoolean'));
+            expectTypeCrossCompatible(new IntegerType(), new InterfaceType('roInt'));
+        });
+
+
     });
 
     describe('equals', () => {
@@ -218,5 +230,14 @@ function expectNotCompatible(sourceMembers: Record<string, BscType>, targetMembe
     const sourceIface = iface(sourceMembers);
     if (sourceIface.isTypeCompatible(targetIface)) {
         assert.fail(`expected type ${(targetIface as any).toJSString()} to not be assignable to type ${(sourceIface as any).toJSString()}`);
+    }
+}
+
+function expectTypeCrossCompatible(source: BscType, target: BscType) {
+    if (!source.isTypeCompatible(target)) {
+        assert.fail(`expected type ${target.toString()} to be assignable to type ${(source).toString()}`);
+    }
+    if (!target.isTypeCompatible(source)) {
+        assert.fail(`expected type ${source.toString()} to be assignable to type ${(target).toString()}`);
     }
 }

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,8 +1,9 @@
 import type { TypeCompatibilityData } from '..';
 import { SymbolTypeFlag } from '../SymbolTable';
-import { isDynamicType, isInterfaceType, isUnionType, isInheritableType, isObjectType, isAssociativeArrayType } from '../astUtils/reflection';
+import { isDynamicType, isInterfaceType, isUnionType, isInheritableType, isObjectType, isAssociativeArrayType, isArrayType, isStringType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
+import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import { InheritableType } from './InheritableType';
 import { isUnionTypeCompatible } from './helpers';
 
@@ -20,10 +21,9 @@ export class InterfaceType extends InheritableType {
         if (isDynamicType(targetType) || isObjectType(targetType) || isUnionTypeCompatible(this, targetType, data)) {
             return true;
         }
-        if (isAssociativeArrayType(targetType) && this.name.toLowerCase() === 'roassociativearray') {
+        if (BuiltInInterfaceAdder.getMatchingRokuComponentName(targetType)?.toLowerCase() === this.name?.toLowerCase()) {
             return true;
         }
-        //TODO: We need to make sure that things don't get assigned to built-in types
         if (this.isEqual(targetType)) {
             return true;
         }

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,9 +1,8 @@
-import type { TypeCompatibilityData } from '..';
+import type { TypeCompatibilityData } from '../interfaces';
 import { SymbolTypeFlag } from '../SymbolTable';
-import { isDynamicType, isInterfaceType, isUnionType, isInheritableType, isObjectType, isAssociativeArrayType, isArrayType, isStringType } from '../astUtils/reflection';
+import { isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import { InheritableType } from './InheritableType';
 import { isUnionTypeCompatible } from './helpers';
 
@@ -21,9 +20,6 @@ export class InterfaceType extends InheritableType {
         if (isDynamicType(targetType) || isObjectType(targetType) || isUnionTypeCompatible(this, targetType, data)) {
             return true;
         }
-        if (BuiltInInterfaceAdder.getMatchingRokuComponentName(targetType)?.toLowerCase() === this.name?.toLowerCase()) {
-            return true;
-        }
         if (this.isEqual(targetType)) {
             return true;
         }
@@ -31,10 +27,7 @@ export class InterfaceType extends InheritableType {
         if (ancestorTypes?.find(ancestorType => ancestorType.isEqual(targetType))) {
             return true;
         }
-        if (isInheritableType(targetType) || isUnionType(targetType) || isAssociativeArrayType(targetType)) {
-            return this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data);
-        }
-        return false;
+        return this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data);
     }
 
     /**

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -1,7 +1,7 @@
 import { isDoubleType, isDynamicType, isFloatType, isIntegerType, isLongIntegerType, isObjectType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isEnumTypeCompatible, isUnionTypeCompatible } from './helpers';
+import { isEnumTypeCompatible, isNativeInterfaceCompatibleNumber, isUnionTypeCompatible } from './helpers';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
@@ -25,7 +25,8 @@ export class LongIntegerType extends BscType {
             isDoubleType(targetType) ||
             isLongIntegerType(targetType) ||
             isUnionTypeCompatible(this, targetType, data) ||
-            isEnumTypeCompatible(this, targetType, data)
+            isEnumTypeCompatible(this, targetType, data) ||
+            isNativeInterfaceCompatibleNumber(this, targetType, data)
         );
     }
 

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -1,7 +1,7 @@
-import { isDynamicType, isEnumMemberType, isEnumType, isObjectType, isStringType } from '../astUtils/reflection';
+import { isDynamicType, isObjectType, isStringType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
-import { isEnumTypeCompatible, isUnionTypeCompatible } from './helpers';
+import { isEnumTypeCompatible, isNativeInterfaceCompatible, isUnionTypeCompatible } from './helpers';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
@@ -25,7 +25,8 @@ export class StringType extends BscType {
             isDynamicType(targetType) ||
             isObjectType(targetType) ||
             isUnionTypeCompatible(this, targetType, data) ||
-            isEnumTypeCompatible(this, targetType, data)
+            isEnumTypeCompatible(this, targetType, data) ||
+            isNativeInterfaceCompatible(this, targetType, 'rostring', data)
         );
     }
 

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,5 @@
 import type { TypeCompatibilityData } from '../interfaces';
-import { isAnyReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isUnionType } from '../astUtils/reflection';
+import { isAnyReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isInterfaceType, isUnionType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 
 export function findTypeIntersection(typesArr1: BscType[], typesArr2: BscType[]) {
@@ -152,6 +152,26 @@ export function isUnionTypeCompatible(thisType: BscType, maybeUnionType: BscType
 export function isEnumTypeCompatible(thisType: BscType, maybeEnumType: BscType, data?: TypeCompatibilityData): boolean {
     if (isEnumMemberType(maybeEnumType) || isEnumType(maybeEnumType)) {
         return thisType.isTypeCompatible(maybeEnumType.underlyingType, data);
+    }
+    return false;
+}
+
+export function isNativeInterfaceCompatible(thisType: BscType, otherType: BscType, allowedType: string, data?: TypeCompatibilityData): boolean {
+    if (isInterfaceType(otherType)) {
+        const lowerOtherName = otherType.name.toLowerCase();
+        return allowedType === lowerOtherName;
+    }
+    return false;
+}
+
+export function isNativeInterfaceCompatibleNumber(thisType: BscType, otherType: BscType, data?: TypeCompatibilityData): boolean {
+    if (isInterfaceType(otherType)) {
+        const lowerOtherName = otherType.name.toLowerCase();
+
+        return lowerOtherName === 'roint' ||
+            lowerOtherName === 'rofloat' ||
+            lowerOtherName === 'rodouble' ||
+            lowerOtherName === 'rolonginteger';
     }
     return false;
 }

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -158,6 +158,7 @@ export function isEnumTypeCompatible(thisType: BscType, maybeEnumType: BscType, 
 
 export function isNativeInterfaceCompatible(thisType: BscType, otherType: BscType, allowedType: string, data?: TypeCompatibilityData): boolean {
     if (isInterfaceType(otherType)) {
+        // TODO: it is not great to do type checking based on interface name
         const lowerOtherName = otherType.name.toLowerCase();
         return allowedType === lowerOtherName;
     }
@@ -166,8 +167,8 @@ export function isNativeInterfaceCompatible(thisType: BscType, otherType: BscTyp
 
 export function isNativeInterfaceCompatibleNumber(thisType: BscType, otherType: BscType, data?: TypeCompatibilityData): boolean {
     if (isInterfaceType(otherType)) {
+        // TODO: it is not great to do type checking based on interface name
         const lowerOtherName = otherType.name.toLowerCase();
-
         return lowerOtherName === 'roint' ||
             lowerOtherName === 'rofloat' ||
             lowerOtherName === 'rodouble' ||


### PR DESCRIPTION
Also fixes type compatibility for `string` -> `roString`, etc.

`roArray` is basically the same as `dynamic[]`

