### PR TITLE
Fixes operator order for `not` keyword

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2373,7 +2373,9 @@ export class Parser {
         if (nextKind === TokenKind.Not || nextKind === TokenKind.Minus) {
             this.current++; //advance
             let operator = this.previous();
-            let right = this.prefixUnary();
+            let right = nextKind === TokenKind.Not
+                ? this.boolean()
+                : this.prefixUnary();
             return new UnaryExpression(operator, right);
         }
         return this.call();


### PR DESCRIPTION
Before:

`not myString = ""` -> `BinaryExpression<=>(UnaryExpression<not>(myString), "")` 

Now:

`not myString = ""` -> `UnaryExpression<not>(BinaryExpression<=>(myString, ""))` 


Fixes #898 

