### PR TITLE
Fix class fields using constructors not transpiling correctly

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -855,6 +855,44 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
             `, 'trim', 'source/main.bs');
         });
+
+
+        it('adds namespacing to constructors on field definitions', async () => {
+            await testTranspile(`
+                namespace MyNS
+                    class KlassOne
+                        other = new KlassTwo()
+                    end class
+
+                    class KlassTwo
+                    end class
+                end namespace
+            `, `
+                function __MyNS_KlassOne_builder()
+                    instance = {}
+                    instance.new = sub()
+                        m.other = MyNS_KlassTwo()
+                    end sub
+                    return instance
+                end function
+                function MyNS_KlassOne()
+                    instance = __MyNS_KlassOne_builder()
+                    instance.new()
+                    return instance
+                end function
+                function __MyNS_KlassTwo_builder()
+                    instance = {}
+                    instance.new = sub()
+                    end sub
+                    return instance
+                end function
+                function MyNS_KlassTwo()
+                    instance = __MyNS_KlassTwo_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, 'trim', 'source/main.bs');
+        });
     });
 
     it('detects using `new` keyword on non-classes', () => {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2305,20 +2305,17 @@ export class MethodStatement extends FunctionStatement {
         for (let field of state.classStatement.fields) {
             let thisQualifiedName = { ...field.name };
             thisQualifiedName.text = 'm.' + field.name.text;
-            if (field.initialValue) {
-                newStatements.push(
-                    new AssignmentStatement(field.equal, thisQualifiedName, field.initialValue)
+            const fieldAssignment = field.initialValue
+                ? new AssignmentStatement(field.equal, thisQualifiedName, field.initialValue)
+                : new AssignmentStatement(
+                    createToken(TokenKind.Equal, '=', field.name.range),
+                    thisQualifiedName,
+                    //if there is no initial value, set the initial value to `invalid`
+                    createInvalidLiteral('invalid', field.name.range)
                 );
-            } else {
-                //if there is no initial value, set the initial value to `invalid`
-                newStatements.push(
-                    new AssignmentStatement(
-                        createToken(TokenKind.Equal, '=', field.name.range),
-                        thisQualifiedName,
-                        createInvalidLiteral('invalid', field.name.range)
-                    )
-                );
-            }
+            // Add parent so namespace lookups work
+            fieldAssignment.parent = state.classStatement;
+            newStatements.push(fieldAssignment);
         }
         state.editor.arraySplice(this.func.body.statements, startingIndex, 0, ...newStatements);
     }


### PR DESCRIPTION
if there was a class field that used a constructor, the constructor was not namespaced correctly in the transpilation. This fixes that issue.

