### PR TITLE
Add manifest loading from files

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -2967,7 +2967,7 @@ describe('Program', () => {
         });
     });
 
-    describe('getManifest', () => {
+    describe('manifest', () => {
         beforeEach(() => {
             fsExtra.emptyDirSync(tempDir);
             fsExtra.writeFileSync(`${tempDir}/manifest`, trim`
@@ -2989,7 +2989,28 @@ describe('Program', () => {
             program.dispose();
         });
 
-        it('loads the manifest', () => {
+        it('loads the manifest from project root', () => {
+            let manifest = program.getManifest();
+            testCommonManifestValues(manifest);
+            expect(manifest.get('bs_const')).to.equal('DEBUG=false');
+        });
+
+        it('loads the manifest from a FileObj', () => {
+            fsExtra.emptyDirSync(tempDir);
+            fsExtra.ensureDirSync(`${tempDir}/someDeepDir`);
+            fsExtra.writeFileSync(`${tempDir}/someDeepDir/manifest`, trim`
+                # Channel Details
+                title=sample manifest
+                major_version=2
+                minor_version=0
+                build_version=0
+                supports_input_launch=1
+                bs_const=DEBUG=false
+            `);
+            program.loadManifest({
+                src: `${tempDir}/someDeepDir/manifest`,
+                dest: 'manifest'
+            });
             let manifest = program.getManifest();
             testCommonManifestValues(manifest);
             expect(manifest.get('bs_const')).to.equal('DEBUG=false');

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1388,7 +1388,7 @@ export class Program {
             parsedManifest.set('bs_const', constString);
 
             this._manifest = parsedManifest;
-        } finally {
+        } catch (e) {
             if (!this._manifest) {
                 this._manifest = new Map();
             }

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1349,51 +1349,59 @@ export class Program {
         return files;
     }
 
+    private _manifest: Map<string, string>;
+
+    /**
+     * Try to find and load the manifest into memory
+     * @param staticFiles A list of all static files
+     */
+    public loadManifest(staticFiles?: FileObj[]) {
+        let manifestPath = path.join(this.options.rootDir, 'manifest'); // @todo
+
+        try {
+            // we only load this manifest once, so do it sync to improve speed downstream
+            const contents = fsExtra.readFileSync(manifestPath, 'utf-8');
+            const parsedManifest = parseManifest(contents);
+
+            // Lift the bs_consts defined in the manifest
+            let bsConsts = getBsConst(parsedManifest, false);
+
+            // Override or delete any bs_consts defined in the bs config
+            for (const key in this.options?.manifest?.bs_const) {
+                const value = this.options.manifest.bs_const[key];
+                if (value === null) {
+                    bsConsts.delete(key);
+                } else {
+                    bsConsts.set(key, value);
+                }
+            }
+
+            // convert the new list of bs consts back into a string for the rest of the down stream systems to use
+            let constString = '';
+            for (const [key, value] of bsConsts) {
+                constString += `${constString !== '' ? ';' : ''}${key}=${value.toString()}`;
+            }
+
+            // Set the updated bs_const value
+            parsedManifest.set('bs_const', constString);
+
+            this._manifest = parsedManifest;
+        } finally {
+            if (!this._manifest) {
+                this._manifest = new Map();
+            }
+        }
+    }
+
     /**
      * Get a map of the manifest information
      */
     public getManifest() {
         if (!this._manifest) {
-            //load the manifest file.
-            //TODO update this to get the manifest from the files array or require it in the options...we shouldn't assume the location of the manifest
-            let manifestPath = path.join(this.options.rootDir, 'manifest');
-
-            let contents: string;
-            try {
-                //we only load this manifest once, so do it sync to improve speed downstream
-                contents = fsExtra.readFileSync(manifestPath, 'utf-8');
-                let parsedManifest = parseManifest(contents);
-
-                // Lift the bs_consts defined in the manifest
-                let bsConsts = getBsConst(parsedManifest, false);
-
-                // Override or delete any bs_consts defined in the bs config
-                for (const key in this.options?.manifest?.bs_const) {
-                    const value = this.options.manifest.bs_const[key];
-                    if (value === null) {
-                        bsConsts.delete(key);
-                    } else {
-                        bsConsts.set(key, value);
-                    }
-                }
-
-                // convert the new list of bs consts back into a string for the rest of the down stream systems to use
-                let constString = '';
-                for (const [key, value] of bsConsts) {
-                    constString += `${constString !== '' ? ';' : ''}${key}=${value.toString()}`;
-                }
-
-                // Set the updated bs_const value
-                parsedManifest.set('bs_const', constString);
-
-                this._manifest = parsedManifest;
-            } catch (err) {
-                this._manifest = new Map();
-            }
+            this.loadManifest();
         }
         return this._manifest;
     }
-    private _manifest: Map<string, string>;
 
     public dispose() {
         this.plugins.emit('beforeProgramDispose', { program: this });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1353,10 +1353,12 @@ export class Program {
 
     /**
      * Try to find and load the manifest into memory
-     * @param staticFiles A list of all static files
+     * @param manifestFileObj A pointer to a potential manifest file object found during loading
      */
-    public loadManifest(staticFiles?: FileObj[]) {
-        let manifestPath = path.join(this.options.rootDir, 'manifest'); // @todo
+    public loadManifest(manifestFileObj?: FileObj) {
+        let manifestPath = manifestFileObj
+            ? manifestFileObj.src
+            : path.join(this.options.rootDir, 'manifest');
 
         try {
             // we only load this manifest once, so do it sync to improve speed downstream

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -60,6 +60,28 @@ describe('ProgramBuilder', () => {
             expect(stub.getCalls()).to.be.lengthOf(3);
         });
 
+        it('finds and loads a manifest before all other files', async () => {
+            sinon.stub(util, 'getFilePaths').returns(Promise.resolve([{
+                src: 'file1.brs',
+                dest: 'file1.brs'
+            }, {
+                src: 'file2.bs',
+                dest: 'file2.bs'
+            }, {
+                src: 'file3.xml',
+                dest: 'file4.xml'
+            }, {
+                src: 'manifest',
+                dest: 'manifest'
+            }]));
+
+            let stubLoadManifest = sinon.stub(builder.program, 'loadManifest');
+            let stubSetFile = sinon.stub(builder.program, 'setFile');
+            sinon.stub(builder, 'getFileContents').returns(Promise.resolve(''));
+            await builder['loadAllFilesAST']();
+            expect(stubLoadManifest.calledBefore(stubSetFile)).to.be.true;
+        });
+
         it('loads all type definitions first', async () => {
             const requestedFiles = [] as string[];
             builder['fileResolvers'].push((filePath) => {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -486,6 +486,8 @@ export class ProgramBuilder {
                 }
             }
 
+            this.program.loadManifest(staticFiles);
+
             const loadFile = async (fileObj) => {
                 try {
                     this.program.setFile(

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -466,59 +466,40 @@ export class ProgramBuilder {
      */
     private async loadAllFilesAST() {
         await this.logger.time(LogLevel.log, ['Parsing files'], async () => {
-            let errorCount = 0;
             let files = await this.logger.time(LogLevel.debug, ['getFilePaths'], async () => {
                 return util.getFilePaths(this.options);
             });
             this.logger.trace('ProgramBuilder.loadAllFilesAST() files:', files);
 
+            const acceptableExtensions = ['.bs', '.brs', '.xml'];
             const typedefFiles = [] as FileObj[];
-            const nonTypedefFiles = [] as FileObj[];
+            const staticFiles = [] as FileObj[];
+            const sourceFiles = [] as FileObj[];
             for (const file of files) {
                 const srcLower = file.src.toLowerCase();
                 if (srcLower.endsWith('.d.bs')) {
                     typedefFiles.push(file);
+                } else if (acceptableExtensions.includes(path.extname(file.src).toLowerCase())) {
+                    sourceFiles.push(file);
                 } else {
-                    nonTypedefFiles.push(file);
+                    staticFiles.push(file);
                 }
             }
 
-            //preload every type definition file first, which eliminates duplicate file loading
-            await Promise.all(
-                typedefFiles.map(async (fileObj) => {
-                    try {
-                        this.program.setFile(
-                            fileObj,
-                            await this.getFileContents(fileObj.src)
-                        );
-                    } catch (e) {
-                        //log the error, but don't fail this process because the file might be fixable later
-                        this.logger.log(e);
-                    }
-                })
-            );
-
-            const acceptableExtensions = ['.bs', '.brs', '.xml'];
-            //parse every file other than the type definitions
-            await Promise.all(
-                nonTypedefFiles.map(async (fileObj) => {
-                    try {
-                        let fileExtension = path.extname(fileObj.src).toLowerCase();
-
-                        //only process certain file types
-                        if (acceptableExtensions.includes(fileExtension)) {
-                            this.program.setFile(
-                                fileObj,
-                                await this.getFileContents(fileObj.src)
-                            );
-                        }
-                    } catch (e) {
-                        //log the error, but don't fail this process because the file might be fixable later
-                        this.logger.log(e);
-                    }
-                })
-            );
-            return errorCount;
+            const loadFile = async (fileObj) => {
+                try {
+                    this.program.setFile(
+                        fileObj,
+                        await this.getFileContents(fileObj.src)
+                    );
+                } catch (e) {
+                    // log the error, but don't fail this process because the file might be fixable later
+                    this.logger.log(e);
+                }
+            };
+            await Promise.all(typedefFiles.map(loadFile)); // first, preload every type definition file, which eliminates duplicate file loading
+            await Promise.all(staticFiles.map(loadFile)); // then, preload all static files
+            await Promise.all(sourceFiles.map(loadFile)); // finally, parse source files
         });
     }
 

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -471,22 +471,28 @@ export class ProgramBuilder {
             });
             this.logger.trace('ProgramBuilder.loadAllFilesAST() files:', files);
 
-            const acceptableExtensions = ['.bs', '.brs', '.xml'];
+            const acceptableSourceExtensions = ['.bs', '.brs', '.xml'];
             const typedefFiles = [] as FileObj[];
             const staticFiles = [] as FileObj[];
             const sourceFiles = [] as FileObj[];
+            let manifestFile: FileObj | null = null;
             for (const file of files) {
                 const srcLower = file.src.toLowerCase();
                 if (srcLower.endsWith('.d.bs')) {
                     typedefFiles.push(file);
-                } else if (acceptableExtensions.includes(path.extname(file.src).toLowerCase())) {
+                } else if (acceptableSourceExtensions.includes(path.extname(file.src).toLowerCase())) {
                     sourceFiles.push(file);
                 } else {
                     staticFiles.push(file);
+                    if (srcLower.endsWith('/manifest')) {
+                        manifestFile = file;
+                    }
                 }
             }
 
-            this.program.loadManifest(staticFiles);
+            if (manifestFile) {
+                this.program.loadManifest(manifestFile);
+            }
 
             const loadFile = async (fileObj) => {
                 try {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -483,7 +483,7 @@ export class ProgramBuilder {
                 } else if (acceptableSourceExtensions.includes(path.extname(srcLower))) {
                     sourceFiles.push(file);
                 } else {
-                    if (file.dest.toLowerCase() === 'manifest') { // todo: evaluate if this is acceptable.
+                    if (file.dest.toLowerCase() === 'manifest') {
                         manifestFile = file;
                     }
                 }


### PR DESCRIPTION
The program is currently set to load a manifest from the project's root. This isn't very flexible, and it causes some issues for projects which generate their manifests in a pre-compile step, i.e., `bs_const` values not getting read and causing code blocks to be removed erroneously.

This PR tweaks `ProgramBuilder.loadAllFilesAST`'s logic, to group/filter files and find a manifest in a first pass, then load the manifest into the program, and finally setting typedefs and code files. I've also adjusted the manifest loading to accept a file object, with some slight code refactoring in the mix.