### PR TITLE
Better go to definition support

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3021,6 +3021,7 @@ describe('BrsFile', () => {
                 range: util.createRange(5, 26, 5, 33)
             }]);
         });
+
         it('returns enum locations', () => {
             const file = program.setFile<BrsFile>('source/main.bs', `
                 sub main()
@@ -3037,6 +3038,78 @@ describe('BrsFile', () => {
             expect(program.getDefinition(file.srcPath, Position.create(2, 40))).to.eql([{
                 uri: URI.file(file.srcPath).toString(),
                 range: util.createRange(5, 25, 5, 31)
+            }]);
+        });
+
+        it('returns interface location', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub test(selectedMovie as Movie)
+                    print selectedMovie
+                end sub
+                interface Movie
+                    url as string
+                end interface
+            `);
+            program.validate();
+            // sub test(selectedMovie as Mo|vie)
+            expect(program.getDefinition(file.srcPath, Position.create(1, 44))).to.eql([{
+                uri: URI.file(file.srcPath).toString(),
+                range: util.createRange(4, 26, 4, 31)
+            }]);
+        });
+
+        it('returns namespaced interface location', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub test(selectedMovie as interfaces.Movie)
+                    print selectedMovie
+                end sub
+                namespace interfaces
+                    interface Movie
+                        url as string
+                    end interface
+                end namespace
+            `);
+            program.validate();
+            //sub test(selectedMovie as interfaces.Mo|vie)
+            expect(program.getDefinition(file.srcPath, Position.create(1, 55))).to.eql([{
+                uri: URI.file(file.srcPath).toString(),
+                range: util.createRange(5, 30, 5, 35)
+            }]);
+        });
+
+        it('returns class location', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub test(selectedMovie as Movie)
+                    print selectedMovie
+                end sub
+                class Movie
+                    url as string
+                end class
+            `);
+            program.validate();
+            //sub test(selectedMovie as Mo|vie)
+            expect(program.getDefinition(file.srcPath, Position.create(1, 44))).to.eql([{
+                uri: URI.file(file.srcPath).toString(),
+                range: util.createRange(4, 22, 4, 27)
+            }]);
+        });
+
+        it('returns namespaced class location', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub test(selectedMovie as classes.Movie)
+                    print selectedMovie
+                end sub
+                namespace classes
+                    class Movie
+                        url as string
+                    end class
+                end namespace
+            `);
+            program.validate();
+            //sub test(selectedMovie as classes.Mo|vie)
+            expect(program.getDefinition(file.srcPath, Position.create(1, 52))).to.eql([{
+                uri: URI.file(file.srcPath).toString(),
+                range: util.createRange(5, 26, 5, 31)
             }]);
         });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1080,7 +1080,8 @@ export class BrsFile implements File {
                 );
                 return results;
             }
-            if (isDottedGetExpression(expression)) {
+
+            if (isDottedGetExpression(expression) || isVariableExpression(expression)) {
 
                 const enumLink = scope.getEnumFileLink(fullName, containingNamespace);
                 if (enumLink) {
@@ -1098,6 +1099,28 @@ export class BrsFile implements File {
                         util.createLocation(
                             URI.file(enumMemberLink.file.srcPath).toString(),
                             enumMemberLink.item.tokens.name.range
+                        )
+                    );
+                    return results;
+                }
+
+                const interfaceFileLink = scope.getInterfaceFileLink(fullName, containingNamespace);
+                if (interfaceFileLink) {
+                    results.push(
+                        util.createLocation(
+                            URI.file(interfaceFileLink.file.srcPath).toString(),
+                            interfaceFileLink.item.tokens.name.range
+                        )
+                    );
+                    return results;
+                }
+
+                const classFileLink = scope.getClassFileLink(fullName, containingNamespace);
+                if (classFileLink) {
+                    results.push(
+                        util.createLocation(
+                            URI.file(classFileLink.file.srcPath).toString(),
+                            classFileLink.item.name.range
                         )
                     );
                     return results;


### PR DESCRIPTION
Add fixes for the "go to definition" logic so that it finds classes and interfaces. 

Here's it working in action!
![goto-definition](https://github.com/rokucommunity/brighterscript/assets/2544493/bb7b10c7-85c6-4a09-af30-2bc212ae642c)
