### PR TITLE
Fixes Transpilation bug - enums as class initial values

### DIFF
--- a/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
@@ -66,8 +66,11 @@ export class BrsFilePreTranspileProcessor {
             };
         }
         //assume we've been given the enum.member syntax, so pop the member and try again
-        const parts = name.split('.');
+        const parts = name.toLowerCase().split('.');
         const memberName = parts.pop();
+        if (containingNamespace) {
+            parts.unshift(containingNamespace.toLowerCase());
+        }
         result = scope?.getEnumMap().get(parts.join('.'));
         if (result) {
             const value = result.item.getMemberValue(memberName);


### PR DESCRIPTION
Previously, there was a transpilation bug when using enums directly (eg. with no namespace prefix) inside a namespace... I was seeing it especially in classes.

```
                namespace MyNS
                    class HasEnumKlass
                        enumValue = MyEnum.A
                    end class

                    enum MyEnum
                        A = "A"
                        B = "B"
                    end enum
                end namespace
```
was being transpiled to (notice the MyEnum.A):
```
            function __MyNS_HasEnumKlass_builder()
                    instance = {}
                    instance.new = sub()
                        m.enumValue = MyEnum.A
                    end sub
                    return instance
                end function
                function MyNS_HasEnumKlass()
                    instance = __MyNS_HasEnumKlass_builder()
                    instance.new()
                    return instance
                end function
```