### PR TITLE
Completion performance

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1157,6 +1157,63 @@ describe('LanguageServer', () => {
         ]);
         expectZeroDiagnostics(server.projects[0].builder.program);
     });
+
+    describe('onCompletion', () => {
+        let completionDocuments: TextDocument[] = [];
+
+        beforeEach(async () => {
+            server['connection'] = server['createConnection']();
+            await server['createProject'](workspacePath);
+            await server['createProject'](workspacePath + '/alpha');
+            await server['createProject'](workspacePath + '/beta');
+            for (const project of server.projects) {
+                const filePath = s`source/file.brs`;
+                const contents = `
+                    function pi()
+                        return 3.141592653589793
+                    end function
+
+                    function buildAwesome()
+                        return 42
+                    end function
+                `;
+                const file = project.builder.program.setFile(filePath, contents);
+                if (file) {
+                    let document = TextDocument.create(util.pathToUri(file.srcPath), 'brightscript', 1, contents);
+                    server['documents']['_documents'][document.uri] = document;
+                    completionDocuments.push(document);
+                }
+                project.builder.program.setFile(s`${rootDir}/source/main.bs`, `
+                    sub main()
+                        print   'completion here
+                    end sub
+                `);
+            }
+        });
+
+        it('should remove duplicate items across projects', async () => {
+            fsExtra.outputFileSync(s`${rootDir}/bsconfig.json`, '');
+            const subProjectConfig = {
+                files: [
+                    '**/*',
+                    { src: '../source/**/*', dest: 'source/common' }
+                ]
+            };
+
+            fsExtra.outputFileSync(s`${rootDir}/alpha/bsconfig.json`, JSON.stringify(subProjectConfig));
+            fsExtra.outputFileSync(s`${rootDir}/beta/bsconfig.json`, JSON.stringify(subProjectConfig));
+            server.run();
+            await server['syncProjects']();
+            const result = await server['onCompletion']({
+                textDocument: { uri: s`${rootDir}/source/main.bs` },
+                position: util.createPosition(2, 26)
+            });
+            expect(result.filter(compItem => compItem.label === 'buildAwesome')).to.length(1);
+            expect(result.filter(compItem => compItem.label === 'pi')).to.length(1);
+            expect(result.filter(compItem => compItem.label === 'LCase')).to.length(1);
+        });
+
+    });
 });
 
 export function getFileProtocolPath(fullPath: string) {

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1164,8 +1164,8 @@ describe('LanguageServer', () => {
         beforeEach(async () => {
             server['connection'] = server['createConnection']();
             await server['createProject'](workspacePath);
-            await server['createProject'](workspacePath + '/alpha');
-            await server['createProject'](workspacePath + '/beta');
+            await server['createProject'](s`${workspacePath}/alpha`);
+            await server['createProject'](s`${workspacePath}/beta`);
             for (const project of server.projects) {
                 const filePath = s`source/file.brs`;
                 const contents = `

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1205,7 +1205,7 @@ describe('LanguageServer', () => {
             server.run();
             await server['syncProjects']();
             const result = await server['onCompletion']({
-                textDocument: { uri: s`${rootDir}/source/main.bs` },
+                textDocument: { uri: util.pathToUri(s`${rootDir}/source/main.bs`) },
                 position: util.createPosition(2, 26)
             });
             expect(result.filter(compItem => compItem.label === 'buildAwesome')).to.length(1);

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -689,7 +689,6 @@ export class LanguageServer {
         //ensure programs are initialized
         await this.waitAllProjectFirstRuns();
 
-
         let filePath = util.uriToPath(params.textDocument.uri);
 
         //wait until the file has settled
@@ -703,11 +702,16 @@ export class LanguageServer {
             .getProjects()
             .flatMap(workspace => workspace.builder.program.getCompletions(filePath, params.position));
 
+        //only send one completion if name and type are the same
+        let completionsMap = new Map<string, CompletionItem>();
+
         for (let completion of completions) {
             completion.commitCharacters = ['.'];
+            let key = `${completion.sortText}-${completion.label}-${completion.kind}`;
+            completionsMap.set(key, completion);
         }
 
-        return completions;
+        return [...completionsMap.values()];
     }
 
     /**

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -896,15 +896,15 @@ export class Program {
                                     scopesDefiningSymbol.push(scope);
                                     //check for consistency across scopes
                                     if (!providedSymbolType) {
-                                        providedSymbolType = symbolInThisScope;
+                                        providedSymbolType = symbolInThisScope.type;
                                     } else {
                                         //get more general type
-                                        if (providedSymbolType.isEqual(symbolInThisScope)) {
+                                        if (providedSymbolType.isEqual(symbolInThisScope.type)) {
                                             //type in this scope is the same as one we're already checking
-                                        } else if (providedSymbolType.isTypeCompatible(symbolInThisScope)) {
+                                        } else if (providedSymbolType.isTypeCompatible(symbolInThisScope.type)) {
                                             //type in this scope is compatible with one we're storing. use most generic
-                                            providedSymbolType = symbolInThisScope;
-                                        } else if (symbolInThisScope.isTypeCompatible(providedSymbolType)) {
+                                            providedSymbolType = symbolInThisScope.type;
+                                        } else if (symbolInThisScope.type.isTypeCompatible(providedSymbolType)) {
                                             // type we're storing is more generic that the type in this scope
                                         } else {
                                             // type in this scope is not compatible with other types for this symbol

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -3399,7 +3399,7 @@ describe('Scope', () => {
             expect(file2.requiredSymbols.length).to.eq(0);
             expect(file2.providedSymbols.symbolMap.get(SymbolTypeFlag.typetime).size).to.eq(1);
             const file2TypeProvides = file2.providedSymbols.symbolMap.get(SymbolTypeFlag.typetime);
-            expectTypeToBe(file2TypeProvides.get('alpha.beta.charlie.someenum'), EnumType);
+            expectTypeToBe(file2TypeProvides.get('alpha.beta.charlie.someenum').type, EnumType);
         });
 
         it('classes that extend classes in other files show change properly', () => {

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1121,6 +1121,33 @@ describe('CompletionsProcessor', () => {
         });
     });
 
+    describe('import completions', () => {
+        it('should show import completions for a single scope', () => {
+            program.setFile('source/common.bs', `
+                import "
+            `);
+            program.setFile('source/common2.bs', `
+                sub SayHello()
+                end sub
+            `);
+            program.setFile('components/widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="widget.bs"/>
+                </component>
+            `);
+            program.setFile('components/widget.bs', `
+                import "pkg:/source/common.bs"
+            `);
+            program.validate();
+            // import "|
+            const completions = program.getCompletions('source/common.bs', util.createPosition(1, 25));
+            expect(completions).to.exist;
+            expect(completions.map(comp => comp.label)).to.include('common2.bs');
+            expect(completions.map(comp => comp.label)).to.include('../components/widget.bs');
+        });
+    });
+
     describe('const completions', () => {
         it('shows up in standard completions', () => {
             program.setFile('source/main.bs', `

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1361,7 +1361,66 @@ describe('CompletionsProcessor', () => {
             `);
             program.validate();
             //          dire|ction.down
-            expectCompletionsIncludes(program.getCompletions('source/main.bs', util.createPosition(3, 33)), [{
+            const completions = program.getCompletions('source/main.bs', util.createPosition(3, 33));
+            expectCompletionsIncludes(completions, [{
+                label: 'Direction',
+                kind: CompletionItemKind.Enum
+            }, {
+                label: 'Logic',
+                kind: CompletionItemKind.Enum
+            }]);
+        });
+
+        it('infers multilevel deep namespace for enum statement completions', () => {
+            program.setFile('source/main.bs', `
+                namespace enums
+                    namespace deep
+                        sub Main()
+                            direction.down
+                        end sub
+                        enum Direction
+                            up
+                            down
+                        end enum
+                    end namespace
+                end namespace
+                enum Logic
+                    yes
+                    no
+                end enum
+            `);
+            program.validate();
+            //          dire|ction.down
+            const completions = program.getCompletions('source/main.bs', util.createPosition(3, 33));
+            expectCompletionsIncludes(completions, [{
+                label: 'Direction',
+                kind: CompletionItemKind.Enum
+            }, {
+                label: 'Logic',
+                kind: CompletionItemKind.Enum
+            }]);
+        });
+
+        it('infers deep namespace for enum statement completions', () => {
+            program.setFile('source/main.bs', `
+                namespace enums.deep.deeper
+                    sub Main()
+                        direction.down
+                    end sub
+                    enum Direction
+                        up
+                        down
+                    end enum
+                end namespace
+                enum Logic
+                    yes
+                    no
+                end enum
+            `);
+            program.validate();
+            //          dire|ction.down
+            const completions = program.getCompletions('source/main.bs', util.createPosition(3, 33));
+            expectCompletionsIncludes(completions, [{
                 label: 'Direction',
                 kind: CompletionItemKind.Enum
             }, {

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -752,7 +752,7 @@ describe('CompletionsProcessor', () => {
                 });
                 program.validate();
                 //get the name of all global completions
-                const globalCompletions = program.globalScope.getAllFiles().flatMap(x => completionProcessor.getBrsFileCompletions(position, x as BrsFile, program.globalScope)).map(x => x.label);
+                const globalCompletions = program.globalScope.getAllFiles().flatMap(x => completionProcessor.getBrsFileCompletions(position, x as BrsFile)).map(x => x.label);
                 //filter out completions from global scope
                 completions = completions.filter(x => !globalCompletions.includes(x.label));
                 expect(completions).to.be.empty;

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -221,7 +221,6 @@ export class CompletionsProcessor {
             return symbolTableToUse;
         }
 
-        //const gotSymbolsFromFile = new Set<string>();
         let gotSymbolsFromThisFile = false;
         let gotSymbolsFromGlobal = false;
         const shouldLookInNamespace: NamespaceStatement = !(shouldLookForMembers || shouldLookForCallFuncMembers) && expression.findAncestor(isNamespaceStatement);

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3485,9 +3485,9 @@ describe('BrsFile', () => {
             program.plugins.emit('onFileValidate', validateFileEvent);
             const runtimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.runtime);
             expect(runtimeSymbols.size).to.eq(2);
-            const someFuncType = runtimeSymbols.get('somefunc');
+            const someFuncType = runtimeSymbols.get('somefunc').type;
             expectTypeToBe(someFuncType, TypedFunctionType);
-            const someFunc2Type = runtimeSymbols.get('somefunc2');
+            const someFunc2Type = runtimeSymbols.get('somefunc2').type;
             expectTypeToBe(someFunc2Type, TypedFunctionType);
         });
 
@@ -3504,7 +3504,7 @@ describe('BrsFile', () => {
             program.plugins.emit('onFileValidate', validateFileEvent);
             const runtimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.runtime);
             expect(runtimeSymbols.size).to.eq(1);
-            const someFuncType = runtimeSymbols.get('somefunc');
+            const someFuncType = runtimeSymbols.get('somefunc').type;
             expectTypeToBe(someFuncType, TypedFunctionType);
             const requiredSymbols = mainFile.requiredSymbols.map(x => x.typeChain[0].name);
             expect(requiredSymbols).to.have.same.members(['OtherFileType', 'OtherFileType']);
@@ -3537,14 +3537,14 @@ describe('BrsFile', () => {
             program.plugins.emit('onFileValidate', validateFileEvent);
             const runtimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.runtime);
             expect(runtimeSymbols.size).to.eq(3);
-            expectTypeToBe(runtimeSymbols.get('klass'), ClassType);
-            expectTypeToBe(runtimeSymbols.get('klass2'), ClassType);
-            expectTypeToBe(runtimeSymbols.get('klass3'), ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass').type, ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass2').type, ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass3').type, ClassType);
             const typetimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.typetime);
             expect(typetimeSymbols.size).to.eq(3);
-            expectTypeToBe(runtimeSymbols.get('klass'), ClassType);
-            expectTypeToBe(runtimeSymbols.get('klass2'), ClassType);
-            expectTypeToBe(runtimeSymbols.get('klass3'), ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass').type, ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass2').type, ClassType);
+            expectTypeToBe(runtimeSymbols.get('klass3').type, ClassType);
         });
 
         it('includes other types defined in the file', () => {
@@ -3569,12 +3569,12 @@ describe('BrsFile', () => {
             program.plugins.emit('onFileValidate', validateFileEvent);
             const runtimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.runtime);
             expect(runtimeSymbols.size).to.eq(2);
-            expectTypeToBe(runtimeSymbols.get('myenum'), EnumType);
-            expectTypeToBe(runtimeSymbols.get('mynamespace.myconst'), FloatType);
+            expectTypeToBe(runtimeSymbols.get('myenum').type, EnumType);
+            expectTypeToBe(runtimeSymbols.get('mynamespace.myconst').type, FloatType);
             const typetimeSymbols = mainFile.providedSymbols.symbolMap.get(SymbolTypeFlag.typetime);
             expect(typetimeSymbols.size).to.eq(2);
-            expectTypeToBe(typetimeSymbols.get('myinterface'), InterfaceType);
-            expectTypeToBe(runtimeSymbols.get('myenum'), EnumType);
+            expectTypeToBe(typetimeSymbols.get('myinterface').type, InterfaceType);
+            expectTypeToBe(runtimeSymbols.get('myenum').type, EnumType);
         });
 
         describe('changes', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -73,7 +73,6 @@ export class BrsFile implements File {
             if (options.pkgPath) {
                 this.pkgPath = options.pkgPath;
             } else {
-
                 //don't rename .d.bs files to .d.brs
                 if (this.extension === '.d.bs') {
                     this.pkgPath = this.destPath;

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -28,15 +28,15 @@ import { CommentFlagProcessor } from '../CommentFlagProcessor';
 import { URI } from 'vscode-uri';
 import type { Statement, AstNode } from '../parser/AstNode';
 import { type Expression } from '../parser/AstNode';
+import type { BscSymbol } from '../SymbolTable';
 import { SymbolTable, SymbolTypeFlag } from '../SymbolTable';
 import type { File } from './File';
 import { Editor } from '../astUtils/Editor';
 import type { UnresolvedSymbol } from '../AstValidationSegmenter';
 import { AstValidationSegmenter } from '../AstValidationSegmenter';
-import type { BscType } from '../types';
 
 
-export type ProvidedSymbolMap = Map<SymbolTypeFlag, Map<string, BscType>>;
+export type ProvidedSymbolMap = Map<SymbolTypeFlag, Map<string, BscSymbol>>;
 export type ChangedSymbolMap = Map<SymbolTypeFlag, Set<string>>;
 
 export interface ProvidedSymbolInfo {
@@ -1383,14 +1383,14 @@ export class BrsFile implements File {
             for (const setOfSymbols of allNeededSymbolSets) {
                 for (const symbol of setOfSymbols) {
 
-                    const fullSymbolkey = symbol.typeChain.map(tce => tce.name).join('.').toLowerCase();
-                    if (this.providedSymbols.symbolMap.get(symbol.flags)?.has(fullSymbolkey)) {
+                    const fullSymbolKey = symbol.typeChain.map(tce => tce.name).join('.').toLowerCase();
+                    if (this.providedSymbols.symbolMap.get(symbol.flags)?.has(fullSymbolKey)) {
                         // this catches namespaced things
                         continue;
                     }
-                    if (!addedSymbols.get(symbol.flags).has(fullSymbolkey)) {
+                    if (!addedSymbols.get(symbol.flags).has(fullSymbolKey)) {
                         requiredSymbols.push(symbol);
-                        addedSymbols.get(symbol.flags).add(fullSymbolkey);
+                        addedSymbols.get(symbol.flags).add(fullSymbolKey);
                     }
                 }
             }
@@ -1405,9 +1405,9 @@ export class BrsFile implements File {
     }
 
     private getProvidedSymbols() {
-        const symbolMap = new Map<SymbolTypeFlag, Map<string, BscType>>();
-        const runTimeSymbolMap = new Map<string, BscType>();
-        const typeTimeSymbolMap = new Map<string, BscType>();
+        const symbolMap = new Map<SymbolTypeFlag, Map<string, BscSymbol>>();
+        const runTimeSymbolMap = new Map<string, BscSymbol>();
+        const typeTimeSymbolMap = new Map<string, BscSymbol>();
 
         const tablesToGetSymbolsFrom: Array<{ table: SymbolTable; namePrefixLower?: string }> = [{
             table: this.parser.symbolTable
@@ -1426,15 +1426,19 @@ export class BrsFile implements File {
 
             for (const symbol of runTimeSymbols) {
                 if (!isAnyReferenceType(symbol.type)) {
-                    const symbolNameLower = symbolTable.namePrefixLower ? `${symbolTable.namePrefixLower}.${symbol.name.toLowerCase()}` : symbol.name.toLowerCase();
-                    runTimeSymbolMap.set(symbolNameLower, symbol.type);
+                    const symbolNameLower = symbolTable.namePrefixLower
+                        ? `${symbolTable.namePrefixLower}.${symbol.name.toLowerCase()}`
+                        : symbol.name.toLowerCase();
+                    runTimeSymbolMap.set(symbolNameLower, symbol);
                 }
             }
 
             for (const symbol of typeTimeSymbols) {
                 if (!isAnyReferenceType(symbol.type)) {
-                    const symbolNameLower = symbolTable.namePrefixLower ? `${symbolTable.namePrefixLower}.${symbol.name.toLowerCase()}` : symbol.name.toLowerCase();
-                    typeTimeSymbolMap.set(symbolNameLower, symbol.type);
+                    const symbolNameLower = symbolTable.namePrefixLower
+                        ? `${symbolTable.namePrefixLower}.${symbol.name.toLowerCase()}`
+                        : symbol.name.toLowerCase();
+                    typeTimeSymbolMap.set(symbolNameLower, symbol);
                 }
             }
         }
@@ -1461,8 +1465,9 @@ export class BrsFile implements File {
                 continue;
 
             }
-            for (const [symbolKey, symbolType] of newSymbolMapForFlag) {
-                const previousType = oldSymbolMapForFlag?.get(symbolKey);
+            for (const [symbolKey, symbol] of newSymbolMapForFlag) {
+                const symbolType = symbol.type;
+                const previousType = oldSymbolMapForFlag?.get(symbolKey)?.type;
                 previousSymbolsCheckedForFlag.add(symbolKey);
                 if (!previousType) {
                     changesForFlag.add(symbolKey);


### PR DESCRIPTION
Previously:
```
for each scope file is in
    on file text completion,
        for each scope the file is in
             get all symbols from entire symbol table
```        

Now:
```
on file text completion,
    get symbols local to the completion position
    for each scope the file was in
         get symbols available at scope level
         get symbols based on namespace inclusion
   get the symbols from global scope

remove duplicates of same completion across different projects
``` 
