### PR TITLE
Fixes test - missing `m` symbol

### DIFF
--- a/src/bscPlugin/fileProviders/ComponentStatementProvider.ts
+++ b/src/bscPlugin/fileProviders/ComponentStatementProvider.ts
@@ -116,6 +116,7 @@ export class ComponentStatementProvider {
                     createFunctionExpression(TokenKind.Sub)
                 );
                 file.ast.statements.unshift(initFunc);
+                initFunc.func.getSymbolTable().pushParentProvider(() => statement.getSymbolTable());
             }
             initFunc.func.body.statements.unshift(...initStatements);
         }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -172,12 +172,11 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         public returnTypeExpression?: TypeExpression
     ) {
         super();
-
+        this.symbolTable = new SymbolTable('FunctionExpression', () => this.parent?.getSymbolTable());
         //if there's a body, and it doesn't have a SymbolTable, assign one
         if (this.body && !this.body.symbolTable) {
-            this.body.symbolTable = new SymbolTable(`Function Body`);
+            this.body.symbolTable = new SymbolTable(`Function Body`, () => this.symbolTable);
         }
-        this.symbolTable = new SymbolTable('FunctionExpression', () => this.parent?.getSymbolTable());
     }
 
     public readonly kind = AstNodeKind.FunctionExpression;

--- a/src/parser/tests/statement/ComponentStatement.spec.ts
+++ b/src/parser/tests/statement/ComponentStatement.spec.ts
@@ -284,7 +284,7 @@ describe('ComponentStatement', () => {
         `);
     });
 
-    it.skip('adds private member to m and creates init function if missing', async () => {
+    it('adds private member to m and creates init function if missing', async () => {
         program.setFile('components/ZombieKeyboard.bs', `
             component ZombieKeyboard
                 private isEnabled = true


### PR DESCRIPTION
Created function expression symbol tables were not correctly parented.
