### PR TITLE
Use regex for faster manifest/typedef detection

### DIFF
--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -471,21 +471,22 @@ export class ProgramBuilder {
             });
             this.logger.trace('ProgramBuilder.loadAllFilesAST() files:', files);
 
-            const acceptableSourceExtensions = ['.bs', '.brs', '.xml'];
             const typedefFiles = [] as FileObj[];
             const sourceFiles = [] as FileObj[];
             let manifestFile: FileObj | null = null;
 
             for (const file of files) {
-                const srcLower = file.src.toLowerCase();
-                if (srcLower.endsWith('.d.bs')) {
-                    typedefFiles.push(file);
-                } else if (acceptableSourceExtensions.includes(path.extname(srcLower))) {
+                // source files (.brs, .bs, .xml)
+                if (/(?<!\.d)\.(bs|brs|xml)$/i.test(file.dest)) {
                     sourceFiles.push(file);
-                } else {
-                    if (file.dest.toLowerCase() === 'manifest') {
-                        manifestFile = file;
-                    }
+
+                    // typedef files (.d.bs)
+                } else if (/\.d\.bs$/i.test(file.dest)) {
+                    typedefFiles.push(file);
+
+                    // manifest file
+                } else if (/^manifest$/i.test(file.dest)) {
+                    manifestFile = file;
                 }
             }
 


### PR DESCRIPTION
Adds slightly faster performance to the logic updated in #942 when dealing with large file lists. This probably doesn't make much difference in practice, but hey, free cycles are free cycles!

The javascript engine will compile and cache regex expressions, so we can use them inline. We also avoid calling `.toLowerCase() because it's fairly expensive. 

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/84645bda-1f73-48da-8fb9-d8ab3eb1d358)

