### PR TITLE
Fix crash in type system when an incoming type is `undefined`

### DIFF
--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -73,6 +73,9 @@ export abstract class BscType {
     }
 
     checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}) {
+        if (!targetType) {
+            return false;
+        }
         let isSuperSet = true;
         data.missingFields ||= [];
         data.fieldMismatches ||= [];
@@ -113,7 +116,7 @@ export abstract class BscType {
                             return superSetSoFar;
                         }
 
-                        const myMemberAllowsTargetType = memberSymbol.type.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
+                        const myMemberAllowsTargetType = memberSymbol.type?.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
                         if (!myMemberAllowsTargetType) {
                             data.fieldMismatches.push({ name: memberSymbol.name, expectedType: memberSymbol.type, actualType: targetType.getMemberType(memberSymbol.name, { flags: flags }) });
                         }
@@ -133,4 +136,3 @@ export abstract class BscType {
         this.hasAddedBuiltInInterfaces = true;
     }
 }
-

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -45,6 +45,12 @@ describe('InterfaceType', () => {
             });
         });
 
+        it('does not crash when given non types', () => {
+            const iface = new InterfaceType('roArray');
+            expect(iface.isTypeCompatible(undefined)).to.be.false;
+            expect(iface.isTypeCompatible(null)).to.be.false;
+        });
+
         it('roku component types are compatible with BscTypes', () => {
             // TODO: Fix String type compatibility -  reason is because of overloaded members (Mid(), StartsWith(), etc)
             // SEE: https://github.com/rokucommunity/brighterscript/issues/926


### PR DESCRIPTION
Fix a few crashes in the type system when an incoming type is `undefined`