### PR TITLE
Fix transpile for non-namespaced enums in namespaced functions

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -181,7 +181,6 @@ export class Scope {
             let member = enumeration.item.findChild<EnumMemberStatement>((child) => isEnumMemberStatement(child) && child.name?.toLowerCase() === memberName);
             return member ? { item: member, file: enumeration.file } : undefined;
         }
-        return enumeration;
     }
 
     /**

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2574,6 +2574,13 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
         );
     }
 
+    /**
+     * Get the value of this enum. Requires that `.parent` is set
+     */
+    public getValue() {
+        return (this.parent as EnumStatement).getMemberValue(this.name);
+    }
+
     public transpile(state: BrsTranspileState): TranspileResult {
         return [];
     }

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -519,6 +519,24 @@ describe('EnumStatement', () => {
     });
 
     describe('transpile', () => {
+        it('supports non-namespaced enum from within a namespace', () => {
+            program.options.autoImportComponentScript = true;
+            testTranspile(`
+                namespace alpha
+                    sub test()
+                        print Direction.up
+                    end sub
+                end namespace
+                enum Direction
+                    up = "up"
+                end enum
+            `, `
+                sub alpha_test()
+                    print "up"
+                end sub
+            `);
+        });
+
         it('transpiles negative number', () => {
             testTranspile(`
                 sub main()


### PR DESCRIPTION
Fixes a critical transpile bug where non-namespaced enums used in namespaced function blocks would be left untranspiled!

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/5d47b4ad-5285-4548-9212-a0c5be5926ef)
