### PR TITLE
Adds Diagnostics for Member Accessibility 

### DIFF
--- a/src/AstValidationSegmenter.ts
+++ b/src/AstValidationSegmenter.ts
@@ -51,7 +51,7 @@ export class AstValidationSegmenter {
         }
         const flag = util.isInTypeExpression(expression) ? SymbolTypeFlag.typetime : SymbolTypeFlag.runtime;
         const typeChain: TypeChainEntry[] = [];
-        const options: GetTypeOptions = { flags: flag, onlyCacheResolvedTypes: true, typeChain: typeChain };
+        const options: GetTypeOptions = { flags: flag, onlyCacheResolvedTypes: true, typeChain: typeChain, data: {} };
 
         const nodeType = expression.getType(options);
         if (!nodeType?.isResolvable()) {
@@ -64,7 +64,7 @@ export class AstValidationSegmenter {
                     symbolsSet = this.unresolvedSegmentsSymbols.get(segment);
                 }
 
-                symbolsSet.add({ typeChain: typeChain, flags: typeChain[0].flags, endChainFlags: flag, containingNamespaces: this.currentNamespaceStatement?.getNameParts()?.map(t => t.text) });
+                symbolsSet.add({ typeChain: typeChain, flags: typeChain[0].data.flags, endChainFlags: flag, containingNamespaces: this.currentNamespaceStatement?.getNameParts()?.map(t => t.text) });
             }
             return true;
         }
@@ -152,7 +152,9 @@ export class AstValidationSegmenter {
 
             if (symbolsRequired) {
                 for (const requiredSymbol of symbolsRequired.values()) {
-                    const changeSymbolSetForFlag = changedSymbols.get(requiredSymbol.flags);
+                    // eslint-disable-next-line no-bitwise
+                    const runTimeOrTypeTimeSymbolFlag = requiredSymbol.flags & (SymbolTypeFlag.runtime | SymbolTypeFlag.typetime);
+                    const changeSymbolSetForFlag = changedSymbols.get(runTimeOrTypeTimeSymbolFlag);
                     if (util.setContainsUnresolvedSymbol(changeSymbolSetForFlag, requiredSymbol)) {
                         segmentsToWalkForValidation.push(segment);
                         break;

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -52,6 +52,7 @@ describe('BrsFileSemanticTokensProcessor', () => {
                 sub new()
                     m.alien = new Humanoids.Aliens.Alien()
                 end sub
+                public alien
             end class
 
             namespace Humanoids.Aliens

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -2307,6 +2307,22 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        it('should flag when trying to use an inaccessible member in the middle of a chain', () => {
+            program.setFile('source/main.bs', `
+                class SomeKlass
+                    protected name as string
+                end class
+
+                sub foo(x as SomeKlass)
+                    print x.name.len()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.memberAccessibilityMismatch('name', SymbolTypeFlag.protected, 'SomeKlass')
+            ]);
+        });
+
         describe('with namespaces', () => {
             it('protected members are accessible', () => {
                 program.setFile('source/main.bs', `

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -2307,6 +2307,33 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        describe('with namespaces', () => {
+            it('protected members are accessible', () => {
+                program.setFile('source/main.bs', `
+                    namespace AccessibilityTest
+                        class MyClass
+                            private data as roAssociativeArray = {}
+                            sub new()
+                                m.data.AddReplace("key", "value")
+                            end sub
+
+                            protected sub printData()
+                                print m.data
+                            end sub
+                        end class
+
+                        class SubClass extends MyClass
+                            sub foo()
+                                m.printData()
+                            end sub
+                        end class
+                    end namespace
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+        });
+
     });
 
     describe('revalidation', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -64,10 +64,14 @@ export class ScopeValidator {
                 let thisFileRequiresChangedSymbol = false;
                 for (let requiredSymbol of file.requiredSymbols) {
                     // eslint-disable-next-line no-bitwise
-                    const runTimeOrTypeTimeSymbolFlag = requiredSymbol.flags & (SymbolTypeFlag.runtime | SymbolTypeFlag.typetime);
-                    const changeSymbolSetForFlag = this.event.changedSymbols.get(runTimeOrTypeTimeSymbolFlag);
-                    if (util.setContainsUnresolvedSymbol(changeSymbolSetForFlag, requiredSymbol)) {
-                        thisFileRequiresChangedSymbol = true;
+                    for (const flag of [SymbolTypeFlag.runtime, SymbolTypeFlag.typetime]) {
+                        // eslint-disable-next-line no-bitwise
+                        if (flag & requiredSymbol.flags) {
+                            const changeSymbolSetForFlag = this.event.changedSymbols.get(flag);
+                            if (util.setContainsUnresolvedSymbol(changeSymbolSetForFlag, requiredSymbol)) {
+                                thisFileRequiresChangedSymbol = true;
+                            }
+                        }
                     }
                 }
                 const thisFileHasChanges = this.event.changedFiles.includes(file);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -640,7 +640,9 @@ export class ScopeValidator {
 
                     // eslint-disable-next-line no-bitwise
                     if (childChainItem.data.flags & SymbolTypeFlag.protected) {
-                        const ancestorClasses = this.event.scope.getClassHierarchy(containingClassStmt?.getName(ParseMode.BrightScript)).map(link => link.item);
+                        const containingClassName = containingClassStmt?.getName(ParseMode.BrighterScript);
+                        const containingNamespaceName = expression.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
+                        const ancestorClasses = this.event.scope.getClassHierarchy(containingClassName, containingNamespaceName).map(link => link.item);
                         const isSubClassOfDefiningClass = ancestorClasses.includes(classStmtThatDefinesChildMember);
 
                         if (!isSubClassOfDefiningClass) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -6,7 +6,7 @@ import type { BrsFile } from '../../files/BrsFile';
 import { DiagnosticOrigin } from '../../interfaces';
 import type { BsDiagnostic, BsDiagnosticWithOrigin, ExtraSymbolData, OnScopeValidateEvent, TypeChainEntry, TypeCompatibilityData } from '../../interfaces';
 import { SymbolTypeFlag } from '../../SymbolTable';
-import type { AssignmentStatement, DottedSetStatement, EnumStatement, NamespaceStatement, ReturnStatement } from '../../parser/Statement';
+import type { AssignmentStatement, ClassStatement, DottedSetStatement, EnumStatement, NamespaceStatement, ReturnStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
@@ -21,7 +21,6 @@ import type { File } from '../../files/File';
 import { InsideSegmentWalkMode } from '../../AstValidationSegmenter';
 import { TokenKind } from '../../lexer/TokenKind';
 import { ParseMode } from '../../parser/Parser';
-
 /**
  * The lower-case names of all platform-included scenegraph nodes
  */
@@ -64,7 +63,9 @@ export class ScopeValidator {
 
                 let thisFileRequiresChangedSymbol = false;
                 for (let requiredSymbol of file.requiredSymbols) {
-                    const changeSymbolSetForFlag = this.event.changedSymbols.get(requiredSymbol.flags);
+                    // eslint-disable-next-line no-bitwise
+                    const runTimeOrTypeTimeSymbolFlag = requiredSymbol.flags & (SymbolTypeFlag.runtime | SymbolTypeFlag.typetime);
+                    const changeSymbolSetForFlag = this.event.changedSymbols.get(runTimeOrTypeTimeSymbolFlag);
                     if (util.setContainsUnresolvedSymbol(changeSymbolSetForFlag, requiredSymbol)) {
                         thisFileRequiresChangedSymbol = true;
                     }
@@ -276,7 +277,7 @@ export class ScopeValidator {
      * Detect calls to functions with the incorrect number of parameters, or wrong types of arguments
      */
     private validateFunctionCall(file: BrsFile, expression: CallExpression) {
-        const getTypeOptions = { flags: SymbolTypeFlag.runtime };
+        const getTypeOptions = { flags: SymbolTypeFlag.runtime, data: {} };
         let funcType = expression?.callee?.getType(getTypeOptions);
         if (funcType?.isResolvable() && isClassType(funcType)) {
             // We're calling a class - get the constructor
@@ -370,13 +371,25 @@ export class ScopeValidator {
      * Detect return statements with incompatible types vs. declared return type
      */
     private validateDottedSetStatement(file: BrsFile, dottedSetStmt: DottedSetStatement) {
+        const typeChainExpectedLHS = [];
         const getTypeOpts = { flags: SymbolTypeFlag.runtime };
 
-        const expectedLHSType = dottedSetStmt?.obj?.getType(getTypeOpts)?.getMemberType(dottedSetStmt.name.text, getTypeOpts);
+        const expectedLHSType = dottedSetStmt?.getType({ ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
         const actualRHSType = dottedSetStmt?.value?.getType(getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
+        const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
+        if (!expectedLHSType?.isResolvable()) {
+            this.addMultiScopeDiagnostic({
+                file: file as File,
+                ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
+                range: typeChainScan.range
+            });
+            return;
+        }
 
-        if (expectedLHSType?.isResolvable() && !expectedLHSType?.isTypeCompatible(actualRHSType, compatibilityData)) {
+        const accessibilityIsOk = this.checkMemberAccessibility(file, dottedSetStmt, typeChainExpectedLHS);
+
+        if (accessibilityIsOk && !expectedLHSType?.isTypeCompatible(actualRHSType, compatibilityData)) {
             this.addMultiScopeDiagnostic({
                 ...DiagnosticMessages.assignmentTypeMismatch(actualRHSType.toString(), expectedLHSType.toString(), compatibilityData),
                 range: dottedSetStmt.range,
@@ -384,7 +397,6 @@ export class ScopeValidator {
             });
         }
     }
-
     /**
      * Detect invalid use of a binary operator
      */
@@ -557,6 +569,8 @@ export class ScopeValidator {
         const lastTypeInfo = typeChain[typeChain.length - 1];
         const parentTypeInfo = typeChain[typeChain.length - 2];
 
+        this.checkMemberAccessibility(file, expression, typeChain);
+
         if (isNamespaceType(exprType)) {
             this.addMultiScopeDiagnostic({
                 ...DiagnosticMessages.itemCannotBeUsedAsVariable('namespace'),
@@ -591,6 +605,59 @@ export class ScopeValidator {
                 });
             }
         }
+    }
+
+    /**
+     * Adds diagnostics for accibility mismatches
+     *
+     * @param file file
+     * @param expression containing expression
+     * @param typeChain type chain to check
+     * @returns true if member accesiibility is okay
+     */
+    private checkMemberAccessibility(file: File, expression: Expression, typeChain: TypeChainEntry[]) {
+        for (let i = 0; i < typeChain.length - 1; i++) {
+            const parentChainItem = typeChain[i];
+            const childChainItem = typeChain[i + 1];
+            if (isClassType(parentChainItem.type)) {
+                const containingClassStmt = expression.findAncestor<ClassStatement>(isClassStatement);
+                const classStmtThatDefinesChildMember = childChainItem.data?.definingNode?.findAncestor<ClassStatement>(isClassStatement);
+                if (classStmtThatDefinesChildMember) {
+                    const definingClassName = classStmtThatDefinesChildMember.getName(ParseMode.BrighterScript);
+                    const inMatchingClassStmt = containingClassStmt?.getName(ParseMode.BrighterScript).toLowerCase() === parentChainItem.type.name.toLowerCase();
+                    // eslint-disable-next-line no-bitwise
+                    if (childChainItem.data.flags & SymbolTypeFlag.private) {
+                        if (!inMatchingClassStmt || childChainItem.data.memberOfAncestor) {
+                            this.addMultiScopeDiagnostic({
+                                ...DiagnosticMessages.memberAccessibilityMismatch(childChainItem.name, childChainItem.data.flags, definingClassName),
+                                range: expression.range,
+                                file: file
+                            });
+                            // there's an error... don't worry about the rest of the chain
+                            return false;
+                        }
+                    }
+
+                    // eslint-disable-next-line no-bitwise
+                    if (childChainItem.data.flags & SymbolTypeFlag.protected) {
+                        const ancestorClasses = this.event.scope.getClassHierarchy(containingClassStmt?.getName(ParseMode.BrightScript)).map(link => link.item);
+                        const isSubClassOfDefiningClass = ancestorClasses.includes(classStmtThatDefinesChildMember);
+
+                        if (!isSubClassOfDefiningClass) {
+                            this.addMultiScopeDiagnostic({
+                                ...DiagnosticMessages.memberAccessibilityMismatch(childChainItem.name, childChainItem.data.flags, definingClassName),
+                                range: expression.range,
+                                file: file
+                            });
+                            // there's an error... don't worry about the rest of the chain
+                            return false;
+                        }
+                    }
+                }
+
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1408,17 +1408,19 @@ export class BrsFile implements File {
             for (const setOfSymbols of allNeededSymbolSets) {
                 for (const symbol of setOfSymbols) {
                     const fullSymbolKey = symbol.typeChain.map(tce => tce.name).join('.').toLowerCase();
-                    // eslint-disable-next-line no-bitwise
-                    const runTimeOrTypeTimeSymbolFlag = symbol.flags & (SymbolTypeFlag.runtime | SymbolTypeFlag.typetime);
-                    if (this.providedSymbols.symbolMap.get(runTimeOrTypeTimeSymbolFlag)?.has(fullSymbolKey)) {
-                        // this catches namespaced things
-                        continue;
+                    for (const flag of [SymbolTypeFlag.runtime, SymbolTypeFlag.typetime]) {
+                        // eslint-disable-next-line no-bitwise
+                        if (symbol.flags & flag) {
+                            if (this.providedSymbols.symbolMap.get(flag)?.has(fullSymbolKey)) {
+                                // this catches namespaced things
+                                continue;
+                            }
+                            if (!addedSymbols.get(flag)?.has(fullSymbolKey)) {
+                                requiredSymbols.push(symbol);
+                                addedSymbols.get(flag)?.add(fullSymbolKey);
+                            }
+                        }
                     }
-                    if (!addedSymbols.get(runTimeOrTypeTimeSymbolFlag)?.has(fullSymbolKey)) {
-                        requiredSymbols.push(symbol);
-                        addedSymbols.get(runTimeOrTypeTimeSymbolFlag).add(fullSymbolKey);
-                    }
-
                 }
             }
             return requiredSymbols;

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1407,16 +1407,18 @@ export class BrsFile implements File {
             addedSymbols.set(SymbolTypeFlag.typetime, new Set());
             for (const setOfSymbols of allNeededSymbolSets) {
                 for (const symbol of setOfSymbols) {
-
                     const fullSymbolKey = symbol.typeChain.map(tce => tce.name).join('.').toLowerCase();
-                    if (this.providedSymbols.symbolMap.get(symbol.flags)?.has(fullSymbolKey)) {
+                    // eslint-disable-next-line no-bitwise
+                    const runTimeOrTypeTimeSymbolFlag = symbol.flags & (SymbolTypeFlag.runtime | SymbolTypeFlag.typetime);
+                    if (this.providedSymbols.symbolMap.get(runTimeOrTypeTimeSymbolFlag)?.has(fullSymbolKey)) {
                         // this catches namespaced things
                         continue;
                     }
-                    if (!addedSymbols.get(symbol.flags).has(fullSymbolKey)) {
+                    if (!addedSymbols.get(runTimeOrTypeTimeSymbolFlag)?.has(fullSymbolKey)) {
                         requiredSymbols.push(symbol);
-                        addedSymbols.get(symbol.flags).add(fullSymbolKey);
+                        addedSymbols.get(runTimeOrTypeTimeSymbolFlag).add(fullSymbolKey);
                     }
+
                 }
             }
             return requiredSymbols;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -774,6 +774,7 @@ export interface ExtraSymbolData {
     description?: string;
     completionPriority?: number; // the higher the number, the lower the priority
     flags?: SymbolTypeFlag;
+    memberOfAncestor?: boolean; // this symbol comes from an ancestor symbol table
 }
 
 export interface GetTypeOptions {
@@ -786,7 +787,7 @@ export interface GetTypeOptions {
 }
 
 export class TypeChainEntry {
-    constructor(public name: string, public type: BscType, public flags: SymbolTypeFlag, public range: Range, public separatorToken: Token = createToken(TokenKind.Dot)) {
+    constructor(public name: string, public type: BscType, public data: ExtraSymbolData, public range: Range, public separatorToken: Token = createToken(TokenKind.Dot)) {
     }
     get isResolved() {
         return this.type?.isResolvable();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -787,7 +787,12 @@ export interface GetTypeOptions {
 }
 
 export class TypeChainEntry {
-    constructor(public name: string, public type: BscType, public data: ExtraSymbolData, public range: Range, public separatorToken: Token = createToken(TokenKind.Dot)) {
+    public data: ExtraSymbolData;
+    constructor(public name: string, public type: BscType, data: ExtraSymbolData, public range: Range, public separatorToken: Token = createToken(TokenKind.Dot)) {
+        if (data) {
+            // make a copy of this data
+            this.data = { ...data };
+        }
     }
     get isResolved() {
         return this.type?.isResolvable();

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -341,7 +341,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         if (funcName) {
             resultType.setName(funcName);
         }
-        options.typeChain?.push(new TypeChainEntry(funcName, resultType, options.flags, this.range));
+        options.typeChain?.push(new TypeChainEntry(funcName, resultType, options.data, this.range));
         return resultType;
     }
 }
@@ -363,7 +363,7 @@ export class FunctionParameterExpression extends Expression {
         const paramType = this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime, typeChain: undefined }) ??
             this.defaultValue?.getType({ ...options, flags: SymbolTypeFlag.runtime, typeChain: undefined }) ??
             DynamicType.instance;
-        options.typeChain?.push(new TypeChainEntry(this.name.text, paramType, options.flags, this.range));
+        options.typeChain?.push(new TypeChainEntry(this.name.text, paramType, options.data, this.range));
         return paramType;
     }
 
@@ -466,7 +466,7 @@ export class DottedGetExpression extends Expression {
     getType(options: GetTypeOptions) {
         const objType = this.obj?.getType(options);
         const result = objType?.getMemberType(this.name?.text, options);
-        options.typeChain?.push(new TypeChainEntry(this.name?.text, result, options.flags, this.name?.range ?? this.range));
+        options.typeChain?.push(new TypeChainEntry(this.name?.text, result, options.data, this.name?.range ?? this.range));
         if (result || options.flags & SymbolTypeFlag.typetime) {
             // All types should be known at typetime
             return result;
@@ -965,7 +965,7 @@ export class VariableExpression extends Expression {
             const symbolTable = this.getSymbolTable();
             resultType = symbolTable?.getSymbolType(nameKey, { ...options, fullName: nameKey, tableProvider: () => this.getSymbolTable() });
         }
-        options.typeChain?.push(new TypeChainEntry(nameKey, resultType, options.flags, this.range));
+        options.typeChain?.push(new TypeChainEntry(nameKey, resultType, options.data, this.range));
         return resultType;
     }
 }
@@ -1174,12 +1174,11 @@ export class CallfuncExpression extends Expression {
         let result: BscType = DynamicType.instance;
         // a little hacky here with checking options.ignoreCall because callFuncExpression has the method name
         // It's nicer for CallExpression, because it's a call on any expression.
-
         const calleeType = this.callee.getType({ ...options, flags: SymbolTypeFlag.runtime });
         if (isComponentType(calleeType) || isReferenceType(calleeType)) {
             const funcType = (calleeType as ComponentType).getCallFuncType?.(this.methodName.text, options);
             if (funcType) {
-                options.typeChain?.push(new TypeChainEntry(this.methodName.text, funcType, options.flags, this.methodName.range, createToken(TokenKind.Callfunc)));
+                options.typeChain?.push(new TypeChainEntry(this.methodName.text, funcType, options.data, this.methodName.range, createToken(TokenKind.Callfunc)));
                 if (options.ignoreCall) {
                     result = funcType;
                 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -27,7 +27,6 @@ import { InterfaceType } from '../types/InterfaceType';
 import type { BscType } from '../types/BscType';
 import { VoidType } from '../types/VoidType';
 import { TypedFunctionType } from '../types/TypedFunctionType';
-import type { BrsFile } from '../files/BrsFile';
 
 export class EmptyStatement extends Statement {
     constructor(
@@ -1935,7 +1934,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
      * Get all ancestor classes, in closest-to-furthest order (i.e. 0 is parent, 1 is grandparent, etc...).
      * This will return an empty array if no ancestors were found
      */
-    public getAncestors(state: { file: BrsFile }) {
+    public getAncestors(state: BrsTranspileState) {
         let ancestors = [] as ClassStatement[];
         let stmt = this as ClassStatement;
         while (stmt) {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -916,9 +916,9 @@ describe('util', () => {
     describe('processTypeChain', () => {
         it('should  find the correct details in a list of type resolutions', () => {
             const chain = [
-                new TypeChainEntry('AlphaNamespace', new NamespaceType('Alpha'), SymbolTypeFlag.runtime, util.createRange(1, 1, 2, 2)),
-                new TypeChainEntry('BetaProp', new ClassType('Beta'), SymbolTypeFlag.runtime, util.createRange(2, 2, 3, 3)),
-                new TypeChainEntry('CharlieProp', new ReferenceType('Charlie', 'Alpha.Beta.CharlieProp', SymbolTypeFlag.runtime, () => null), SymbolTypeFlag.runtime, util.createRange(3, 3, 4, 4))
+                new TypeChainEntry('AlphaNamespace', new NamespaceType('Alpha'), { flags: SymbolTypeFlag.runtime }, util.createRange(1, 1, 2, 2)),
+                new TypeChainEntry('BetaProp', new ClassType('Beta'), { flags: SymbolTypeFlag.runtime }, util.createRange(2, 2, 3, 3)),
+                new TypeChainEntry('CharlieProp', new ReferenceType('Charlie', 'Alpha.Beta.CharlieProp', SymbolTypeFlag.runtime, () => null), { flags: SymbolTypeFlag.runtime }, util.createRange(3, 3, 4, 4))
             ];
 
             const result = util.processTypeChain(chain);
@@ -931,8 +931,8 @@ describe('util', () => {
 
         it('respects the separatorToken', () => {
             const chain = [
-                new TypeChainEntry('roSGNodeCustom', new ComponentType('Custom'), SymbolTypeFlag.runtime, util.createRange(1, 1, 2, 2)),
-                new TypeChainEntry('someCallFunc', new TypedFunctionType(VoidType.instance), SymbolTypeFlag.runtime, util.createRange(2, 2, 3, 3), createToken(TokenKind.Callfunc))
+                new TypeChainEntry('roSGNodeCustom', new ComponentType('Custom'), { flags: SymbolTypeFlag.runtime }, util.createRange(1, 1, 2, 2)),
+                new TypeChainEntry('someCallFunc', new TypedFunctionType(VoidType.instance), { flags: SymbolTypeFlag.runtime }, util.createRange(2, 2, 3, 3), createToken(TokenKind.Callfunc))
             ];
 
             const result = util.processTypeChain(chain);


### PR DESCRIPTION
- Adds diagnostics for setting unknown fields of classes

![image](https://github.com/rokucommunity/brighterscript/assets/810290/957f8878-8f81-46e8-8343-f80bea0b1bf8)
![image](https://github.com/rokucommunity/brighterscript/assets/810290/79191afa-93e3-423e-b290-15a8b7d2fa11)


- Adds diagnostics for accessing `private` or `protected` class members when you shouldn't have access to them.

Private members are available in the class that defined them
Protected members are available in the class that defined them, and all sub classes.


https://github.com/rokucommunity/brighterscript/assets/810290/bcb37181-ea2f-4f7f-8892-47e4105ca37a

Solves #966 
Solves #967 
Solves #918 
