### PR TITLE
Fix cross namespace collision detection

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -115,6 +115,20 @@ describe('Scope', () => {
         expectZeroDiagnostics(program);
     });
 
+    it.only('does not flag unrelated namespace const and function collision', () => {
+        program.setFile('source/main.bs', `
+            namespace alpha
+                const options = {}
+            end namespace
+            namespace beta
+                sub options()
+                end sub
+            end namespace
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
     it('flags parameter with same name as namespace', () => {
         program.setFile('source/main.bs', `
             namespace NameA.NameB

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -115,7 +115,7 @@ describe('Scope', () => {
         expectZeroDiagnostics(program);
     });
 
-    it.only('does not flag unrelated namespace const and function collision', () => {
+    it('does not flag unrelated namespace const and function collision', () => {
         program.setFile('source/main.bs', `
             namespace alpha
                 const options = {}
@@ -127,6 +127,37 @@ describe('Scope', () => {
         `);
         program.validate();
         expectZeroDiagnostics(program);
+    });
+
+    it('does flag related namespace const and function collision', () => {
+        program.setFile('source/main.bs', `
+            namespace alpha
+                const options = {}
+            end namespace
+            namespace alpha
+                sub options()
+                end sub
+            end namespace
+        `);
+        program.validate();
+        expectDiagnostics(program, [
+            DiagnosticMessages.nameCollision('Const', 'Function', 'options').message
+        ]);
+    });
+
+    it('does flag namespaced const and un-namespaced function collision', () => {
+        program.setFile('source/main.bs', `
+            namespace alpha
+                const options = {}
+            end namespace
+
+            sub options()
+            end sub
+        `);
+        program.validate();
+        expectDiagnostics(program, [
+            DiagnosticMessages.nameCollision('Const', 'Function', 'options').message
+        ]);
     });
 
     it('flags parameter with same name as namespace', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -264,10 +264,13 @@ export class Scope {
                 links.push({ item: nsContainersWithStatement?.namespaceStatements?.[0], file: nsContainersWithStatement?.file as BrsFile });
             }
         }
-
+        const fullNameLower = (containingNamespace ? `${containingNamespace}.${name}` : name).toLowerCase();
         const callable = this.getCallableByName(name);
         if (callable) {
-            links.push({ item: callable.functionStatement, file: callable.file as BrsFile });
+            if (!callable.hasNamespace || callable.getName(ParseMode.BrighterScript).toLowerCase() === fullNameLower) {
+                // this callable has no namespace, or has same namespace
+                links.push({ item: callable.functionStatement, file: callable.file as BrsFile });
+            }
         }
         // remove empty links
         return links.filter(link => link);


### PR DESCRIPTION
Fixes a bug where a const and a function are not allowed to have the same name across different namespaces.