### PR TITLE
Adds missing Completion Items

### DIFF
--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1039,6 +1039,27 @@ describe('CompletionsProcessor', () => {
             expect(results[0]?.label).to.equal('something');
         });
 
+        it('includes function parameters at the end of the function', () => {
+            program.setFile('source/main.brs', `
+                sub main(myFuncParam as string)
+                    myValue = 234
+                    print
+                end sub
+            `);
+
+            program.validate();
+            // print |
+            let completions = program.getCompletions(`${rootDir}/source/main.brs`, Position.create(2, 28));
+            expectCompletionsIncludes(completions, [{
+                label: 'myFuncParam',
+                kind: CompletionItemKind.Variable
+            }, {
+                label: 'myValue',
+                kind: CompletionItemKind.Variable
+            }]);
+        });
+
+
     });
 
     describe('getCompletions - XmlFile.spec', () => {
@@ -1706,6 +1727,27 @@ describe('CompletionsProcessor', () => {
             }]);
         });
 
+        it('does not include global values (true, false, invalid)', () => {
+            program.setFile('source/main.bs', `
+                sub foo(thing as  )
+                    print thing
+                end sub
+            `);
+            program.validate();
+            //  sub foo(thing as | )
+            const completions = program.getCompletions('source/main.bs', util.createPosition(1, 34));
+            expectCompletionsExcludes(completions, [{
+                label: 'true',
+                kind: CompletionItemKind.Value
+            }, {
+                label: 'false',
+                kind: CompletionItemKind.Value
+            }, {
+                label: 'invalid',
+                kind: CompletionItemKind.Value
+            }]);
+        });
+
         it('finds custom types', () => {
             program.setFile('source/main.bs', `
                 sub foo(thing as  )
@@ -1893,6 +1935,42 @@ describe('CompletionsProcessor', () => {
             expectCompletionsExcludes(completions, [{
                 label: 'Alpha',
                 kind: CompletionItemKind.Module
+            }]);
+        });
+    });
+
+    describe('global values', () => {
+        it('should include true, false', () => {
+            program.setFile('source/main.bs', `
+                sub foo()
+                    fooValue =
+                end sub
+            `);
+            program.validate();
+            // fooValue =  |
+            const completions = program.getCompletions('source/main.bs', util.createPosition(2, 32));
+            expectCompletionsIncludes(completions, [{
+                label: 'true',
+                kind: CompletionItemKind.Value
+            }]);
+            expectCompletionsIncludes(completions, [{
+                label: 'false',
+                kind: CompletionItemKind.Value
+            }]);
+        });
+
+        it('should include invalid', () => {
+            program.setFile('source/main.bs', `
+                sub foo()
+                    fooValue =
+                end sub
+            `);
+            program.validate();
+            // fooValue =  |
+            const completions = program.getCompletions('source/main.bs', util.createPosition(2, 32));
+            expectCompletionsIncludes(completions, [{
+                label: 'invalid',
+                kind: CompletionItemKind.Value
             }]);
         });
     });

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,11 +1,11 @@
-import { isArrayType, isBody, isBrsFile, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isArrayType, isBody, isBrsFile, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { ExtraSymbolData, OnFileValidateEvent } from '../../interfaces';
 import { TokenKind } from '../../lexer/TokenKind';
 import type { AstNode, Expression, Statement } from '../../parser/AstNode';
-import type { LiteralExpression } from '../../parser/Expression';
+import type { FunctionExpression, LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
 import { SymbolTypeFlag } from '../../SymbolTable';
@@ -138,7 +138,7 @@ export class BrsFileValidator {
             },
             FunctionParameterExpression: (node) => {
                 const paramName = node.name?.text;
-                const symbolTable = node.getSymbolTable();
+                const symbolTable = node.findAncestor<FunctionExpression>(isFunctionExpression)?.body.getSymbolTable();
                 const nodeType = node.getType({ flags: SymbolTypeFlag.typetime });
                 symbolTable?.addSymbol(paramName, { definingNode: node }, nodeType, SymbolTypeFlag.runtime);
             },


### PR DESCRIPTION
- Adds `true` `false` and `invalid` when appropriate
- Ensures function parameters are included in completion results, even if you're at the end of the function block
- `private` and `protected` class members only are included in completion results when they are accessible


![image](https://github.com/rokucommunity/brighterscript/assets/810290/352c9685-43e6-4b99-94db-9cd28395c9cd)


solves #988

