### PR TITLE
Assign `.program` to the builder BEFORE emitting `afterProgramCreate` event

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -8,7 +8,7 @@ import { standardizePath as s, util } from './util';
 import { Logger, LogLevel } from './Logger';
 import * as diagnosticUtils from './diagnosticUtils';
 import type { BscFile, BsDiagnostic } from '.';
-import { Range } from '.';
+import { Deferred, Range } from '.';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { BrsFile } from './files/BrsFile';
 import { expectZeroDiagnostics } from './testHelpers.spec';
@@ -39,6 +39,21 @@ describe('ProgramBuilder', () => {
 
     afterEach(() => {
         builder.dispose();
+    });
+
+    it('includes .program in the afterProgramCreate event', async () => {
+        builder = new ProgramBuilder();
+        const deferred = new Deferred<Program>();
+        builder.plugins.add({
+            name: 'test',
+            afterProgramCreate: () => {
+                deferred.resolve(builder.program);
+            }
+        });
+        builder['createProgram']();
+        expect(
+            await deferred.promise
+        ).to.exist;
     });
 
     describe('loadAllFilesAST', () => {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -124,7 +124,7 @@ export class ProgramBuilder {
         }
         this.logger.logLevel = this.options.logLevel as LogLevel;
 
-        this.program = this.createProgram();
+        this.createProgram();
 
         //parse every file in the entire project
         await this.loadAllFilesAST();
@@ -139,10 +139,11 @@ export class ProgramBuilder {
     }
 
     protected createProgram() {
-        const program = new Program(this.options, this.logger, this.plugins);
+        this.program = new Program(this.options, this.logger, this.plugins);
 
-        this.plugins.emit('afterProgramCreate', program);
-        return program;
+        this.plugins.emit('afterProgramCreate', this.program);
+
+        return this.program;
     }
 
     protected loadPlugins() {


### PR DESCRIPTION
There's a small bug where the ProgramBuilder doesn't have a reference to .program when the afterProgramCreate. This solves that by assigning `.program` before emitting the event.