### PR TITLE
Renamed `File` interface to `BscFile`

### DIFF
--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -1,6 +1,6 @@
 import type { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { BsDiagnostic, CommentFlag, DiagnosticCode } from './interfaces';
 import { util } from './util';
 
@@ -9,7 +9,7 @@ export class CommentFlagProcessor {
         /**
          * The file this processor applies to
          */
-        public file: File,
+        public file: BscFile,
         /**
          * An array of strings containing the types of text that a comment starts with. (i.e. `REM`, `'`, `<!--`)
          */

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -2,7 +2,7 @@ import type { BsDiagnostic } from '.';
 import { DiagnosticCollection } from './DiagnosticCollection';
 import type { Project } from './LanguageServer';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import util from './util';
 import { expect } from './chai-config.spec';
 
@@ -109,7 +109,7 @@ describe('DiagnosticCollection', () => {
             newDiagnostics.push({
                 file: {
                     srcPath: srcPath
-                } as File,
+                } as BscFile,
                 range: util.createRange(0, 0, 0, 0),
                 //the code doesn't matter as long as the messages are different, so just enforce unique messages for this test files
                 code: 123,

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -18,7 +18,7 @@ import { createVisitor, WalkMode } from './astUtils/visitors';
 import { tempDir, rootDir } from './testHelpers.spec';
 import { URI } from 'vscode-uri';
 import { BusyStatusTracker } from './BusyStatusTracker';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 
 const sinon = createSandbox();
 
@@ -499,7 +499,7 @@ describe('LanguageServer', () => {
 
     describe('onSignatureHelp', () => {
         let callDocument: TextDocument;
-        let importingXmlFile: File;
+        let importingXmlFile: BscFile;
         const functionFileBaseName = 'buildAwesome';
         const funcDefinitionLine = 'function buildAwesome(confirm = true as Boolean)';
         beforeEach(async () => {

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -11,7 +11,7 @@ import { DiagnosticSeverity, Range } from 'vscode-languageserver';
 import { BrsFile } from './files/BrsFile';
 import { expectZeroDiagnostics } from './testHelpers.spec';
 import type { BsConfig } from './BsConfig';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { BsDiagnostic } from './interfaces';
 import { tempDir, rootDir, stagingDir } from './testHelpers.spec';
 
@@ -402,7 +402,7 @@ function createBsDiagnostic(filePath: string, messages: string[]): BsDiagnostic[
     return diagnostics;
 }
 function createDiagnostic(
-    file: File,
+    file: BscFile,
     code: number,
     message: string,
     startLine = 0,

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -14,7 +14,7 @@ import * as fsExtra from 'fs-extra';
 import * as requireRelative from 'require-relative';
 import { Throttler } from './Throttler';
 import { AssetFile } from './files/AssetFile';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { BrsFile } from './files/BrsFile';
 import { URI } from 'vscode-uri';
 
@@ -69,7 +69,7 @@ export class ProgramBuilder {
     private staticDiagnostics = [] as BsDiagnostic[];
 
     public addDiagnostic(srcPath: string, diagnostic: Partial<BsDiagnostic>) {
-        let file: File = this.program.getFile(srcPath);
+        let file: BscFile = this.program.getFile(srcPath);
         if (!file) {
             // eslint-disable-next-line @typescript-eslint/dot-notation
             const paths = this.program['getPaths'](srcPath, this.program.options.rootDir ?? this.options.rootDir);

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -19,7 +19,7 @@ import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
 import { isBrsFile, isXmlFile, isEnumMemberStatement, isNamespaceStatement, isNamespaceType, isReferenceType, isCallableType } from './astUtils/reflection';
 import { SymbolTable, SymbolTypeFlag } from './SymbolTable';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { BscType } from './types/BscType';
 import { NamespaceType } from './types/NamespaceType';
 import { referenceTypeFactory } from './types/ReferenceType';
@@ -476,14 +476,14 @@ export class Scope {
      * @param filePath can be a srcPath or destPath
      * @param normalizePath should this function repair and standardize the path? Passing false should have a performance boost if you can guarantee your path is already sanitized
      */
-    public getFile<TFile extends File>(filePath: string, normalizePath = true) {
+    public getFile<TFile extends BscFile>(filePath: string, normalizePath = true) {
         if (typeof filePath !== 'string') {
             return undefined;
         }
 
-        const key: keyof Pick<File, 'srcPath' | 'destPath'> = path.isAbsolute(filePath) ? 'srcPath' : 'destPath';
+        const key: keyof Pick<BscFile, 'srcPath' | 'destPath'> = path.isAbsolute(filePath) ? 'srcPath' : 'destPath';
         let map = this.cache.getOrAdd('fileMaps-srcPath', () => {
-            const result = new Map<string, File>();
+            const result = new Map<string, BscFile>();
             for (const file of this.getAllFiles()) {
                 result.set(file[key].toLowerCase(), file);
             }
@@ -507,9 +507,9 @@ export class Scope {
      * Get the list of files referenced by this scope that are actually loaded in the program.
      * Includes files from this scope and all ancestor scopes
      */
-    public getAllFiles(): File[] {
+    public getAllFiles(): BscFile[] {
         return this.cache.getOrAdd('getAllFiles', () => {
-            let result = [] as File[];
+            let result = [] as BscFile[];
             let dependencies = this.dependencyGraph.getAllDependencies(this.dependencyGraphKey);
             for (let dependency of dependencies) {
                 //load components by their name
@@ -607,7 +607,7 @@ export class Scope {
     /**
      * Call a function for each file directly included in this scope (excluding files found only in parent scopes).
      */
-    public enumerateOwnFiles(callback: (file: File) => void) {
+    public enumerateOwnFiles(callback: (file: BscFile) => void) {
         const files = this.getOwnFiles();
         for (const file of files) {
             //either XML components or files without a typedef
@@ -774,7 +774,7 @@ export class Scope {
         this.diagnostics = this.diagnostics.filter(diag => !(diag.origin === DiagnosticOrigin.ASTSegment && diag.astSegment === astSegment));
     }
 
-    clearAstSegmentDiagnosticsByFile(file: File) {
+    clearAstSegmentDiagnosticsByFile(file: BscFile) {
         const lowerSrcPath = file.srcPath.toLowerCase();
         this.diagnostics = this.diagnostics.filter(diag => !(diag.origin === DiagnosticOrigin.ASTSegment && diag.file.srcPath.toLowerCase() === lowerSrcPath));
     }
@@ -1298,7 +1298,7 @@ export class Scope {
     /**
      * Determine if this file is included in this scope (excluding parent scopes)
      */
-    public hasFile(file: File) {
+    public hasFile(file: BscFile) {
         let files = this.getOwnFiles();
         let hasFile = files.includes(file);
         return hasFile;
@@ -1307,7 +1307,7 @@ export class Scope {
     /**
      * Get the definition (where was this thing first defined) of the symbol under the position
      */
-    public getDefinition(file: File, position: Position): Location[] {
+    public getDefinition(file: BscFile, position: Position): Location[] {
         // Overridden in XMLScope. Brs files use implementation in BrsFile
         return [];
     }
@@ -1329,5 +1329,5 @@ export class Scope {
 }
 
 interface AugmentedNewExpression extends NewExpression {
-    file: File;
+    file: BscFile;
 }

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -7,7 +7,7 @@ import type { Program } from './Program';
 import util from './util';
 import { isXmlFile } from './astUtils/reflection';
 import { SGFieldTypes } from './parser/SGTypes';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { SGElement } from './parser/SGTypes';
 import { SymbolTypeFlag } from './SymbolTable';
 import type { BaseFunctionType } from './types/BaseFunctionType';
@@ -201,7 +201,7 @@ export class XmlScope extends Scope {
         return this.cache.getOrAdd('getOwnFiles', () => {
             let result = [
                 this.xmlFile
-            ] as File[];
+            ] as BscFile[];
             let scriptDestPaths = this.xmlFile.getOwnDependencies();
             for (let destPath of scriptDestPaths) {
                 let file = this.program.getFile(destPath, false);
@@ -216,7 +216,7 @@ export class XmlScope extends Scope {
     /**
      * Get the definition (where was this thing first defined) of the symbol under the position
      */
-    public getDefinition(file: File, position: Position): Location[] {
+    public getDefinition(file: BscFile, position: Position): Location[] {
         let results = [] as Location[];
         //if the position is within the file's parent component name
         if (

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -32,21 +32,21 @@ import type { InheritableType } from '../types/InheritableType';
 import { BscTypeKind } from '../types/BscTypeKind';
 import type { NamespaceType } from '../types/NamespaceType';
 import type { BaseFunctionType } from '../types/BaseFunctionType';
-import type { File } from '../files/File';
+import type { BscFile } from '../files/BscFile';
 import type { ComponentType } from '../types/ComponentType';
 import type { AssociativeArrayType } from '../types/AssociativeArrayType';
 import { TokenKind } from '../lexer/TokenKind';
 
 // File reflection
-export function isBrsFile(file: File | undefined): file is BrsFile {
+export function isBrsFile(file: BscFile | undefined): file is BrsFile {
     return file?.constructor.name === 'BrsFile';
 }
 
-export function isXmlFile(file: (File | XmlFile | undefined)): file is XmlFile {
+export function isXmlFile(file: (BscFile | XmlFile | undefined)): file is XmlFile {
     return file?.constructor.name === 'XmlFile';
 }
 
-export function isAssetFile(file: (File | AssetFile | undefined)): file is AssetFile {
+export function isAssetFile(file: (BscFile | AssetFile | undefined)): file is AssetFile {
     return file?.constructor.name === 'AssetFile';
 }
 

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -4,7 +4,7 @@ import type { Range } from 'vscode-languageserver';
 import { Program } from '../../Program';
 import { expectCodeActions, trim } from '../../testHelpers.spec';
 import { standardizePath as s, util } from '../../util';
-import type { File } from '../../files/File';
+import type { BscFile } from '../../files/BscFile';
 import { rootDir } from '../../testHelpers.spec';
 
 describe('CodeActionsProcessor', () => {
@@ -22,7 +22,7 @@ describe('CodeActionsProcessor', () => {
     /**
      * Helper function for testing code actions
      */
-    function testGetCodeActions(file: File | string, range: Range, expected: string[]) {
+    function testGetCodeActions(file: BscFile | string, range: Range, expected: string[]) {
         program.validate();
         expect(
             program.getCodeActions(

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -4,7 +4,7 @@ import { codeActionUtil } from '../../CodeActionUtil';
 import type { DiagnosticMessageType } from '../../DiagnosticMessages';
 import { DiagnosticCodeMap } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
-import type { File } from '../../files/File';
+import type { BscFile } from '../../files/BscFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { OnGetCodeActionsEvent } from '../../interfaces';
 import { ParseMode } from '../../parser/Parser';
@@ -34,7 +34,7 @@ export class CodeActionsProcessor {
     /**
      * Generic import suggestion function. Shouldn't be called directly from the main loop, but instead called by more specific diagnostic handlers
      */
-    private suggestImports(diagnostic: Diagnostic, key: string, files: File[]) {
+    private suggestImports(diagnostic: Diagnostic, key: string, files: BscFile[]) {
         //skip if we already have this suggestion
         if (this.suggestedImports.has(key)) {
             return;

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -1,6 +1,6 @@
 import { isBlock, isBrsFile, isCallableType, isClassStatement, isClassType, isComponentType, isConstStatement, isEnumMemberType, isEnumType, isFunctionExpression, isInterfaceType, isMethodStatement, isNamespaceStatement, isNamespaceType, isNativeType, isXmlFile, isXmlScope } from '../../astUtils/reflection';
 import type { FileReference, ProvideCompletionsEvent } from '../../interfaces';
-import type { File } from '../../files/File';
+import type { BscFile } from '../../files/BscFile';
 import { DeclarableTypes, Keywords, TokenKind } from '../../lexer/TokenKind';
 import type { XmlScope } from '../../XmlScope';
 import { util } from '../../util';
@@ -496,7 +496,7 @@ export class CompletionsProcessor {
 
     public getAllClassMemberCompletions(scope: Scope) {
         let results = new Map<string, CompletionItem>();
-        let filesSearched = new Set<File>();
+        let filesSearched = new Set<BscFile>();
         for (const file of scope.getAllFiles()) {
             if (isBrsFile(file) && !filesSearched.has(file)) {
                 for (let cs of file.parser.references.classStatements) {

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '../../chai-config.spec';
 import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-protocol';
 import type { BrsFile } from '../../files/BrsFile';
-import type { File } from '../../files/File';
+import type { BscFile } from '../../files/BscFile';
 import type { SemanticToken } from '../../interfaces';
 import { Program } from '../../Program';
 import { expectZeroDiagnostics } from '../../testHelpers.spec';
@@ -19,7 +19,7 @@ describe('BrsFileSemanticTokensProcessor', () => {
         program.dispose();
     });
 
-    function expectSemanticTokens(file: File, tokens: SemanticToken[], validateDiagnostics = true) {
+    function expectSemanticTokens(file: BscFile, tokens: SemanticToken[], validateDiagnostics = true) {
         program.validate();
         if (validateDiagnostics) {
             expectZeroDiagnostics(program);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -17,7 +17,7 @@ import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryEx
 import { CallExpression } from '../../parser/Expression';
 import { createVisitor } from '../../astUtils/visitors';
 import type { BscType } from '../../types';
-import type { File } from '../../files/File';
+import type { BscFile } from '../../files/BscFile';
 import { InsideSegmentWalkMode } from '../../AstValidationSegmenter';
 import { TokenKind } from '../../lexer/TokenKind';
 import { ParseMode } from '../../parser/Parser';
@@ -228,21 +228,21 @@ export class ScopeValidator {
             const unquotedComponentName = componentName?.text?.replace(/"/g, '');
             if (unquotedComponentName && !platformNodeNames.has(unquotedComponentName.toLowerCase()) && !this.event.program.getComponent(unquotedComponentName)) {
                 this.addDiagnosticOnce({
-                    file: file as File,
+                    file: file as BscFile,
                     ...DiagnosticMessages.unknownRoSGNode(unquotedComponentName),
                     range: componentName.range
                 });
             } else if (call?.args.length !== 2) {
                 // roSgNode should only ever have 2 args in `createObject`
                 this.addDiagnosticOnce({
-                    file: file as File,
+                    file: file as BscFile,
                     ...DiagnosticMessages.mismatchCreateObjectArgumentCount(firstParamStringValue, [2], call?.args.length),
                     range: call.range
                 });
             }
         } else if (!platformComponentNames.has(firstParamStringValue.toLowerCase())) {
             this.addDiagnosticOnce({
-                file: file as File,
+                file: file as BscFile,
                 ...DiagnosticMessages.unknownBrightScriptComponent(firstParamStringValue),
                 range: firstParamToken.range
             });
@@ -259,7 +259,7 @@ export class ScopeValidator {
             if (!validArgCounts.includes(call?.args.length)) {
                 // Incorrect number of arguments included in `createObject()`
                 this.addDiagnosticOnce({
-                    file: file as File,
+                    file: file as BscFile,
                     ...DiagnosticMessages.mismatchCreateObjectArgumentCount(firstParamStringValue, validArgCounts, call?.args.length),
                     range: call.range
                 });
@@ -268,7 +268,7 @@ export class ScopeValidator {
             // Test for deprecation
             if (brightScriptComponent.isDeprecated) {
                 this.addDiagnosticOnce({
-                    file: file as File,
+                    file: file as BscFile,
                     ...DiagnosticMessages.deprecatedBrightScriptComponent(firstParamStringValue, brightScriptComponent.deprecatedDescription),
                     range: call.range
                 });
@@ -384,7 +384,7 @@ export class ScopeValidator {
         const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
         if (!expectedLHSType?.isResolvable()) {
             this.addMultiScopeDiagnostic({
-                file: file as File,
+                file: file as BscFile,
                 ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
                 range: typeChainScan.range
             });
@@ -560,7 +560,7 @@ export class ScopeValidator {
             } else {
                 const typeChainScan = util.processTypeChain(typeChain);
                 this.addMultiScopeDiagnostic({
-                    file: file as File,
+                    file: file as BscFile,
                     ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
                     range: typeChainScan.range
                 });
@@ -619,7 +619,7 @@ export class ScopeValidator {
      * @param typeChain type chain to check
      * @returns true if member accesiibility is okay
      */
-    private checkMemberAccessibility(file: File, expression: Expression, typeChain: TypeChainEntry[]) {
+    private checkMemberAccessibility(file: BscFile, expression: Expression, typeChain: TypeChainEntry[]) {
         for (let i = 0; i < typeChain.length - 1; i++) {
             const parentChainItem = typeChain[i];
             const childChainItem = typeChain[i + 1];

--- a/src/files/AssetFile.ts
+++ b/src/files/AssetFile.ts
@@ -1,10 +1,10 @@
 import type { BsDiagnostic } from '../interfaces';
-import type { File } from './File';
+import type { BscFile } from './BscFile';
 import { standardizePath as s } from '../util';
 import type { FileData } from './LazyFileData';
 import { LazyFileData } from './LazyFileData';
 
-export class AssetFile implements File {
+export class AssetFile implements BscFile {
     /**
      * Create a new instance of this file
      */

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -30,7 +30,7 @@ import type { Statement, AstNode } from '../parser/AstNode';
 import { type Expression } from '../parser/AstNode';
 import type { BscSymbol } from '../SymbolTable';
 import { SymbolTable, SymbolTypeFlag } from '../SymbolTable';
-import type { File } from './File';
+import type { BscFile } from './BscFile';
 import { Editor } from '../astUtils/Editor';
 import type { UnresolvedSymbol } from '../AstValidationSegmenter';
 import { AstValidationSegmenter } from '../AstValidationSegmenter';
@@ -48,7 +48,7 @@ export interface ProvidedSymbolInfo {
 /**
  * Holds all details about this file within the scope of the whole program
  */
-export class BrsFile implements File {
+export class BrsFile implements BscFile {
     constructor(options: {
         /**
          * The path to the file in its source location (where the source code lives in the file system)
@@ -162,7 +162,7 @@ export class BrsFile implements File {
         return this.diagnostics;
     }
 
-    public addDiagnostic(diagnostic: Diagnostic & { file?: File }) {
+    public addDiagnostic(diagnostic: Diagnostic & { file?: BscFile }) {
         if (!diagnostic.file) {
             diagnostic.file = this;
         }

--- a/src/files/BscFile.ts
+++ b/src/files/BscFile.ts
@@ -1,10 +1,8 @@
 import type { SourceMapGenerator } from 'source-map';
 import type { Editor } from '../astUtils/Editor';
 import type { BsDiagnostic, CommentFlag } from '../interfaces';
-import type { BrsFile } from './BrsFile';
-import type { XmlFile } from './XmlFile';
 
-export interface File {
+export interface BscFile {
     /**
      * A string name representing the file type. This is generally the class name (i.e. 'BrsFile', 'XmlFile')
      */
@@ -101,19 +99,15 @@ export interface SerializeFileResult {
     content: Buffer;
     map?: SourceMapGenerator;
 }
-/**
- * @deprecated use `File` instead
- */
-//included for backwards compatibility reasons. Remove in v1
-export type BscFile = BrsFile | XmlFile;
+
 
 /**
  * Create a basic `File` object.
  */
-export function createFile(props: Partial<File>) {
+export function createFile(props: Partial<BscFile>) {
     props.diagnostics ??= [];
     props.dependencies ??= [];
     props.dependencyGraphKey ??= props.destPath;
     props.disposables ??= [];
-    return props as File;
+    return props as BscFile;
 }

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -15,11 +15,11 @@ import { type SGToken } from '../parser/SGTypes';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
 import type { IToken, TokenType } from 'chevrotain';
 import { TranspileState } from '../parser/TranspileState';
-import type { File } from './File';
+import type { BscFile } from './BscFile';
 import type { Editor } from '../astUtils/Editor';
 import type { FunctionScope } from '../FunctionScope';
 
-export class XmlFile implements File {
+export class XmlFile implements BscFile {
     /**
      * Create a new instance of BrsFile
      */
@@ -406,7 +406,7 @@ export class XmlFile implements File {
     /**
      * Determines if this xml file has a reference to the specified file (or if it's itself)
      */
-    public doesReferenceFile(file: File) {
+    public doesReferenceFile(file: BscFile) {
         return this.cache.getOrAdd(`doesReferenceFile: ${file.destPath}`, () => {
             if (file === this) {
                 return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export * from './astUtils/reflection';
 export * from './astUtils/creators';
 export * from './astUtils/xml';
 export * from './astUtils/Editor';
-export * from './files/File';
+export * from './files/BscFile';
 export * from './parser/BrsTranspileState';
 export * from './astUtils/Editor';
 export * from './SymbolTable';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,7 +14,7 @@ import type { SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
 import type { Editor } from './astUtils/Editor';
 import type { Identifier, Token } from './lexer/Token';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { FileFactory } from './files/Factory';
 import type { LazyFileData } from './files/LazyFileData';
 import type { SymbolTable, SymbolTypeFlag } from './SymbolTable';
@@ -23,7 +23,7 @@ import { createToken } from './astUtils/creators';
 import { TokenKind } from './lexer/TokenKind';
 
 export interface BsDiagnostic extends Diagnostic {
-    file: File;
+    file: BscFile;
     /**
      * A generic data container where additional details of the diagnostic can be stored. These are stripped out before being sent to a languageclient, and not printed to the console.
      */
@@ -43,7 +43,7 @@ export interface BsDiagnosticWithOrigin extends BsDiagnostic {
 }
 
 export interface Callable {
-    file: File;
+    file: BscFile;
     name: string;
     /**
      * Is the callable declared as "sub". If falsey, assumed declared as "function"
@@ -86,7 +86,7 @@ export interface FunctionCall {
     range: Range;
     expression: CallExpression;
     functionScope: FunctionScope;
-    file: File;
+    file: BscFile;
     name: string;
     args: CallableArg[];
     nameRange: Range;
@@ -180,7 +180,7 @@ export interface CallableContainer {
 export type CallableContainerMap = Map<string, CallableContainer[]>;
 
 export interface CommentFlag {
-    file: File;
+    file: BscFile;
     /**
      * The location of the ignore comment.
      */
@@ -410,7 +410,7 @@ export interface CompilerPlugin {
 }
 export type PluginHandler<T, R = void> = (event: T) => R;
 
-export interface OnGetCodeActionsEvent<TFile extends File = File> {
+export interface OnGetCodeActionsEvent<TFile extends BscFile = BscFile> {
     program: Program;
     file: TFile;
     range: Range;
@@ -434,26 +434,26 @@ export type OnProgramValidateEvent = BeforeProgramValidateEvent;
 export type AfterProgramValidateEvent = BeforeProgramValidateEvent;
 
 
-export interface ProvideCompletionsEvent<TFile extends File = File> {
+export interface ProvideCompletionsEvent<TFile extends BscFile = BscFile> {
     program: Program;
     file: TFile;
     scopes: Scope[];
     position: Position;
     completions: CompletionItem[];
 }
-export type BeforeProvideCompletionsEvent<TFile extends File = File> = ProvideCompletionsEvent<TFile>;
-export type AfterProvideCompletionsEvent<TFile extends File = File> = ProvideCompletionsEvent<TFile>;
+export type BeforeProvideCompletionsEvent<TFile extends BscFile = BscFile> = ProvideCompletionsEvent<TFile>;
+export type AfterProvideCompletionsEvent<TFile extends BscFile = BscFile> = ProvideCompletionsEvent<TFile>;
 
 export interface BeforeBuildProgramEvent {
     program: Program;
-    files: File[];
+    files: BscFile[];
     editor: Editor;
 }
 export type AfterBuildProgramEvent = BeforeBuildProgramEvent;
 
 export interface ProvideHoverEvent {
     program: Program;
-    file: File;
+    file: BscFile;
     position: Position;
     scopes: Scope[];
     hovers: Hover[];
@@ -510,10 +510,10 @@ export interface OnFileParseEvent {
 }
 export interface AfterFileParseEvent {
     program: Program;
-    file: File;
+    file: BscFile;
 }
 
-export interface OnGetSemanticTokensEvent<T extends File = File> {
+export interface OnGetSemanticTokensEvent<T extends BscFile = BscFile> {
     /**
      * The program this file is from
      */
@@ -533,23 +533,23 @@ export interface OnGetSemanticTokensEvent<T extends File = File> {
 }
 
 export type BeforeFileValidateEvent = OnFileValidateEvent;
-export interface OnFileValidateEvent<T extends File = File> {
+export interface OnFileValidateEvent<T extends BscFile = BscFile> {
     program: Program;
     file: T;
 }
 export type AfterFileValidateEvent = OnFileValidateEvent;
 
-export interface OnFileValidateEvent<T extends File = File> {
+export interface OnFileValidateEvent<T extends BscFile = BscFile> {
     program: Program;
     file: T;
 }
 export interface TranspileEntry {
-    file: File;
+    file: BscFile;
     outputPath: string;
 }
 
 export interface ScopeValidationOptions {
-    changedFiles?: File[];
+    changedFiles?: BscFile[];
     changedSymbols?: Map<SymbolTypeFlag, Set<string>>;
     force?: boolean;
 }
@@ -557,11 +557,11 @@ export interface ScopeValidationOptions {
 export interface OnScopeValidateEvent {
     program: Program;
     scope: Scope;
-    changedFiles?: File[];
+    changedFiles?: BscFile[];
     changedSymbols?: Map<SymbolTypeFlag, Set<string>>;
 }
 
-export interface AfterFileTranspileEvent<TFile extends File = File> {
+export interface AfterFileTranspileEvent<TFile extends BscFile = BscFile> {
     /**
      * The program this event was triggered for
      */
@@ -582,8 +582,8 @@ export interface AfterFileTranspileEvent<TFile extends File = File> {
     typedef?: string;
 }
 
-export type BeforeProvideFileEvent<TFile extends File = File> = ProvideFileEvent<TFile>;
-export interface ProvideFileEvent<TFile extends File = File> {
+export type BeforeProvideFileEvent<TFile extends BscFile = BscFile> = ProvideFileEvent<TFile>;
+export interface ProvideFileEvent<TFile extends BscFile = BscFile> {
     /**
      * The lower-case file extension for the srcPath. (i.e. ".brs", ".xml")
      */
@@ -617,19 +617,19 @@ export interface ProvideFileEvent<TFile extends File = File> {
      */
     fileFactory: FileFactory;
 }
-export type AfterProvideFileEvent<TFile extends File = File> = ProvideFileEvent<TFile>;
+export type AfterProvideFileEvent<TFile extends BscFile = BscFile> = ProvideFileEvent<TFile>;
 
-export interface BeforeFileAddEvent<TFile extends File = File> {
+export interface BeforeFileAddEvent<TFile extends BscFile = BscFile> {
     file: TFile;
     program: Program;
 }
-export type AfterFileAddEvent<TFile extends File = File> = BeforeFileAddEvent<TFile>;
+export type AfterFileAddEvent<TFile extends BscFile = BscFile> = BeforeFileAddEvent<TFile>;
 
-export interface BeforeFileRemoveEvent<TFile extends File = File> {
+export interface BeforeFileRemoveEvent<TFile extends BscFile = BscFile> {
     file: TFile;
     program: Program;
 }
-export type AfterFileRemoveEvent<TFile extends File = File> = BeforeFileRemoveEvent<TFile>;
+export type AfterFileRemoveEvent<TFile extends BscFile = BscFile> = BeforeFileRemoveEvent<TFile>;
 
 export type BeforePrepareProgramEvent = PrepareProgramEvent;
 /**
@@ -642,17 +642,17 @@ export interface PrepareProgramEvent {
 export type AfterPrepareProgramEvent = PrepareProgramEvent;
 
 
-export type BeforePrepareFileEvent<TFile extends File = File> = PrepareFileEvent<TFile>;
+export type BeforePrepareFileEvent<TFile extends BscFile = BscFile> = PrepareFileEvent<TFile>;
 /**
  * Prepare the file for building
  */
-export interface PrepareFileEvent<TFile extends File = File> {
+export interface PrepareFileEvent<TFile extends BscFile = BscFile> {
     program: Program;
     file: TFile;
     editor: Editor;
 }
-export type OnPrepareFileEvent<TFile extends File = File> = PrepareFileEvent<TFile>;
-export type AfterPrepareFileEvent<TFile extends File = File> = PrepareFileEvent<TFile>;
+export type OnPrepareFileEvent<TFile extends BscFile = BscFile> = PrepareFileEvent<TFile>;
+export type AfterPrepareFileEvent<TFile extends BscFile = BscFile> = PrepareFileEvent<TFile>;
 
 
 /**
@@ -666,8 +666,8 @@ export interface SerializedCodeFile {
 
 export interface BeforeSerializeProgramEvent {
     program: Program;
-    files: File[];
-    result: Map<File, SerializedFile[]>;
+    files: BscFile[];
+    result: Map<BscFile, SerializedFile[]>;
 }
 export type OnSerializeProgramEvent = BeforeSerializeProgramEvent;
 export type AfterSerializeProgramEvent = BeforeSerializeProgramEvent;
@@ -686,8 +686,8 @@ export interface SerializedFile {
     pkgPath: string;
 }
 
-export type BeforeSerializeFileEvent<TFile extends File = File> = SerializeFileEvent<TFile>;
-export interface SerializeFileEvent<TFile extends File = File> {
+export type BeforeSerializeFileEvent<TFile extends BscFile = BscFile> = SerializeFileEvent<TFile>;
+export interface SerializeFileEvent<TFile extends BscFile = BscFile> {
     program: Program;
     file: TFile;
     /**
@@ -696,13 +696,13 @@ export interface SerializeFileEvent<TFile extends File = File> {
      */
     result: Map<TFile, SerializedFile[]>;
 }
-export type AfterSerializeFileEvent<TFile extends File = File> = SerializeFileEvent<TFile>;
+export type AfterSerializeFileEvent<TFile extends BscFile = BscFile> = SerializeFileEvent<TFile>;
 
 
 export interface BeforeWriteProgramEvent {
     program: Program;
     stagingDir: string;
-    files: Map<File, SerializedFile[]>;
+    files: Map<BscFile, SerializedFile[]>;
 }
 export type AfterWriteProgramEvent = BeforeWriteProgramEvent;
 
@@ -723,7 +723,7 @@ export interface WriteFileEvent {
 export type AfterWriteFileEvent = BeforeWriteFileEvent;
 
 export interface TranspileObj {
-    file: File;
+    file: BscFile;
     /**
      * The absolute path to where the file should be written during build. (i.e. somewhere inside the stagingDir)
      */
@@ -732,7 +732,7 @@ export interface TranspileObj {
 
 export interface BeforeFileDisposeEvent {
     program: Program;
-    file: File;
+    file: BscFile;
 }
 export type AfterFileDisposeEvent = BeforeFileDisposeEvent;
 export interface BeforeProgramDisposeEvent {
@@ -815,7 +815,7 @@ export interface TypeCompatibilityData {
 }
 
 export interface NamespaceContainer {
-    file: File;
+    file: BscFile;
     fullName: string;
     fullNameLower: string;
     parentNameLower: string;

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -12,7 +12,7 @@ import { standardizePath as s } from './util';
 import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';
 import undent from 'undent';
-import type { File } from './files/File';
+import type { BscFile } from './files/BscFile';
 import type { BscType } from './types/BscType';
 
 export const tempDir = s`${__dirname}/../.tmp`;
@@ -69,7 +69,7 @@ interface PartialDiagnostic {
     tags?: Partial<DiagnosticTag>[];
     relatedInformation?: Partial<DiagnosticRelatedInformation>[];
     data?: unknown;
-    file?: Partial<File>;
+    file?: Partial<BscFile>;
 }
 
 /**
@@ -255,10 +255,10 @@ export function getTestGetTypedef(scopeGetter: () => [program: Program, rootDir:
 }
 
 function getTestFileAction(
-    action: (file: File) => Promise<{ code: string; map?: string }>,
+    action: (file: BscFile) => Promise<{ code: string; map?: string }>,
     scopeGetter: () => [program: Program, rootDir: string]
 ) {
-    return async function testFileAction<TFile extends File = File>(source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
+    return async function testFileAction<TFile extends BscFile = BscFile>(source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
         let [program, rootDir] = scopeGetter();
         expected = expected ? expected : source;
         let file = program.setFile<TFile>({ src: s`${rootDir}/${destPath}`, dest: destPath }, source);

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -13,7 +13,7 @@ import { TokenKind } from '../lexer/TokenKind';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { SymbolTypeFlag } from '../SymbolTable';
-import type { File } from '../files/File';
+import type { BscFile } from '../files/BscFile';
 
 export class BsClassValidator {
     private scope: Scope;
@@ -380,6 +380,6 @@ export class BsClassValidator {
 }
 
 type AugmentedClassStatement = ClassStatement & {
-    file: File;
+    file: BscFile;
     parentClass: AugmentedClassStatement | undefined;
 };


### PR DESCRIPTION
Resolves #1005 

Renames `File` interface to `BscFile` and removes the `BscFile` type. This is so this project does not clash with the Javascript `File` type.


