### PR TITLE
Updates the Member types for Component Fields

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -33,6 +33,7 @@ import { ArrayType } from './types/ArrayType';
 import { AssociativeArrayType } from './types/AssociativeArrayType';
 import { BooleanType } from './types/BooleanType';
 import type { BsDiagnostic } from './interfaces';
+import { DoubleType } from './types';
 
 const sinon = createSandbox();
 
@@ -2669,7 +2670,7 @@ describe('Program', () => {
             expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts), ComponentType);
             expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts).getMemberType('control', rtOpts), StringType);
             expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts).getMemberType('repeat', rtOpts), BooleanType);
-            expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts).getMemberType('duration', rtOpts), FloatType);
+            expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts).getMemberType('duration', rtOpts), DoubleType);
             expectTypeToBe(table.getSymbolType('roSGNodeTimer', opts).getMemberType('fire', rtOpts), DynamicType);
 
             expectTypeToBe(table.getSymbolType('roSGNodeNode', opts), ComponentType);

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -10,7 +10,7 @@ import { createSandbox } from 'sinon';
 import { ComponentType } from './types/ComponentType';
 import { SymbolTypeFlag } from './SymbolTable';
 import { AssociativeArrayType } from './types/AssociativeArrayType';
-import { ArrayType, FloatType, TypedFunctionType } from './types';
+import { ArrayType, BooleanType, DoubleType, DynamicType, FloatType, IntegerType, StringType, TypedFunctionType } from './types';
 const sinon = createSandbox();
 
 describe('XmlScope', () => {
@@ -203,19 +203,65 @@ describe('XmlScope', () => {
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Widget" extends="Group">
                     <interface>
-                        <field id="alpha" type="assocArray" />
-                        <field id="beta" type="float" />
-                        <field id="charlie" type="nodeArray" />
+                        <field id="isAA" type="assocArray" />
+                        <field id="isFloat" type="float" />
+                        <field id="isNodeArray" type="nodeArray" />
+                        <field id="isArray" type="array" />
+                        <field id="isStringArray" type="stringarray" />
+                        <field id="isIntArray" type="intarray" />
+                        <field id="isUri" type="uri" />
+                        <field id="isBool" type="boolean" />
+                        <field id="isColor" type="color" />
+                        <field id="isColorArray" type="colorarray" />
+                        <field id="isVector2d" type="vector2d" />
+                        <field id="isTime" type="time" />
+                        <field id="isRect2d" type="rect2D" />
+                        <field id="isRect2dArray" type="rect2Darray" />
                     </interface>
                 </component>
             `);
             program.validate();
             const widgetType = program.globalScope.symbolTable.getSymbolType('roSGNodeWidget', { flags: SymbolTypeFlag.typetime });
 
-            expectTypeToBe(widgetType.getMemberType('alpha', { flags: SymbolTypeFlag.runtime }), AssociativeArrayType);
-            expectTypeToBe(widgetType.getMemberType('beta', { flags: SymbolTypeFlag.runtime }), FloatType);
-            expectTypeToBe(widgetType.getMemberType('charlie', { flags: SymbolTypeFlag.runtime }), ArrayType);
-            expectTypeToBe((widgetType.getMemberType('charlie', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, ComponentType);
+            expectTypeToBe(widgetType.getMemberType('isAA', { flags: SymbolTypeFlag.runtime }), AssociativeArrayType);
+            expectTypeToBe(widgetType.getMemberType('isFloat', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(widgetType.getMemberType('isNodeArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isNodeArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, ComponentType);
+
+            expectTypeToBe(widgetType.getMemberType('isArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, DynamicType);
+
+            expectTypeToBe(widgetType.getMemberType('isStringArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isStringArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, StringType);
+
+            expectTypeToBe(widgetType.getMemberType('isIntArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isIntArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, IntegerType);
+
+            expectTypeToBe(widgetType.getMemberType('isBool', { flags: SymbolTypeFlag.runtime }), BooleanType);
+            expectTypeToBe(widgetType.getMemberType('isColor', { flags: SymbolTypeFlag.runtime }), IntegerType);
+
+            expectTypeToBe(widgetType.getMemberType('isColorArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isColorArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, IntegerType);
+
+            expectTypeToBe(widgetType.getMemberType('isVector2d', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isVector2d', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, FloatType);
+
+            expectTypeToBe(widgetType.getMemberType('isTime', { flags: SymbolTypeFlag.runtime }), DoubleType);
+
+            expectTypeToBe(widgetType.getMemberType('isRect2d', { flags: SymbolTypeFlag.runtime }), AssociativeArrayType);
+            let rect2dtype = (widgetType.getMemberType('isRect2d', { flags: SymbolTypeFlag.runtime }) as AssociativeArrayType);
+            expectTypeToBe(rect2dtype.getMemberType('height', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dtype.getMemberType('width', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dtype.getMemberType('x', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dtype.getMemberType('y', { flags: SymbolTypeFlag.runtime }), FloatType);
+
+            expectTypeToBe(widgetType.getMemberType('isRect2dArray', { flags: SymbolTypeFlag.runtime }), ArrayType);
+            expectTypeToBe((widgetType.getMemberType('isRect2dArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType, AssociativeArrayType);
+            let rect2dArrayDefault = (widgetType.getMemberType('isRect2dArray', { flags: SymbolTypeFlag.runtime }) as ArrayType).defaultType as AssociativeArrayType;
+            expectTypeToBe(rect2dArrayDefault.getMemberType('height', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dArrayDefault.getMemberType('width', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dArrayDefault.getMemberType('x', { flags: SymbolTypeFlag.runtime }), FloatType);
+            expectTypeToBe(rect2dArrayDefault.getMemberType('y', { flags: SymbolTypeFlag.runtime }), FloatType);
         });
 
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1196,6 +1196,17 @@ export class Util {
         if (bscType) {
             return bscType;
         }
+
+        function getRect2dType() {
+            const rect2dType = new AssociativeArrayType();
+            rect2dType.addMember('height', {}, FloatType.instance, SymbolTypeFlag.runtime);
+            rect2dType.addMember('width', {}, FloatType.instance, SymbolTypeFlag.runtime);
+            rect2dType.addMember('x', {}, FloatType.instance, SymbolTypeFlag.runtime);
+            rect2dType.addMember('y', {}, FloatType.instance, SymbolTypeFlag.runtime);
+            return rect2dType;
+        }
+
+
         if (typeDescriptorLower.startsWith('array of ')) {
             let arrayOfTypeName = typeDescriptorLower.substring(9); //cut off beginning 'array of'
             if (arrayOfTypeName.endsWith('s')) {
@@ -1216,9 +1227,13 @@ export class Util {
             return this.getNodeFieldType(actualTypeName, lookupTable);
         } else if (typeDescriptorLower === 'uri') {
             return StringType.instance;
+        } else if (typeDescriptorLower === 'color') {
+            return IntegerType.instance;
         } else if (typeDescriptorLower === 'vector2d' || typeDescriptorLower === 'floatarray') {
             return new ArrayType(FloatType.instance);
-        } else if (typeDescriptorLower === 'intarray') {
+        } else if (typeDescriptorLower === 'vector2darray') {
+            return new ArrayType(new ArrayType(FloatType.instance));
+        } else if (typeDescriptorLower === 'intarray' || typeDescriptorLower === 'colorarray') {
             return new ArrayType(IntegerType.instance);
         } else if (typeDescriptorLower === 'boolarray') {
             return new ArrayType(BooleanType.instance);
@@ -1227,23 +1242,29 @@ export class Util {
         } else if (typeDescriptorLower === 'int') {
             return IntegerType.instance;
         } else if (typeDescriptorLower === 'time') {
-            return FloatType.instance;
+            return DoubleType.instance;
         } else if (typeDescriptorLower === 'str') {
             return StringType.instance;
         } else if (typeDescriptorLower === 'bool') {
             return BooleanType.instance;
+        } else if (typeDescriptorLower === 'array') {
+            return new ArrayType();
         } else if (typeDescriptorLower === 'assocarray' || typeDescriptorLower === 'associative array') {
             return new AssociativeArrayType();
         } else if (typeDescriptorLower === 'node') {
             return ComponentType.instance;
         } else if (typeDescriptorLower === 'nodearray') {
             return new ArrayType(ComponentType.instance);
+        } else if (typeDescriptorLower === 'rect2d') {
+            return getRect2dType();
+        } else if (typeDescriptorLower === 'rect2darray') {
+            return new ArrayType(getRect2dType());
         } else if (lookupTable) {
             //try doing a lookup
             return lookupTable.getSymbolType(typeDescriptorLower, { flags: SymbolTypeFlag.typetime });
         }
 
-        //  TODO: Handle  'rect2d', 'rect2dArray', 'color', 'colorarray', 'time'
+        //  TODO: Handle  'rect2d', 'rect2dArray',
         return DynamicType.instance;
     }
 


### PR DESCRIPTION
Includes all the fields types as defined here: https://developer.roku.com/en-ca/docs/references/scenegraph/xml-elements/interface.md#attributes

Fixes (in particular) the `type="array"` isse @georgejecook has.

