### PR TITLE
Fixes Compatibility checks for types defined recursively.

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1461,6 +1461,60 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('recursive types are allowed as array members', () => {
+            program.setFile('source/util.bs', `
+                interface ChainNode
+                    name as string
+                    nextItems as ChainNode[]
+                end interface
+
+                function getChain(cNode as ChainNode) as string
+                    output = cNode.name
+                    for each item in cNode.nextItems
+                        output += " - " + getChain(item)
+                    end for
+                    return output
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('deeply recursive types are allowed', () => {
+            program.setFile('source/util.bs', `
+                interface ChainNode
+                    name as string
+                    nextItem as ChainNodeWrapper
+                end interface
+
+                interface ChainNodeWrapper
+                    node as ChainNode
+                end interface
+
+                function getChain(cNode as ChainNode) as string
+                    output = cNode.name
+                    if cNode.nextItem <> invalid
+                        output += " - " + getChain(cNode.nextItem.node)
+                    end if
+                    return output
+                end function
+
+                sub useChain()
+                    chain3 = {name: "C", nextItem: invalid}
+                    wrapper3 = {node: chain3}
+                    chain2 = {name: "B", nextItem: wrapper3}
+                    wrapper2 = {node: chain2}
+                    chain1 = {name: "A", nextItem: wrapper2}
+
+                    print getChain(chain1)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+
     });
 
     describe('cannotFindName', () => {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1442,6 +1442,25 @@ describe('ScopeValidator', () => {
                 expectZeroDiagnostics(program);
             });
         });
+
+        it('recursive types are allowed', () => {
+            program.setFile('source/util.bs', `
+                interface ChainNode
+                    name as string
+                    next as ChainNode
+                end interface
+
+                function getChain(cNode as ChainNode) as string
+                    output = cNode.name
+                    if cNode.next <> invalid
+                        output += " - " + getChain(cNode.next)
+                    end if
+                    return output
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('cannotFindName', () => {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -3,7 +3,7 @@ import { SymbolTypeFlag } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { ExtraSymbolData, TypeCompatibilityData } from '../interfaces';
-import { isInheritableType, isReferenceType } from '../astUtils/reflection';
+import { isArrayType, isInheritableType, isReferenceType } from '../astUtils/reflection';
 
 export abstract class BscType {
 
@@ -117,7 +117,9 @@ export abstract class BscType {
                         }
                         const typesAreInheritableWithSameName = isInheritableType(memberSymbol.type) && isInheritableType(typeOfTargetSymbol) &&
                             memberSymbol.type.name.toLowerCase() === typeOfTargetSymbol.name.toLowerCase();
-                        const myMemberAllowsTargetType = typesAreInheritableWithSameName || memberSymbol.type?.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
+                        const typesAreArraysWithSameDefault = isArrayType(memberSymbol.type) && isArrayType(typeOfTargetSymbol) &&
+                            memberSymbol.type.defaultType.isEqual(typeOfTargetSymbol.defaultType);
+                        const myMemberAllowsTargetType = typesAreInheritableWithSameName || typesAreArraysWithSameDefault || memberSymbol.type?.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
                         if (!myMemberAllowsTargetType) {
                             data.fieldMismatches.push({ name: memberSymbol.name, expectedType: memberSymbol.type, actualType: targetType.getMemberType(memberSymbol.name, { flags: flags }) });
                         }

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -3,7 +3,7 @@ import { SymbolTypeFlag } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { ExtraSymbolData, TypeCompatibilityData } from '../interfaces';
-import { isReferenceType } from '../astUtils/reflection';
+import { isInheritableType, isReferenceType } from '../astUtils/reflection';
 
 export abstract class BscType {
 
@@ -115,8 +115,9 @@ export abstract class BscType {
                         if (!superSetSoFar) {
                             return superSetSoFar;
                         }
-
-                        const myMemberAllowsTargetType = memberSymbol.type?.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
+                        const typesAreInheritableWithSameName = isInheritableType(memberSymbol.type) && isInheritableType(typeOfTargetSymbol) &&
+                            memberSymbol.type.name.toLowerCase() === typeOfTargetSymbol.name.toLowerCase();
+                        const myMemberAllowsTargetType = typesAreInheritableWithSameName || memberSymbol.type?.isTypeCompatible(typeOfTargetSymbol, { depth: data.depth });
                         if (!myMemberAllowsTargetType) {
                             data.fieldMismatches.push({ name: memberSymbol.name, expectedType: memberSymbol.type, actualType: targetType.getMemberType(memberSymbol.name, { flags: flags }) });
                         }

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -12,7 +12,7 @@ import { AssociativeArrayType } from './AssociativeArrayType';
 import { ArrayType } from './ArrayType';
 import { BooleanType } from './BooleanType';
 import { typeCompatibilityMessage } from '../DiagnosticMessages';
-import { TypeCompatibilityData } from '..';
+import type { TypeCompatibilityData } from '..';
 
 describe('InterfaceType', () => {
     describe('toJSString', () => {

--- a/src/types/InterfaceType.spec.ts
+++ b/src/types/InterfaceType.spec.ts
@@ -12,6 +12,7 @@ import { AssociativeArrayType } from './AssociativeArrayType';
 import { ArrayType } from './ArrayType';
 import { BooleanType } from './BooleanType';
 import { typeCompatibilityMessage } from '../DiagnosticMessages';
+import { TypeCompatibilityData } from '..';
 
 describe('InterfaceType', () => {
     describe('toJSString', () => {
@@ -80,6 +81,19 @@ describe('InterfaceType', () => {
             expect(
                 iface({ name: new StringType() }).isEqual(iface({ name: new IntegerType() }))
             ).to.be.false;
+        });
+
+        it('works for recursive types', () => {
+            let linkListNode1 = iface({ name: StringType.instance }, 'LinkNode');
+            linkListNode1.addMember('next', {}, linkListNode1, SymbolTypeFlag.runtime);
+
+            let linkListNode2 = iface({ name: StringType.instance }, 'LinkNode');
+            linkListNode2.addMember('next', {}, linkListNode2, SymbolTypeFlag.runtime);
+
+            let compatData = {} as TypeCompatibilityData;
+            let typesAreEqual = linkListNode1.isEqual(linkListNode2, compatData);
+            expect(typesAreEqual).to.be.true;
+            expect(compatData?.fieldMismatches ?? []).to.be.empty;
         });
     });
 


### PR DESCRIPTION
This PR just makes the assumption that if something is the same name (and it's deeply nested) that it's probably the same type.

I think that's a fair assumption. 

We can't make that assumption at the top level, because we have to do checks at the top level for differences in the same file... in that case, types with the same name *might* be different.
