### PR TITLE
adds support for libpkg prefix

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -712,7 +712,7 @@ describe('Program', () => {
             program.setFile('components/component1.brs', '');
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
 
         it('accepts libpkg .bs script reference', () => {
@@ -725,7 +725,7 @@ describe('Program', () => {
             program.setFile('components/component1.bs', '');
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
 
         it('does not set function not found diagnostic for function in libpkg referenced script reference', () => {
@@ -744,7 +744,7 @@ describe('Program', () => {
             );
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
 
         it('does not set function not found diagnostic for function in libpkg referenced .bs script reference', () => {
@@ -763,7 +763,7 @@ describe('Program', () => {
             );
 
             program.validate();
-            expect(program.getDiagnostics()).to.be.empty;
+            expectZeroDiagnostics(program);
         });
 
         it('sets function not found diagnostic for missing function in libpkg referenced script reference', () => {

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -702,7 +702,7 @@ describe('Program', () => {
             }]);
         });
 
-        it('accepts libpkg references script reference', () => {
+        it('accepts libpkg .brs script reference', () => {
             program.setFile('components/component1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="HeroScene" extends="Scene">
@@ -710,6 +710,19 @@ describe('Program', () => {
                 </component>
             `);
             program.setFile('components/component1.brs', '');
+
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+        });
+
+        it('accepts libpkg .bs script reference', () => {
+            program.setFile('components/component1.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="HeroScene" extends="Scene">
+                    <script type="text/brightscript" uri="libpkg:/components/component1.bs" />
+                </component>
+            `);
+            program.setFile('components/component1.bs', '');
 
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
@@ -726,6 +739,25 @@ describe('Program', () => {
                 </component>
             `);
             program.setFile('components/component1.brs', `
+                function isFound()
+                end function`
+            );
+
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+        });
+
+        it('does not set function not found diagnostic for function in libpkg referenced .bs script reference', () => {
+            program.setFile('components/component1.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="HeroScene" extends="Scene">
+                    <script type="text/brightscript" uri="libpkg:/components/component1.bs" />
+                    <interface>
+                        <function name="isFound"/>
+                    </interface>
+                </component>
+            `);
+            program.setFile('components/component1.bs', `
                 function isFound()
                 end function`
             );

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -25,6 +25,7 @@ import * as fsExtra from 'fs-extra';
 import { URI } from 'vscode-uri';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
+import { XmlFile } from './XmlFile';
 
 let sinon = sinonImport.createSandbox();
 
@@ -2172,6 +2173,27 @@ describe('BrsFile', () => {
     });
 
     describe('transpile', () => {
+        it('transpilies libpkg:/ paths when encountered', () => {
+            program.setFile('source/lib.bs', `
+                import "libpkg:/source/numbers.bs"
+            `);
+            program.setFile('source/numbers.bs', `
+                sub test()
+                end sub
+            `);
+            testTranspile(`
+                <component name="TestButton" extends="Group">
+                    <script type="text/brightscript" uri="libpkg:/source/lib.bs"/>
+                </component>
+            `, `
+                <component name="TestButton" extends="Group">
+                    <script type="text/brightscript" uri="libpkg:/source/lib.brs" />
+                    <script type="text/brightscript" uri="pkg:/source/numbers.brs" />
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, undefined, 'components/TestButton.xml');
+        });
+
         it('excludes trailing commas in array literals', () => {
             testTranspile(`
                 sub main()

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -25,7 +25,6 @@ import * as fsExtra from 'fs-extra';
 import { URI } from 'vscode-uri';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
-import { XmlFile } from './XmlFile';
 
 let sinon = sinonImport.createSandbox();
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -383,7 +383,7 @@ describe('util', () => {
         });
 
         it('sets default value for bslibDestinationDir', () => {
-            expect(util.normalizeConfig(<any>{ }).bslibDestinationDir).to.equal('source');
+            expect(util.normalizeConfig(<any>{}).bslibDestinationDir).to.equal('source');
         });
 
         it('strips leading and/or trailing slashes from bslibDestinationDir', () => {
@@ -427,6 +427,16 @@ describe('util', () => {
             expect(util.getPkgPathFromTarget('components/component1.xml', 'pkg:/')).to.equal(null);
             expect(util.getPkgPathFromTarget('components/component1.xml', 'pkg:')).to.equal(null);
             expect(util.getPkgPathFromTarget('components/component1.xml', 'pkg')).to.equal(s`components/pkg`);
+        });
+
+        it('supports pkg:/ and libpkg:/', () => {
+            expect(util.getPkgPathFromTarget('components/component1.xml', 'pkg:/source/lib.brs')).to.equal(s`source/lib.brs`);
+            expect(util.getPkgPathFromTarget('components/component1.xml', 'libpkg:/source/lib.brs')).to.equal(s`source/lib.brs`);
+        });
+
+        it('works case insensitive', () => {
+            expect(util.getPkgPathFromTarget('components/component1.xml', 'PKG:/source/lib.brs')).to.equal(s`source/lib.brs`);
+            expect(util.getPkgPathFromTarget('components/component1.xml', 'LIBPKG:/source/lib.brs')).to.equal(s`source/lib.brs`);
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -413,20 +413,21 @@ export class Util {
      * compute the pkg path for the target relative to the source file's location
      */
     public getPkgPathFromTarget(containingFilePathAbsolute: string, targetPath: string) {
-        //if the target starts with 'pkg:', it's an absolute path. Return as is
-        for (const packagePathPrefix of ['pkg:', 'libpkg:']) {
-
-            if (targetPath.startsWith(`${packagePathPrefix}/`)) {
-                targetPath = targetPath.substring(packagePathPrefix.length + 1);
-                if (targetPath === '') {
-                    return null;
-                } else {
-                    return path.normalize(targetPath);
-                }
-            }
-            if (targetPath === packagePathPrefix) {
+        // https://regex101.com/r/w7CG2N/1
+        const regexp = /^(?:pkg|libpkg):(\/)?/i;
+        const [fullScheme, slash] = regexp.exec(targetPath) ?? [];
+        //if the target starts with 'pkg:' or 'libpkg:' then it's an absolute path. Return as is
+        if (slash) {
+            targetPath = targetPath.substring(fullScheme.length);
+            if (targetPath === '') {
                 return null;
+            } else {
+                return path.normalize(targetPath);
             }
+        }
+        //if the path is exactly `pkg:` or `libpkg:`
+        if (targetPath === fullScheme && !slash) {
+            return null;
         }
 
         //remove the filename

--- a/src/util.ts
+++ b/src/util.ts
@@ -414,16 +414,19 @@ export class Util {
      */
     public getPkgPathFromTarget(containingFilePathAbsolute: string, targetPath: string) {
         //if the target starts with 'pkg:', it's an absolute path. Return as is
-        if (targetPath.startsWith('pkg:/')) {
-            targetPath = targetPath.substring(5);
-            if (targetPath === '') {
-                return null;
-            } else {
-                return path.normalize(targetPath);
+        for (const packagePathPrefix of ['pkg:', 'libpkg:']) {
+
+            if (targetPath.startsWith(`${packagePathPrefix}/`)) {
+                targetPath = targetPath.substring(packagePathPrefix.length + 1);
+                if (targetPath === '') {
+                    return null;
+                } else {
+                    return path.normalize(targetPath);
+                }
             }
-        }
-        if (targetPath === 'pkg:') {
-            return null;
+            if (targetPath === packagePathPrefix) {
+                return null;
+            }
         }
 
         //remove the filename


### PR DESCRIPTION
We found that component libraries that use libpkg:/path/file.brs in the script imports would result in files not being found.

This pr adds support for both pkg types.