### PR TITLE
Prevent overwriting the Program._manifest if already set on startup

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1385,8 +1385,13 @@ export class Program {
     /**
      * Try to find and load the manifest into memory
      * @param manifestFileObj A pointer to a potential manifest file object found during loading
+     * @param replaceIfAlreadyLoaded should we overwrite the internal `_manifest` if it already exists
      */
-    public loadManifest(manifestFileObj?: FileObj) {
+    public loadManifest(manifestFileObj?: FileObj, replaceIfAlreadyLoaded = true) {
+        //if we already have a manifest instance, and should not replace...then don't replace
+        if (!replaceIfAlreadyLoaded && this._manifest) {
+            return;
+        }
         let manifestPath = manifestFileObj
             ? manifestFileObj.src
             : path.join(this.options.rootDir, 'manifest');

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -504,7 +504,7 @@ export class ProgramBuilder {
             }
 
             if (manifestFile) {
-                this.program!.loadManifest(manifestFile);
+                this.program!.loadManifest(manifestFile, false);
             }
 
             const loadFile = async (fileObj) => {


### PR DESCRIPTION
Some plugins might want to load the manifest and preprocess it before the program gets to it. However, sometimes there are timing issues, so now we don't replace the manifest on startup if a plugin has already overwritten it.