### PR TITLE
Backport v1 syntax changes

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -891,7 +891,10 @@ export class Scope {
                 if (isCustomType(param.type) && param.typeToken) {
                     const paramTypeName = param.type.name;
                     const currentNamespaceName = func.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
-                    if (!this.hasClass(paramTypeName, currentNamespaceName) && !this.hasInterface(paramTypeName) && !this.hasEnum(paramTypeName)) {
+                    // check for built in types
+                    const isBuiltInType = util.isBuiltInType(paramTypeName);
+
+                    if (!isBuiltInType && !this.hasClass(paramTypeName, currentNamespaceName) && !this.hasInterface(paramTypeName) && !this.hasEnum(paramTypeName)) {
                         this.diagnostics.push({
                             ...DiagnosticMessages.functionParameterTypeIsInvalid(param.name.text, paramTypeName),
                             range: param.typeToken.range,

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression } from '../parser/Expression';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -259,6 +259,9 @@ export function isAnnotationExpression(element: AstNode | undefined): element is
 }
 export function isTypedefProvider(element: any): element is TypedefProvider {
     return 'getTypedef' in element;
+}
+export function isTypeCastExpression(element: any): element is TypeCastExpression {
+    return element?.constructor.name === 'TypeCastExpression';
 }
 
 // BscType reflection

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3704,7 +3704,7 @@ describe('BrsFile', () => {
             `);
         });
 
-        it('allows union types for primitives', () => {
+        it.only('allows union types for primitives', () => {
             testTranspile(`
                 sub main(x as string or float, y as object or float or string)
                 end sub

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3638,7 +3638,7 @@ describe('BrsFile', () => {
     });
 
 
-    describe.only('backporting v1 syntax changes', () => {
+    describe('backporting v1 syntax changes', () => {
 
         it('transpiles typed arrays to dynamic', () => {
             testTranspile(`
@@ -3666,7 +3666,6 @@ describe('BrsFile', () => {
                     print (myNode as roSGNode).id
                     print (myNode as roSGNode).getParent().id
                     myNode2 = myNode as roSgNode
-
                     print (myString as string).len()
                     print (myString as string).right(3)
                     myString2 = myString as string
@@ -3676,10 +3675,21 @@ describe('BrsFile', () => {
                     print myNode.id
                     print myNode.getParent().id
                     myNode2 = myNode
-
-                    print  myString.len()
+                    print myString.len()
                     print myString.right(3)
                     myString2 = myString
+                end sub
+            `);
+        });
+
+        it('allows and removes multiple typecasts in transpiled code', () => {
+            testTranspile(`
+                sub main(myNode)
+                    print ((myNode as roSGNode as roSGNodeLabel).text as string as ifStringOps).len()
+                end sub
+            `, `
+                sub main(myNode)
+                    print myNode.text.len()
                 end sub
             `);
         });
@@ -3689,7 +3699,7 @@ describe('BrsFile', () => {
                 sub main(x as roSGNode, y as roSGNodeEvent, z as ifArray)
                 end sub
             `, `
-                sub main(x as dynamic, y as dynamic, z as dynamic)
+                sub main(x as object, y as object, z as object)
                 end sub
             `);
         });
@@ -3699,12 +3709,12 @@ describe('BrsFile', () => {
                 sub main(x as roSGNodeGroup, y as roSGNodeRowList, z as roSGNodeCustomComponent)
                 end sub
             `, `
-                sub main(x as dynamic, y as dynamic, z as dynamic)
+                sub main(x as object, y as object, z as object)
                 end sub
             `);
         });
 
-        it.only('allows union types for primitives', () => {
+        it('allows union types for primitives', () => {
             testTranspile(`
                 sub main(x as string or float, y as object or float or string)
                 end sub
@@ -3749,6 +3759,28 @@ describe('BrsFile', () => {
                 end namespace
 
                 sub main(x as alpha.beta.IFaceA or alpha.beta.IFaceB)
+                end sub
+            `, `
+                sub main(x as dynamic)
+                end sub
+            `);
+        });
+
+        it('allows union types of arrays', () => {
+            testTranspile(`
+                namespace alpha.beta
+                    interface IFaceA
+                        name as string
+                        data as integer
+                    end interface
+
+                    interface IFaceB
+                        name as string
+                        value as float
+                    end interface
+                end namespace
+
+                sub main(x as alpha.beta.IFaceA[][] or alpha.beta.IFaceB[] or ifStringOps)
                 end sub
             `, `
                 sub main(x as dynamic)

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isTypeCastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { VoidType } from '../types/VoidType';
 import { DynamicType } from '../types/DynamicType';
@@ -554,6 +554,9 @@ export class GroupingExpression extends Expression {
     public readonly range: Range;
 
     transpile(state: BrsTranspileState) {
+        if (isTypeCastExpression(this.expression)) {
+            return this.expression.transpile(state);
+        }
         return [
             state.transpileToken(this.tokens.left),
             ...this.expression.transpile(state),
@@ -1543,44 +1546,18 @@ export class RegexLiteralExpression extends Expression {
     }
 }
 
-export class TypeExpression extends Expression implements TypedefProvider {
-    constructor(
-        /**
-         * The standard AST expression that represents the type for this TypeExpression.
-         */
-        public typeToken: Token
-    ) {
-        super();
-        this.range = typeToken?.range;
-    }
-
-
-    public range: Range;
-
-    public transpile(state: BrsTranspileState): TranspileResult {
-        return [util.tokenToBscType(this.typeToken)?.toTypeString() ?? 'dynamic'];
-    }
-    public walk(visitor: WalkVisitor, options: WalkOptions) {
-    }
-
-    getTypedef(state: TranspileState): (string | SourceNode)[] {
-        // TypeDefs should pass through any valid type names
-        return this.expression.transpile(state as BrsTranspileState);
-    }
-
-}
 
 export class TypeCastExpression extends Expression {
     constructor(
         public obj: Expression,
-        public asToken?: Token,
-        public typeExpression?: TypeExpression
+        public asToken: Token,
+        public typeToken: Token
     ) {
         super();
         this.range = util.createBoundingRange(
             this.obj,
             this.asToken,
-            this.typeExpression
+            this.typeToken
         );
     }
 
@@ -1592,7 +1569,6 @@ export class TypeCastExpression extends Expression {
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
-            walk(this, 'typeExpression', visitor, options);
         }
     }
 }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2576,6 +2576,82 @@ export class Parser {
     }
 
     /**
+     * Creates a TypeExpression, which wraps standard ASTNodes that represent a BscType
+     */
+    private typeExpression(): TypeExpression {
+        const changedTokens: { token: Token; oldKind: TokenKind }[] = [];
+        try {
+            let expr: Expression = this.getTypeExpressionPart(changedTokens);
+            while (this.options.mode === ParseMode.BrighterScript && this.matchAny(TokenKind.Or)) {
+                // If we're in Brighterscript mode, allow union types with "or" between types
+                // TODO: Handle Union types in parens? eg. "(string or integer)"
+                let operator = this.previous();
+                let right = this.getTypeExpressionPart(changedTokens);
+                if (right) {
+                    expr = new BinaryExpression(expr, operator, right);
+                } else {
+                    break;
+                }
+            }
+            if (expr) {
+                return new TypeExpression(expr);
+            }
+
+        } catch (error) {
+            // Something went wrong - reset the kind to what it was previously
+            for (const changedToken of changedTokens) {
+                changedToken.token.kind = changedToken.oldKind;
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Gets a single "part" of a type of a potential Union type
+     * Note: this does not NEED to be part of a union type, but the logic is the same
+     *
+     * @param changedTokens an array that is modified with any tokens that have been changed from their default kind to identifiers - eg. when a keyword is used as type
+     * @returns an expression that was successfully parsed
+     */
+    private getTypeExpressionPart(changedTokens: { token: Token; oldKind: TokenKind }[]) {
+        let expr: VariableExpression | DottedGetExpression | TypedArrayExpression;
+        if (this.checkAny(...DeclarableTypes)) {
+            // if this is just a type, just use directly
+            expr = new VariableExpression(this.advance() as Identifier);
+        } else {
+            if (this.checkAny(...AllowedTypeIdentifiers)) {
+                // Since the next token is allowed as a type identifier, change the kind
+                let nextToken = this.peek();
+                changedTokens.push({ token: nextToken, oldKind: nextToken.kind });
+                nextToken.kind = TokenKind.Identifier;
+            }
+            expr = this.identifyingExpression(AllowedTypeIdentifiers);
+        }
+
+        //Check if it has square brackets, thus making it an array
+        if (expr && this.check(TokenKind.LeftSquareBracket)) {
+            if (this.options.mode === ParseMode.BrightScript) {
+                // typed arrays not allowed in Brightscript
+                this.warnIfNotBrighterScriptMode('typed arrays');
+                return expr;
+            }
+
+            // Check if it is an array - that is, if it has `[]` after the type
+            // eg. `string[]` or `SomeKlass[]`
+            // This is while loop, so it supports multidimensional arrays (eg. integer[][])
+            while (this.check(TokenKind.LeftSquareBracket)) {
+                const leftBracket = this.advance();
+                if (this.check(TokenKind.RightSquareBracket)) {
+                    const rightBracket = this.advance();
+                    expr = new TypedArrayExpression(expr, leftBracket, rightBracket);
+                }
+            }
+        }
+
+        return expr;
+    }
+
+    /**
      * Tries to get the next token as a type
      * Allows for built-in types (double, string, etc.) or namespaced custom types in Brighterscript mode
      * Will return a token of whatever is next to be parsed

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -83,6 +83,7 @@ import {
     TemplateStringExpression,
     TemplateStringQuasiExpression,
     TernaryExpression,
+    TypeCastExpression,
     UnaryExpression,
     VariableExpression,
     XmlAttributeGetExpression
@@ -1004,7 +1005,7 @@ export class Parser {
         // parse argument default value
         if (this.match(TokenKind.Equal)) {
             // it seems any expression is allowed here -- including ones that operate on other arguments!
-            defaultValue = this.expression();
+            defaultValue = this.expression(false);
         }
 
         let asToken = null;
@@ -2277,8 +2278,29 @@ export class Parser {
         this.pendingAnnotations = parentAnnotations;
     }
 
-    private expression(): Expression {
-        const expression = this.anonymousFunction();
+    private expression(findTypeCast = true): Expression {
+        let expression = this.anonymousFunction();
+        let asToken: Token;
+        let typeToken: Token;
+        if (findTypeCast) {
+            do {
+                if (this.check(TokenKind.As)) {
+                    this.warnIfNotBrighterScriptMode('type cast');
+                    // Check if this expression is wrapped in any type casts
+                    // allows for multiple casts:
+                    // myVal = foo() as dynamic as string
+
+                    asToken = this.advance();
+                    typeToken = this.typeToken();
+                    if (asToken && typeToken) {
+                        expression = new TypeCastExpression(expression, asToken, typeToken);
+                    }
+                } else {
+                    break;
+                }
+
+            } while (asToken && typeToken);
+        }
         this._references.expressions.add(expression);
         return expression;
     }
@@ -2575,12 +2597,11 @@ export class Parser {
         return expression;
     }
 
-
-
     /**
      * Tries to get the next token as a type
      * Allows for built-in types (double, string, etc.) or namespaced custom types in Brighterscript mode
      * Will return a token of whatever is next to be parsed
+     * Will allow v1 type syntax (typed arrays, union types), but there is no validation on types used this way
      */
     private typeToken(): Token {
         let typeToken: Token;
@@ -2622,7 +2643,6 @@ export class Parser {
                     resultToken = createToken(TokenKind.Dynamic, null, util.createBoundingRange(resultToken, typeToken, orToken));
                     isAUnion = true;
                 }
-
             }
         }
         if (isAUnion) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,6 +35,7 @@ import * as requireRelative from 'require-relative';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
 import type { AstNode, Expression, Statement } from './parser/AstNode';
+import { components, events, interfaces } from './roku-types';
 
 export class Util {
     public clearConsole() {
@@ -1526,6 +1527,15 @@ export class Util {
                 range: this.createRange(0, 0, 0, Number.MAX_VALUE)
             }]);
         }
+    }
+
+    public isBuiltInType(typeName: string) {
+        const typeNameLower = typeName.toLowerCase();
+        if (typeNameLower.startsWith('rosgnode')) {
+            // NOTE: this is unsafe and only used to avoid validation errors in backported v1 type syntax
+            return true;
+        }
+        return components[typeNameLower] || interfaces[typeNameLower] || events[typeNameLower];
     }
 }
 


### PR DESCRIPTION
Allows:
- typed array syntax
- union type syntax
- using built-in component/object/interface/event types
- type cast syntax

This does NO additional validation. Use this syntax at your own risk.

In transpiled code:
- Typed Arrays are converted to `dynamic`
- Union types are converted to `dynamic`
- Built in types are converted to `object` (just like Classes/interfaces)
- Type casts are completely ignored and removed

