### PR TITLE
Built-in Objects have their interfaces as members

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -2801,6 +2801,24 @@ describe('Program', () => {
             expect(roSGNodeNodeType.isTypeCompatible(rowListType)).to.be.true;
             expect(roSGNodeNodeType.isTypeCompatible(taskType)).to.be.true;
         });
+
+        it('built-in objects have interfaces as members', () => {
+            const table = program.globalScope.symbolTable;
+            const opts = { flags: SymbolTypeFlag.typetime };
+            const labelType = table.getSymbolType('roSGNodeLabel', opts);
+            const registryType = table.getSymbolType('roRegistry', opts);
+
+            expectTypeToBe(labelType.getMemberType('ifSGNodeChildren', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+            expectTypeToBe(registryType.getMemberType('ifRegistry', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+        });
+
+        it('built-in interfaces do not have themselves as members', () => {
+            const table = program.globalScope.symbolTable;
+            const opts = { flags: SymbolTypeFlag.typetime };
+            const ifAAType = table.getSymbolType('ifAssociativeArray', opts);
+
+            expect(ifAAType.getMemberType('ifAssociativeArray', { flags: SymbolTypeFlag.runtime }).isResolvable()).to.be.false;
+        });
     });
 
     describe('manifest', () => {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -169,6 +169,11 @@ export class Program {
             this.globalScope.symbolTable.addSymbol(callable.name, { description: callable.shortDescription }, callable.type, SymbolTypeFlag.runtime);
         }
 
+        for (const ifaceData of Object.values(interfaces) as BRSInterfaceData[]) {
+            const nodeType = new InterfaceType(ifaceData.name);
+            nodeType.addBuiltInInterfaces();
+            this.globalScope.symbolTable.addSymbol(ifaceData.name, { description: ifaceData.description }, nodeType, SymbolTypeFlag.typetime);
+        }
 
         for (const nodeData of Object.values(nodes) as SGNodeData[]) {
             this.recursivelyAddNodeToSymbolTable(nodeData);
@@ -181,12 +186,6 @@ export class Program {
                 // we will add `roSGNode` as shorthand for `roSGNodeNode`, since all roSgNode components are SceneGraph nodes
                 this.globalScope.symbolTable.addSymbol(componentData.name, { description: componentData.description }, nodeType, SymbolTypeFlag.typetime);
             }
-        }
-
-        for (const ifaceData of Object.values(interfaces) as BRSInterfaceData[]) {
-            const nodeType = new InterfaceType(ifaceData.name);
-            nodeType.addBuiltInInterfaces();
-            this.globalScope.symbolTable.addSymbol(ifaceData.name, { description: ifaceData.description }, nodeType, SymbolTypeFlag.typetime);
         }
 
         for (const eventData of Object.values(events) as BRSEventData[]) {

--- a/src/types/BuiltInInterfaceAdder.ts
+++ b/src/types/BuiltInInterfaceAdder.ts
@@ -51,6 +51,15 @@ export class BuiltInInterfaceAdder {
         for (const iface of interfacesToLoop) {
             const lowerIfaceName = iface.name.toLowerCase();
             const ifaceData = (interfaces[lowerIfaceName] ?? events[lowerIfaceName]) as BRSInterfaceData;
+
+            if (builtInComponent.interfaces) {
+                // this type has interfaces - add them directly as members
+                const ifaceType = this.getLookupTable()?.getSymbolType(iface.name, { flags: SymbolTypeFlag.typetime });
+                if (ifaceType) {
+                    builtInMemberTable.addSymbol(iface.name, { completionPriority: 1 }, ifaceType, SymbolTypeFlag.runtime);
+                }
+            }
+
             for (const method of ifaceData.methods ?? []) {
                 const methodFuncType = this.buildMethodFromDocData(method, overrides, thisType);
                 builtInMemberTable.addSymbol(method.name, { description: method.description, completionPriority: 1 }, methodFuncType, SymbolTypeFlag.runtime);


### PR DESCRIPTION
Adds all the interfaces a built-in object has as accessible members.


![image](https://github.com/rokucommunity/brighterscript/assets/810290/128301d7-b8e6-4346-a9d2-f8ec2794acbd)


addresses: #1038 