### PR TITLE
Do not do validation on dotted sets of AAs

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1597,6 +1597,56 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('allows setting a member of an overriden member of an aa', () => {
+            program.setFile('source/main.bs', `
+                sub makeAA()
+                    myAA = {}
+                    addItemsToAA(myAA)
+                    myAA.items.value = "other string"
+                end sub
+
+                sub addItemsToAA(someAA)
+                    someAA.items = {value: "some string"}
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows accessing a member of an overriden member of an aa', () => {
+            program.setFile('source/main.bs', `
+                sub makeAA()
+                    myAA = {}
+                    addItemsToAA(myAA)
+                    print myAA.items.value.len()
+                end sub
+
+                sub addItemsToAA(someAA)
+                    someAA.items = {value: "some string"}
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows using a member of an overriden member of an aa in a different way', () => {
+            program.setFile('source/main.bs', `
+                sub makeAA()
+                    myAA = {}
+                    addItemsToAA(myAA)
+                    for each item in myAA.items
+                        print item
+                    end for
+                end sub
+
+                sub addItemsToAA(someAA)
+                    someAA.items = [0, 1, 2, 3]
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('itemCannotBeUsedAsVariable', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { isAssignmentStatement, isBrsFile, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isObjectType, isPrimitiveType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
+import { isAssignmentStatement, isAssociativeArrayType, isBrsFile, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isObjectType, isPrimitiveType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -376,13 +376,19 @@ export class ScopeValidator {
      * Detect return statements with incompatible types vs. declared return type
      */
     private validateDottedSetStatement(file: BrsFile, dottedSetStmt: DottedSetStatement) {
-        const typeChainExpectedLHS = [];
+        const typeChainExpectedLHS = [] as TypeChainEntry[];
         const getTypeOpts = { flags: SymbolTypeFlag.runtime };
 
         const expectedLHSType = dottedSetStmt?.getType({ ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
         const actualRHSType = dottedSetStmt?.value?.getType(getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
         const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
+        // check if anything in typeChain is an AA - if so, just allow it
+        if (typeChainExpectedLHS.find(typeChainItem => isAssociativeArrayType(typeChainItem.type))) {
+            // something in the chain is an AA
+            // treat members as dynamic - they could have been set without the type system's knowledge
+            return;
+        }
         if (!expectedLHSType?.isResolvable()) {
             this.addMultiScopeDiagnostic({
                 file: file as BscFile,


### PR DESCRIPTION
![image](https://github.com/rokucommunity/brighterscript/assets/810290/97b37225-8181-477d-a72a-a5b96ad6e6b0)


We agreed that since AAs can change and have their properties overwritten, there will be no validation on invalid types on dotted-set's and dotted-gets of AAs

Addresses #1037 