### PR TITLE
Changed adding invalid as arg to empty callfunc invocations by default

### DIFF
--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -283,7 +283,7 @@
             "default": false
         },
         "legacyCallfuncHandling": {
-            "description": "Legacy RokuOS versions required at least a single argument in callfunc() invocations. Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present. This is not necessary in modern RokuOS versions.",
+            "description": "Legacy RokuOS versions required at least one argument in callfunc() invocations. Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present. This is not necessary in modern RokuOS versions.",
             "type": "boolean",
             "default": false
         }

--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -281,6 +281,11 @@
             "description": "Allow brighterscript features (classes, interfaces, etc...) to be included in BrightScript (`.brs`) files, and force those files to be transpiled.",
             "type": "boolean",
             "default": false
+        },
+        "legacyCallfuncHandling": {
+            "description": "Legacy RokuOS versions required at least a single argument in callfunc() invocations. Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present. This is not necessary in modern RokuOS versions.",
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -196,7 +196,7 @@ export interface BsConfig {
      */
     bslibDestinationDir?: string;
 
-    /* Legacy RokuOS versions required at least a single argument in callfunc() invocations.
+    /* Legacy RokuOS versions required at least one argument in callfunc() invocations.
      * Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present.
      * This is not necessary in modern RokuOS versions.
      */

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -195,6 +195,12 @@ export interface BsConfig {
      * scripts inside `source` that depend on bslib.brs.  Defaults to `source`.
      */
     bslibDestinationDir?: string;
+
+    /* Legacy RokuOS versions required at least a single argument in callfunc() invocations.
+     * Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present.
+     * This is not necessary in modern RokuOS versions.
+     */
+    legacyCallfuncHandling?: boolean;
 }
 
 type OptionalBsConfigFields =

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2613,7 +2613,8 @@ describe('BrsFile', () => {
                 expectZeroDiagnostics(program);
             });
 
-            it('sets invalid on empty callfunc', async () => {
+            it('sets invalid on empty callfunc with legacyCallfuncHandling=true', async () => {
+                program.options.legacyCallfuncHandling = true;
                 await testTranspile(`
                     sub main()
                         node = invalid
@@ -2626,6 +2627,24 @@ describe('BrsFile', () => {
                         node = invalid
                         node.callfunc("doSomething", invalid)
                         m.top.node.callfunc("doSomething", invalid)
+                        m.top.node.callfunc("doSomething", 1)
+                    end sub
+                `);
+            });
+
+            it('empty callfunc allowed by default', async () => {
+                await testTranspile(`
+                    sub main()
+                        node = invalid
+                        node@.doSomething()
+                        m.top.node@.doSomething()
+                        m.top.node@.doSomething(1)
+                    end sub
+                `, `
+                    sub main()
+                        node = invalid
+                        node.callfunc("doSomething")
+                        m.top.node.callfunc("doSomething")
                         m.top.node.callfunc("doSomething", 1)
                     end sub
                 `);

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1140,14 +1140,11 @@ export class CallfuncExpression extends Expression {
             state.sourceNode(this.operator, '.callfunc'),
             state.transpileToken(this.openingParen),
             //the name of the function
-            state.sourceNode(this.methodName, ['"', this.methodName.text, '"']),
-            ', '
+            state.sourceNode(this.methodName, ['"', this.methodName.text, '"'])
         );
-        //transpile args
-        //callfunc with zero args never gets called, so pass invalid as the first parameter if there are no args
-        if (this.args.length === 0) {
-            result.push('invalid');
-        } else {
+        if (this.args?.length > 0) {
+            result.push(', ');
+            //transpile args
             for (let i = 0; i < this.args.length; i++) {
                 //add comma between args
                 if (i > 0) {
@@ -1156,7 +1153,10 @@ export class CallfuncExpression extends Expression {
                 let arg = this.args[i];
                 result.push(...arg.transpile(state));
             }
+        } else if (state.options.legacyCallfuncHandling) {
+            result.push(', ', 'invalid');
         }
+
         result.push(
             state.transpileToken(this.closingParen)
         );

--- a/src/util.ts
+++ b/src/util.ts
@@ -375,7 +375,8 @@ export class Util {
             emitDefinitions: config.emitDefinitions === true ? true : false,
             removeParameterTypes: config.removeParameterTypes === true ? true : false,
             logLevel: logLevel,
-            bslibDestinationDir: bslibDestinationDir
+            bslibDestinationDir: bslibDestinationDir,
+            legacyCallfuncHandling: config.legacyCallfuncHandling === true ? true : false
         };
 
         //mutate `config` in case anyone is holding a reference to the incomplete one


### PR DESCRIPTION
New `bsconfig.json` option:

```
        "legacyCallfuncHandling": {
            "description": "Legacy RokuOS versions required at least a single argument in callfunc() invocations. Previous brighterscript versions handled this by inserting invalid as an argument when no other args are present. This is not necessary in modern RokuOS versions.",
            "type": "boolean",
            "default": false
        }
```

addresses #1018