### PR TITLE
Fix parsing issues with multi-index IndexedSet and IndexedGet

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2582,6 +2582,40 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('handles multi-index multi-dimensional arrays', () => {
+            testTranspile(`
+                sub main()
+                    myMultiArray = [[[[[[[[["hello"]]]]]]]]]
+                    myMultiArray[0][0][0][0][0][0][0][0][0] = "goodbye"
+                    print myMultiArray[0, 0, 0, 0, 0, 0, 0, 0, 0]
+                end sub
+            `, `
+                sub main()
+                    myMultiArray = [
+                        [
+                            [
+                                [
+                                    [
+                                        [
+                                            [
+                                                [
+                                                    [
+                                                        "hello"
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                    myMultiArray[0][0][0][0][0][0][0][0][0] = "goodbye"
+                    print myMultiArray[0, 0, 0, 0, 0, 0, 0, 0, 0]
+                end sub
+            `);
+        });
+
         it('transpiles calls to fully-qualified namespaced functions', () => {
             testTranspile(`
                 namespace NameA
@@ -3852,6 +3886,5 @@ describe('BrsFile', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
-
     });
 });

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2053,7 +2053,8 @@ export class Parser {
                         ? right
                         : new BinaryExpression(left, operator, right),
                     left.openingSquare,
-                    left.closingSquare
+                    left.closingSquare,
+                    left.additionalIndexes
                 );
             } else if (isDottedGetExpression(left)) {
                 return new DottedSetStatement(
@@ -2437,22 +2438,36 @@ export class Parser {
     private indexedGet(expr: Expression) {
         let openingSquare = this.previous();
         let questionDotToken = this.getMatchingTokenAtOffset(-2, TokenKind.QuestionDot);
-        let index: Expression;
-        let closingSquare: Token;
+        let indexes: Expression[] = [];
+
+
+        //consume leading newlines
         while (this.match(TokenKind.Newline)) { }
+
         try {
-            index = this.expression();
+            indexes.push(
+                this.expression()
+            );
+            //consume additional indexes separated by commas
+            while (this.check(TokenKind.Comma)) {
+                //discard the comma
+                this.advance();
+                indexes.push(
+                    this.expression()
+                );
+            }
         } catch (error) {
             this.rethrowNonDiagnosticError(error);
         }
-
+        //consume trailing newlines
         while (this.match(TokenKind.Newline)) { }
-        closingSquare = this.tryConsume(
+
+        const closingSquare = this.tryConsume(
             DiagnosticMessages.expectedRightSquareBraceAfterArrayOrObjectIndex(),
             TokenKind.RightSquareBracket
         );
 
-        return new IndexedGetExpression(expr, index, openingSquare, closingSquare, questionDotToken);
+        return new IndexedGetExpression(expr, indexes.shift(), openingSquare, closingSquare, questionDotToken, indexes);
     }
 
     private newExpression() {
@@ -3002,6 +3017,11 @@ export class Parser {
         return this.previous()?.kind === tokenKind;
     }
 
+    /**
+     * Check that the next token kind is the expected kind
+     * @param tokenKind the expected next kind
+     * @returns true if the next tokenKind is the expected value
+     */
     private check(tokenKind: TokenKind): boolean {
         const nextKind = this.peek().kind;
         if (nextKind === TokenKind.Eof) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1043,7 +1043,8 @@ export class IndexedSetStatement extends Statement {
         readonly index: Expression,
         readonly value: Expression,
         readonly openingSquare: Token,
-        readonly closingSquare: Token
+        readonly closingSquare: Token,
+        readonly additionalIndexes?: Expression[]
     ) {
         super();
         this.range = util.createBoundingRange(
@@ -1053,6 +1054,7 @@ export class IndexedSetStatement extends Statement {
             closingSquare,
             value
         );
+        this.additionalIndexes ??= [];
     }
 
     public readonly range: Range;
@@ -1062,20 +1064,30 @@ export class IndexedSetStatement extends Statement {
         if (CompoundAssignmentOperators.includes((this.value as BinaryExpression)?.operator?.kind)) {
             return this.value.transpile(state);
         } else {
-            return [
+            const result = [];
+            result.push(
                 //obj
                 ...this.obj.transpile(state),
                 //   [
-                state.transpileToken(this.openingSquare),
-                //    index
-                ...this.index.transpile(state),
-                //         ]
+                state.transpileToken(this.openingSquare)
+            );
+            const indexes = [this.index, ...this.additionalIndexes ?? []];
+            for (let i = 0; i < indexes.length; i++) {
+                //add comma between indexes
+                if (i > 0) {
+                    result.push(', ');
+                }
+                let index = indexes[i];
+                result.push(
+                    ...(index?.transpile(state) ?? [])
+                );
+            }
+            result.push(
                 state.transpileToken(this.closingSquare),
-                //           =
                 ' = ',
-                //             value
                 ...this.value.transpile(state)
-            ];
+            );
+            return result;
         }
     }
 
@@ -1083,6 +1095,7 @@ export class IndexedSetStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
             walk(this, 'index', visitor, options);
+            walkArray(this.additionalIndexes, visitor, options, this);
             walk(this, 'value', visitor, options);
         }
     }

--- a/src/parser/tests/expression/Indexing.spec.ts
+++ b/src/parser/tests/expression/Indexing.spec.ts
@@ -5,9 +5,10 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
-import { AssignmentStatement, DottedSetStatement, IndexedSetStatement } from '../../Statement';
+import type { IndexedSetStatement } from '../../Statement';
+import { AssignmentStatement } from '../../Statement';
 import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
-import { isAssignmentStatement, isDottedGetExpression, isDottedSetStatement, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isVariableExpression } from '../../../astUtils/reflection';
+import { isAssignmentStatement, isDottedGetExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isVariableExpression } from '../../../astUtils/reflection';
 import type { DottedGetExpression, IndexedGetExpression, VariableExpression } from '../../Expression';
 import { WalkMode } from '../../../astUtils/visitors';
 


### PR DESCRIPTION
Fixes parsing and transpile issues with mutli-index `IndexedGetExpression` and `IndexedSetStatement`.

The solution is a little "icky", because we can't break backwards compatability, so I had to add `additionalIndexes` to the two AST node types. In v1, we should merge those into a single `.indexes` prop on the nodes instead. 

Fixes #1048 

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/b3051453-1374-4599-8232-ffb07345e8a7)
