### PR TITLE
Allow Additional v1 Syntax:

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3860,6 +3860,19 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('allows built-in types for interface members', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                interface MyBase
+                    regex as roRegex
+                    node as roSGNodeLabel
+                    sub outputMatches(textInput as string)
+                    function getLabelParent() as roSGNode
+                end interface
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
         it('allows extends on interfaces', () => {
             testTranspile(`
                 interface MyBase
@@ -3885,6 +3898,46 @@ describe('BrsFile', () => {
             `);
             program.validate();
             expectZeroDiagnostics(program);
+        });
+
+        it('allows built-in types for class members', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                class MyBase
+                    regex as roRegex
+                    node as roSGNodeLabel
+
+                    sub outputMatches(textInput as string)
+                        matches = m.regex.match(textInput)
+                        if matches.count() > 1
+                            m.node.text = matches[1]
+                        else
+                            m.node.text = "no match"
+                        end if
+                    end sub
+
+                    function getLabelParent() as roSGNode
+                        return m.node.getParent()
+                    end function
+                end class
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows types on lhs of assignments', () => {
+            testTranspile(`
+                sub foo(node as roSGNode)
+                    nodeParent as roSGNode = node.getParent()
+                    text as string = nodeParent.id
+                    print text
+                end sub
+            `, `
+                sub foo(node as object)
+                    nodeParent = node.getParent()
+                    text = nodeParent.id
+                    print text
+                end sub
+            `);
         });
     });
 });

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -324,7 +324,8 @@ export class BsClassValidator {
                             const namespace = classStatement.findAncestor<NamespaceStatement>(isNamespaceStatement);
                             const currentNamespaceName = namespace?.getName(ParseMode.BrighterScript);
                             //check if this custom type is in our class map
-                            if (!this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName)) {
+                            const isBuiltInType = util.isBuiltInType(lowerFieldTypeName);
+                            if (!isBuiltInType && !this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName)) {
                                 this.diagnostics.push({
                                     ...DiagnosticMessages.cannotFindType(fieldTypeName),
                                     range: statement.type?.range ?? statement.range,


### PR DESCRIPTION
Allows without diagnostic, but no deeper validation:

- built-in types for class member types
- type declarations on LHS of assignments

eg. this is now ok:

```
class Foo
    node as roSGNode
end class

sub someFunc()
    myStr as string = "hello"
end sub
```