### PR TITLE
If a namespace shadows a function, still allow processing to continue

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -7,7 +7,7 @@ import { Program } from './Program';
 import PluginInterface from './PluginInterface';
 import { expectDiagnostics, expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics, trim } from './testHelpers.spec';
 import { Logger } from './Logger';
-import { BrsFile } from './files/BrsFile';
+import type { BrsFile } from './files/BrsFile';
 import type { NamespaceStatement } from './parser/Statement';
 import type { CompilerPlugin, OnScopeValidateEvent } from './interfaces';
 import { DiagnosticOrigin } from './interfaces';

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1282,19 +1282,6 @@ describe('Scope', () => {
                 ]);
             });
 
-            it('should validate when a namespace has a name collision', () => {
-                program.setFile('source/main.bs', `
-                    namespace Log ' this is invalid because it has the same name as a global function
-                        function anything()
-                        end function
-                    end namespace
-                `);
-                program.validate();
-                expectDiagnosticsIncludes(program, [
-                    DiagnosticMessages.nameCollision('Namespace', 'Global Function', 'Log').message
-                ]);
-            });
-
             it('should validate when a namespace has a name collision with a class', () => {
                 program.setFile('source/main.bs', `
                     namespace SomeKlass
@@ -2252,26 +2239,6 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectZeroDiagnostics(program);
-            });
-
-            it('should validate when a namespace in a .d.bs file has an invalid name', () => {
-                program.setFile('source/roku_modules/anything.d.bs', `
-                    namespace Log ' this is invalid because it has the same name as a global function
-                        function anything()
-                        end function
-                    end namespace
-                `);
-                program.setFile('source/main.bs', `
-                    namespace alpha
-                         sub someFunc()
-                         end sub
-                    end namespace
-                `);
-                program.validate();
-                expectDiagnosticsIncludes(program, [
-                    DiagnosticMessages.nameCollision('Namespace', 'Global Function', 'Log').message
-                ]);
-
             });
         });
     });


### PR DESCRIPTION
This fixes an issue in the JellyFin-roku project

The issue was that it was using the `roku-log` which declares the namespace `log`.
Previously, this was a problem because it shadows the native function `log`, and `Scope.linkSymbolTable()` panicked when the type of something that should have been a namespace wasn't a namespace, and quit processing the rest of the namespaces.

Anyway, that's fixed in this PR. More work needs to be done to handle *general* shadowing, but this fixes the specific issue for Jellyfin-roku
