### PR TITLE
Fix sourcemap comment and add `file` prop to map

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2681,6 +2681,28 @@ describe('BrsFile', () => {
             testTranspile(`function abc()\nend function`, undefined, 'none');
         });
 
+        it('generates proper sourcemap comment', () => {
+            program.options.sourceMap = true;
+            const file = program.setFile('source/main.bs', `
+                sub main()
+                end sub
+            `);
+            expect(file.transpile().code).to.eql(undent`
+                sub main()
+                end sub
+                '//# sourceMappingURL=./main.brs.map
+            `);
+        });
+
+        it('includes sourcemap.name property', () => {
+            program.options.sourceMap = true;
+            const file = program.setFile('source/main.bs', `
+                sub main()
+                end sub
+            `);
+            expect(file.transpile().map.toJSON().file).to.eql('main.brs');
+        });
+
         it('handles sourcemap edge case', async () => {
             let source =
                 'sub main()\n' +

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1505,11 +1505,12 @@ export class BrsFile {
         state.editor.undoAll();
 
         if (this.program.options.sourceMap) {
-            return new SourceNode(null, null, null, [
+            const stagingFileName = path.basename(state.srcPath).replace(/\.bs$/, '.brs');
+            return new SourceNode(null, null, stagingFileName, [
                 transpileResult,
                 //add the sourcemap reference comment
-                `'//# sourceMappingURL=./${path.basename(state.srcPath)}.map`
-            ]).toStringWithSourceMap();
+                state.newline + `'//# sourceMappingURL=./${stagingFileName}.map`
+            ]).toStringWithSourceMap({ file: stagingFileName });
         } else {
             return {
                 code: transpileResult.toString(),


### PR DESCRIPTION
- Adds the `file` prop to sourcemaps to better align with the spec.
- fixes the filename in the sourceMappingUrl comment at the bottom of every file
- moves the sourceMappingUrl entry to a new line to make the file more clean