### PR TITLE
Fix member hovers for classes, interfaces and enums

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -158,6 +158,13 @@ export function isInterfaceMethodStatement(element: AstNode | undefined): elemen
 export function isInterfaceFieldStatement(element: AstNode | undefined): element is InterfaceFieldStatement {
     return element?.kind === AstNodeKind.InterfaceFieldStatement;
 }
+export function isMemberField(element: AstNode | undefined): element is InterfaceFieldStatement | FieldStatement {
+    return isFieldStatement(element) || isInterfaceFieldStatement(element);
+}
+export function isMemberMethod(element: AstNode | undefined): element is InterfaceMethodStatement | MethodStatement {
+    return isMethodStatement(element) || isInterfaceMethodStatement(element);
+}
+
 export function isEnumStatement(element: AstNode | undefined): element is EnumStatement {
     return element?.kind === AstNodeKind.EnumStatement;
 }

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -582,6 +582,20 @@ describe('HoverProcessor', () => {
             let hover = program.getHover(file.srcPath, util.createPosition(3, 24))[0];
             expect(hover?.contents).to.eql([`${fence('SomeIFace.name as string')}${commentSep}Some description`]);
         });
+
+        it('should include leading trivia of enum member field hover', () => {
+            let file = program.setFile('source/main.bs', `
+                enum Direction
+                    ' Go Up
+                    up  = "up"
+                    down =  "down"
+                end enum
+            `);
+            program.validate();
+            //    u|p  = "up"
+            let hover = program.getHover(file.srcPath, util.createPosition(3, 22))[0];
+            expect(hover?.contents).to.eql([`${fence('Direction.up as Direction')}${commentSep}Go Up`]);
+        });
     });
 
     describe('callFunc', () => {

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,5 +1,5 @@
 import { SourceNode } from 'source-map';
-import { isBrsFile, isCallfuncExpression, isClassStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isMemberField, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
+import { isBrsFile, isCallfuncExpression, isClassStatement, isEnumMemberStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isMemberField, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { ExtraSymbolData, Hover, ProvideHoverEvent, TypeChainEntry } from '../../interfaces';
@@ -13,7 +13,7 @@ import type { AstNode, Expression } from '../../parser/AstNode';
 import type { Scope } from '../../Scope';
 import type { FunctionScope } from '../../FunctionScope';
 import type { BscType } from '../../types/BscType';
-import type { ClassStatement, FieldStatement, InterfaceFieldStatement, InterfaceStatement } from '../../parser/Statement';
+import type { ClassStatement, EnumStatement, FieldStatement, InterfaceFieldStatement, InterfaceStatement } from '../../parser/Statement';
 
 const fence = (code: string) => util.mdFence(code, 'brightscript');
 
@@ -169,6 +169,9 @@ export class HoverProcessor {
                 } else if (isMemberField(expression)) {
                     hoverContent = this.getMemberHover(expression, exprType);
                     descriptionNode = expression;
+                } else if (isEnumMemberStatement(expression)) {
+                    hoverContent = fence(`${(expression.parent as EnumStatement)?.name}.${expression.tokens.name.text} as ${exprType.toString()}`.trim());
+                    descriptionNode = expression;
                 } else if (isNamespaceType(exprType) ||
                     isEnumType(expression.getType({ flags: SymbolTypeFlag.typetime }))) {
                     hoverContent = this.getCustomTypeHover(exprType, extraData);
@@ -185,7 +188,7 @@ export class HoverProcessor {
                     modifiers.push(TokenKind.Optional);
                 }
                 if (modifiers.length > 0) {
-                    hoverContent += `\n*(${modifiers.join(', ').toLowerCase()})*`;
+                    hoverContent += `\n * (${modifiers.join(', ').toLowerCase()})* `;
                 }
 
                 if (descriptionNode) {

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,5 +1,5 @@
 import { SourceNode } from 'source-map';
-import { isBrsFile, isCallfuncExpression, isClassStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
+import { isBrsFile, isCallfuncExpression, isClassStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isMemberField, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { ExtraSymbolData, Hover, ProvideHoverEvent, TypeChainEntry } from '../../interfaces';
@@ -13,6 +13,7 @@ import type { AstNode, Expression } from '../../parser/AstNode';
 import type { Scope } from '../../Scope';
 import type { FunctionScope } from '../../FunctionScope';
 import type { BscType } from '../../types/BscType';
+import type { ClassStatement, FieldStatement, InterfaceFieldStatement, InterfaceStatement } from '../../parser/Statement';
 
 const fence = (code: string) => util.mdFence(code, 'brightscript');
 
@@ -116,6 +117,14 @@ export class HoverProcessor {
         return result;
     }
 
+    private getMemberHover(memberExpression: FieldStatement | InterfaceFieldStatement, expressionType: BscType) {
+        let nameText = `${(memberExpression.parent as ClassStatement | InterfaceStatement)?.getName(ParseMode.BrighterScript)}.${memberExpression.tokens.name.text}`;
+        let exprTypeString = expressionType.toString();
+        const innerText = `${nameText} as ${exprTypeString}`.trim();
+        let result = fence(innerText);
+        return result;
+    }
+
     private getBrsFileHover(file: BrsFile): Hover {
         //get the token at the position
         let token = file.getTokenAt(this.event.position);
@@ -154,8 +163,12 @@ export class HoverProcessor {
                 const exprNameString = !processedTypeChain.containsDynamic ? fullName : token.text;
                 const useCustomTypeHover = isInTypeExpression || expression?.findAncestor(isNewExpression);
                 let hoverContent = '';
+                let descriptionNode;
                 if (useCustomTypeHover && isInheritableType(exprType)) {
                     hoverContent = this.getCustomTypeHover(exprType, extraData);
+                } else if (isMemberField(expression)) {
+                    hoverContent = this.getMemberHover(expression, exprType);
+                    descriptionNode = expression;
                 } else if (isNamespaceType(exprType) ||
                     isEnumType(expression.getType({ flags: SymbolTypeFlag.typetime }))) {
                     hoverContent = this.getCustomTypeHover(exprType, extraData);
@@ -175,7 +188,9 @@ export class HoverProcessor {
                     hoverContent += `\n*(${modifiers.join(', ').toLowerCase()})*`;
                 }
 
-                if (extraData.description) {
+                if (descriptionNode) {
+                    hoverContent = this.buildContentsWithDocsFromExpression(hoverContent, descriptionNode);
+                } else if (extraData.description) {
                     hoverContent = this.buildContentsWithDocsFromDescription(hoverContent, extraData.description);
                 } else if (extraData.definingNode) {
                     hoverContent = this.buildContentsWithDocsFromExpression(hoverContent, extraData.definingNode);


### PR DESCRIPTION
Fixes: #907

Enums members
![image](https://github.com/rokucommunity/brighterscript/assets/810290/f810b8e3-2915-4015-a382-31a4db47d864)


Class Members (looks same as interfaces):

![image](https://github.com/rokucommunity/brighterscript/assets/810290/fcdc5147-f6cf-4e27-9be3-21c7944c71cb)

