### PR TITLE
Support when tokens have null ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001518",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
-      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
+      "version": "1.0.30001585",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz",
+      "integrity": "sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==",
       "dev": true,
       "funding": [
         {
@@ -8284,9 +8284,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001518",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
-      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
+      "version": "1.0.30001585",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz",
+      "integrity": "sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==",
       "dev": true
     },
     "caseless": {

--- a/src/astUtils/creators.spec.ts
+++ b/src/astUtils/creators.spec.ts
@@ -1,6 +1,4 @@
 import { expect } from '../chai-config.spec';
-import { interpolatedRange } from '..';
-import { TranspileState } from '../parser/TranspileState';
 import { createStringLiteral } from './creators';
 
 describe('creators', () => {
@@ -18,15 +16,6 @@ describe('creators', () => {
             expect(createStringLiteral('"hello world').token.text).to.equal('"hello world');
             //trailing
             expect(createStringLiteral('hello world"').token.text).to.equal('hello world"');
-        });
-    });
-
-    describe('interpolatedRange', () => {
-        it('can be used in sourcemaps', () => {
-            const state = new TranspileState('source/main.brs', {});
-            const node = state.sourceNode({ range: interpolatedRange }, 'code');
-            //should not crash
-            node.toStringWithSourceMap();
         });
     });
 });

--- a/src/astUtils/creators.ts
+++ b/src/astUtils/creators.ts
@@ -9,6 +9,7 @@ import { Block, MethodStatement } from '../parser/Statement';
 /**
  * A range that points to the beginning of the file. Used to give non-null ranges to programmatically-added source code.
  * (Hardcoded range to prevent circular dependency issue in `../util.ts`)
+ * @deprecated don't use this, it screws up sourcemaps. Just set range to null
  */
 export const interpolatedRange = {
     start: {
@@ -83,7 +84,7 @@ const tokenDefaults = {
     [TokenKind.Whitespace]: ' '
 };
 
-export function createToken<T extends TokenKind>(kind: T, text?: string, range = interpolatedRange): Token & { kind: T } {
+export function createToken<T extends TokenKind>(kind: T, text?: string, range?: Range): Token & { kind: T } {
     return {
         kind: kind,
         text: text ?? tokenDefaults[kind as string] ?? kind.toString().toLowerCase(),
@@ -140,7 +141,7 @@ export function createBooleanLiteral(value: 'true' | 'false', range?: Range) {
 export function createFunctionExpression(kind: TokenKind.Sub | TokenKind.Function) {
     return new FunctionExpression(
         [],
-        new Block([], interpolatedRange),
+        new Block([]),
         createToken(kind),
         kind === TokenKind.Sub ? createToken(TokenKind.EndSub) : createToken(TokenKind.EndFunction),
         createToken(TokenKind.LeftParen),

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -5,7 +5,7 @@ import { FunctionExpression, NamespacedVariableNameExpression, BinaryExpression,
 import type { Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
 import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isNamespacedVariableNameExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression, isTryCatchStatement, isCatchStatement, isThrowStatement } from './reflection';
-import { createToken, createStringLiteral, interpolatedRange as range } from './creators';
+import { createToken, createStringLiteral } from './creators';
 import { Program } from '../Program';
 import { BrsFile } from '../files/BrsFile';
 import { XmlFile } from '../files/XmlFile';
@@ -25,12 +25,12 @@ describe('reflection', () => {
     });
 
     describe('Statements', () => {
-        const ident = createToken(TokenKind.Identifier, 'a', range);
-        const expr = createStringLiteral('', range);
-        const token = createToken(TokenKind.StringLiteral, '', range);
+        const ident = createToken(TokenKind.Identifier, 'a');
+        const expr = createStringLiteral('');
+        const token = createToken(TokenKind.StringLiteral, '');
         const body = new Body([]);
         const assignment = new AssignmentStatement(undefined, ident, expr);
-        const block = new Block([], range);
+        const block = new Block([]);
         const expression = new ExpressionStatement(expr);
         const comment = new CommentStatement([token]);
         const exitFor = new ExitForStatement({ exitFor: token });
@@ -50,7 +50,7 @@ describe('reflection', () => {
         const dottedSet = new DottedSetStatement(expr, ident, expr);
         const indexedSet = new IndexedSetStatement(expr, expr, expr, token, token);
         const library = new LibraryStatement({ library: token, filePath: token });
-        const namespace = new NamespaceStatement(token, new NamespacedVariableNameExpression(createVariableExpression('a', range)), body, token);
+        const namespace = new NamespaceStatement(token, new NamespacedVariableNameExpression(createVariableExpression('a')), body, token);
         const cls = new ClassStatement(token, ident, [], token);
         const imports = new ImportStatement(token, token);
         const catchStmt = new CatchStatement({ catch: token }, ident, block);
@@ -183,19 +183,19 @@ describe('reflection', () => {
     });
 
     describe('Expressions', () => {
-        const ident = createToken(TokenKind.Identifier, 'a', range);
-        const expr = createStringLiteral('', range);
-        const token = createToken(TokenKind.StringLiteral, '', range);
-        const block = new Block([], range);
+        const ident = createToken(TokenKind.Identifier, 'a');
+        const expr = createStringLiteral('');
+        const token = createToken(TokenKind.StringLiteral, '');
+        const block = new Block([]);
         const charCode: Token & { charCode: number } = {
             kind: TokenKind.EscapedCharCodeLiteral,
             text: '0',
-            range: range,
+            range: undefined,
             isReserved: false,
             charCode: 0,
             leadingWhitespace: ''
         };
-        const nsVar = new NamespacedVariableNameExpression(createVariableExpression('a', range));
+        const nsVar = new NamespacedVariableNameExpression(createVariableExpression('a'));
         const binary = new BinaryExpression(expr, token, expr);
         const call = new CallExpression(expr, token, token, []);
         const fun = new FunctionExpression([], block, token, token, token, token);

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2278,11 +2278,9 @@ describe('BrsFile', () => {
                         two = 2
                         print \`1\${two}\${3}\n\`
                         print (1 as integer)
-                        print SOURCE_FILE_PATH
                         print SOURCE_LINE_NUM
                         print FUNCTION_NAME
                         print SOURCE_FUNCTION_NAME
-                        print SOURCE_LOCATION
                         print PKG_LOCATION
                         print PKG_PATH
                         print LINE_NUM
@@ -2334,11 +2332,9 @@ describe('BrsFile', () => {
                         two = 2
                         print ("1" + bslib_toString(two) + bslib_toString(3) + chr(10))
                         print 1
-                        print "file" + ":///c:/projects/roku/brighterscript9__null_range/.tmp/rootDir/source/main.bs"
                         print -1
                         print "test"
                         print "test"
-                        print "file" + ":///c:/projects/roku/brighterscript9__null_range/.tmp/rootDir/source/main.bs:-1"
                         print "pkg:/source/main.brs:" + str(LINE_NUM)
                         print "pkg:/source/main.brs"
                         print LINE_NUM
@@ -2396,6 +2392,22 @@ describe('BrsFile', () => {
                         return instance
                     end function
                 `);
+            });
+
+            it('handles source literals properly', () => {
+                const fsPath = rootDir.replace(/\\/g, '/');
+                doTest(`
+                    sub test()
+                        print SOURCE_FILE_PATH
+                        print SOURCE_LOCATION
+                    end sub
+                `, `
+                    sub test()
+                        print "file" + ":///${fsPath}/source/main.bs"
+                        print "file" + ":///${fsPath}/source/main.bs:-1"
+                    end sub
+                `);
+
             });
             function doTest(source: string, expected = source) {
                 const file = program.setFile<BrsFile>('source/main.bs', '');

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -25,6 +25,7 @@ import * as fsExtra from 'fs-extra';
 import { URI } from 'vscode-uri';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
+import * as fileUrl from 'file-url';
 
 let sinon = sinonImport.createSandbox();
 
@@ -2395,7 +2396,8 @@ describe('BrsFile', () => {
             });
 
             it('handles source literals properly', () => {
-                const fsPath = rootDir.replace(/\\/g, '/');
+                const pathUrl = fileUrl(rootDir);
+                let text = `"${pathUrl.substring(0, 4)}" + "${pathUrl.substring(4)}`;
                 doTest(`
                     sub test()
                         print SOURCE_FILE_PATH
@@ -2403,11 +2405,10 @@ describe('BrsFile', () => {
                     end sub
                 `, `
                     sub test()
-                        print "file" + ":///${fsPath}/source/main.bs"
-                        print "file" + ":///${fsPath}/source/main.bs:-1"
+                        print ${text}/source/main.bs"
+                        print ${text}/source/main.bs:-1"
                     end sub
                 `);
-
             });
             function doTest(source: string, expected = source) {
                 const file = program.setFile<BrsFile>('source/main.bs', '');

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -481,7 +481,7 @@ export class BrsFile {
             for (let param of func.parameters) {
                 scope.variableDeclarations.push({
                     nameRange: param.name.range,
-                    lineIndex: param.name.range.start.line,
+                    lineIndex: param.name.range?.start.line,
                     name: param.name.text,
                     type: param.type
                 });
@@ -492,7 +492,7 @@ export class BrsFile {
                 ForEachStatement: (stmt) => {
                     scope.variableDeclarations.push({
                         nameRange: stmt.item.range,
-                        lineIndex: stmt.item.range.start.line,
+                        lineIndex: stmt.item.range?.start.line,
                         name: stmt.item.text,
                         type: new DynamicType()
                     });
@@ -501,7 +501,7 @@ export class BrsFile {
                     const { identifier } = stmt.tokens;
                     scope.labelStatements.push({
                         nameRange: identifier.range,
-                        lineIndex: identifier.range.start.line,
+                        lineIndex: identifier.range?.start.line,
                         name: identifier.text
                     });
                 }
@@ -527,7 +527,7 @@ export class BrsFile {
             if (scope) {
                 scope.variableDeclarations.push({
                     nameRange: statement.name.range,
-                    lineIndex: statement.name.range.start.line,
+                    lineIndex: statement.name.range?.start.line,
                     name: statement.name.text,
                     type: this.getBscTypeFromAssignment(statement, scope)
                 });

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -102,7 +102,9 @@ export class Lexer {
             kind: TokenKind.Eof,
             isReserved: false,
             text: '',
-            range: util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1),
+            range: this.options.trackLocations
+                ? util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
+                : undefined,
             leadingWhitespace: this.leadingWhitespace
         });
         this.leadingWhitespace = '';
@@ -113,10 +115,10 @@ export class Lexer {
      * Fill in missing/invalid options with defaults
      */
     private sanitizeOptions(options: ScanOptions) {
-        return {
-            includeWhitespace: false,
-            ...options
-        } as ScanOptions;
+        options ??= {};
+        options.includeWhitespace ??= false;
+        options.trackLocations ??= true;
+        return options;
     }
 
     /**
@@ -1054,17 +1056,27 @@ export class Lexer {
     }
 
     /**
-     * Creates a `TokenLocation` at the lexer's current position for the provided `text`.
-     * @returns the range of `text` as a `TokenLocation`
+     * Creates a `Range` at the lexer's current position
+     * @returns the range of `text`
      */
     private rangeOf(): Range {
-        return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
+        if (this.options.trackLocations) {
+            return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
+        } else {
+            return undefined;
+        }
     }
 }
 
 export interface ScanOptions {
     /**
      * If true, the whitespace tokens are included. If false, they are discarded
+     * @default false
      */
-    includeWhitespace: boolean;
+    includeWhitespace?: boolean;
+    /**
+     * Should locations be tracked. If false, the `range` property will be omitted
+     * @default true
+     */
+    trackLocations?: boolean;
 }

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -40,7 +40,7 @@ export interface Identifier extends Token {
  * @returns `true` is `obj` is a `Token`, otherwise `false`
  */
 export function isToken(obj: Record<string, any>): obj is Token {
-    return !!(obj.kind && obj.text && obj.range);
+    return !!(obj.kind && obj.text);
 }
 
 /**

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import { Block, CommentStatement, FunctionStatement, NamespaceStatement } from './Statement';
+import type { Block, CommentStatement, FunctionStatement, NamespaceStatement } from './Statement';
 import type { Range } from 'vscode-languageserver';
 import util from '../util';
 import type { BrsTranspileState } from './BrsTranspileState';

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -16,6 +16,7 @@ import { VoidType } from '../types/VoidType';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { FunctionType } from '../types/FunctionType';
+import type { AstNode } from './AstNode';
 import { Expression } from './AstNode';
 import { SymbolTable } from '../SymbolTable';
 import { SourceNode } from 'source-map';
@@ -942,6 +943,20 @@ export class SourceLiteralExpression extends Expression {
         return nameParts.join('$');
     }
 
+    /**
+     * Get the line number from our token or from the closest ancestor that has a range
+     */
+    private getClosestLineNumber() {
+        let node: AstNode = this;
+        while (node) {
+            if (node.range) {
+                return node.range.start.line + 1;
+            }
+            node = node.parent;
+        }
+        return -1;
+    }
+
     transpile(state: BrsTranspileState) {
         let text: string;
         switch (this.token.kind) {
@@ -950,7 +965,8 @@ export class SourceLiteralExpression extends Expression {
                 text = `"${pathUrl.substring(0, 4)}" + "${pathUrl.substring(4)}"`;
                 break;
             case TokenKind.SourceLineNumLiteral:
-                text = `${(this.token.range?.start?.line ?? -2) + 1}`;
+                //TODO find first parent that has range, or default to -1
+                text = `${this.getClosestLineNumber()}`;
                 break;
             case TokenKind.FunctionNameLiteral:
                 text = `"${this.getFunctionName(state, ParseMode.BrightScript)}"`;
@@ -960,7 +976,8 @@ export class SourceLiteralExpression extends Expression {
                 break;
             case TokenKind.SourceLocationLiteral:
                 const locationUrl = fileUrl(state.srcPath);
-                text = `"${locationUrl.substring(0, 4)}" + "${locationUrl.substring(4)}:${(this.token.range?.start?.line ?? -2) + 1}"`;
+                //TODO find first parent that has range, or default to -1
+                text = `"${locationUrl.substring(0, 4)}" + "${locationUrl.substring(4)}:${this.getClosestLineNumber()}"`;
                 break;
             case TokenKind.PkgPathLiteral:
                 let pkgPath1 = `pkg:/${state.file.pkgPath}`

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import type { Block, CommentStatement, FunctionStatement, NamespaceStatement } from './Statement';
+import { Block, CommentStatement, FunctionStatement, NamespaceStatement } from './Statement';
 import type { Range } from 'vscode-languageserver';
 import util from '../util';
 import type { BrsTranspileState } from './BrsTranspileState';
@@ -926,7 +926,7 @@ export class SourceLiteralExpression extends Expression {
     public readonly range: Range;
 
     private getFunctionName(state: BrsTranspileState, parseMode: ParseMode) {
-        let func = state.file.getFunctionScopeAtPosition(this.token.range.start).func;
+        let func = this.findAncestor<FunctionExpression>(isFunctionExpression);
         let nameParts = [];
         while (func.parentFunction) {
             let index = func.parentFunction.childFunctionExpressions.indexOf(func);
@@ -948,7 +948,7 @@ export class SourceLiteralExpression extends Expression {
                 text = `"${pathUrl.substring(0, 4)}" + "${pathUrl.substring(4)}"`;
                 break;
             case TokenKind.SourceLineNumLiteral:
-                text = `${this.token.range.start.line + 1}`;
+                text = `${(this.token.range?.start?.line ?? -2) + 1}`;
                 break;
             case TokenKind.FunctionNameLiteral:
                 text = `"${this.getFunctionName(state, ParseMode.BrightScript)}"`;
@@ -958,7 +958,7 @@ export class SourceLiteralExpression extends Expression {
                 break;
             case TokenKind.SourceLocationLiteral:
                 const locationUrl = fileUrl(state.srcPath);
-                text = `"${locationUrl.substring(0, 4)}" + "${locationUrl.substring(4)}:${this.token.range.start.line + 1}"`;
+                text = `"${locationUrl.substring(0, 4)}" + "${locationUrl.substring(4)}:${(this.token.range?.start?.line ?? -2) + 1}"`;
                 break;
             case TokenKind.PkgPathLiteral:
                 let pkgPath1 = `pkg:/${state.file.pkgPath}`

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -29,7 +29,7 @@ export class BinaryExpression extends Expression {
         public right: Expression
     ) {
         super();
-        this.range = util.createRangeFromPositions(this.left.range.start, this.right.range.end);
+        this.range = util.createBoundingRange(this.left, this.operator, this.right);
     }
 
     public readonly range: Range;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -11,7 +11,7 @@ import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { InternalWalkMode, walk, createVisitor, WalkMode, walkArray } from '../astUtils/visitors';
 import { isCallExpression, isCommentStatement, isEnumMemberStatement, isExpression, isExpressionStatement, isFieldStatement, isFunctionExpression, isFunctionStatement, isIfStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInvalidType, isLiteralExpression, isMethodStatement, isNamespaceStatement, isTypedefProvider, isUnaryExpression, isVoidType } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
-import { createInvalidLiteral, createMethodStatement, createToken, interpolatedRange } from '../astUtils/creators';
+import { createInvalidLiteral, createMethodStatement, createToken } from '../astUtils/creators';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import type { SourceNode } from 'source-map';
@@ -25,7 +25,7 @@ export class EmptyStatement extends Statement {
         /**
          * Create a negative range to indicate this is an interpolated location
          */
-        public range: Range = interpolatedRange
+        public range: Range = undefined
     ) {
         super();
     }
@@ -157,7 +157,7 @@ export class AssignmentStatement extends Statement {
 export class Block extends Statement {
     constructor(
         readonly statements: Statement[],
-        readonly startingRange: Range
+        readonly startingRange?: Range
     ) {
         super();
         this.range = util.createBoundingRange(
@@ -1171,7 +1171,7 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
                 this.nameExpression,
                 this.body,
                 this.endKeyword
-            ) ?? interpolatedRange;
+            );
         }
         return this._range;
     }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -68,21 +68,21 @@ export class Body extends Statement implements TypedefProvider {
                 //this is the first statement. do nothing related to spacing and newlines
 
                 //if comment is on same line as prior sibling
-            } else if (isCommentStatement(statement) && previousStatement && statement.range.start.line === previousStatement.range.end.line) {
+            } else if (isCommentStatement(statement) && previousStatement && statement.range?.start.line === previousStatement.range?.end.line) {
                 result.push(
                     ' '
                 );
 
                 //add double newline if this is a comment, and next is a function
             } else if (isCommentStatement(statement) && nextStatement && isFunctionStatement(nextStatement)) {
-                result.push('\n\n');
+                result.push(state.newline, state.newline);
 
                 //add double newline if is function not preceeded by a comment
             } else if (isFunctionStatement(statement) && previousStatement && !(isCommentStatement(previousStatement))) {
-                result.push('\n\n');
+                result.push(state.newline, state.newline);
             } else {
                 //separate statements by a single newline
-                result.push('\n');
+                result.push(state.newline);
             }
 
             result.push(...statement.transpile(state));
@@ -260,7 +260,7 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
             );
             //add newline for all except final comment
             if (i < this.comments.length - 1) {
-                result.push('\n');
+                result.push(state.newline);
             }
         }
         return result;
@@ -1236,13 +1236,15 @@ export class ImportStatement extends Statement implements TypedefProvider {
         if (this.filePathToken) {
             //remove quotes
             this.filePath = this.filePathToken.text.replace(/"/g, '');
-            //adjust the range to exclude the quotes
-            this.filePathToken.range = util.createRange(
-                this.filePathToken.range.start.line,
-                this.filePathToken.range.start.character + 1,
-                this.filePathToken.range.end.line,
-                this.filePathToken.range.end.character - 1
-            );
+            if (this.filePathToken.range) {
+                //adjust the range to exclude the quotes
+                this.filePathToken.range = util.createRange(
+                    this.filePathToken.range.start.line,
+                    this.filePathToken.range.start.character + 1,
+                    this.filePathToken.range.end.line,
+                    this.filePathToken.range.end.character - 1
+                );
+            }
         }
     }
     public filePath: string;

--- a/src/parser/tests/Parser.spec.ts
+++ b/src/parser/tests/Parser.spec.ts
@@ -1,6 +1,5 @@
 import type { Token } from '../../lexer/Token';
 import { TokenKind, ReservedWords } from '../../lexer/TokenKind';
-import { interpolatedRange } from '../../astUtils/creators';
 import type { Range } from 'vscode-languageserver';
 
 /* A set of utilities to be used while writing tests for the BRS parser. */
@@ -13,7 +12,7 @@ export function token(kind: TokenKind, text?: string): Token {
         kind: kind,
         text: text!,
         isReserved: ReservedWords.has((text ?? '').toLowerCase()),
-        range: interpolatedRange,
+        range: null,
         leadingWhitespace: ''
     };
 }

--- a/src/preprocessor/Chunk.ts
+++ b/src/preprocessor/Chunk.ts
@@ -93,10 +93,7 @@ export class ErrorChunk implements Chunk {
         readonly hashError: Token,
         readonly message: Token
     ) {
-        this.range = util.createRangeFromPositions(
-            this.hashError.range.start,
-            (this.message ?? this.hashError).range.end
-        );
+        this.range = util.createBoundingRange(this.hashError, this.message);
     }
     public readonly range: Range;
 

--- a/src/preprocessor/PreprocessorParser.ts
+++ b/src/preprocessor/PreprocessorParser.ts
@@ -105,7 +105,7 @@ export class PreprocessorParser {
      */
     private hashIf(): CC.Chunk | undefined {
         if (this.match(TokenKind.HashIf)) {
-            let startingLine = this.previous().range.start.line;
+            let startingLine = this.previous().range?.start?.line;
             let elseChunk: CC.Chunk[] | undefined;
 
             let ifCondition = this.advance();

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -175,9 +175,9 @@ export function expectZeroDiagnostics(arg: DiagnosticCollection) {
         for (const diagnostic of diagnostics) {
             //escape any newlines
             diagnostic.message = diagnostic.message.replace(/\r/g, '\\r').replace(/\n/g, '\\n');
-            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.file?.srcPath ?? ''}#(${diagnostic.range.start.line}:${diagnostic.range.start.character})-(${diagnostic.range.end.line}:${diagnostic.range.end.character})`;
+            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.file?.srcPath ?? ''}#(${diagnostic.range?.start.line}:${diagnostic.range?.start.character})-(${diagnostic.range?.end.line}:${diagnostic.range?.end.character})`;
             //print the line containing the error (if we can find it)srcPath
-            const line = diagnostic.file?.fileContents?.split(/\r?\n/g)?.[diagnostic.range.start.line];
+            const line = diagnostic.file?.fileContents?.split(/\r?\n/g)?.[diagnostic.range?.start.line];
             if (line) {
                 message += '\n' + getDiagnosticLine(diagnostic, line, chalk.red);
             }

--- a/src/util.ts
+++ b/src/util.ts
@@ -843,7 +843,10 @@ export class Util {
      * Get a location object back by extracting location information from other objects that contain location
      */
     public getRange(startObj: { range: Range }, endObj: { range: Range }): Range {
-        return util.createRangeFromPositions(startObj.range.start, endObj.range.end);
+        if (!startObj?.range || !endObj?.range) {
+            return undefined;
+        }
+        return util.createRangeFromPositions(startObj.range?.start, endObj.range?.end);
     }
 
     /**
@@ -862,10 +865,10 @@ export class Util {
      */
     public linesTouch(first: { range: Range }, second: { range: Range }) {
         if (first && second && (
-            first.range.start.line === second.range.start.line ||
-            first.range.start.line === second.range.end.line ||
-            first.range.end.line === second.range.start.line ||
-            first.range.end.line === second.range.end.line
+            first.range?.start.line === second.range?.start.line ||
+            first.range?.start.line === second.range?.end.line ||
+            first.range?.end.line === second.range?.start.line ||
+            first.range?.end.line === second.range?.end.line
         )) {
             return true;
         } else {


### PR DESCRIPTION
Many plugins use `Parser.parse()` to generate AST used to replace existing code. This causes the generated sourcemaps to be very incorrect. To mitigate this, we should support generating AST without any range information at all. But, lots of our codebase explodes when that happens. 

This PR adds a test that verifies _most_ expressions and statements  can transpile to proper code without needing tokens. There may be some edge cases, but we've tried to hit as many as possible.

Here's how you can leverage this new functionality:

```typescript
const tokens = Parser.parse('print hello', { trackLocations: false });
```

The tokens array will have all the same tokens, but none of them will have location information, making them much safer to inject into AST without messing with sourcemaps.