### PR TITLE
Adds validation for calling `new` on a non-class constructor

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -8,7 +8,6 @@ import type { CallableContainer, BsDiagnosticWithOrigin, FileReference, Callable
 import type { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
 import type { NamespaceStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement } from './parser/Statement';
-import type { NewExpression } from './parser/Expression';
 import { ParseMode } from './parser/Parser';
 import { util } from './util';
 import { globalCallableMap } from './globalCallables';
@@ -1086,19 +1085,6 @@ export class Scope {
 
     }
 
-
-    public getNewExpressions() {
-        let result = [] as AugmentedNewExpression[];
-        this.enumerateBrsFiles((file) => {
-            let expressions = file['_cachedLookups'].newExpressions as AugmentedNewExpression[];
-            for (let expression of expressions) {
-                expression.file = file;
-                result.push(expression);
-            }
-        });
-        return result;
-    }
-
     private validateClasses() {
         let validator = new BsClassValidator(this);
         validator.validate();
@@ -1331,8 +1317,4 @@ export class Scope {
         }
         return items;
     }
-}
-
-interface AugmentedNewExpression extends NewExpression {
-    file: BscFile;
 }

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -1,4 +1,4 @@
-import type { AALiteralExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, NewExpression, VariableExpression } from '../parser/Expression';
+import type { AALiteralExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, VariableExpression } from '../parser/Expression';
 import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement } from '../parser/Statement';
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
@@ -68,10 +68,6 @@ export class CachedLookups {
      */
     get expressions(): Set<Expression> {
         return this.getFromCache<Set<Expression>>('expressions');
-    }
-
-    get newExpressions(): NewExpression[] {
-        return this.getFromCache<Array<NewExpression>>('newExpressions');
     }
 
     get classStatements(): ClassStatement[] {
@@ -166,7 +162,6 @@ export class CachedLookups {
         const importStatements: ImportStatement[] = [];
         const functionStatements: FunctionStatement[] = [];
         const functionExpressions: FunctionExpression[] = [];
-        const newExpressions: NewExpression[] = [];
 
         const propertyHints: Record<string, string> = {};
         const addPropertyHints = (item: Token | AALiteralExpression) => {
@@ -266,12 +261,6 @@ export class CachedLookups {
                     functionExpressions.push(expression);
                 }
             },
-            NewExpression: e => {
-                newExpressions.push(e);
-                for (const p of e.call.args) {
-                    expressions.add(p);
-                }
-            },
             ExpressionStatement: s => {
                 expressions.add(s.expression);
             },
@@ -348,7 +337,6 @@ export class CachedLookups {
         this.cache.set('importStatements', importStatements);
         this.cache.set('functionStatements', functionStatements);
         this.cache.set('functionExpressions', functionExpressions);
-        this.cache.set('newExpressions', newExpressions);
         this.cache.set('propertyHints', propertyHints);
     }
 }

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1729,7 +1729,7 @@ describe('ScopeValidator', () => {
         it('validates when a class member is accessed from a class directly', () => {
             program.setFile('source/util.bs', `
                 class Klass
-                      name as string
+                    name as string
                 end class
 
                 sub doStuff()
@@ -1757,6 +1757,22 @@ describe('ScopeValidator', () => {
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.itemCannotBeUsedAsVariable('Alpha.Klass')
+            ]);
+        });
+
+        it('validates when new is is used on a class instance', () => {
+            program.setFile('source/util.bs', `
+                class Klass
+                    name as string
+                end class
+
+                sub doStuff(someKlass as Klass)
+                    print new someKlass()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.expressionIsNotConstructable('someKlass')
             ]);
         });
     });

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1201,7 +1201,7 @@ describe('BrsFile BrighterScript classes', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.expressionIsNotConstructable('sub')
+            DiagnosticMessages.expressionIsNotConstructable('quack')
         ]);
     });
 
@@ -1599,8 +1599,9 @@ describe('BrsFile BrighterScript classes', () => {
             end sub
         `);
         program.validate();
-        expectDiagnostics(program, [
-            DiagnosticMessages.cannotFindName('Duck')
+        expectDiagnosticsIncludes(program, [
+            DiagnosticMessages.cannotFindName('Duck'),
+            DiagnosticMessages.expressionIsNotConstructable('Duck')
         ]);
     });
 

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -4,7 +4,6 @@ import type { CallExpression } from '../parser/Expression';
 import { ParseMode } from '../parser/Parser';
 import type { ClassStatement, MethodStatement, NamespaceStatement } from '../parser/Statement';
 import { CancellationTokenSource } from 'vscode-languageserver';
-import util from '../util';
 import { isCallExpression, isFieldStatement, isMethodStatement, isNamespaceStatement } from '../astUtils/reflection';
 import type { BsDiagnostic } from '../interfaces';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
@@ -34,59 +33,8 @@ export class BsClassValidator {
         this.detectCircularReferences();
         this.validateMemberCollisions();
         this.verifyChildConstructor();
-        this.verifyNewExpressions();
 
         this.cleanUp();
-    }
-
-    /**
-     * Given a class name optionally prefixed with a namespace name, find the class that matches
-     */
-    private getClassByName(className: string, namespaceName?: string) {
-        let fullName = util.getFullyQualifiedClassName(className, namespaceName);
-        let cls = this.classes.get(fullName.toLowerCase());
-        //if we couldn't find the class by its full namespaced name, look for a global class with that name
-        if (!cls) {
-            cls = this.classes.get(className.toLowerCase());
-        }
-        return cls;
-    }
-
-
-    /**
-     * Find all "new" statements in the program,
-     * and make sure we can find a class with that name
-     */
-    private verifyNewExpressions() {
-        this.scope.enumerateBrsFiles((file) => {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            let newExpressions = file['_cachedLookups'].newExpressions;
-            for (let newExpression of newExpressions) {
-                let className = newExpression.className.getName(ParseMode.BrighterScript);
-                const namespaceName = newExpression.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
-                let newableClass = this.getClassByName(
-                    className,
-                    namespaceName
-                );
-
-                if (!newableClass) {
-                    //try and find functions with this name.
-                    let fullName = util.getFullyQualifiedClassName(className, namespaceName);
-                    let callable = this.scope.getCallableByName(fullName);
-                    //if we found a callable with this name, the user used a "new" keyword in front of a function. add error
-                    if (callable) {
-                        this.diagnostics.push({
-                            ...DiagnosticMessages.expressionIsNotConstructable(callable.isSub ? 'sub' : 'function'),
-                            file: file,
-                            range: newExpression.className.range
-                        });
-
-                    } else {
-                        //could not find a class with this name (handled by ScopeValidator)
-                    }
-                }
-            }
-        });
     }
 
     private verifyChildConstructor() {


### PR DESCRIPTION
![image](https://github.com/rokucommunity/brighterscript/assets/810290/f66e7003-0a4f-48c4-a8e3-b4d7e5fbbef0)

![image](https://github.com/rokucommunity/brighterscript/assets/810290/4c034a3f-d882-4450-97f8-39ff207fee9b)


Previously, the check for this was in `ClassValidator` and only checked for `new` with callables. It was moved to `ScopeValidator`, and made more general, so it catches ALL uses of `new` on non-classes

As a result, `CachedLookups.newExpressions` was not used anymore, so it was removed.