### PR TITLE
Allow negative patterns in diagnostic filters

### DIFF
--- a/docs/bsconfig.md
+++ b/docs/bsconfig.md
@@ -75,7 +75,7 @@ Type: `Array<string | number | {src: string; codes: number[]}`
 A list of filters used to hide diagnostics.
 
 - A `string` value should be a relative-to-root-dir or absolute file path or glob pattern of the files that should be excluded. Any file matching this pattern will have all diagnostics supressed. These file paths refer to the location of the source files pre-compilation and are relative to [`rootDir`](#rootdir). Absolute file paths may be used as well.
-    - A file glob may be previxed with `!` to make it a negative pattern which "un-ignores" the files it matches. (See examples below).
+    - A file glob may be prefixed with `!` to make it a negative pattern which "un-ignores" the files it matches. (See examples below).
 - A `number` value should be a diagnostic code. This will supress all diagnostics with that code for the whole project.
 - An object can also be provided to filter specific diagnostic codes for a file pattern. For example,
 

--- a/docs/bsconfig.md
+++ b/docs/bsconfig.md
@@ -74,7 +74,8 @@ Type: `Array<string | number | {src: string; codes: number[]}`
 
 A list of filters used to hide diagnostics.
 
-- A `string` value should be a relative-to-root-dir or absolute file path or glob pattern of the files that should be excluded. Any file matching this pattern will have all diagnostics supressed.
+- A `string` value should be a relative-to-root-dir or absolute file path or glob pattern of the files that should be excluded. Any file matching this pattern will have all diagnostics supressed. These file paths refer to the location of the source files pre-compilation and are relative to [`rootDir`](#rootdir). Absolute file paths may be used as well.
+    - A file glob may be previxed with `!` to make it a negative pattern which "un-ignores" the files it matches. (See examples below).
 - A `number` value should be a diagnostic code. This will supress all diagnostics with that code for the whole project.
 - An object can also be provided to filter specific diagnostic codes for a file pattern. For example,
 
@@ -88,6 +89,28 @@ A list of filters used to hide diagnostics.
 Defaults to `undefined`.
 
 If a child bsconfig extends from a parent bsconfig, and both bsconfigs specify `diagnosticFilters`, the parent bsconfig's `diagnosticFilters` field will be completely overwritten.
+
+### Negative patterns in `diagnosticFilters`
+
+A negative pattern can be used to un-ignore some files or codes which were previously ignored. For example,
+
+```jsonc
+"diagnosticFilters": [
+    { "src": "vendor/**/*" }, //ignore all codes from vendor libraries
+    { "src": "!vendor/unreliable/**/*" } //EXCEPT do show errors from this one specific library
+]
+```
+
+A specific error code can be unignored globally by using a pattern which matches everything. For example,
+
+```jsonc
+"diagnosticFilters": [
+    { "src": "vendor/**/*" }, //ignore all errors from vendor libraries
+    { "src": "!*/**/*", "codes": [1000] } //EXCEPT do show this particular code everywhere
+]
+```
+
+The semantics of overriding match the way `git` treats `.gitignore` files: Negative patterns override earlier positive patterns, and positive patterns override earlier negative patterns.
 
 ## `diagnosticLevel`
 

--- a/docs/bsconfig.md
+++ b/docs/bsconfig.md
@@ -101,7 +101,7 @@ A negative pattern can be used to un-ignore some files or codes which were previ
 ]
 ```
 
-A specific error code can be unignored globally by using a pattern which matches everything. For example,
+A specific error code can be unignored in multiple places by using a pattern which matches everything under `rootDir`. For example,
 
 ```jsonc
 "diagnosticFilters": [

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -6,7 +6,7 @@ import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 let rootDir = s`${process.cwd()}/rootDir`;
 
-describe('DiagnosticFilterer', () => {
+describe.only('DiagnosticFilterer', () => {
 
     let filterer: DiagnosticFilterer;
     let options = util.normalizeConfig({
@@ -109,7 +109,7 @@ describe('DiagnosticFilterer', () => {
                 filterer.getDiagnosticFilters({
                     diagnosticFilters: [1, 2, 3]
                 })
-            ).to.eql([{ codes: [1, 2, 3] }]);
+            ).to.eql([{ codes: [1, 2, 3], isNegative: false }]);
         });
 
         it('handles standard diagnostic filters', () => {
@@ -117,7 +117,7 @@ describe('DiagnosticFilterer', () => {
                 filterer.getDiagnosticFilters({
                     diagnosticFilters: [{ src: 'file.brs', codes: [1, 2, 'X3'] }]
                 })
-            ).to.eql([{ src: 'file.brs', codes: [1, 2, 'X3'] }]);
+            ).to.eql([{ src: 'file.brs', codes: [1, 2, 'X3'], isNegative: false }]);
         });
 
         it('handles string-only diagnostic filter object', () => {
@@ -125,14 +125,14 @@ describe('DiagnosticFilterer', () => {
                 filterer.getDiagnosticFilters({
                     diagnosticFilters: [{ src: 'file.brs' }]
                 })
-            ).to.eql([{ src: 'file.brs' }]);
+            ).to.eql([{ src: 'file.brs', isNegative: false }]);
         });
 
         it('handles code-only diagnostic filter object', () => {
             expect(filterer.getDiagnosticFilters({
                 diagnosticFilters: [{ codes: [1, 2, 'X3'] }]
             })).to.eql([
-                { codes: [1, 2, 'X3'] }
+                { codes: [1, 2, 'X3'], isNegative: false }
             ]);
         });
 
@@ -141,14 +141,14 @@ describe('DiagnosticFilterer', () => {
                 filterer.getDiagnosticFilters({
                     diagnosticFilters: ['file.brs']
                 })
-            ).to.eql([{ src: 'file.brs' }]);
+            ).to.eql([{ src: 'file.brs', isNegative: false }]);
         });
 
         it('converts ignoreErrorCodes to diagnosticFilters', () => {
             expect(filterer.getDiagnosticFilters({
                 ignoreErrorCodes: [1, 2, 'X3']
             })).to.eql([
-                { codes: [1, 2, 'X3'] }
+                { codes: [1, 2, 'X3'], isNegative: false }
             ]);
         });
     });

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -110,21 +110,13 @@ describe('DiagnosticFilterer', () => {
             };
 
             it('should unignore specific error codes for specific files', () => {
-                const diagnostics = filterer.filter(optionsWithNegatives, [
-                    getDiagnostic(1, `${rootDir}/source/common.brs`), //remove
-                    getDiagnostic(3, `${rootDir}/source/common.brs`), //remove
-                    getDiagnostic(1, `${rootDir}/lib/special/a.brs`), //keep
-                    getDiagnostic(3, `${rootDir}/lib/special/a.brs`), //keep
-                    getDiagnostic(7, `${rootDir}/lib/special/a.brs`) //remove
-                ]);
-
-                expect(diagnostics).to.have.length(2);
-
-                expect(diagnostics[0].code).equals(1);
-                expect(diagnostics[0].file.srcPath).equals(`${rootDir}/lib/special/a.brs`);
-
-                expect(diagnostics[1].code).equals(3);
-                expect(diagnostics[1].file.srcPath).equals(`${rootDir}/lib/special/a.brs`);
+                expect(
+                    filterer.filter(optionsWithNegatives, [
+                        getDiagnostic(1, `${rootDir}/lib/special/a.brs`), //keep
+                        getDiagnostic(3, `${rootDir}/lib/special/a.brs`), //keep
+                        getDiagnostic(7, `${rootDir}/lib/special/a.brs`) //remove
+                    ]).map(x => x.code)
+                ).to.eql([1, 3]);
             });
 
             it('should unignore all codes from specific file', () => {

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from './chai-config.spec';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
 import type { BsDiagnostic } from './interfaces';
-import { standardizePath as s } from './util';
+import util, { standardizePath as s } from './util';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 let rootDir = s`${process.cwd()}/rootDir`;
@@ -9,7 +9,7 @@ let rootDir = s`${process.cwd()}/rootDir`;
 describe('DiagnosticFilterer', () => {
 
     let filterer: DiagnosticFilterer;
-    let options = {
+    let options = util.normalizeConfig({
         rootDir: rootDir,
         diagnosticFilters: [
             //ignore these codes globally
@@ -21,7 +21,7 @@ describe('DiagnosticFilterer', () => {
             //ignore specific codes for main.brs
             { src: 'source/main.brs', codes: [4] }
         ]
-    };
+    });
 
     afterEach(() => {
         sinon.restore();

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from './chai-config.spec';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
 import type { BsDiagnostic } from './interfaces';
-import util, { standardizePath as s } from './util';
+import { standardizePath as s } from './util';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 let rootDir = s`${process.cwd()}/rootDir`;
@@ -9,7 +9,7 @@ let rootDir = s`${process.cwd()}/rootDir`;
 describe('DiagnosticFilterer', () => {
 
     let filterer: DiagnosticFilterer;
-    let options = util.normalizeConfig({
+    let options = {
         rootDir: rootDir,
         diagnosticFilters: [
             //ignore these codes globally
@@ -21,7 +21,7 @@ describe('DiagnosticFilterer', () => {
             //ignore specific codes for main.brs
             { src: 'source/main.brs', codes: [4] }
         ]
-    });
+    };
 
     afterEach(() => {
         sinon.restore();
@@ -87,7 +87,7 @@ describe('DiagnosticFilterer', () => {
         });
 
         describe('with negative globs', () => {
-            let optionsWithNegatives = util.normalizeConfig({
+            let optionsWithNegatives = {
                 rootDir: rootDir,
                 diagnosticFilters: [
                     //ignore these codes globally
@@ -107,7 +107,7 @@ describe('DiagnosticFilterer', () => {
                     //re-ignore code 10 globally, overriding previous unignores
                     { codes: [10] }
                 ]
-            });
+            };
 
             it('should unignore specific error codes for specific files', () => {
                 const diagnostics = filterer.filter(optionsWithNegatives, [

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -28,7 +28,7 @@ export class DiagnosticFilterer {
     /**
      * Filter a list of diagnostics based on the provided filters
      */
-    public filter(options: FinalizedBsConfig, diagnostics: BsDiagnostic[]) {
+    public filter(options: BsConfig, diagnostics: BsDiagnostic[]) {
         this.filters = this.getDiagnosticFilters(options);
         this.rootDir = options.rootDir;
 

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -1,7 +1,7 @@
 import type { BsDiagnostic } from './interfaces';
 import * as path from 'path';
 import * as minimatch from 'minimatch';
-import type { BsConfig, FinalizedBsConfig } from './BsConfig';
+import type { BsConfig } from './BsConfig';
 import { standardizePath as s } from './util';
 
 interface DiagnosticWithSuppression {

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -137,10 +137,9 @@ export class DiagnosticFilterer {
         }
     }
 
-    public getDiagnosticFilters(config1: BsConfig) {
-
-        let globalIgnoreCodes: (number | string)[] = [...config1.ignoreErrorCodes ?? []];
-        let diagnosticFilters = [...config1.diagnosticFilters ?? []];
+    public getDiagnosticFilters(config: BsConfig) {
+        let globalIgnoreCodes: (number | string)[] = [...config.ignoreErrorCodes ?? []];
+        let diagnosticFilters = [...config.diagnosticFilters ?? []];
 
         let result: NormalizedFilter[] = [];
 
@@ -158,6 +157,11 @@ export class DiagnosticFilterer {
                     src: trimmedFilter,
                     isNegative: isNegative
                 });
+                continue;
+            }
+
+            //filter out bad inputs
+            if (!filter || typeof filter !== 'object') {
                 continue;
             }
 


### PR DESCRIPTION
This feature lets users prefix a glob with `!` to make it a negative pattern which un-ignores certain errors. My use case for this is one which I've added to the documentation; I want to ignore errors from all dependencies in a project _except_ for one specific dependency, and I don't want to have to maintain a list of all other dependencies any time one is added or moved.

Using file paths to indicate un-ignores means that it's not possible to un-ignore a code without specifying a file path. A workaround for this is to use the glob `!*/**/*`, matching everything in the rootDir. I've added this to the documentation and the tests.

The implementation is such that it's possible to un-un-un-un-ignore patterns to any depth. This is likely overkill and would be inadvisable to do in practice, but I think the semantics of this are actually simpler and more familiar than it would be to have things bottom out at a specific level.