### PR TITLE
Removes `CommentStatement` and all comment tokens from Lexer output

### DIFF
--- a/src/AstValidationSegmenter.ts
+++ b/src/AstValidationSegmenter.ts
@@ -1,6 +1,6 @@
 import type { DottedGetExpression, TypeExpression, VariableExpression } from './parser/Expression';
 import { SymbolTypeFlag } from './SymbolTableFlag';
-import { isBody, isClassStatement, isCommentStatement, isInterfaceStatement, isNamespaceStatement, isVariableExpression } from './astUtils/reflection';
+import { isBody, isClassStatement, isInterfaceStatement, isNamespaceStatement, isVariableExpression } from './astUtils/reflection';
 import { ChildrenSkipper, WalkMode, createVisitor } from './astUtils/visitors';
 import type { GetTypeOptions, TypeChainEntry } from './interfaces';
 import type { AstNode } from './parser/AstNode';
@@ -43,7 +43,7 @@ export class AstValidationSegmenter {
     }
 
     checkExpressionForUnresolved(segment: AstNode, expression: VariableExpression | DottedGetExpression | TypeExpression, assignedSymbols?: Set<string>) {
-        if (!expression || isCommentStatement(expression)) {
+        if (!expression) {
             return false;
         }
         if (isVariableExpression(expression) && expression.tokens.name.text.toLowerCase() === 'm') {
@@ -74,7 +74,7 @@ export class AstValidationSegmenter {
     private currentNamespaceStatement: NamespaceStatement;
 
     checkSegmentWalk(segment: AstNode) {
-        if (isNamespaceStatement(segment) || isBody(segment) || isCommentStatement(segment)) {
+        if (isNamespaceStatement(segment) || isBody(segment)) {
             return;
         }
         if (isClassStatement(segment)) {

--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -89,7 +89,8 @@ describe('CommentFlagProcessor', () => {
         });
 
         it('works for special case', () => {
-            const token = Lexer.scan(`print "hi" 'bs:disable-line: 123456 999999   aaaab`).tokens[2];
+            const tokens = Lexer.scan(`print "hi" 'bs:disable-line: 123456 999999   aaaab`).tokens;
+            const token = tokens[2].leadingTrivia[1];
             expect(
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
@@ -109,7 +110,7 @@ describe('CommentFlagProcessor', () => {
         });
 
         it('tokenizes bs:disable-line comment with codes', () => {
-            const token = Lexer.scan(`'bs:disable-line:1 2 3`).tokens[0];
+            const token = Lexer.scan(`'bs:disable-line:1 2 3`).tokens[0].leadingTrivia[0];
             expect(
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
@@ -129,7 +130,8 @@ describe('CommentFlagProcessor', () => {
         });
 
         it('tokenizes bs:disable-line comment with leading space', () => {
-            const token = Lexer.scan(`' bs:disable-line:1`).tokens[0];
+            const tokens = Lexer.scan(`' bs:disable-line:1`).tokens;
+            const token = tokens[0].leadingTrivia[0];
             expect(
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
@@ -143,7 +145,8 @@ describe('CommentFlagProcessor', () => {
         });
 
         it('tokenizes bs:disable-line comment with leading tab', () => {
-            const token = Lexer.scan(`'\tbs:disable-line:1`).tokens[0];
+            const tokens = Lexer.scan(`'\tbs:disable-line:1`).tokens;
+            const token = tokens[0].leadingTrivia[0];
             expect(
                 processor['tokenize'](token.text, token.range)
             ).to.eql({

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -3,7 +3,7 @@ import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
 import type { Expression } from '../parser/AstNode';
-import { isAAMemberExpression, isBinaryExpression, isCallExpression, isCommentStatement, isDottedGetExpression, isFunctionExpression, isIndexedGetExpression, isMethodStatement, isNamespaceStatement, isNewExpression, isVariableExpression } from './reflection';
+import { isAAMemberExpression, isBinaryExpression, isCallExpression, isDottedGetExpression, isFunctionExpression, isIndexedGetExpression, isMethodStatement, isNamespaceStatement, isNewExpression, isVariableExpression } from './reflection';
 import type { Parser } from '../parser/Parser';
 import { ParseMode } from '../parser/Parser';
 import type { Token } from '../lexer/Token';
@@ -170,12 +170,11 @@ export class CachedLookups {
                 propertyHints[name.toLowerCase()] = name;
             } else {
                 for (const member of item.elements) {
-                    if (!isCommentStatement(member)) {
-                        const name = member.tokens.key.text;
-                        if (!name.startsWith('"')) {
-                            propertyHints[name.toLowerCase()] = name;
-                        }
+                    const name = member.tokens.key.text;
+                    if (!name.startsWith('"')) {
+                        propertyHints[name.toLowerCase()] = name;
                     }
+
                 }
             }
         };
@@ -294,9 +293,7 @@ export class CachedLookups {
             ArrayLiteralExpression: e => {
                 for (const element of e.elements) {
                     //keep everything except comments
-                    if (!isCommentStatement(element)) {
-                        expressions.add(element);
-                    }
+                    expressions.add(element);
                 }
             },
             DottedGetExpression: e => {

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-disable no-multi-spaces */
 import { expect } from '../chai-config.spec';
-import { PrintStatement, Block, Body, AssignmentStatement, CommentStatement, ExitForStatement, ExitWhileStatement, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EmptyStatement, TryCatchStatement, CatchStatement, ThrowStatement } from '../parser/Statement';
+import { PrintStatement, Block, Body, AssignmentStatement, ExitForStatement, ExitWhileStatement, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EmptyStatement, TryCatchStatement, CatchStatement, ThrowStatement } from '../parser/Statement';
 import { FunctionExpression, BinaryExpression, CallExpression, DottedGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, XmlAttributeGetExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression } from '../parser/Expression';
 import type { Token } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
-import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isCommentStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression, isTryCatchStatement, isCatchStatement, isThrowStatement, isLiteralInvalid, isLiteralBoolean, isLiteralNumber, isLiteralInteger, isLiteralLongInteger, isLiteralFloat, isLiteralDouble } from './reflection';
+import { isPrintStatement, isIfStatement, isBody, isAssignmentStatement, isBlock, isExpressionStatement, isExitForStatement, isExitWhileStatement, isFunctionStatement, isIncrementStatement, isGotoStatement, isLabelStatement, isReturnStatement, isEndStatement, isStopStatement, isForStatement, isForEachStatement, isWhileStatement, isDottedSetStatement, isIndexedSetStatement, isLibraryStatement, isNamespaceStatement, isImportStatement, isExpression, isBinaryExpression, isCallExpression, isFunctionExpression, isDottedGetExpression, isXmlAttributeGetExpression, isIndexedGetExpression, isGroupingExpression, isLiteralExpression, isEscapedCharCodeLiteralExpression, isArrayLiteralExpression, isAALiteralExpression, isUnaryExpression, isVariableExpression, isSourceLiteralExpression, isNewExpression, isCallfuncExpression, isTemplateStringQuasiExpression, isTemplateStringExpression, isTaggedTemplateStringExpression, isBrsFile, isXmlFile, isClassStatement, isStatement, isAnnotationExpression, isTryCatchStatement, isCatchStatement, isThrowStatement, isLiteralInvalid, isLiteralBoolean, isLiteralNumber, isLiteralInteger, isLiteralLongInteger, isLiteralFloat, isLiteralDouble } from './reflection';
 import { createToken, createStringLiteral, interpolatedRange as range, createInvalidLiteral, createBooleanLiteral, createIntegerLiteral, createVariableExpression, createFloatLiteral, createDoubleLiteral, createLongIntegerLiteral } from './creators';
 import { Program } from '../Program';
 import { BrsFile } from '../files/BrsFile';
@@ -31,7 +31,6 @@ describe('reflection', () => {
         const assignment = new AssignmentStatement({ equals: undefined, name: ident, value: expr });
         const block = new Block({ statements: [], startingRange: range });
         const expression = new ExpressionStatement({ expression: expr });
-        const comment = new CommentStatement({ comments: [token] });
         const exitFor = new ExitForStatement({ exitFor: token });
         const exitWhile = new ExitWhileStatement({ exitWhile: token });
         const funs = new FunctionStatement({
@@ -92,10 +91,6 @@ describe('reflection', () => {
         it('isExpressionStatement', () => {
             expect(isExpressionStatement(expression)).to.be.true;
             expect(isExpressionStatement(body)).to.be.false;
-        });
-        it('isCommentStatement', () => {
-            expect(isCommentStatement(comment)).to.be.true;
-            expect(isCommentStatement(body)).to.be.false;
         });
         it('isExitForStatement', () => {
             expect(isExitForStatement(exitFor)).to.be.true;

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -79,9 +79,6 @@ export function isBlock(element: AstNode | undefined): element is Block {
 }
 export function isExpressionStatement(element: AstNode | undefined): element is ExpressionStatement {
     return element?.kind === AstNodeKind.ExpressionStatement;
-}
-export function isCommentStatement(element: AstNode | undefined): element is CommentStatement {
-    return element?.kind === AstNodeKind.CommentStatement;
 }
 export function isExitForStatement(element: AstNode | undefined): element is ExitForStatement {
     return element?.kind === AstNodeKind.ExitForStatement;

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -306,8 +306,6 @@ describe('astUtils visitors', () => {
 
             program.setFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
-                //The comment statement is weird because it can't be both a statement and expression, but is treated that way. Just ignore it for now until we refactor comments.
-                //'CommentStatement:1:CommentStatement',          // '<comment>
                 'PrintStatement:1:LiteralExpression',             // print <"msg">; 3
                 'PrintStatement:1:LiteralExpression',             // print "msg"; <3>
                 'PrintStatement:1:TemplateStringExpression',      // print <`expand ${var}`>
@@ -819,7 +817,6 @@ describe('astUtils visitors', () => {
                 'Block',
                 'AssignmentStatement',
                 'AALiteralExpression',
-                'CommentStatement',
                 'AAMemberExpression',
                 'LiteralExpression'
             ]);
@@ -894,8 +891,7 @@ describe('astUtils visitors', () => {
                 'LiteralExpression',
                 //else
                 'Block',
-                'ReturnStatement',
-                'CommentStatement'
+                'ReturnStatement'
             ]);
         });
 

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
 import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, TypeExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { Editor } from './Editor';
@@ -107,7 +107,6 @@ export function createVisitor(
         AssignmentStatement?: (statement: AssignmentStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         Block?: (statement: Block, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ExpressionStatement?: (statement: ExpressionStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
-        CommentStatement?: (statement: CommentStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ExitForStatement?: (statement: ExitForStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ExitWhileStatement?: (statement: ExitWhileStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         FunctionStatement?: (statement: FunctionStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;

--- a/src/bscPlugin/SignatureHelpUtil.ts
+++ b/src/bscPlugin/SignatureHelpUtil.ts
@@ -78,11 +78,10 @@ export class SignatureHelpUtil {
         const funcStartPosition = func.range.start;
 
         // Get function comments in reverse order
-        let currentToken = file.getTokenAt(funcStartPosition);
+        const trivia = func.getLeadingTrivia().reverse();
         let functionComments = [] as string[];
-        while (currentToken) {
-            currentToken = file.getPreviousToken(currentToken);
 
+        for (const currentToken of trivia) {
             if (!currentToken) {
                 break;
             }
@@ -106,6 +105,7 @@ export class SignatureHelpUtil {
                     break;
                 }
                 functionComments.unshift(currentToken.text);
+            } else if (kind === TokenKind.Whitespace) {
             } else {
                 break;
             }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isArrayType, isBody, isBrsFile, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isArrayType, isBody, isBrsFile, isClassStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -292,7 +292,6 @@ export class BrsFileValidator {
                     !isClassStatement(statement) &&
                     !isEnumStatement(statement) &&
                     !isInterfaceStatement(statement) &&
-                    !isCommentStatement(statement) &&
                     !isLibraryStatement(statement) &&
                     !isImportStatement(statement) &&
                     !isConstStatement(statement)
@@ -309,10 +308,6 @@ export class BrsFileValidator {
     private validateImportStatements() {
         let topOfFileIncludeStatements = [] as Array<LibraryStatement | ImportStatement>;
         for (let stmt of this.event.file.parser.ast.statements) {
-            //skip comments
-            if (isCommentStatement(stmt)) {
-                continue;
-            }
             //if we found a non-library statement, this statement is not at the top of the file
             if (isLibraryStatement(stmt) || isImportStatement(stmt)) {
                 topOfFileIncludeStatements.push(stmt);

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -822,9 +822,11 @@ describe('BrsFile BrighterScript classes', () => {
                     smokey = Animal("Smokey")
                     smokey.move(1)
                     '> Bear moved 1 meters
+
                     donald = Duck("Donald")
                     donald.move(2)
                     '> Waddling...\\nDonald moved 2 meters
+
                     dewey = BabyDuck("Dewey")
                     dewey.move(3)
                     '> Waddling...\\nDewey moved 2 meters\\nFell over...I'm new at this

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -27,7 +27,7 @@ import type { StandardizedFileEntry } from 'roku-deploy';
 
 let sinon = sinonImport.createSandbox();
 
-describe.only('BrsFile', () => {
+describe('BrsFile', () => {
     let program: Program;
     let srcPath = s`${rootDir}/source/main.brs`;
     let destPath = 'source/main.brs';
@@ -2347,6 +2347,17 @@ describe.only('BrsFile', () => {
 
                 'a function that does something
                 sub foo2()
+                end sub
+            `);
+        });
+
+
+        it('keeps comment in correct place in empty function', async () => {
+            await testTranspile(`
+                sub noop1()
+                end sub
+
+                sub noop2() 'comment in empty function
                 end sub
             `);
         });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -27,7 +27,7 @@ import type { StandardizedFileEntry } from 'roku-deploy';
 
 let sinon = sinonImport.createSandbox();
 
-describe('BrsFile', () => {
+describe.only('BrsFile', () => {
     let program: Program;
     let srcPath = s`${rootDir}/source/main.brs`;
     let destPath = 'source/main.brs';

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2114,7 +2114,7 @@ describe.only('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it.only('keeps end-of-line comments with their line', async () => {
+        it('keeps end-of-line comments with their line', async () => {
             await testTranspile(`
                 function DoSomething() 'comment 1
                     name = "bob" 'comment 2
@@ -2127,6 +2127,7 @@ describe.only('BrsFile', () => {
                 function DoSomething()
                     'lots of empty white space
                     'that will be removed during transpile
+                    'since there are newlines below this comment one newline will be preserved
 
 
 
@@ -2135,6 +2136,8 @@ describe.only('BrsFile', () => {
                 function DoSomething()
                     'lots of empty white space
                     'that will be removed during transpile
+                    'since there are newlines below this comment one newline will be preserved
+
                 end function
             `);
         });
@@ -2333,6 +2336,17 @@ describe.only('BrsFile', () => {
                         name: "child" 'comment
                         'comment
                     }
+                end sub
+            `);
+        });
+
+        it('keeps spaces in between comments when a statement ends in a comment ', async () => {
+            await testTranspile(`
+                sub foo()
+                end sub 'comment
+
+                'a function that does something
+                sub foo2()
                 end sub
             `);
         });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2114,7 +2114,7 @@ describe.only('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
-        it('keeps end-of-line comments with their line', async () => {
+        it.only('keeps end-of-line comments with their line', async () => {
             await testTranspile(`
                 function DoSomething() 'comment 1
                     name = "bob" 'comment 2

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -251,6 +251,17 @@ export class BrsFile implements BscFile {
     }
 
     /**
+     * Get the token at the specified position, or the next token
+     */
+    public getCurrentOrNextTokenAt(position: Position) {
+        for (let token of this.parser.tokens) {
+            if (util.comparePositionToRange(position, token.range) < 0) {
+                return token;
+            }
+        }
+    }
+
+    /**
      * Walk the AST and find the expression that this token is most specifically contained within
      */
     public getClosestExpression(position: Position) {
@@ -738,9 +749,9 @@ export class BrsFile implements BscFile {
         return false;
     }
 
-    public getTokensUntil(currentToken: Token, tokenKind: TokenKind, direction: -1 | 1 = -1) {
+    public getTokensUntil(currentToken: Token, tokenKind: TokenKind, direction: -1 | 1 = 1) {
         let tokens = [];
-        for (let i = this.parser.tokens.indexOf(currentToken); direction === -1 ? i >= 0 : i === this.parser.tokens.length; i += direction) {
+        for (let i = this.parser.tokens.indexOf(currentToken); direction === -1 ? i >= 0 : i < this.parser.tokens.length; i += direction) {
             currentToken = this.parser.tokens[i];
             if (currentToken.kind === TokenKind.Newline || currentToken.kind === tokenKind) {
                 break;
@@ -748,6 +759,16 @@ export class BrsFile implements BscFile {
             tokens.push(currentToken);
         }
         return tokens;
+    }
+
+    public getNextTokenByPredicate(currentToken: Token, test: (Token) => boolean, direction: -1 | 1 = 1) {
+        for (let i = this.parser.tokens.indexOf(currentToken); direction === -1 ? i >= 0 : i < this.parser.tokens.length; i += direction) {
+            currentToken = this.parser.tokens[i];
+            if (test(currentToken)) {
+                return currentToken;
+            }
+        }
+        return undefined;
     }
 
     public getPreviousToken(token: Token) {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1071,7 +1071,18 @@ export class BrsFile implements BscFile {
         let transpileResult: SourceNode | undefined;
 
         if (this.needsTranspiled) {
-            transpileResult = new SourceNode(null, null, state.srcPath, this.ast.transpile(state));
+            const astTranspile = this.ast.transpile(state);
+            const trailingComments = [];
+            if (util.hasLeadingComments(this.parser.eofToken)) {
+                if (util.isLeadingCommentOnSameLine(this.ast.statements[this.ast.statements.length - 1], this.parser.eofToken)) {
+                    trailingComments.push(' ');
+                } else {
+                    trailingComments.push('\n');
+                }
+                trailingComments.push(...state.transpileLeadingComments(this.parser.eofToken));
+            }
+
+            transpileResult = new SourceNode(null, null, state.srcPath, [...astTranspile, ...trailingComments]);
         } else if (this.program.options.sourceMap) {
             //emit code as-is with a simple map to the original file location
             transpileResult = util.simpleMap(state.srcPath, this.fileContents);

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -470,9 +470,11 @@ export class BrsFile implements BscFile {
         const processor = new CommentFlagProcessor(this, ['rem', `'`], diagnosticCodes, [DiagnosticCodeMap.unknownDiagnosticCode]);
 
         this.commentFlags = [];
-        for (let token of tokens) {
-            if (token.kind === TokenKind.Comment) {
-                processor.tryAdd(token.text, token.range);
+        for (let lexerToken of tokens) {
+            for (let triviaToken of lexerToken.leadingTrivia ?? []) {
+                if (triviaToken.kind === TokenKind.Comment) {
+                    processor.tryAdd(triviaToken.text, triviaToken.range);
+                }
             }
         }
         this.commentFlags.push(...processor.commentFlags);

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -9,7 +9,7 @@ import { rangeToArray } from '../parser/Parser.spec';
 import { Range } from 'vscode-languageserver';
 import util from '../util';
 
-describe.only('lexer', () => {
+describe('lexer', () => {
     it('recognizes the `const` keyword', () => {
         let { tokens } = Lexer.scan('const');
         expect(tokens.map(x => x.kind)).to.eql([
@@ -326,21 +326,7 @@ describe.only('lexer', () => {
                 Range.create(3, 0, 3, 1) //  /n
             ]);
         });
-        it('finds correct location for comment after if statement', () => {
-            let { tokens } = Lexer.scan(`
-                sub a()
-                    if true then
-                        print false
-                    else if true then
-                        print "true"
-                    else
-                        print "else"
-                    end if 'comment
-                end sub
-            `);
-            let comments = tokens.filter(x => x.kind === TokenKind.Comment);
-            expect(comments).to.be.lengthOf(0);
-        });
+
         it('ignores everything after `\'`', () => {
             let { tokens } = Lexer.scan('= \' (');
             expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Eof]);

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -9,7 +9,7 @@ import { rangeToArray } from '../parser/Parser.spec';
 import { Range } from 'vscode-languageserver';
 import util from '../util';
 
-describe('lexer', () => {
+describe.only('lexer', () => {
     it('recognizes the `const` keyword', () => {
         let { tokens } = Lexer.scan('const');
         expect(tokens.map(x => x.kind)).to.eql([
@@ -134,7 +134,6 @@ describe('lexer', () => {
         expect(tokens.map(t => t.kind)).to.deep.equal([
             TokenKind.Newline,
             TokenKind.Newline,
-            TokenKind.Comment,
             TokenKind.Newline,
             TokenKind.Newline,
             TokenKind.Newline,
@@ -235,12 +234,32 @@ describe('lexer', () => {
     });
 
     describe('comments', () => {
-        it('does not include carriage return character', () => {
-            let tokens = Lexer.scan(`'someComment\r\nprint "hello"`).tokens;
-            expect(tokens[0].text).to.equal(`'someComment`);
+        it('are not included in output', () => {
+            let kinds = Lexer.scan(`
+                'comment
+                REM some comment
+                print 1 ' comment after
+            `).tokens
+                .map(x => x.kind);
+
+            expect(kinds.length).to.eq(7);
+            expect(kinds).to.eql([
+                TokenKind.Newline,
+                TokenKind.Newline,
+                TokenKind.Newline,
+                TokenKind.Print,
+                TokenKind.IntegerLiteral,
+                TokenKind.Newline,
+                TokenKind.Eof
+            ]);
         });
 
-        it('includes the comment characters in the text', () => {
+        it('do not remove Newline token from output', () => {
+            let tokens = Lexer.scan(`'someComment\r\nprint "hello"`).tokens;
+            expect(tokens[0].kind).to.equal(TokenKind.Newline);
+        });
+
+        it('includes no comment characters in the text', () => {
             let text = Lexer.scan(`
                 'comment
                 REM some comment
@@ -248,10 +267,7 @@ describe('lexer', () => {
                 .filter(x => ![TokenKind.Newline, TokenKind.Eof].includes(x.kind))
                 .map(x => x.text);
 
-            expect(text).to.eql([
-                `'comment`,
-                'REM some comment'
-            ]);
+            expect(text).to.eql([]);
         });
 
         it('tracks the correct location', () => {
@@ -273,7 +289,7 @@ describe('lexer', () => {
                 [1, 24, 1, 25, '('],
                 [1, 25, 1, 26, ')'],
                 [1, 26, 1, 27, ' '],
-                [1, 27, 1, 41, `'first comment`],
+                //  skip `'first comment`
                 [1, 41, 1, 42, '\n'],
                 [2, 0, 2, 20, '                    '],
                 [2, 20, 2, 21, 'k'],
@@ -282,10 +298,10 @@ describe('lexer', () => {
                 [2, 23, 2, 24, ' '],
                 [2, 24, 2, 25, '2'],
                 [2, 25, 2, 26, ' '],
-                [2, 26, 2, 42, `' second comment`],
+                //  skip `' second comment`
                 [2, 42, 2, 43, '\n'],
                 [3, 0, 3, 20, '                    '],
-                [3, 20, 3, 37, 'REM third comment'],
+                //  skip `REM third comment`
                 [3, 37, 3, 38, '\n'],
                 [4, 0, 4, 16, '                '],
                 [4, 16, 4, 23, 'end sub'],
@@ -293,21 +309,6 @@ describe('lexer', () => {
                 [5, 0, 5, 12, '            '],
                 [5, 12, 5, 13, '']//EOF
             ]);
-        });
-
-        it('tracks the correct location for comments', () => {
-            let tokens = Lexer.scan(`
-                'comment
-                REM some comment
-            `).tokens.filter(x => ![TokenKind.Newline, TokenKind.Eof].includes(x.kind));
-
-            expect(tokens[0].range).to.eql(
-                Range.create(1, 16, 1, 24)
-            );
-
-            expect(tokens[1].range).to.eql(
-                Range.create(2, 16, 2, 32)
-            );
         });
 
         it('finds correct location for newlines', () => {
@@ -338,24 +339,21 @@ describe('lexer', () => {
                 end sub
             `);
             let comments = tokens.filter(x => x.kind === TokenKind.Comment);
-            expect(comments).to.be.lengthOf(1);
-            expect(comments[0].range).to.eql(
-                Range.create(8, 27, 8, 35)
-            );
+            expect(comments).to.be.lengthOf(0);
         });
         it('ignores everything after `\'`', () => {
             let { tokens } = Lexer.scan('= \' (');
-            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Comment, TokenKind.Eof]);
+            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Eof]);
         });
 
         it('ignores everything after `REM`', () => {
             let { tokens } = Lexer.scan('= REM (');
-            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Comment, TokenKind.Eof]);
+            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Eof]);
         });
 
         it('ignores everything after `rem`', () => {
             let { tokens } = Lexer.scan('= rem (');
-            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Comment, TokenKind.Eof]);
+            expect(tokens.map(t => t.kind)).to.deep.equal([TokenKind.Equal, TokenKind.Eof]);
         });
     }); // comments
 

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -1059,6 +1059,7 @@ export class Lexer {
             leadingWhitespace: this.leadingWhitespace,
             leadingTrivia: []
         };
+
         if (this.isTrivia(token)) {
             this.pushTrivia(token);
         } else {
@@ -1066,7 +1067,9 @@ export class Lexer {
             this.leadingTrivia = [];
         }
         this.leadingWhitespace = '';
-        this.tokens.push(token);
+        if (kind !== TokenKind.Comment) {
+            this.tokens.push(token);
+        }
         this.sync();
         return token;
     }

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -45,7 +45,7 @@ export interface Identifier extends Token {
  * @returns `true` is `obj` is a `Token`, otherwise `false`
  */
 export function isToken(obj: Record<string, any>): obj is Token {
-    return !!(obj.kind && (obj.kind === TokenKind.Eof || obj.text) && obj.range);
+    return !!(obj?.kind && (obj.kind === TokenKind.Eof || obj.text) && obj?.range);
 }
 
 /**

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -45,7 +45,7 @@ export interface Identifier extends Token {
  * @returns `true` is `obj` is a `Token`, otherwise `false`
  */
 export function isToken(obj: Record<string, any>): obj is Token {
-    return !!(obj.kind && obj.text && obj.range);
+    return !!(obj.kind && (obj.kind === TokenKind.Eof || obj.text) && obj.range);
 }
 
 /**

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -20,7 +20,7 @@ export abstract class AstNode {
     /**
      *  The starting and ending location of the node.
      */
-    public abstract range: Range | undefined;
+    public abstract range?: Range | undefined;
 
     public abstract transpile(state: BrsTranspileState): TranspileResult;
 

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -224,7 +224,6 @@ export enum AstNodeKind {
     EmptyStatement = 'EmptyStatement',
     AssignmentStatement = 'AssignmentStatement',
     ExpressionStatement = 'ExpressionStatement',
-    CommentStatement = 'CommentStatement',
     ExitForStatement = 'ExitForStatement',
     ExitWhileStatement = 'ExitWhileStatement',
     FunctionStatement = 'FunctionStatement',

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -58,11 +58,11 @@ export class BinaryExpression extends Expression {
 
     public readonly range: Range | undefined;
 
-    transpile(state: BrsTranspileState) {
+    transpile(state: BrsTranspileState): TranspileResult {
         return [
             state.sourceNode(this.left, this.left.transpile(state)),
             ' ',
-            ...state.transpileToken(this.tokens.operator),
+            state.transpileToken(this.tokens.operator),
             ' ',
             state.sourceNode(this.right, this.right.transpile(state))
         ];
@@ -144,7 +144,7 @@ export class CallExpression extends Expression {
         }
 
         result.push(
-            ...state.transpileToken(this.tokens.openingParen, '(')
+            state.transpileToken(this.tokens.openingParen, '(')
         );
         for (let i = 0; i < this.args.length; i++) {
             //add comma between args
@@ -156,7 +156,7 @@ export class CallExpression extends Expression {
         }
         if (this.tokens.closingParen) {
             result.push(
-                ...state.transpileToken(this.tokens.closingParen)
+                state.transpileToken(this.tokens.closingParen)
             );
         }
         return result;
@@ -264,18 +264,18 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         let results = [] as TranspileResult;
         //'function'|'sub'
         results.push(
-            ...state.transpileToken(this.tokens.functionType, 'function')
+            state.transpileToken(this.tokens.functionType, 'function')
         );
         //functionName?
         if (name) {
             results.push(
                 ' ',
-                ...state.transpileToken(name)
+                state.transpileToken(name)
             );
         }
         //leftParen
         results.push(
-            ...state.transpileToken(this.tokens.leftParen)
+            state.transpileToken(this.tokens.leftParen)
         );
         //parameters
         for (let i = 0; i < this.parameters.length; i++) {
@@ -289,14 +289,14 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         //right paren
         results.push(
-            ...state.transpileToken(this.tokens.rightParen)
+            state.transpileToken(this.tokens.rightParen)
         );
         //as [Type]
         if (!state.options.removeParameterTypes && this.returnTypeExpression) {
             results.push(
                 ' ',
                 //as
-                ...state.transpileToken(this.tokens.as, 'as'),
+                state.transpileToken(this.tokens.as, 'as'),
                 ' ',
                 //return type
                 ...this.returnTypeExpression.transpile(state)
@@ -447,7 +447,7 @@ export class FunctionParameterExpression extends Expression {
     public transpile(state: BrsTranspileState) {
         let result: TranspileResult = [
             //name
-            ...state.transpileToken(this.tokens.name)
+            state.transpileToken(this.tokens.name)
         ];
         //default value
         if (this.defaultValue) {
@@ -538,8 +538,8 @@ export class DottedGetExpression extends Expression {
         } else {
             return [
                 ...this.obj.transpile(state),
-                ...state.transpileToken(this.tokens.dot, '.'),
-                ...state.transpileToken(this.tokens.name)
+                state.transpileToken(this.tokens.dot, '.'),
+                state.transpileToken(this.tokens.name)
             ];
         }
     }
@@ -608,8 +608,8 @@ export class XmlAttributeGetExpression extends Expression {
     transpile(state: BrsTranspileState) {
         return [
             ...this.obj.transpile(state),
-            ...state.transpileToken(this.tokens.at, '@'),
-            ...state.transpileToken(this.tokens.name)
+            state.transpileToken(this.tokens.at, '@'),
+            state.transpileToken(this.tokens.name)
         ];
     }
 
@@ -667,7 +667,7 @@ export class IndexedGetExpression extends Expression {
         result.push(
             ...this.obj.transpile(state),
             this.tokens.questionDot ? state.transpileToken(this.tokens.questionDot) : '',
-            ...state.transpileToken(this.tokens.openingSquare, '[')
+            state.transpileToken(this.tokens.openingSquare, '[')
         );
         for (let i = 0; i < this.indexes.length; i++) {
             //add comma between indexes
@@ -680,7 +680,7 @@ export class IndexedGetExpression extends Expression {
             );
         }
         result.push(
-            ...state.transpileToken(this.tokens.closingSquare, ']')
+            state.transpileToken(this.tokens.closingSquare, ']')
         );
         return result;
     }
@@ -736,9 +736,9 @@ export class GroupingExpression extends Expression {
             return this.expression.transpile(state);
         }
         return [
-            ...state.transpileToken(this.tokens.leftParen),
+            state.transpileToken(this.tokens.leftParen),
             ...this.expression.transpile(state),
-            ...state.transpileToken(this.tokens.rightParen)
+            state.transpileToken(this.tokens.rightParen)
         ];
     }
 
@@ -798,7 +798,7 @@ export class LiteralExpression extends Expression {
         }
 
         return [
-            ...state.transpileToken({ ...this.tokens.value, text: text })
+            state.transpileToken({ ...this.tokens.value, text: text })
         ];
     }
 
@@ -872,7 +872,7 @@ export class ArrayLiteralExpression extends Expression {
     transpile(state: BrsTranspileState) {
         let result: TranspileResult = [];
         result.push(
-            ...state.transpileToken(this.tokens.open, '[')
+            state.transpileToken(this.tokens.open, '[')
         );
         let hasChildren = this.elements.length > 0;
         state.blockDepth++;
@@ -995,7 +995,7 @@ export class AALiteralExpression extends Expression {
         let result: TranspileResult = [];
         //open curly
         result.push(
-            ...state.transpileToken(this.tokens.open, '{')
+            state.transpileToken(this.tokens.open, '{')
         );
         let hasChildren = this.elements.length > 0;
         //add newline if the object has children and the first child isn't a comment starting on the same line as opening curly
@@ -1098,7 +1098,7 @@ export class UnaryExpression extends Expression {
         }
 
         return [
-            ...state.transpileToken(this.tokens.operator),
+            state.transpileToken(this.tokens.operator),
             separatingWhitespace,
             ...this.right.transpile(state)
         ];
@@ -1158,7 +1158,7 @@ export class VariableExpression extends Expression {
             //transpile  normally
         } else {
             result.push(
-                ...state.transpileToken(this.tokens.name)
+                state.transpileToken(this.tokens.name)
             );
         }
         return result;
@@ -1419,7 +1419,7 @@ export class CallfuncExpression extends Expression {
         result.push(
             ...this.callee.transpile(state),
             state.sourceNode(this.tokens.operator, '.callfunc'),
-            ...state.transpileToken(this.tokens.openingParen, '('),
+            state.transpileToken(this.tokens.openingParen, '('),
             //the name of the function
             state.sourceNode(this.tokens.methodName, ['"', this.tokens.methodName.text, '"'])
         );
@@ -1439,7 +1439,7 @@ export class CallfuncExpression extends Expression {
         }
 
         result.push(
-            ...state.transpileToken(this.tokens.closingParen, ')')
+            state.transpileToken(this.tokens.closingParen, ')')
         );
         return result;
     }
@@ -1682,7 +1682,7 @@ export class TaggedTemplateStringExpression extends Expression {
     transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
         result.push(
-            ...state.transpileToken(this.tokens.tagName),
+            state.transpileToken(this.tokens.tagName),
             '(['
         );
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -112,7 +112,12 @@ export class Parser {
      */
     public ast = new Body({ statements: [] });
 
-    public eofToken: Token;
+    public get eofToken(): Token {
+        const lastToken = this.tokens[this.tokens.length - 1];
+        if (lastToken?.kind === TokenKind.Eof) {
+            return lastToken;
+        }
+    }
 
     public get statements() {
         return this.ast.statements;
@@ -195,7 +200,6 @@ export class Parser {
         this.pendingAnnotations = [];
 
         this.ast = this.body();
-        this.eofToken = this.isAtEnd() ? this.peek() : undefined;
         //now that we've built the AST, link every node to its parent
         this.ast.link();
         return this;

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -3011,7 +3011,8 @@ export class Parser {
     }
 
     private isAtEnd(): boolean {
-        return this.peek().kind === TokenKind.Eof;
+        const peekToken = this.peek();
+        return !peekToken || peekToken.kind === TokenKind.Eof;
     }
 
     private peekNext(): Token {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -113,7 +113,7 @@ export class Parser {
     public ast = new Body({ statements: [] });
 
     public get eofToken(): Token {
-        const lastToken = this.tokens[this.tokens.length - 1];
+        const lastToken = this.tokens?.[this.tokens.length - 1];
         if (lastToken?.kind === TokenKind.Eof) {
             return lastToken;
         }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -112,6 +112,8 @@ export class Parser {
      */
     public ast = new Body({ statements: [] });
 
+    public eofToken: Token;
+
     public get statements() {
         return this.ast.statements;
     }
@@ -191,6 +193,7 @@ export class Parser {
         this.pendingAnnotations = [];
 
         this.ast = this.body();
+        this.eofToken = this.isAtEnd() ? this.peek() : undefined;
         //now that we've built the AST, link every node to its parent
         this.ast.link();
         return this;

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -75,14 +75,14 @@ export class SGAttribute {
 
     public transpile(state: TranspileState) {
         const result = [
-            state.transpileToken(this.tokens.key)
+            ...state.transpileToken(this.tokens.key)
         ];
         if (this.tokens.value) {
             result.push(
-                state.transpileToken(this.tokens.equals, '='),
-                state.transpileToken(this.tokens.openingQuote, '"'),
-                state.transpileToken(this.tokens.value),
-                state.transpileToken(this.tokens.closingQuote, '"')
+                ...state.transpileToken(this.tokens.equals, '='),
+                ...state.transpileToken(this.tokens.openingQuote, '"'),
+                ...state.transpileToken(this.tokens.value),
+                ...state.transpileToken(this.tokens.closingQuote, '"')
             );
         }
         return new SourceNode(null, null, null, result);
@@ -291,8 +291,8 @@ export class SGElement {
 
     public transpile(state: TranspileState) {
         return new SourceNode(null, null, null, [
-            state.transpileToken(this.tokens.startTagOpen, '<'), // <
-            state.transpileToken(this.tokens.startTagName),
+            ...state.transpileToken(this.tokens.startTagOpen, '<'), // <
+            ...state.transpileToken(this.tokens.startTagName),
             this.transpileAttributes(state, this.attributes),
             this.transpileBody(state)
         ]);
@@ -302,12 +302,12 @@ export class SGElement {
         if (this.isSelfClosing) {
             return new SourceNode(null, null, null, [
                 ' ',
-                state.transpileToken(this.tokens.startTagClose, '/>'),
+                ...state.transpileToken(this.tokens.startTagClose, '/>'),
                 state.newline
             ]);
         } else {
             const chunks = [
-                state.transpileToken(this.tokens.startTagClose, '>'),
+                ...state.transpileToken(this.tokens.startTagClose, '>'),
                 state.newline
             ];
             state.blockDepth++;
@@ -320,9 +320,9 @@ export class SGElement {
             state.blockDepth--;
             chunks.push(
                 state.indentText,
-                state.transpileToken(this.tokens.endTagOpen, '</'),
-                state.transpileToken(this.tokens.endTagName ?? this.tokens.startTagName),
-                state.transpileToken(this.tokens.endTagClose, '>'),
+                ...state.transpileToken(this.tokens.endTagOpen, '</'),
+                ...state.transpileToken(this.tokens.endTagName ?? this.tokens.startTagName),
+                ...state.transpileToken(this.tokens.endTagClose, '>'),
                 state.newline
             );
             return new SourceNode(null, null, null, chunks);
@@ -368,7 +368,7 @@ export class SGScript extends SGElement {
         if (this.cdata) {
             return new SourceNode(null, null, null, [
                 '>',
-                state.transpileToken(this.cdata),
+                ...state.transpileToken(this.cdata),
                 '</',
                 this.tokens.startTagName.text,
                 '>',

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -1,10 +1,9 @@
 import { expect } from '../chai-config.spec';
 import type { NamespaceStatement, ClassStatement } from './Statement';
-import { Body, CommentStatement, EmptyStatement } from './Statement';
+import { Body, EmptyStatement } from './Statement';
 import { ParseMode, Parser } from './Parser';
 import { WalkMode } from '../astUtils/visitors';
 import { isClassStatement, isNamespaceStatement } from '../astUtils/reflection';
-import { CancellationTokenSource } from 'vscode-languageserver';
 import { Program } from '../Program';
 import { trim } from '../testHelpers.spec';
 import type { BrsFile } from '../files/BrsFile';
@@ -64,19 +63,6 @@ describe('Statement', () => {
             }
             expect(node!.getName(ParseMode.BrighterScript)).to.equal('NameA.NameB');
             expect(node!.getName(ParseMode.BrightScript)).to.equal('NameA_NameB');
-        });
-    });
-
-    describe('CommentStatement', () => {
-        describe('walk', () => {
-            it('skips visitor if canceled', () => {
-                const comment = new CommentStatement({ comments: [] });
-                const cancel = new CancellationTokenSource();
-                cancel.cancel();
-                comment.walk(() => {
-                    throw new Error('Should not have been called');
-                }, { walkMode: WalkMode.visitAllRecursive, cancel: cancel.token });
-            });
         });
     });
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -80,15 +80,14 @@ export class Body extends Statement implements TypedefProvider {
             let previousStatement = this.statements[i - 1];
             let nextStatement = this.statements[i + 1];
 
-            ///if (!previousStatement) {
-            //this is the first statement. do nothing related to spacing and newlines
+            if (!previousStatement) {
+                //this is the first statement. do nothing related to spacing and newlines
 
-            //if comment is on same line as prior sibling
-            if (util.hasLeadingComments(statement) && previousStatement && util.getLeadingComments(statement)?.[0]?.range.start.line === previousStatement.range.end.line) {
+                //if comment is on same line as prior sibling
+            } else if (util.hasLeadingComments(statement) && previousStatement && util.getLeadingComments(statement)?.[0]?.range.start.line === previousStatement.range.end.line) {
                 result.push(
                     ' '
                 );
-
                 //add double newline if this is a comment, and next is a function
             } else if (util.hasLeadingComments(statement) && nextStatement && isFunctionStatement(nextStatement)) {
                 result.push('\n\n');

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -280,6 +280,10 @@ export class ExpressionStatement extends Statement {
             walk(this, 'expression', visitor, options);
         }
     }
+
+    getLeadingTrivia(): Token[] {
+        return this.expression.getLeadingTrivia();
+    }
 }
 
 
@@ -500,18 +504,11 @@ export class IfStatement extends Statement {
         if (thenNodes.length > 0) {
             results.push(thenNodes);
         }
-        results.push('\n');
-
         //else branch
-        if (this.tokens.else) {
-            //else
-            results.push(
-                state.indent(),
-                ...state.transpileToken(this.tokens.else)
-            );
-        }
-
         if (this.elseBranch) {
+            //else
+            results.push(...state.transpileEndBlockToken(this.thenBranch, this.tokens.else, 'else'));
+
             if (isIfStatement(this.elseBranch)) {
                 //chained elseif
                 state.lineage.unshift(this.elseBranch);
@@ -538,19 +535,12 @@ export class IfStatement extends Statement {
                 if (body.length > 0) {
                     results.push(...body);
                 }
-                results.push('\n');
             }
         }
 
         //end if
-        results.push(state.indent());
-        if (this.tokens.endIf) {
-            results.push(
-                ...state.transpileToken(this.tokens.endIf)
-            );
-        } else {
-            results.push('end if');
-        }
+        results.push(...state.transpileEndBlockToken(this.elseBranch ?? this.thenBranch, this.tokens.endIf, 'end if'));
+
         return results;
     }
 
@@ -761,6 +751,10 @@ export class DimStatement extends Statement {
         }
         return type;
     }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.dim?.leadingTrivia ?? [];
+    }
 }
 
 export class GotoStatement extends Statement {
@@ -798,6 +792,10 @@ export class GotoStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.goto?.leadingTrivia ?? [];
     }
 }
 
@@ -882,6 +880,10 @@ export class ReturnStatement extends Statement {
             walk(this, 'value', visitor, options);
         }
     }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.return?.leadingTrivia ?? [];
+    }
 }
 
 export class EndStatement extends Statement {
@@ -910,6 +912,10 @@ export class EndStatement extends Statement {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.end?.leadingTrivia ?? [];
+    }
 }
 
 export class StopStatement extends Statement {
@@ -936,6 +942,10 @@ export class StopStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.stop?.leadingTrivia ?? [];
     }
 }
 
@@ -1023,14 +1033,8 @@ export class ForStatement extends Statement {
         result.push(...this.body.transpile(state));
         state.lineage.shift();
 
-        // add new line before "end for"
-        result.push('\n');
-
         //end for
-        result.push(
-            state.indent(),
-            ...state.transpileToken(this.tokens.endFor, 'end for')
-        );
+        result.push(...state.transpileEndBlockToken(this.body, this.tokens.endFor, 'end for'));
 
         return result;
     }
@@ -1046,6 +1050,10 @@ export class ForStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'body', visitor, options);
         }
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.for?.leadingTrivia ?? [];
     }
 }
 
@@ -1115,14 +1123,9 @@ export class ForEachStatement extends Statement {
         result.push(...this.body.transpile(state));
         state.lineage.shift();
 
-        // add new line before "end for"
-        result.push('\n');
-
         //end for
-        result.push(
-            state.indent(),
-            ...state.transpileToken(this.tokens.endFor, 'end for')
-        );
+        result.push(...state.transpileEndBlockToken(this.body, this.tokens.endFor, 'end for'));
+
         return result;
     }
 
@@ -1133,6 +1136,10 @@ export class ForEachStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'body', visitor, options);
         }
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.forEach?.leadingTrivia ?? [];
     }
 }
 
@@ -1185,14 +1192,8 @@ export class WhileStatement extends Statement {
         result.push(...this.body.transpile(state));
         state.lineage.shift();
 
-        //trailing newline only if we have body statements
-        result.push('\n');
-
         //end while
-        result.push(
-            state.indent(),
-            ...state.transpileToken(this.tokens.endWhile, 'end while')
-        );
+        result.push(...state.transpileEndBlockToken(this.body, this.tokens.endWhile, 'end while'));
 
         return result;
     }
@@ -1204,6 +1205,10 @@ export class WhileStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'body', visitor, options);
         }
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.while?.leadingTrivia ?? [];
     }
 }
 
@@ -1275,6 +1280,10 @@ export class DottedSetStatement extends Statement {
             kind: this.kind
         }));
         return result;
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.obj.getLeadingTrivia();
     }
 }
 
@@ -1353,6 +1362,10 @@ export class IndexedSetStatement extends Statement {
             walk(this, 'value', visitor, options);
         }
     }
+
+    getLeadingTrivia(): Token[] {
+        return this.obj.getLeadingTrivia();
+    }
 }
 
 export class LibraryStatement extends Statement implements TypedefProvider {
@@ -1400,6 +1413,10 @@ export class LibraryStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.library?.leadingTrivia ?? [];
     }
 }
 
@@ -1579,6 +1596,10 @@ export class ImportStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.import?.leadingTrivia ?? [];
     }
 }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -36,7 +36,7 @@ export class EmptyStatement extends Statement {
     /**
      * Create a negative range to indicate this is an interpolated location
      */
-    public readonly range: Range;
+    public readonly range?: Range;
 
     public readonly kind = AstNodeKind.EmptyStatement;
 
@@ -152,7 +152,7 @@ export class AssignmentStatement extends Statement {
 
     public readonly value: Expression;
 
-    public readonly typeExpression: TypeExpression;
+    public readonly typeExpression?: TypeExpression;
 
     public readonly kind = AstNodeKind.AssignmentStatement;
 
@@ -164,9 +164,9 @@ export class AssignmentStatement extends Statement {
             return this.value.transpile(state);
         } else {
             return [
-                ...state.transpileToken(this.tokens.name),
+                state.transpileToken(this.tokens.name),
                 ' ',
-                ...state.transpileToken(this.tokens.equals ?? createToken(TokenKind.Equal)),
+                state.transpileToken(this.tokens.equals ?? createToken(TokenKind.Equal)),
                 ' ',
                 ...this.value.transpile(state)
             ];
@@ -209,7 +209,7 @@ export class Block extends Statement {
     }
 
     public readonly statements: Statement[];
-    public readonly startingRange: Range;
+    public readonly startingRange?: Range;
 
     public readonly kind = AstNodeKind.Block;
 
@@ -302,7 +302,7 @@ export class ExitForStatement extends Statement {
 
     public readonly kind = AstNodeKind.ExitForStatement;
 
-    public readonly range: Range;
+    public readonly range?: Range;
 
     transpile(state: BrsTranspileState) {
         return this.tokens.exitFor ? state.transpileToken(this.tokens.exitFor) : ['exit for'];
@@ -335,7 +335,7 @@ export class ExitWhileStatement extends Statement {
 
     public readonly kind = AstNodeKind.ExitWhileStatement;
 
-    public readonly range: Range;
+    public readonly range?: Range;
 
     transpile(state: BrsTranspileState) {
         return this.tokens.exitWhile ? state.transpileToken(this.tokens.exitWhile) : ['exit while'];
@@ -498,7 +498,7 @@ export class IfStatement extends Statement {
         if (this.tokens.then) {
             results.push(' ');
             results.push(
-                ...state.transpileToken(this.tokens.then)
+                state.transpileToken(this.tokens.then)
             );
         }
         state.lineage.unshift(this);
@@ -594,7 +594,7 @@ export class IncrementStatement extends Statement {
     transpile(state: BrsTranspileState) {
         return [
             ...this.value.transpile(state),
-            ...state.transpileToken(this.tokens.operator)
+            state.transpileToken(this.tokens.operator)
         ];
     }
 
@@ -653,7 +653,7 @@ export class PrintStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         let result = [
-            ...state.transpileToken(this.tokens.print),
+            state.transpileToken(this.tokens.print),
             ' '
         ] as TranspileResult;
         for (let i = 0; i < this.expressions.length; i++) {
@@ -724,10 +724,10 @@ export class DimStatement extends Statement {
 
     public transpile(state: BrsTranspileState) {
         let result: TranspileResult = [
-            ...state.transpileToken(this.tokens.dim, 'dim'),
+            state.transpileToken(this.tokens.dim, 'dim'),
             ' ',
-            ...state.transpileToken(this.tokens.name),
-            ...state.transpileToken(this.tokens.openingSquare, '[')
+            state.transpileToken(this.tokens.name),
+            state.transpileToken(this.tokens.openingSquare, '[')
         ];
         for (let i = 0; i < this.dimensions.length; i++) {
             if (i > 0) {
@@ -737,7 +737,7 @@ export class DimStatement extends Statement {
                 ...this.dimensions![i].transpile(state)
             );
         }
-        result.push(...state.transpileToken(this.tokens.closingSquare, ']'));
+        result.push(state.transpileToken(this.tokens.closingSquare, ']'));
         return result;
     }
 
@@ -789,9 +789,9 @@ export class GotoStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         return [
-            ...state.transpileToken(this.tokens.goto, 'goto'),
+            state.transpileToken(this.tokens.goto, 'goto'),
             ' ',
-            ...state.transpileToken(this.tokens.label)
+            state.transpileToken(this.tokens.label)
         ];
     }
 
@@ -833,8 +833,8 @@ export class LabelStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         return [
-            ...state.transpileToken(this.tokens.name),
-            ...state.transpileToken(this.tokens.colon, ':')
+            state.transpileToken(this.tokens.name),
+            state.transpileToken(this.tokens.colon, ':')
 
         ];
     }
@@ -871,7 +871,7 @@ export class ReturnStatement extends Statement {
     transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
         result.push(
-            ...state.transpileToken(this.tokens.return, 'return')
+            state.transpileToken(this.tokens.return, 'return')
         );
         if (this.value) {
             result.push(' ');
@@ -910,7 +910,7 @@ export class EndStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         return [
-            ...state.transpileToken(this.tokens.end, 'end')
+            state.transpileToken(this.tokens.end, 'end')
         ];
     }
 
@@ -941,7 +941,7 @@ export class StopStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         return [
-            ...state.transpileToken(this.tokens.stop, 'stop')
+            state.transpileToken(this.tokens.stop, 'stop')
         ];
     }
 
@@ -1009,7 +1009,7 @@ export class ForStatement extends Statement {
         let result = [] as TranspileResult;
         //for
         result.push(
-            ...state.transpileToken(this.tokens.for, 'for'),
+            state.transpileToken(this.tokens.for, 'for'),
             ' '
         );
         //i=1
@@ -1019,7 +1019,7 @@ export class ForStatement extends Statement {
         );
         //to
         result.push(
-            ...state.transpileToken(this.tokens.to, 'to'),
+            state.transpileToken(this.tokens.to, 'to'),
             ' '
         );
         //final value
@@ -1028,7 +1028,7 @@ export class ForStatement extends Statement {
         if (this.increment) {
             result.push(
                 ' ',
-                ...state.transpileToken(this.tokens.step, 'step'),
+                state.transpileToken(this.tokens.step, 'step'),
                 ' ',
                 this.increment!.transpile(state)
             );
@@ -1108,17 +1108,17 @@ export class ForEachStatement extends Statement {
         let result = [] as TranspileResult;
         //for each
         result.push(
-            ...state.transpileToken(this.tokens.forEach, 'for each'),
+            state.transpileToken(this.tokens.forEach, 'for each'),
             ' '
         );
         //item
         result.push(
-            ...state.transpileToken(this.tokens.item),
+            state.transpileToken(this.tokens.item),
             ' '
         );
         //in
         result.push(
-            ...state.transpileToken(this.tokens.in, 'in'),
+            state.transpileToken(this.tokens.in, 'in'),
             ' '
         );
         //target
@@ -1185,7 +1185,7 @@ export class WhileStatement extends Statement {
         let result = [] as TranspileResult;
         //while
         result.push(
-            ...state.transpileToken(this.tokens.while, 'while'),
+            state.transpileToken(this.tokens.while, 'while'),
             ' '
         );
         //condition
@@ -1260,7 +1260,7 @@ export class DottedSetStatement extends Statement {
                 ...this.obj.transpile(state),
                 this.tokens.dot ? state.tokenToSourceNode(this.tokens.dot) : '.',
                 //name
-                ...state.transpileToken(this.tokens.name),
+                state.transpileToken(this.tokens.name),
                 ' = ',
                 //right-hand-side of assignment
                 ...this.value.transpile(state)
@@ -1339,7 +1339,7 @@ export class IndexedSetStatement extends Statement {
                 //obj
                 ...this.obj.transpile(state),
                 //   [
-                ...state.transpileToken(this.tokens.openingSquare)
+                state.transpileToken(this.tokens.openingSquare)
             );
             for (let i = 0; i < this.indexes.length; i++) {
                 //add comma between indexes
@@ -1352,7 +1352,7 @@ export class IndexedSetStatement extends Statement {
                 );
             }
             result.push(
-                ...state.transpileToken(this.tokens.closingSquare),
+                state.transpileToken(this.tokens.closingSquare),
                 ' = ',
                 ...this.value.transpile(state)
             );
@@ -1400,13 +1400,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
         result.push(
-            ...state.transpileToken(this.tokens.library)
+            state.transpileToken(this.tokens.library)
         );
         //there will be a parse error if file path is missing, but let's prevent a runtime error just in case
         if (this.tokens.filePath) {
             result.push(
                 ' ',
-                ...state.transpileToken(this.tokens.filePath)
+                state.transpileToken(this.tokens.filePath)
             );
         }
         return result;
@@ -1591,9 +1591,9 @@ export class ImportStatement extends Statement implements TypedefProvider {
         //add the import statement as a comment just for debugging purposes
         return [
             `'`,
-            ...state.transpileToken(this.tokens.import, 'import'),
+            state.transpileToken(this.tokens.import, 'import'),
             ' ',
-            ...state.transpileToken(this.tokens.path)
+            state.transpileToken(this.tokens.path)
         ];
     }
 
@@ -2388,7 +2388,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 state.classStatement = this;
                 result.push(
                     'instance.',
-                    ...state.transpileToken(statement.tokens.name),
+                    state.transpileToken(statement.tokens.name),
                     ' = ',
                     ...statement.transpile(state),
                     state.newline,
@@ -2457,7 +2457,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 result.push(', ');
             }
             result.push(
-                ...state.transpileToken(param.tokens.name)
+                state.transpileToken(param.tokens.name)
             );
             i++;
         }
@@ -2885,7 +2885,7 @@ export class TryCatchStatement extends Statement {
 
     public transpile(state: BrsTranspileState): TranspileResult {
         return [
-            ...state.transpileToken(this.tokens.try, 'try'),
+            state.transpileToken(this.tokens.try, 'try'),
             ...this.tryBranch.transpile(state),
             state.newline,
             state.indent(),
@@ -2940,7 +2940,7 @@ export class CatchStatement extends Statement {
 
     public transpile(state: BrsTranspileState): TranspileResult {
         return [
-            ...state.transpileToken(this.tokens.catch, 'catch'),
+            state.transpileToken(this.tokens.catch, 'catch'),
             ' ',
             this.tokens.exceptionVariable?.text ?? 'e',
             ...(this.catchBranch?.transpile(state) ?? [])
@@ -2985,7 +2985,7 @@ export class ThrowStatement extends Statement {
 
     public transpile(state: BrsTranspileState) {
         const result = [
-            ...state.transpileToken(this.tokens.throw, 'throw'),
+            state.transpileToken(this.tokens.throw, 'throw'),
             ' '
         ] as TranspileResult;
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -407,6 +407,13 @@ export class FunctionStatement extends Statement implements TypedefProvider {
 
     getTypedef(state: BrsTranspileState) {
         let result = [];
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -732,7 +739,7 @@ export class DimStatement extends Statement {
                 ...this.dimensions[i].transpile(state)
             );
         }
-        result.push(state.transpileToken(this.tokens.closingSquare, ']'));
+        result.push(...state.transpileToken(this.tokens.closingSquare, ']'));
         return result;
     }
 
@@ -1498,11 +1505,19 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     }
 
     getTypedef(state: BrsTranspileState) {
-        let result = [
-            'namespace ',
+        let result = [];
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
+
+        result.push('namespace ',
             ...this.getName(ParseMode.BrighterScript),
             state.newline
-        ];
+        );
         state.blockDepth++;
         result.push(
             ...this.body.getTypedef(state)
@@ -1710,6 +1725,13 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
 
     getTypedef(state: BrsTranspileState) {
         const result = [] as TranspileResult;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -1851,6 +1873,13 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
 
     getTypedef(state: BrsTranspileState): (string | SourceNode)[] {
         const result = [] as TranspileResult;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -1961,6 +1990,13 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
 
     getTypedef(state: BrsTranspileState) {
         const result = [] as TranspileResult;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -2129,6 +2165,13 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
     getTypedef(state: BrsTranspileState) {
         const result = [] as TranspileResult;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -2569,6 +2612,13 @@ export class MethodStatement extends FunctionStatement {
 
     getTypedef(state: BrsTranspileState) {
         const result = [] as Array<string | SourceNode>;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -2754,6 +2804,13 @@ export class FieldStatement extends Statement implements TypedefProvider {
     getTypedef(state: BrsTranspileState) {
         const result = [];
         if (this.tokens.name) {
+            for (let comment of util.getLeadingComments(this) ?? []) {
+                result.push(
+                    comment.text,
+                    state.newline,
+                    state.indent()
+                );
+            }
             for (let annotation of this.annotations ?? []) {
                 result.push(
                     ...annotation.getTypedef(state),
@@ -3080,6 +3137,13 @@ export class EnumStatement extends Statement implements TypedefProvider {
 
     getTypedef(state: BrsTranspileState) {
         const result = [] as TranspileResult;
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
         for (let annotation of this.annotations ?? []) {
             result.push(
                 ...annotation.getTypedef(state),
@@ -3179,9 +3243,15 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
     }
 
     getTypedef(state: BrsTranspileState): (string | SourceNode)[] {
-        const result = [
-            this.tokens.name.text
-        ] as TranspileResult;
+        const result = [];
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
+        result.push(this.tokens.name.text);
         if (this.tokens.equals) {
             result.push(' ', this.tokens.equals.text, ' ');
             if (this.value) {
@@ -3269,7 +3339,15 @@ export class ConstStatement extends Statement implements TypedefProvider {
     }
 
     getTypedef(state: BrsTranspileState): (string | SourceNode)[] {
-        return [
+        const result = [];
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
+        result.push(
             this.tokens.const ? state.tokenToSourceNode(this.tokens.const) : 'const',
             ' ',
             state.tokenToSourceNode(this.tokens.name),
@@ -3277,7 +3355,8 @@ export class ConstStatement extends Statement implements TypedefProvider {
             this.tokens.equals ? state.tokenToSourceNode(this.tokens.equals) : '=',
             ' ',
             ...this.value.transpile(state)
-        ];
+        );
+        return result;
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -5,6 +5,15 @@ import { TokenKind } from '../lexer/TokenKind';
 import type { Token } from '../lexer/Token';
 import util from '../util';
 
+
+interface TranspileToken {
+    range?: Range;
+    text: string;
+    kind?: TokenKind;
+    leadingWhitespace?: string;
+    leadingTrivia?: Array<TranspileToken>;
+}
+
 /**
  * Holds the state of a transpile operation as it works its way through the transpile process
  */
@@ -73,7 +82,7 @@ export class TranspileState {
      * because the entire token is passed by reference, instead of the raw string being copied to the parameter,
      * only to then be copied again for the SourceNode constructor
      */
-    public tokenToSourceNode(token: Token) {
+    public tokenToSourceNode(token: TranspileToken) {
         return new SourceNode(
             //convert 0-based range line to 1-based SourceNode line
             token.range ? token.range.start.line + 1 : null,
@@ -84,7 +93,7 @@ export class TranspileState {
         );
     }
 
-    public transpileLeadingComments(token: Token) {
+    public transpileLeadingComments(token: TranspileToken) {
         const leadingCommentsSourceNodes = [];
         const leadingTrivia = (token?.leadingTrivia ?? []);
         const justComments = leadingTrivia.filter(t => t.kind === TokenKind.Comment || t.kind === TokenKind.Newline);
@@ -123,7 +132,7 @@ export class TranspileState {
     /**
      * Create a SourceNode from a token, accounting for missing range and multi-line text
      */
-    public transpileToken(token: Token, defaultValue?: string) {
+    public transpileToken(token: TranspileToken, defaultValue?: string): Array<SourceNode | string> {
         if (!token && defaultValue !== undefined) {
             return [new SourceNode(null, null, null, defaultValue)];
         }

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -133,7 +133,7 @@ export class TranspileState {
     /**
      * Create a SourceNode from a token, accounting for missing range and multi-line text
      */
-    public transpileToken(token: TranspileToken, defaultValue?: string): Array<SourceNode | string> {
+    public transpileToken(token: TranspileToken, defaultValue?: string): TranspileResult {
         if (!token && defaultValue !== undefined) {
             return [new SourceNode(null, null, null, defaultValue)];
         }
@@ -167,7 +167,7 @@ export class TranspileState {
         }
     }
 
-    public transpileEndBlockToken(previousLocatable: { range: Range }, endToken: Token, defaultValue: string, alwaysAddNewlineBeforeEndToken = true) {
+    public transpileEndBlockToken(previousLocatable: { range?: Range }, endToken: Token, defaultValue: string, alwaysAddNewlineBeforeEndToken = true) {
         const result = [];
 
         if (util.hasLeadingComments(endToken)) {

--- a/src/parser/tests/Parser.spec.ts
+++ b/src/parser/tests/Parser.spec.ts
@@ -28,7 +28,7 @@ export function identifier(text: string) {
 /**
  * Test whether a range matches a group of elements with a `range`
  */
-export function rangeMatch(range: Range, elements: ({ range: Range })[]): boolean {
+export function rangeMatch(range: Range, elements: ({ range?: Range })[]): boolean {
     return range.start.line === elements[0].range.start.line &&
         range.start.character === elements[0].range.start.character &&
         range.end.line === elements[elements.length - 1].range.end.line &&

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -4,7 +4,7 @@ import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, rangeMatch, token } from '../Parser.spec';
-import { isBlock, isCommentStatement, isFunctionStatement, isIfStatement } from '../../../astUtils/reflection';
+import { isBlock, isFunctionStatement, isIfStatement } from '../../../astUtils/reflection';
 import type { Block, FunctionStatement, IfStatement } from '../../Statement';
 
 describe('parser if statements', () => {
@@ -100,7 +100,7 @@ describe('parser if statements', () => {
             assert.fail('Missing single-line if inside if-then');
         }
         expect(ifs.elseBranch).to.exist;
-        if (!isBlock(ifs.elseBranch) || !isCommentStatement(ifs.elseBranch.statements[0])) {
+        if (!isBlock(ifs.elseBranch)) {
             assert.fail('Missing comment inside else branch');
         }
     });

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -199,10 +199,8 @@ describe('parser associative array literals', () => {
         expect(commas).to.deep.equal([
             true, // p1
             true, // p2
-            false, // comment
             false, // p3
             false, // p4
-            false, // comment
             true // p5
         ]);
     });

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -6,7 +6,7 @@ import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import type { AssignmentStatement } from '../../Statement';
 import type { AALiteralExpression, AAMemberExpression } from '../../Expression';
-import { isAALiteralExpression, isAssignmentStatement, isCommentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
+import { isAALiteralExpression, isAssignmentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
 import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 
@@ -195,7 +195,7 @@ describe('parser associative array literals', () => {
             }
         `);
         const commas = ((statements[0] as AssignmentStatement).value as AALiteralExpression).elements
-            .map(s => !isCommentStatement(s) && !!s.tokens.comma);
+            .map(s => !!s.tokens.comma);
         expect(commas).to.deep.equal([
             true, // p1
             true, // p2

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -84,7 +84,6 @@ describe('InterfaceStatement', () => {
                 prop as dynamic
             end interface
         `, `
-            'this comment was throwing exception during transpile
         `);
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ import { VoidType } from './types/VoidType';
 import { ParseMode } from './parser/Parser';
 import type { CallExpression, CallfuncExpression, DottedGetExpression, FunctionParameterExpression, IndexedGetExpression, LiteralExpression, NewExpression, TypeExpression, VariableExpression, XmlAttributeGetExpression } from './parser/Expression';
 import { Logger, LogLevel } from './Logger';
-import type { Identifier, Locatable, Token } from './lexer/Token';
+import { isToken, type Identifier, type Locatable, type Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
 import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLongIntegerType, isNumberType, isStringType, isTypeExpression, isTypedArrayExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
@@ -2060,6 +2060,25 @@ export class Util {
 
     public getAstNodeFriendlyName(node: AstNode) {
         return node?.kind.replace(/Statement|Expression/g, '');
+    }
+
+
+    public hasLeadingComments(input: Token | AstNode) {
+        const leadingTrivia = isToken(input) ? input?.leadingTrivia : input?.getLeadingTrivia() ?? [];
+        return !!leadingTrivia.find(t => t.kind === TokenKind.Comment);
+    }
+
+    public getLeadingComments(input: Token | AstNode) {
+        const leadingTrivia = isToken(input) ? input?.leadingTrivia : input?.getLeadingTrivia() ?? [];
+        return leadingTrivia.filter(t => t.kind === TokenKind.Comment);
+    }
+
+    public isLeadingCommentOnSameLine(line: { range: Range }, input: Token | AstNode) {
+        const leadingCommentRange = this.getLeadingComments(input)?.[0];
+        if (leadingCommentRange) {
+            return this.linesTouch(line, leadingCommentRange);
+        }
+        return false;
     }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1101,7 +1101,7 @@ export class Util {
      *  Gets the bounding range of a bunch of ranges or objects that have ranges
      *  TODO: this does a full iteration of the args. If the args were guaranteed to be in range order, we could optimize this
      */
-    public createBoundingRange(...locatables: Array<{ range?: Range } | Range>): Range | undefined {
+    public createBoundingRange(...locatables: Array<{ range?: Range } | Range | undefined>): Range | undefined {
         let startPosition: Position | undefined;
         let endPosition: Position | undefined;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1581,7 +1581,7 @@ export class Util {
     }
 
 
-    public concatAnnotationLeadingTrivia(stmt: Statement, otherTrivia: Token[]): Token[] {
+    public concatAnnotationLeadingTrivia(stmt: Statement, otherTrivia: Token[] = []): Token[] {
         return [...(stmt.annotations?.map(anno => anno.getLeadingTrivia()).flat() ?? []), ...otherTrivia];
     }
 


### PR DESCRIPTION
- Comments now reside SOLELY in leading trivia.
- `TranspileState.transpileToken()` will automatically transpile comments (if they exist) ahead of the token
- To still indent comments before a "block closing token" (eg. `}`, `end sub`, etc), use TranspileState.transpileEndBlockToken()`
- Modified getSignatureHelp, getDocumentation, etc. to use leading trivia only
