### PR TITLE
Export symbol type flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,4 +35,4 @@ export * from './BusyStatusTracker';
 export * from './Logger';
 export * from './parser/SGTypes';
 export * from './parser/SGParser';
-
+export * from './SymbolTypeFlag';


### PR DESCRIPTION
Add back in the missing `SymbolTypeFlag` interface so plugins can use it.