### PR TITLE
Fix classname as variable for completions and validations

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1783,7 +1783,6 @@ describe('Scope', () => {
                     class MyClass
                         member as integer
                     end class
-
                 `);
                 program.validate();
                 expectDiagnostics(program, [
@@ -2021,6 +2020,24 @@ describe('Scope', () => {
             it('finds unknown members of primitive types', () => {
                 program.setFile(`source/main.bs`, `
                     sub fn(input as SomeKlass)
+                        piValue = input.getPi().someProp
+                    end sub
+
+                    class SomeKlass
+                        function getPi() as float
+                            return 3.14
+                        end function
+                    end class
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.cannotFindName('someProp').message
+                ]);
+            });
+
+            it('finds unknown methods of primitive types', () => {
+                program.setFile(`source/main.bs`, `
+                    sub fn(input as SomeKlass)
                         piValue = input.getPi().noMethod()
                     end sub
 
@@ -2031,11 +2048,10 @@ describe('Scope', () => {
                     end class
                 `);
                 program.validate();
-                //TODO: ideally, if this is a primitive type, we should know all the possible members
-                // This *SHOULD* be an error, but currently, during Runtime, an unknown member (from DottedtGetExpression) is returned as Dynamic.instance
-                expectZeroDiagnostics(program);
+                expectDiagnostics(program, [
+                    DiagnosticMessages.cannotFindName('noMethod').message
+                ]);
             });
-
 
             it('finds members of arrays', () => {
                 program.setFile(`source/main.bs`, `

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1059,6 +1059,47 @@ describe('CompletionsProcessor', () => {
             }]);
         });
 
+        it.only('treats class name as a function', () => {
+            program.setFile('source/main.bs', `
+                class SomeKlass
+                    name as string
+                end class
+
+                sub test()
+                    print SomeKlass.
+                end sub
+            `);
+
+            program.validate();
+            // print SomeKlass.|
+            let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(6, 36));
+            expectCompletionsIncludes(completions, [{
+                label: 'ifFunction',
+                kind: CompletionItemKind.Interface
+            }]);
+        });
+
+        it.only('treats namespaced class name as a function', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    class SomeKlass
+                        name as string
+                    end class
+                end namespace
+
+                sub test()
+                    print alpha.SomeKlass.
+                end sub
+            `);
+
+            program.validate();
+            // print alpha.SomeKlass.|
+            let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(8, 42));
+            expectCompletionsIncludes(completions, [{
+                label: 'ifFunction',
+                kind: CompletionItemKind.Interface
+            }]);
+        });
 
     });
 

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1059,7 +1059,7 @@ describe('CompletionsProcessor', () => {
             }]);
         });
 
-        it.only('treats class name as a function', () => {
+        it('treats class name as a function', () => {
             program.setFile('source/main.bs', `
                 class SomeKlass
                     name as string
@@ -1079,7 +1079,7 @@ describe('CompletionsProcessor', () => {
             }]);
         });
 
-        it.only('treats namespaced class name as a function', () => {
+        it('treats namespaced class name as a function', () => {
             program.setFile('source/main.bs', `
                 namespace alpha
                     class SomeKlass
@@ -1088,11 +1088,12 @@ describe('CompletionsProcessor', () => {
                 end namespace
 
                 sub test()
-                    print alpha.SomeKlass.
+                    print alpha.SomeKlass.toStr()
                 end sub
             `);
 
             program.validate();
+            expectZeroDiagnostics(program);
             // print alpha.SomeKlass.|
             let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(8, 42));
             expectCompletionsIncludes(completions, [{

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -21,6 +21,7 @@ import type { AstNode } from '../../parser/AstNode';
 import type { ClassStatement, FunctionStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Token } from '../../lexer/Token';
 import { createIdentifier } from '../../astUtils/creators';
+import { FunctionType } from '../../types/FunctionType';
 
 export class CompletionsProcessor {
     constructor(
@@ -249,6 +250,11 @@ export class CompletionsProcessor {
                 currentSymbols = symbolTable?.getAllSymbols(symbolTableLookupFlag) ?? [];
                 const tokenType = expression.getType({ flags: SymbolTypeFlag.runtime });
                 if (isClassType(tokenType)) {
+                    if (tokenType.name.split('.').pop().toLowerCase() === beforeDotToken?.text.toLowerCase()) {
+                        // className is used as variable -- it actually refers to the constructor here
+                        currentSymbols = FunctionType.instance.getMemberTable().getAllSymbols(symbolTableLookupFlag);
+                    }
+
                     currentSymbols = currentSymbols.filter((symbol) => {
                         if (symbol.name === 'new') {
                             // don't return the constructor as a property

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -21,7 +21,6 @@ import type { AstNode } from '../../parser/AstNode';
 import type { ClassStatement, FunctionStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Token } from '../../lexer/Token';
 import { createIdentifier } from '../../astUtils/creators';
-import { FunctionType } from '../../types/FunctionType';
 
 export class CompletionsProcessor {
     constructor(
@@ -250,11 +249,6 @@ export class CompletionsProcessor {
                 currentSymbols = symbolTable?.getAllSymbols(symbolTableLookupFlag) ?? [];
                 const tokenType = expression.getType({ flags: SymbolTypeFlag.runtime });
                 if (isClassType(tokenType)) {
-                    if (tokenType.name.split('.').pop().toLowerCase() === beforeDotToken?.text.toLowerCase()) {
-                        // className is used as variable -- it actually refers to the constructor here
-                        currentSymbols = FunctionType.instance.getMemberTable().getAllSymbols(symbolTableLookupFlag);
-                    }
-
                     currentSymbols = currentSymbols.filter((symbol) => {
                         if (symbol.name === 'new') {
                             // don't return the constructor as a property

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1733,12 +1733,12 @@ describe('ScopeValidator', () => {
                 end class
 
                 sub doStuff()
-                    print klass.name ' only valid use of "Klass" is as a constructor: "new Klass()"
+                    print klass.name ' only valid use of "Klass" is as a constructor: "new Klass()", or as a function
                 end sub
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.itemCannotBeUsedAsVariable('Klass')
+                DiagnosticMessages.cannotFindName('name', 'function.name')
             ]);
         });
 
@@ -1756,7 +1756,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.itemCannotBeUsedAsVariable('Alpha.Klass')
+                DiagnosticMessages.cannotFindName('name', 'function.name')
             ]);
         });
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { isAssignmentStatement, isAssociativeArrayType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isObjectType, isPrimitiveType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
+import { isAssignmentStatement, isAssociativeArrayType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isObjectType, isPrimitiveType, isReferenceType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -582,9 +582,9 @@ export class ScopeValidator {
         const shouldIgnoreLHS = this.ignoreUnresolvedAssignmentLHS(expression, exprType, typeData?.definingNode);
 
         if (!this.isTypeKnown(exprType) && !shouldIgnoreLHS) {
-            if (expression.getType({ flags: oppositeSymbolType })?.isResolvable()) {
+            if (expression.getType({ flags: oppositeSymbolType, isExistenceTest: true })?.isResolvable()) {
                 const oppoSiteTypeChain = [];
-                const invalidlyUsedResolvedType = expression.getType({ flags: oppositeSymbolType, typeChain: oppoSiteTypeChain });
+                const invalidlyUsedResolvedType = expression.getType({ flags: oppositeSymbolType, typeChain: oppoSiteTypeChain, isExistenceTest: true });
                 const typeChainScan = util.processTypeChain(oppoSiteTypeChain);
                 if (isUsedAsType) {
                     this.addMultiScopeDiagnostic({
@@ -592,11 +592,18 @@ export class ScopeValidator {
                         range: expression.range,
                         file: file
                     });
-                } else {
+                } else if (invalidlyUsedResolvedType && !isReferenceType(invalidlyUsedResolvedType)) {
                     this.addMultiScopeDiagnostic({
                         ...DiagnosticMessages.itemCannotBeUsedAsVariable(invalidlyUsedResolvedType.toString()),
                         range: expression.range,
                         file: file
+                    });
+                } else {
+                    const typeChainScan = util.processTypeChain(typeChain);
+                    this.addMultiScopeDiagnostic({
+                        file: file as BscFile,
+                        ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
+                        range: typeChainScan.range
                     });
                 }
 
@@ -676,7 +683,6 @@ export class ScopeValidator {
         let isFirst = true;
         for (let i = 0; i < typeChain.length - 1; i++) { // do not look at final entry - we CAN use the constructor as a variable
             const tce = typeChain[i];
-
             lowerNameSoFar += `${lowerNameSoFar ? '.' : ''}${tce.name.toLowerCase()}`;
             if (!isNamespaceType(tce.type)) {
                 if (isFirst && containingNamespaceName) {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2836,7 +2836,7 @@ describe('BrsFile', () => {
                 program.setFile('source/main.bs', `
                     sub test()
                         someNode = createObject("roSGNode", "Rectangle")
-                        someNode@.someFunction(test.value)
+                        someNode@.someFunction({test: "value"})
                     end sub
                 `);
                 program.validate();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -833,6 +833,7 @@ export interface GetTypeOptions {
     ignoreCall?: boolean; // get the type of this expression, NOT it's return type
     onlyCacheResolvedTypes?: boolean;
     ignoreCacheForRetrieval?: boolean;
+    isExistenceTest?: boolean;
 }
 
 export class TypeChainEntry {

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -149,11 +149,11 @@ describe('TemplateStringExpression', () => {
         it('properly transpiles one line template string with expressions', async () => {
             await testTranspile(`
                 sub main()
-                    a = \`hello \${LINE_NUM.text} world \${"template" + "".getChars()} test\`
+                    a = \`hello \${LINE_NUM.text} world \${"template" + "".trim()} test\`
                 end sub
             `, `
                 sub main()
-                    a = ("hello " + bslib_toString(LINE_NUM.text) + " world " + bslib_toString("template" + "".getChars()) + " test")
+                    a = ("hello " + bslib_toString(LINE_NUM.text) + " world " + bslib_toString("template" + "".trim()) + " test")
                 end sub
             `);
         });
@@ -220,12 +220,12 @@ describe('TemplateStringExpression', () => {
 
         it('properly transpiles more complex multiline template string', async () => {
             await testTranspile(`
-                sub main()
-                    a = \`I am multiline\n\${a.isRunning()}\nmore\`
+                sub main(data)
+                    a = \`I am multiline\n\${data.isRunning()}\nmore\`
                 end sub
             `, `
-                sub main()
-                    a = ("I am multiline" + chr(10) + bslib_toString(a.isRunning()) + chr(10) + "more")
+                sub main(data)
+                    a = ("I am multiline" + chr(10) + bslib_toString(data.isRunning()) + chr(10) + "more")
                 end sub
             `);
         });

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -184,11 +184,11 @@ describe('ConstStatement', () => {
             await testTranspile(`
                 const API_KEY ="ABC"
                 sub main()
-                    print API_KEY.toString()
+                    print API_KEY.toStr()
                 end sub
             `, `
                 sub main()
-                    print "ABC".toString()
+                    print "ABC".toStr()
                 end sub
             `);
         });

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -38,6 +38,7 @@ export abstract class BscType {
     }
 
     getMemberTable() {
+        this.addBuiltInInterfaces();
         return this.memberTable;
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ import { URI } from 'vscode-uri';
 import * as xml2js from 'xml2js';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo, TranspileResult, TypeChainEntry, TypeChainProcessResult } from './interfaces';
+import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo, TranspileResult, TypeChainEntry, TypeChainProcessResult, GetTypeOptions } from './interfaces';
 import { BooleanType } from './types/BooleanType';
 import { DoubleType } from './types/DoubleType';
 import { DynamicType } from './types/DynamicType';
@@ -26,7 +26,7 @@ import type { CallExpression, CallfuncExpression, DottedGetExpression, FunctionP
 import { Logger, LogLevel } from './Logger';
 import { isToken, type Identifier, type Locatable, type Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
-import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLongIntegerType, isNumberType, isStringType, isTypeExpression, isTypedArrayExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
+import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isClassType, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLongIntegerType, isNewExpression, isNumberType, isStringType, isTypeExpression, isTypedArrayExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
 import { SourceNode } from 'source-map';
 import * as requireRelative from 'require-relative';
@@ -2115,6 +2115,18 @@ export class Util {
         const leadingCommentRange = this.getLeadingComments(input)?.[0];
         if (leadingCommentRange) {
             return this.linesTouch(line, leadingCommentRange);
+        }
+        return false;
+    }
+
+    public isClassUsedAsFunction(potentialClassType: BscType, expression: Expression, options: GetTypeOptions) {
+        // eslint-disable-next-line no-bitwise
+        if (options.flags & SymbolTypeFlag.runtime &&
+            isClassType(potentialClassType) &&
+            !options.isExistenceTest &&
+            potentialClassType.name.toLowerCase() === this.getAllDottedGetPartsAsString(expression).toLowerCase() &&
+            !expression.findAncestor(isNewExpression)) {
+            return true;
         }
         return false;
     }


### PR DESCRIPTION

https://github.com/rokucommunity/brighterscript/assets/810290/96313697-7232-4e9e-bdc3-60876fc83783

When a Class constructor function is used outside of `new` it is treated as a function type, allowing code completion and validation based on that.

This PR also adds member (and method) validation on primitive types in general