### PR TITLE
Removes diagnostic when using variable declared with unknown type

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1647,6 +1647,44 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('does not show a diagnostic when using a function param with unknown type', () => {
+            program.setFile('source/main.bs', `
+                function test(item as Whatever)
+                    return {data: item}
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('Whatever')
+            ]);
+        });
+
+        it('does not show a diagnostic when using a variable declared with unknown type cast', () => {
+            program.setFile('source/main.bs', `
+                function test()
+                    item = {} as Whatever
+                    return {data: item}
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('Whatever')
+            ]);
+        });
+
+        it('does not show a diagnostic when using a variable declared with unknown type', () => {
+            program.setFile('source/main.bs', `
+                function test()
+                    item as Whatever = {}
+                    return {data: item}
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('Whatever')
+            ]);
+        });
     });
 
     describe('itemCannotBeUsedAsVariable', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { isAssignmentStatement, isAssociativeArrayType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isObjectType, isPrimitiveType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
+import { isAssignmentStatement, isAssociativeArrayType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isObjectType, isPrimitiveType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -140,7 +140,7 @@ export class ScopeValidator {
     /**
      * If this is the lhs of an assignment, we don't need to flag it as unresolved
      */
-    private ignoreUnresolvedAssignmentLHS(expression: Expression, exprType: BscType, definingNode?: AstNode) {
+    private hasValidDeclaration(expression: Expression, exprType: BscType, definingNode?: AstNode) {
         if (!isVariableExpression(expression)) {
             return false;
         }
@@ -149,6 +149,9 @@ export class ScopeValidator {
             // this symbol was defined in a "normal" assignment (eg. not a compound assignment)
             assignmentAncestor = definingNode;
             return assignmentAncestor?.tokens.name?.text.toLowerCase() === expression?.tokens.name?.text.toLowerCase();
+        } else if (isFunctionParameterExpression(definingNode)) {
+            // this symbol was defined in a function param
+            return true;
         } else {
             assignmentAncestor = expression?.findAncestor(isAssignmentStatement);
         }
@@ -434,8 +437,13 @@ export class ScopeValidator {
         const expectedLHSType = assignStmt.typeExpression.getType({ ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
         const actualRHSType = assignStmt.value?.getType(getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
-
-        if (!expectedLHSType?.isTypeCompatible(actualRHSType, compatibilityData)) {
+        if (!expectedLHSType || !expectedLHSType.isResolvable()) {
+            this.addMultiScopeDiagnostic({
+                ...DiagnosticMessages.cannotFindName(assignStmt.typeExpression.getName(ParseMode.BrighterScript)),
+                range: assignStmt.typeExpression.range,
+                file: file
+            });
+        } else if (!expectedLHSType?.isTypeCompatible(actualRHSType, compatibilityData)) {
             this.addMultiScopeDiagnostic({
                 ...DiagnosticMessages.assignmentTypeMismatch(actualRHSType.toString(), expectedLHSType.toString(), compatibilityData),
                 range: assignStmt.range,
@@ -579,9 +587,9 @@ export class ScopeValidator {
             data: typeData
         });
 
-        const shouldIgnoreLHS = this.ignoreUnresolvedAssignmentLHS(expression, exprType, typeData?.definingNode);
+        const hasValidDeclaration = this.hasValidDeclaration(expression, exprType, typeData?.definingNode);
 
-        if (!this.isTypeKnown(exprType) && !shouldIgnoreLHS) {
+        if (!this.isTypeKnown(exprType) && !hasValidDeclaration) {
             if (expression.getType({ flags: oppositeSymbolType })?.isResolvable()) {
                 const oppoSiteTypeChain = [];
                 const invalidlyUsedResolvedType = expression.getType({ flags: oppositeSymbolType, typeChain: oppoSiteTypeChain });
@@ -613,6 +621,7 @@ export class ScopeValidator {
         if (isUsedAsType) {
             return;
         }
+
         const containingNamespaceName = expression.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
 
         if (!(isCallExpression(expression.parent) && isNewExpression(expression.parent?.parent))) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -175,7 +175,7 @@ export class AssignmentStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            //TODO: Walk TypeExpression. We need to decide how to implement types on assignments
+            walk(this, 'typeExpression', visitor, options);
             walk(this, 'value', visitor, options);
         }
     }


### PR DESCRIPTION
- Addresses #1095 
- Any variable declared via assignment or as function param will not cause the "Cannot find ..."  Diagnostic
- Adds validation for invalid type in the `typeExpression` in an assignment statement


![image](https://github.com/rokucommunity/brighterscript/assets/810290/2162c996-ad18-477a-ade5-04877212711e)
