### PR TITLE
Fixes issue with AA overriding built-in properties

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1059,6 +1059,7 @@ export class AALiteralExpression extends Expression {
 
     getType(options: GetTypeOptions): BscType {
         const resultType = new AssociativeArrayType();
+        resultType.addBuiltInInterfaces();
         for (const element of this.elements) {
             if (isAAMemberExpression(element)) {
                 resultType.addMember(element.tokens.key.text, { definingNode: element }, element.getType(options), SymbolTypeFlag.runtime);

--- a/src/types/AssociativeArrayType.ts
+++ b/src/types/AssociativeArrayType.ts
@@ -1,3 +1,4 @@
+import { SymbolTable } from '../SymbolTable';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { isAssociativeArrayType, isClassType, isDynamicType, isObjectType } from '../astUtils/reflection';
 import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
@@ -43,5 +44,17 @@ export class AssociativeArrayType extends BscType {
 
     isEqual(otherType: BscType) {
         return isAssociativeArrayType(otherType) && this.checkCompatibilityBasedOnMembers(otherType, SymbolTypeFlag.runtime);
+    }
+
+    private builtInMemberTable: SymbolTable;
+
+    getBuiltInMemberTable(): SymbolTable {
+        if (this.builtInMemberTable) {
+            return this.builtInMemberTable;
+        }
+        this.builtInMemberTable = new SymbolTable(`${this.__identifier} Built-in Members`);
+        this.pushMemberProvider(() => this.builtInMemberTable);
+        return this.builtInMemberTable;
+
     }
 }


### PR DESCRIPTION
Fixes #1102

AssociativeArray types now follow the same pattern as Class Types, where the built in members are from a different symbol provider, so if they are overriden, the overriden type info is used.
