### PR TITLE
Fix transpile crash when token has no text

### DIFF
--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -140,11 +140,7 @@ export class TranspileState {
         const leadingCommentsSourceNodes = this.transpileLeadingComments(token);
 
         if (!token.range) {
-            try {
-                return [new SourceNode(null, null, null, [...leadingCommentsSourceNodes, token.text])];
-            } catch (e) {
-                console.log(e);
-            }
+            return [new SourceNode(null, null, null, [...leadingCommentsSourceNodes, token.text])];
         }
         //split multi-line text
         if (token.range?.end.line > token.range?.start.line) {

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -134,16 +134,20 @@ export class TranspileState {
      * Create a SourceNode from a token, accounting for missing range and multi-line text
      */
     public transpileToken(token: TranspileToken, defaultValue?: string): TranspileResult {
-        if (!token && defaultValue !== undefined) {
+        if (!token?.text && defaultValue !== undefined) {
             return [new SourceNode(null, null, null, defaultValue)];
         }
         const leadingCommentsSourceNodes = this.transpileLeadingComments(token);
 
         if (!token.range) {
-            return [new SourceNode(null, null, null, [...leadingCommentsSourceNodes, token.text])];
+            try {
+                return [new SourceNode(null, null, null, [...leadingCommentsSourceNodes, token.text])];
+            } catch (e) {
+                console.log(e);
+            }
         }
         //split multi-line text
-        if (token.range.end.line > token.range.start.line) {
+        if (token.range?.end.line > token.range?.start.line) {
             const lines = token.text.split(/\r?\n/g);
             const code = [
                 this.sourceNode(token, [...leadingCommentsSourceNodes, lines[0]])

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -258,10 +258,18 @@ function getTestFileAction(
     action: (file: BscFile) => Promise<{ code: string; map?: string }>,
     scopeGetter: () => [program: Program, rootDir: string]
 ) {
-    return async function testFileAction<TFile extends BscFile = BscFile>(source: string, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
+    return async function testFileAction<TFile extends BscFile = BscFile>(sourceOrFile: string | BscFile, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
         let [program, rootDir] = scopeGetter();
-        expected = expected ? expected : source;
-        let file = program.setFile<TFile>({ src: s`${rootDir}/${destPath}`, dest: destPath }, source);
+        let file: BscFile;
+        if (typeof sourceOrFile === 'string') {
+            expected = expected ? expected : sourceOrFile;
+            file = program.setFile<TFile>({ src: s`${rootDir}/${destPath}`, dest: destPath }, sourceOrFile);
+        } else {
+            file = sourceOrFile;
+            if (!expected) {
+                throw new Error('`expected` is required when passing a file');
+            }
+        }
         program.validate();
         if (failOnDiagnostic !== false) {
             expectZeroDiagnostics(program);
@@ -279,7 +287,7 @@ function getTestFileAction(
         expect(sources[0]).to.equal(sources[1]);
         return {
             file: file,
-            source: source,
+            source: sourceOrFile,
             expected: expected,
             actual: codeWithMap.code,
             map: codeWithMap.map

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -258,9 +258,9 @@ function getTestFileAction(
     action: (file: BscFile) => Promise<{ code: string; map?: string }>,
     scopeGetter: () => [program: Program, rootDir: string]
 ) {
-    return async function testFileAction<TFile extends BscFile = BscFile>(sourceOrFile: string | BscFile, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
+    return async function testFileAction<TFile extends BscFile = BscFile>(sourceOrFile: string | TFile, expected?: string, formatType: 'trim' | 'none' = 'trim', destPath = 'source/main.bs', failOnDiagnostic = true) {
         let [program, rootDir] = scopeGetter();
-        let file: BscFile;
+        let file: TFile;
         if (typeof sourceOrFile === 'string') {
             expected = expected ? expected : sourceOrFile;
             file = program.setFile<TFile>({ src: s`${rootDir}/${destPath}`, dest: destPath }, sourceOrFile);


### PR DESCRIPTION
Fix crash in during transpile when token is defined but doesn't have `text` (no idea how this happens, but better to prevent crashing)