### PR TITLE
More validation performance

### DIFF
--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -10,8 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "benchmark": "^2.1.4",
-                "brighterscript1": "file:.tmp/brighterscript-0.66.0-alpha.71700251305166.tgz",
-                "brighterscript2": "npm:brighterscript@^0.65.10",
+                "brighterscript1": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
+                "brighterscript2": "npm:brighterscript@^0.65.25",
                 "chalk": "^4.1.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^11.1.1",
@@ -607,9 +607,9 @@
         },
         "node_modules/brighterscript1": {
             "name": "brighterscript",
-            "version": "0.66.0-alpha.7",
-            "resolved": "file:.tmp/brighterscript-0.66.0-alpha.71700251305166.tgz",
-            "integrity": "sha512-uXFzXBIqBbIJMY/ynyje8DhBwKLnnrO50FQNji/eKESeiYAXnJUJXjG1P2YIC/5trfm+fogWSqH+UiVOs4/8QQ==",
+            "version": "1.0.0-alpha.27",
+            "resolved": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
+            "integrity": "sha512-7nHIHK7YIi4K0o2rN3DsLM2MYTIB9+L8Iyd6txcq7hLCCbf8G+RqE7MGVhEolnIHuVAHxT+M8v2GlQBLTnMlDg==",
             "license": "MIT",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
@@ -635,11 +635,10 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.3",
+                "roku-deploy": "^3.12.0",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "uuid": "^9.0.0",
-                "v8-profiler-next": "^1.9.0",
                 "vscode-languageserver": "7.0.0",
                 "vscode-languageserver-protocol": "3.16.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -773,9 +772,9 @@
         },
         "node_modules/brighterscript2": {
             "name": "brighterscript",
-            "version": "0.65.10",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.10.tgz",
-            "integrity": "sha512-JGBkH6VDgTfwTMHtvauwUeR8XAotuhURbtr3r9+zaWU/KyO0jwSCLUnoNUjSmsz9ddnWe6KOY3NpR5vVG/iraA==",
+            "version": "0.65.25",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.25.tgz",
+            "integrity": "sha512-sezfScxcXZfzEJ702HCMjfPsIH/x3mfLAFDObGU+xAC2E8m/zxrPOHKlD9Qpmdvd7/j4TgsujhiRQ1tnk8BzGA==",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -784,7 +783,6 @@
                 "chevrotain": "^7.0.1",
                 "chokidar": "^3.5.1",
                 "clear": "^0.1.0",
-                "coveralls-next": "^4.2.0",
                 "cross-platform-clear-console": "^2.3.0",
                 "debounce-promise": "^3.1.0",
                 "eventemitter3": "^4.0.0",
@@ -800,7 +798,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.5",
+                "roku-deploy": "^3.12.0",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -1123,15 +1121,9 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -1143,6 +1135,9 @@
             },
             "engines": {
                 "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -2320,9 +2315,9 @@
             }
         },
         "node_modules/moment": {
-            "version": "2.29.4",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
             "engines": {
                 "node": "*"
             }
@@ -2872,9 +2867,9 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.10.5",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.5.tgz",
-            "integrity": "sha512-acSi9LKKE8cC1mXul2wNiw7++dxNEWJJCVBS9FJQY7LYaYQ4kQVnWuptjrZ5W8Mu8xhvhytdMVZZhoMCTUoKvQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.12.0.tgz",
+            "integrity": "sha512-YiCZeQ+sEmFW9ZfXtMNH+/CBSHQ5deNZYWONM+s6gCEQsrz7kCMFPj5YEdgfqW+d2b8G1ve9GELHcSt2FsfM8g==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",
@@ -4090,8 +4085,8 @@
             }
         },
         "brighterscript1": {
-            "version": "file:.tmp/brighterscript-0.66.0-alpha.71700251305166.tgz",
-            "integrity": "sha512-uXFzXBIqBbIJMY/ynyje8DhBwKLnnrO50FQNji/eKESeiYAXnJUJXjG1P2YIC/5trfm+fogWSqH+UiVOs4/8QQ==",
+            "version": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
+            "integrity": "sha512-7nHIHK7YIi4K0o2rN3DsLM2MYTIB9+L8Iyd6txcq7hLCCbf8G+RqE7MGVhEolnIHuVAHxT+M8v2GlQBLTnMlDg==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -4116,11 +4111,10 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.3",
+                "roku-deploy": "^3.12.0",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "uuid": "^9.0.0",
-                "v8-profiler-next": "^1.9.0",
                 "vscode-languageserver": "7.0.0",
                 "vscode-languageserver-protocol": "3.16.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -4228,9 +4222,9 @@
             }
         },
         "brighterscript2": {
-            "version": "npm:brighterscript@0.65.10",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.10.tgz",
-            "integrity": "sha512-JGBkH6VDgTfwTMHtvauwUeR8XAotuhURbtr3r9+zaWU/KyO0jwSCLUnoNUjSmsz9ddnWe6KOY3NpR5vVG/iraA==",
+            "version": "npm:brighterscript@0.65.25",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.25.tgz",
+            "integrity": "sha512-sezfScxcXZfzEJ702HCMjfPsIH/x3mfLAFDObGU+xAC2E8m/zxrPOHKlD9Qpmdvd7/j4TgsujhiRQ1tnk8BzGA==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -4239,7 +4233,6 @@
                 "chevrotain": "^7.0.1",
                 "chokidar": "^3.5.1",
                 "clear": "^0.1.0",
-                "coveralls-next": "^4.2.0",
                 "cross-platform-clear-console": "^2.3.0",
                 "debounce-promise": "^3.1.0",
                 "eventemitter3": "^4.0.0",
@@ -4255,7 +4248,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.5",
+                "roku-deploy": "^3.12.0",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -4514,9 +4507,9 @@
             }
         },
         "chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -5439,9 +5432,9 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "moment": {
-            "version": "2.29.4",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
         },
         "ms": {
             "version": "2.1.2",
@@ -5834,9 +5827,9 @@
             }
         },
         "roku-deploy": {
-            "version": "3.10.5",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.5.tgz",
-            "integrity": "sha512-acSi9LKKE8cC1mXul2wNiw7++dxNEWJJCVBS9FJQY7LYaYQ4kQVnWuptjrZ5W8Mu8xhvhytdMVZZhoMCTUoKvQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.12.0.tgz",
+            "integrity": "sha512-YiCZeQ+sEmFW9ZfXtMNH+/CBSHQ5deNZYWONM+s6gCEQsrz7kCMFPj5YEdgfqW+d2b8G1ve9GELHcSt2FsfM8g==",
             "requires": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -10,8 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "benchmark": "^2.1.4",
-                "brighterscript1": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
-                "brighterscript2": "npm:brighterscript@^0.65.25",
+                "brighterscript1": "file:.tmp/brighterscript-1.0.0-alpha.271710379524630.tgz",
+                "brighterscript2": "npm:brighterscript@^0.65.26",
                 "chalk": "^4.1.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^11.1.1",
@@ -608,8 +608,8 @@
         "node_modules/brighterscript1": {
             "name": "brighterscript",
             "version": "1.0.0-alpha.27",
-            "resolved": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
-            "integrity": "sha512-7nHIHK7YIi4K0o2rN3DsLM2MYTIB9+L8Iyd6txcq7hLCCbf8G+RqE7MGVhEolnIHuVAHxT+M8v2GlQBLTnMlDg==",
+            "resolved": "file:.tmp/brighterscript-1.0.0-alpha.271710379524630.tgz",
+            "integrity": "sha512-jrDewnNL/z5N4dSLj4GT3mK6S6GvyuvQICSgw3rokEMd803RIlBhziEeyqJXASygfiLvmsxUN8Y1WOPI7hewBQ==",
             "license": "MIT",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
@@ -772,9 +772,9 @@
         },
         "node_modules/brighterscript2": {
             "name": "brighterscript",
-            "version": "0.65.25",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.25.tgz",
-            "integrity": "sha512-sezfScxcXZfzEJ702HCMjfPsIH/x3mfLAFDObGU+xAC2E8m/zxrPOHKlD9Qpmdvd7/j4TgsujhiRQ1tnk8BzGA==",
+            "version": "0.65.26",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.26.tgz",
+            "integrity": "sha512-VT1Dzj0K4A1vcmsmv63mcI4hD7W8yQ3ZPF0LLxpgSGj27UCxUquz99w1qCkgzhvLk0jIdV7wGj7vnH3kttrJKQ==",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -4085,8 +4085,8 @@
             }
         },
         "brighterscript1": {
-            "version": "file:.tmp/brighterscript-1.0.0-alpha.271710342329984.tgz",
-            "integrity": "sha512-7nHIHK7YIi4K0o2rN3DsLM2MYTIB9+L8Iyd6txcq7hLCCbf8G+RqE7MGVhEolnIHuVAHxT+M8v2GlQBLTnMlDg==",
+            "version": "file:.tmp/brighterscript-1.0.0-alpha.271710379524630.tgz",
+            "integrity": "sha512-jrDewnNL/z5N4dSLj4GT3mK6S6GvyuvQICSgw3rokEMd803RIlBhziEeyqJXASygfiLvmsxUN8Y1WOPI7hewBQ==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -4222,9 +4222,9 @@
             }
         },
         "brighterscript2": {
-            "version": "npm:brighterscript@0.65.25",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.25.tgz",
-            "integrity": "sha512-sezfScxcXZfzEJ702HCMjfPsIH/x3mfLAFDObGU+xAC2E8m/zxrPOHKlD9Qpmdvd7/j4TgsujhiRQ1tnk8BzGA==",
+            "version": "npm:brighterscript@0.65.26",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.26.tgz",
+            "integrity": "sha512-VT1Dzj0K4A1vcmsmv63mcI4hD7W8yQ3ZPF0LLxpgSGj27UCxUquz99w1qCkgzhvLk0jIdV7wGj7vnH3kttrJKQ==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -924,7 +924,7 @@ describe('Scope', () => {
                 }]);
             });
 
-            it('detects local function with same name as scope function', () => {
+            it('detects local variable with same name as scope function', () => {
                 program.setFile(`source/main.brs`, `
                     sub main()
                         getHello = "override"
@@ -938,6 +938,22 @@ describe('Scope', () => {
                 expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarShadowedByScopedFunction().message,
                     range: Range.create(2, 24, 2, 32)
+                }]);
+            });
+
+            it('detects function param with same name as scope function', () => {
+                program.setFile(`source/main.brs`, `
+                    sub main(getHello = "hello")
+                        print getHello ' prints <Function: gethello> (i.e. local variable override does NOT work for same-scope-defined methods)
+                    end sub
+                    function getHello()
+                        return "hello"
+                    end function
+                `);
+                program.validate();
+                expectDiagnostics(program, [{
+                    message: DiagnosticMessages.localVarShadowedByScopedFunction().message,
+                    range: Range.create(1, 29, 1, 37)
                 }]);
             });
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -595,25 +595,25 @@ export class Scope {
 
             //sort the callables by filepath and then method name, so the errors will be consistent
             // eslint-disable-next-line prefer-arrow-callback
-            callables = callables.sort((a, b) => {
-                const pathA = a.callable.file.srcPath;
-                const pathB = b.callable.file.srcPath;
-                //sort by path
-                if (pathA < pathB) {
-                    return -1;
-                } else if (pathA > pathB) {
-                    return 1;
-                }
-                //sort by function name
-                const funcA = b.callable.name;
-                const funcB = b.callable.name;
-                if (funcA < funcB) {
-                    return -1;
-                } else if (funcA > funcB) {
-                    return 1;
-                }
-                return 0;
-            });
+            /* callables = callables.sort((a, b) => {
+                 const pathA = a.callable.file.srcPath;
+                 const pathB = b.callable.file.srcPath;
+                 //sort by path
+                 if (pathA < pathB) {
+                     return -1;
+                 } else if (pathA > pathB) {
+                     return 1;
+                 }
+                 //sort by function name
+                 const funcA = b.callable.name;
+                 const funcB = b.callable.name;
+                 if (funcA < funcB) {
+                     return -1;
+                 } else if (funcA > funcB) {
+                     return 1;
+                 }
+                 return 0;
+             });*/
 
             //get a list of all callables, indexed by their lower case names
             return util.getCallableContainersByLowerName(callables);

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -298,7 +298,7 @@ export class CompletionsProcessor {
             let ignoreAllPropertyNames = false;
 
             // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-            switch (tokenBefore.kind) {
+            switch (tokenBefore?.kind) {
                 case TokenKind.New:
                     //we are after a new keyword; so we can only be namespaces that have a class or classes at this point
                     currentSymbols = currentSymbols.filter(symbol => isClassType(symbol.type) || this.isNamespaceTypeWithMemberType(symbol.type, isClassType));

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -146,6 +146,13 @@ export class ScopeValidator {
                             type: forEachStmt.getType({ flags: SymbolTypeFlag.runtime }),
                             nameRange: forEachStmt.tokens.item.range
                         });
+                    },
+                    FunctionParameterExpression: (funcParam) => {
+                        this.detectShadowedLocalVar(file, {
+                            name: funcParam.tokens.name.text,
+                            type: funcParam.getType({ flags: SymbolTypeFlag.runtime }),
+                            nameRange: funcParam.tokens.name.range
+                        });
                     }
                 });
                 const segmentsToWalkForValidation = (thisFileHasChanges || !hasChangeInfo)

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -26,7 +26,7 @@ import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
 import type { AstNode, Expression, Statement } from '../parser/AstNode';
-import type { UnresolvedSymbol } from '../AstValidationSegmenter';
+import type { AssignedSymbol, UnresolvedSymbol } from '../AstValidationSegmenter';
 import { AstValidationSegmenter } from '../AstValidationSegmenter';
 import type { BscSymbol } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
@@ -1164,6 +1164,19 @@ export class BrsFile implements BscFile {
     public get providedSymbols() {
         return this.cache?.getOrAdd(`providedSymbols`, () => {
             return this.getProvidedSymbols();
+        });
+    }
+
+    public get assignedSymbols() {
+        return this.cache.getOrAdd(`assignedSymbols`, () => {
+            const allAssignedSymbolsEntries = this.validationSegmenter.assignedTokensInSegment.entries() ?? [];
+
+            let allAssignedSymbolsSet: AssignedSymbol[] = [];
+
+            for (const [_segment, assignedSymbolSet] of allAssignedSymbolsEntries) {
+                allAssignedSymbolsSet.push(...assignedSymbolSet.values());
+            }
+            return allAssignedSymbolsSet;
         });
     }
 


### PR DESCRIPTION
Refactors local variable checking to only check un-changed `AstSegment`s for function shadowing if those segments make an assignment to a symbol that changed.

Before:
```
validate@local   ---------- 51.368 ops/sec
validate@0.65.26 --------- 101.435 ops/sec
```

After: 
```
validate@local   --------- 286.331 ops/sec
validate@0.65.26 --------- 102.877 ops/sec
```