### PR TITLE
Added ArrayDefaultTypeReferenceType for when array symbol is not defined yet

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -23,7 +23,7 @@ import type { ObjectType } from '../types/ObjectType';
 import type { AstNode, Expression, Statement } from '../parser/AstNode';
 import type { AssetFile } from '../files/AssetFile';
 import { AstNodeKind } from '../parser/AstNode';
-import type { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType } from '../types/ReferenceType';
+import type { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType, ArrayDefaultTypeReferenceType } from '../types/ReferenceType';
 import type { EnumMemberType, EnumType } from '../types/EnumType';
 import type { UnionType } from '../types/UnionType';
 import type { UninitializedType } from '../types/UninitializedType';
@@ -337,6 +337,9 @@ export function isTypePropertyReferenceType(value: any): value is TypePropertyRe
 export function isBinaryOperatorReferenceType(value: any): value is BinaryOperatorReferenceType {
     return value?.__reflection?.name === 'BinaryOperatorReferenceType';
 }
+export function isArrayDefaultTypeReferenceType(value: any): value is ArrayDefaultTypeReferenceType {
+    return value?.__reflection?.name === 'ArrayDefaultTypeReferenceType';
+}
 export function isNamespaceType(value: any): value is NamespaceType {
     return value?.kind === BscTypeKind.NamespaceType;
 }
@@ -360,9 +363,9 @@ export function isCallableType(target): target is BaseFunctionType {
     return isFunctionType(target) || isTypedFunctionType(target);
 }
 
-export function isAnyReferenceType(target): target is ReferenceType | TypePropertyReferenceType | BinaryOperatorReferenceType {
+export function isAnyReferenceType(target): target is ReferenceType | TypePropertyReferenceType | BinaryOperatorReferenceType | ArrayDefaultTypeReferenceType {
     const name = target?.__reflection?.name;
-    return name === 'ReferenceType' || name === 'TypePropertyReferenceType' || name === 'BinaryOperatorReferenceType';
+    return name === 'ReferenceType' || name === 'TypePropertyReferenceType' || name === 'BinaryOperatorReferenceType' || name === 'ArrayDefaultTypeReferenceType';
 }
 
 const numberTypeKinds = [

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -9,6 +9,7 @@ import type { FunctionExpression, LiteralExpression } from '../../parser/Express
 import { ParseMode } from '../../parser/Parser';
 import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
+import { ArrayDefaultTypeReferenceType } from '../../types/ReferenceType';
 import { AssociativeArrayType } from '../../types/AssociativeArrayType';
 import { DynamicType } from '../../types/DynamicType';
 import util from '../../util';
@@ -97,7 +98,10 @@ export class BrsFileValidator {
             ForEachStatement: (node) => {
                 //register the for loop variable
                 const loopTargetType = node.target.getType({ flags: SymbolTypeFlag.runtime });
-                const loopVarType = isArrayType(loopTargetType) ? loopTargetType.defaultType : DynamicType.instance;
+                let loopVarType = isArrayType(loopTargetType) ? loopTargetType.defaultType : DynamicType.instance;
+                if (!loopTargetType.isResolvable()) {
+                    loopVarType = new ArrayDefaultTypeReferenceType(loopTargetType);
+                }
                 node.parent.getSymbolTable()?.addSymbol(node.tokens.item.text, { definingNode: node }, loopVarType, SymbolTypeFlag.runtime);
             },
             NamespaceStatement: (node) => {

--- a/src/types/ReferenceType.spec.ts
+++ b/src/types/ReferenceType.spec.ts
@@ -4,7 +4,7 @@ import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { expectTypeToBe } from '../testHelpers.spec';
 import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
-import { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType } from './ReferenceType';
+import { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType, ArrayDefaultTypeReferenceType } from './ReferenceType';
 import { StringType } from './StringType';
 import { FloatType } from './FloatType';
 import { ClassType } from './ClassType';
@@ -14,6 +14,7 @@ import { NamespaceType } from './NamespaceType';
 import { createToken } from '../astUtils/creators';
 import { TokenKind } from '../lexer/TokenKind';
 import { util } from '../util';
+import { ArrayType } from './ArrayType';
 
 const runtimeFlag = SymbolTypeFlag.runtime;
 
@@ -158,4 +159,22 @@ describe('PropertyReferenceType', () => {
 
     });
 
+});
+
+describe('ArrayDefaultTypeReferenceType', () => {
+
+    it('should resolve the default type of an array, which is defined in the future', () => {
+        const table = new SymbolTable('test');
+        const futureArray = new ReferenceType('futureArray', 'futureArray', runtimeFlag, () => table);
+
+        const myArrayDefaultType = new ArrayDefaultTypeReferenceType(futureArray);
+        expect(myArrayDefaultType.isResolvable()).to.be.false;
+        expect((myArrayDefaultType as any).kind).to.equal(DynamicType.instance.kind);
+
+        //Define the symbol
+        table.addSymbol('futureArray', {}, new ArrayType(IntegerType.instance), runtimeFlag);
+        //myArrayDefaultType is now treated as integer
+        expect(myArrayDefaultType.isResolvable()).to.be.true;
+        expect((myArrayDefaultType as any).kind).to.equal(IntegerType.instance.kind);
+    });
 });


### PR DESCRIPTION
Needed to add a whole new ReferenceType for this use case!

Because the for-each-loop target was defined on a namespace, it wasn't defined yet at File-validation time (Namespaces are only defined at scope linking), so the default type was unknown.

Now that we have a reference type for this particular case, the array symbol can be defined in the future, and the for-each item will be automatically known.


![image](https://github.com/rokucommunity/brighterscript/assets/810290/3a2ffa3e-de0a-43e5-9073-fa673dd0f0b8)
