### PR TITLE
Add plugin hook for documentSymbol

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -883,8 +883,8 @@ describe('LanguageServer', () => {
                 expect(namespaceSymbol.name).to.equal('MyFirstNamespace');
                 const classChildrenSymbols = namespaceSymbol.children!;
                 expect(classChildrenSymbols.length).to.equal(2);
-                expect(classChildrenSymbols[0].name).to.equal('MyFirstNamespace.pi');
-                expect(classChildrenSymbols[1].name).to.equal('MyFirstNamespace.buildAwesome');
+                expect(classChildrenSymbols[0].name).to.equal('pi');
+                expect(classChildrenSymbols[1].name).to.equal('buildAwesome');
             }
         });
     });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1,14 +1,14 @@
 import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
-import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location } from 'vscode-languageserver';
+import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, DocumentSymbol } from 'vscode-languageserver';
 import { CompletionItemKind } from 'vscode-languageserver';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent } from './interfaces';
+import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent } from './interfaces';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
@@ -959,6 +959,23 @@ export class Program {
         }
 
         return result ?? [];
+    }
+
+    public getDocumentSymbols(srcPath: string): DocumentSymbol[] | undefined {
+        let file = this.getFile(srcPath);
+        if (file) {
+            const event: ProvideDocumentSymbolsEvent = {
+                program: this,
+                file: file,
+                documentSymbols: []
+            };
+            this.plugins.emit('beforeProvideDocumentSymbols', event);
+            this.plugins.emit('provideDocumentSymbols', event);
+            this.plugins.emit('afterProvideDocumentSymbols', event);
+            return event.documentSymbols;
+        } else {
+            return undefined;
+        }
     }
 
     /**

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,9 +1,10 @@
 import { isBrsFile, isXmlFile } from '../astUtils/reflection';
-import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent } from '../interfaces';
+import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent } from '../interfaces';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { CompletionsProcessor } from './completions/CompletionsProcessor';
 import { DefinitionProvider } from './definition/DefinitionProvider';
+import { DocumentSymbolProcessor } from './documentSymbol/DocumentSymbolProcessor';
 import { HoverProcessor } from './hover/HoverProcessor';
 import { ReferencesProvider } from './references/ReferencesProvider';
 import { BrsFileSemanticTokensProcessor } from './semanticTokens/BrsFileSemanticTokensProcessor';
@@ -22,6 +23,10 @@ export class BscPlugin implements CompilerPlugin {
 
     public provideHover(event: ProvideHoverEvent) {
         return new HoverProcessor(event).process();
+    }
+
+    public provideDocumentSymbols(event: ProvideDocumentSymbolsEvent) {
+        return new DocumentSymbolProcessor(event).process();
     }
 
     public provideCompletions(event: ProvideCompletionsEvent) {

--- a/src/bscPlugin/documentSymbol/DocumentSymbolProcessor.spec.ts
+++ b/src/bscPlugin/documentSymbol/DocumentSymbolProcessor.spec.ts
@@ -1,0 +1,219 @@
+import { expect } from '../../chai-config.spec';
+import { Program } from '../../Program';
+import { createSandbox } from 'sinon';
+import { rootDir } from '../../testHelpers.spec';
+import type { DocumentSymbol } from 'vscode-languageserver-types';
+import { SymbolKind } from 'vscode-languageserver-types';
+let sinon = createSandbox();
+
+describe('DocumentSymbolProcessor', () => {
+    let program: Program;
+    beforeEach(() => {
+        program = new Program({ rootDir: rootDir, sourceMap: true });
+    });
+    afterEach(() => {
+        sinon.restore();
+        program.dispose();
+    });
+
+    function doTest(source: string, expected: SymbolTree) {
+        program.setFile('source/main.brs', source);
+        expectSymbols(
+            program.getDocumentSymbols('source/main.brs'),
+            expected
+        );
+    }
+
+    it('finds functions', () => {
+        doTest(`
+            function alpha()
+            end function
+            function beta()
+            end function
+        `, {
+            'alpha': SymbolKind.Function,
+            'beta': SymbolKind.Function
+        });
+    });
+
+    it('finds namespaces', () => {
+        doTest(`
+            namespace alpha
+            end namespace
+            namespace beta
+            end namespace
+            namespace charlie
+                namespace delta
+                end namespace
+            end namespace
+        `, {
+            alpha: SymbolKind.Namespace,
+            beta: SymbolKind.Namespace,
+            charlie: {
+                kind: SymbolKind.Namespace,
+                children: {
+                    delta: SymbolKind.Namespace
+                }
+            }
+        });
+    });
+
+    it('finds classes', () => {
+        doTest(`
+            class alpha
+            end class
+
+            namespace beta
+                class charlie
+                    name as string
+                    sub speak()
+                        print "I am " + m.name
+                    end sub
+                end class
+            end namespace
+        `, {
+            alpha: SymbolKind.Class,
+            beta: {
+                kind: SymbolKind.Namespace,
+                children: {
+                    charlie: {
+                        kind: SymbolKind.Class,
+                        children: {
+                            name: SymbolKind.Field,
+                            speak: SymbolKind.Method
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it('finds interfaces', () => {
+        doTest(`
+            interface alpha
+                name as string
+            end interface
+
+            namespace beta
+                interface charlie
+                    age as string
+                    sub speak() as void
+                end interface
+            end namespace
+        `, {
+            alpha: {
+                kind: SymbolKind.Interface,
+                children: {
+                    name: SymbolKind.Field
+                }
+            },
+            beta: {
+                kind: SymbolKind.Namespace,
+                children: {
+                    charlie: {
+                        kind: SymbolKind.Interface,
+                        children: {
+                            age: SymbolKind.Field,
+                            speak: SymbolKind.Method
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it('finds consts', () => {
+        doTest(`
+            const alpha = 1
+            namespace beta
+                const charlie = 2
+            end namespace
+            const delta = 3
+        `, {
+            alpha: SymbolKind.Constant,
+            beta: {
+                kind: SymbolKind.Namespace,
+                children: {
+                    charlie: SymbolKind.Constant
+                }
+            },
+            delta: SymbolKind.Constant
+        });
+    });
+
+    it('finds enums', () => {
+        doTest(`
+            enum alpha
+                a = 1
+                b = 2
+            end enum
+            namespace beta
+                enum charlie
+                    c = 3
+                    d = 4
+                end enum
+            end namespace
+        `, {
+            alpha: {
+                kind: SymbolKind.Enum,
+                children: {
+                    a: SymbolKind.EnumMember,
+                    b: SymbolKind.EnumMember
+                }
+            },
+            beta: {
+                kind: SymbolKind.Namespace,
+                children: {
+                    charlie: {
+                        kind: SymbolKind.Enum,
+                        children: {
+                            c: SymbolKind.EnumMember,
+                            d: SymbolKind.EnumMember
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    function expectSymbols(documentSymbols: DocumentSymbol[], expected: SymbolTree) {
+        expect(
+            symbolKindToString(createSymbolTree(documentSymbols))
+        ).to.eql(
+            symbolKindToString(expected)
+        );
+    }
+
+    const SymbolKindMap = new Map(Object.entries(SymbolKind).map(x => [x[1], x[0]]));
+
+    function symbolKindToString(tree: SymbolTree) {
+        //recursively walk the tree and convert every .kind property to a string
+        for (let key in tree) {
+            let value = tree[key];
+            if (typeof value === 'object') {
+                tree[key] = symbolKindToString(value as any) as any;
+            } else {
+                tree[key] = SymbolKindMap.get(value as any);
+            }
+        }
+        return tree;
+    }
+
+    function createSymbolTree(documentSymbols: DocumentSymbol[]) {
+        let tree = {} as SymbolTree;
+        for (let symbol of documentSymbols) {
+            tree[symbol.name] = symbol.kind;
+            if (symbol.children?.length > 0) {
+                tree[symbol.name] = {
+                    kind: symbol.kind,
+                    children: createSymbolTree(symbol.children)
+                };
+            }
+        }
+        return tree;
+    }
+});
+
+interface SymbolTree {
+    [key: string]: SymbolKind | string | { kind: SymbolKind | string; children: SymbolTree };
+}

--- a/src/bscPlugin/documentSymbol/DocumentSymbolProcessor.ts
+++ b/src/bscPlugin/documentSymbol/DocumentSymbolProcessor.ts
@@ -1,0 +1,77 @@
+import { DocumentSymbol, SymbolKind } from 'vscode-languageserver-types';
+import { isBrsFile, isClassStatement, isConstStatement, isEnumMemberStatement, isEnumStatement, isFieldStatement, isFunctionStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isMethodStatement, isNamespaceStatement } from '../../astUtils/reflection';
+import type { BrsFile } from '../../files/BrsFile';
+import type { ProvideDocumentSymbolsEvent } from '../../interfaces';
+import type { Statement } from '../../parser/AstNode';
+
+export class DocumentSymbolProcessor {
+    public constructor(
+        public event: ProvideDocumentSymbolsEvent
+    ) {
+
+    }
+
+    public process() {
+        if (isBrsFile(this.event.file)) {
+            return this.getBrsFileDocumentSymbols(this.event.file);
+        }
+    }
+
+    private getBrsFileDocumentSymbols(file: BrsFile) {
+        for (const statement of file.ast.statements) {
+            const symbol = getSymbolsFromStatement(statement);
+            if (symbol) {
+                this.event.documentSymbols.push(symbol);
+            }
+        }
+        return this.event.documentSymbols;
+
+        function getSymbolsFromStatement(statement: Statement) {
+            if (isFunctionStatement(statement)) {
+                return DocumentSymbol.create(statement.name.text, '', SymbolKind.Function, statement.range, statement.name.range);
+
+            } else if (isMethodStatement(statement)) {
+                return DocumentSymbol.create(statement.name.text, '', SymbolKind.Method, statement.range, statement.name.range);
+
+            } else if (isInterfaceMethodStatement(statement)) {
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.Method, statement.range, statement.tokens.name.range);
+
+            } else if (isFieldStatement(statement)) {
+                return DocumentSymbol.create(statement.name.text, '', SymbolKind.Field, statement.range, statement.name.range);
+
+            } else if (isInterfaceFieldStatement(statement)) {
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.Field, statement.range, statement.tokens.name.range);
+
+            } else if (isConstStatement(statement)) {
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.Constant, statement.range, statement.tokens.name.range);
+
+            } else if (isNamespaceStatement(statement)) {
+                const children = statement.body.statements
+                    .map(getSymbolsFromStatement)
+                    .filter(x => !!x);
+                return DocumentSymbol.create(statement.nameExpression.getNameParts().pop(), '', SymbolKind.Namespace, statement.range, statement.nameExpression.range, children);
+
+            } else if (isClassStatement(statement)) {
+                const children = statement.body
+                    .map(getSymbolsFromStatement)
+                    .filter(x => !!x);
+                return DocumentSymbol.create(statement.name.text, '', SymbolKind.Class, statement.range, statement.name.range, children);
+
+            } else if (isInterfaceStatement(statement)) {
+                const children = statement.body
+                    .map(getSymbolsFromStatement)
+                    .filter(x => !!x);
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.Interface, statement.range, statement.tokens.name.range, children);
+
+            } else if (isEnumStatement(statement)) {
+                const children = statement.body
+                    .map(getSymbolsFromStatement)
+                    .filter(x => !!x);
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.Enum, statement.range, statement.tokens.name.range, children);
+
+            } else if (isEnumMemberStatement(statement)) {
+                return DocumentSymbol.create(statement.tokens.name.text, '', SymbolKind.EnumMember, statement.range, statement.tokens.name.range);
+            }
+        }
+    }
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Range, Diagnostic, CodeAction, SemanticTokenTypes, SemanticTokenModifiers, Position, CompletionItem, Location } from 'vscode-languageserver';
+import type { Range, Diagnostic, CodeAction, SemanticTokenTypes, SemanticTokenModifiers, Position, CompletionItem, Location, DocumentSymbol } from 'vscode-languageserver';
 import type { Scope } from './Scope';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
@@ -261,6 +261,22 @@ export interface CompilerPlugin {
     afterProvideReferences?(event: AfterProvideReferencesEvent): any;
 
 
+    /**
+     * Called before the `provideDocumentSymbols` hook
+     */
+    beforeProvideDocumentSymbols?(event: BeforeProvideDocumentSymbolsEvent): any;
+    /**
+     * Provide all of the `DocumentSymbol`s for the given file
+     * @param event
+     */
+    provideDocumentSymbols?(event: ProvideDocumentSymbolsEvent): any;
+    /**
+     * Called after `provideDocumentSymbols`. Use this if you want to intercept or sanitize the document symbols data provided by bsc or other plugins
+     * @param event
+     */
+    afterProvideDocumentSymbols?(event: AfterProvideDocumentSymbolsEvent): any;
+
+
     onGetSemanticTokens?: PluginHandler<OnGetSemanticTokensEvent>;
     //scope events
     afterScopeCreate?: (scope: Scope) => void;
@@ -370,6 +386,21 @@ export interface ProvideReferencesEvent<TFile = BscFile> {
 }
 export type BeforeProvideReferencesEvent<TFile = BscFile> = ProvideReferencesEvent<TFile>;
 export type AfterProvideReferencesEvent<TFile = BscFile> = ProvideReferencesEvent<TFile>;
+
+
+export interface ProvideDocumentSymbolsEvent<TFile = BscFile> {
+    program: Program;
+    /**
+     * The file that the `documentSymbol` request was invoked in
+     */
+    file: TFile;
+    /**
+     * The result list of symbols
+     */
+    documentSymbols: DocumentSymbol[];
+}
+export type BeforeProvideDocumentSymbolsEvent<TFile = BscFile> = ProvideDocumentSymbolsEvent<TFile>;
+export type AfterProvideDocumentSymbolsEvent<TFile = BscFile> = ProvideDocumentSymbolsEvent<TFile>;
 
 
 export interface OnGetSemanticTokensEvent<T extends BscFile = BscFile> {

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -39,7 +39,7 @@ export interface Identifier extends Token {
  * @param obj the object to check for `Token`-ness
  * @returns `true` is `obj` is a `Token`, otherwise `false`
  */
-export function isToken(obj: Record<string, any>): obj is Token {
+export function isToken(obj: any): obj is Token {
     return !!(obj.kind && obj.text);
 }
 


### PR DESCRIPTION
- Adds new plugin hooks for providing document symbols. 
- Migrates the logic out of `BrsFile` and into `BscPlugin`
- Adds a few missing document symbol entries
- Remove the leading namespace values from the symbols since they're shown in grey next to the symbols

**Before:**
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/cc6db0b4-a02d-44d8-aa7b-64194f0df73b)

**After:**
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/6c69ed78-3f5e-4762-bd19-c8209f45916a)

Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/385