### PR TITLE
[WIP] Validate a file in a single scope context only

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -756,13 +756,18 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     incompatibleSymbolDefinition: (symbol: string, scopeName: string) => ({
-        message: `'${symbol}' is incompatible across scope group (${scopeName})`, // TODO: Add scopes where it was defined
+        message: `'${symbol}' is incompatible across these scopes: ${scopeName}`,
         code: 1145,
         severity: DiagnosticSeverity.Error
     }),
     memberAccessibilityMismatch: (memberName: string, accessModifierFlag: SymbolTypeFlag, definingClassName: string) => ({
         message: `Member '${memberName}' is ${accessModifierNameFromFlag(accessModifierFlag)}${accessModifierAdditionalInfo(accessModifierFlag, definingClassName)}`, // TODO: Add scopes where it was defined
         code: 1146,
+        severity: DiagnosticSeverity.Error
+    }),
+    symbolNotDefinedInScopes: (symbol: string, scopesListString: string) => ({
+        message: `'${symbol}' is not defined in these scopes: ${scopesListString}`,
+        code: 1147,
         severity: DiagnosticSeverity.Error
     })
 };

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -3,7 +3,7 @@ import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
 import type { Expression } from '../parser/AstNode';
-import { isAAMemberExpression, isBinaryExpression, isCallExpression, isDottedGetExpression, isFunctionExpression, isIndexedGetExpression, isMethodStatement, isNamespaceStatement, isNewExpression, isVariableExpression } from './reflection';
+import { isAAMemberExpression, isBinaryExpression, isCallExpression, isDottedGetExpression, isFunctionExpression, isIndexedGetExpression, isLiteralExpression, isMethodStatement, isNamespaceStatement, isNewExpression, isVariableExpression } from './reflection';
 import type { Parser } from '../parser/Parser';
 import { ParseMode } from '../parser/Parser';
 import type { Token } from '../lexer/Token';
@@ -201,7 +201,7 @@ export class CachedLookups {
                         break;
 
                         //when we hit a variable expression, we're definitely at the leftmost expression so stop
-                    } else if (isVariableExpression(node)) {
+                    } else if (isVariableExpression(node) || isLiteralExpression(node)) {
                         break;
                         //if
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -592,7 +592,7 @@ export interface TranspileEntry {
 
 
 export interface ScopeValidationOptions {
-    changedFiles?: BscFile[];
+    filesToBeValidatedInScopeContext?: Set<BscFile>;
     changedSymbols?: Map<SymbolTypeFlag, Set<string>>;
     force?: boolean;
     initialValidation?: boolean;


### PR DESCRIPTION
With version 1, we will be changing how validation works. The goal is that all files will still be totally validated, except the method will be different.
Currently, in v0.65, when a file changes, all files in all affected scopes are validated. This validation is rather basic - checking number of function arguments, verifying no duplicate function names, etc.

In version 1, the validation is much more rigorous, as all known types, namespaces, variables, etc. are fully checked for how they are used (as function args, return values, property access, etc.). This is taking MUCH longer to do, especially for files that are included in many scopes, like a utils file with common functions that’s included in every component.
So we are going to experiment with only checking the first scope a file is in, then also producing validation errors if we expect there might be errors in other scopes.

For example, let’s say `FileA` references function `someFunc` that is not defined in the same file, and `FileA` is included in 2 different components.

If `FileA` changes, it will only be fully validated in the scope of the first component. In that context, if `someFunc` is defined (and its usage is consistent with its definition) there will be no error. However, we also check that someFunc is available (and compatible) in the context of the second scope.

If `someFunc` is not defined in the second component, or it has a different function signature, we will add a diagnostic error to say that the symbol is inconsistent across scopes.

Because we only need to fully check the files in the first scope, things go much quicker. The only downside is that the errors will be a little non-specific, eg. “Function `someFunc` is not compatible in `Component A` and `Component B`”, vs. if we fully validated, we know stuff like the properties of the return type of the function are different, and these are the differences, and it’s ok, or maybe a problem in the the context of the usage, etc.