### PR TITLE
Fix bug in range and position caching

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4578,5 +4578,21 @@ describe('BrsFile', () => {
                 end sub
             `);
         });
+
+
+        //fails at the specific length of statement including leading tabs and spaces
+        it('allows long statements', () => {
+            program.setFile('source/main.bs', `function request()\r\nhzzzzandleInterceptedScreenDataaaaaaaaaaainterceptedScreenData() 'bs:disable-line \r\nend function`);
+            program.validate();
+            expectZeroDiagnostics(program);
+
+            program.setFile('source/main.bs', `function request()\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\thandleInterceptedScreenDataaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(m._aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaainterceptedScreenData) 'bs:disable-line \r\nend function`);
+            program.validate();
+            expectZeroDiagnostics(program);
+
+            program.setFile('source/main.bs', `function request()\r\n\t\t\t\thandleInterceptedScreenData(m._aaaaaaainterceptedScreenData) 'bs:disable-line 1001\r\nend function`);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1073,7 +1073,11 @@ export class Util {
     private rangeCache = new Map<number, Range>();
 
     /**
-     * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower
+     * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower.
+     *
+     * This function caches the `Range` objects to reduce garbage collection churn.
+     *
+     * See this jsbench for why we chose this method: https://jsbench.me/r1lub4hjro
      */
     public createRange(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         //skip the cache if any number is higher than the max integer we can store for each key chunk (8191)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1076,16 +1076,23 @@ export class Util {
      * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower
      */
     public createRange(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
-        // eslint-disable-next-line no-bitwise
-        const key = (startLine << 39) + (startCharacter << 26) + (endLine << 13) + endCharacter;
+        let maxNumber = 8190;
+        let isOverflowRange = false;
+        if ((startLine > maxNumber) || (startCharacter > maxNumber) || (endLine > maxNumber) || (endCharacter > maxNumber)) {
+            isOverflowRange = true;
+        }
 
+        // eslint-disable-next-line no-bitwise
+        const key = (startLine << 52) + (startCharacter << 39) + (endLine << 26) + (endCharacter << 13);
         let range = this.rangeCache.get(key);
         if (!range) {
             range = {
                 start: this.createPosition(startLine, startCharacter),
                 end: this.createPosition(endLine, endCharacter)
             };
-            this.rangeCache.set(key, range);
+            if (!isOverflowRange) {
+                this.rangeCache.set(key, range);
+            }
         }
         return range;
     }


### PR DESCRIPTION
Fixes an issue in `util.createRange()` and `util.createPosition()` where integers over 13 bits long would sometimes generate an incorrect cache key (thus returning the wrong cached value and wrong position/range values). 