### PR TITLE
Adds `typecast m as <Type>` statement

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -109,6 +109,22 @@ second line text`
 authStatus = user <> invalid ? "logged in" : "not logged in"
 ```
 
+## [Typecasts](typecasts.md)
+```BrighterScript
+nodeId = (node as roSgNode).id
+```
+
+## [Typed Arrays](typed-arrays.md)
+```brighterscript
+function getY(translation as float[]) as float
+    yValue = -1
+    if translation.count() > 1
+        yValue = translation[1] ' yValue is known to be of type float
+    end if
+    yValue
+end function
+```
+
 ## [Union Types](union-types.md)
 ```brighterscript
 sub logData(data as string or number)

--- a/docs/typecasts.md
+++ b/docs/typecasts.md
@@ -1,0 +1,111 @@
+# BrighterScript Typecasts
+
+In BrighterScript, the inferred types of expressions can be explicitly changed through typecasts.
+
+There are two ways of doing this - through inline typecasts, or through typecast statements.
+
+Any expressions that has been typecast will be assumed to be that type.
+
+## Inline typecasts
+
+To invoke an inline typecast, use the `as <type>` syntax after an expression. The whole typecast can also be enclosed in parentheses as well.
+
+In this example, the `node` parameter is `dynamic`, but is cast to the built-in type `roSgNode`. `roSgNode` has an `id` property that is a `string`.
+Due to the assignment, `nodeId` is also known to be a string.
+
+Because of the typecast, the intellisense code completion also knows the type, so at the `.` after the typecast, members of `roSgNode` will be suggested.
+
+Example:
+
+```BrighterScript
+function getPrefixedId(node, prefix as string) as string
+    nodeId = (node as roSgNode).id
+    return prefix + nodeId
+end function
+```
+
+## Typecast Statments
+
+In order to specify all usages of an expression are explicity set to a certian type, you can use a `typecast` statement.
+
+Syntax:
+
+`typecast m as <type>`
+
+Rules:
+
+- `Typecast` statements are only allowed at the top of files (along with `import` and `library` statements), and as the first statement in a function or namespace.
+- There can be a maximum of one `typecast` statement per block
+- Only runtime symbols can be typecast
+- Currently only `m` is supported
+
+This is very usefuly for components, so that the actual type of Associative Array `m` can narrowed to provide better validation.
+
+**pkg:/components/Widget.xml**
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Widget" extends="Group">
+    <script uri="Widget.bs" />
+    <script uri="Widget.interface.bs" />
+    <interface>
+        <field id="enabled" type="boolean" value="false" />
+        <field id="state" type="string" />
+    </interface>
+    <children>
+        <label id="myLabel" />
+    </children>
+</component>
+```
+
+**pkg:/components/Widget.interface.xml**
+
+```BrighterScript
+interface WidgetObject
+    top as roSgNodeWidget
+    label as roSgNodeLabel
+    value as string
+end interface
+```
+
+**pkg:/components/Widget.bs**
+
+```BrighterScript
+typecast m as WidgetObject
+
+sub init
+    m.label = m.top.findNode("myLabel")
+    m.value = "Test"
+    m.top.state = "ok"
+    printDetails()
+end sub
+
+sub printDetails()
+    ' all members of `m` are known
+    print m.top.subtype()
+    print m.label.text
+    print m.top.state
+end sub
+```
+
+`Typecast` statements are also useful in inline functions to explicity set the type of `m`:
+
+```BrighterScript
+interface Greeter
+    greeting as string
+    name as string
+    function doGreeting() as string
+end iterface
+
+function createGreater(name as string) as Greeter
+    myGreeter = {
+        greeting: "Hello"
+        name: name
+        doGreeting: function () as string
+            typecast m as Greeter
+            return `${m.greeting} ${m.name} ' m is explicity set to be of type Greeter
+        end function
+    }
+    retrun myGreeter
+end function
+```

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -765,7 +765,7 @@ export let DiagnosticMessages = {
         code: 1146,
         severity: DiagnosticSeverity.Error
     }),
-    typeCastMStatementMustBeDeclaredAtStart: () => ({
+    typecastMStatementMustBeDeclaredAtStart: () => ({
         message: `'typecast m' statement must be declared at the top of the file or beginning of function`,
         code: 1147,
         severity: DiagnosticSeverity.Error

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -100,8 +100,8 @@ export let DiagnosticMessages = {
         code: 1015,
         severity: DiagnosticSeverity.Error
     }),
-    expectedIdentifierAfterKeyword: (keywordText: string, expectedText = '') => ({
-        message: `Expected identifier ${expectedText ? `'${expectedText}' ` : ''}after '${keywordText}' keyword`,
+    expectedIdentifierAfterKeyword: (keywordText: string) => ({
+        message: `Expected identifier after '${keywordText}' keyword`,
         code: 1016,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -100,8 +100,8 @@ export let DiagnosticMessages = {
         code: 1015,
         severity: DiagnosticSeverity.Error
     }),
-    expectedIdentifierAfterKeyword: (keywordText: string) => ({
-        message: `Expected identifier after '${keywordText}' keyword`,
+    expectedIdentifierAfterKeyword: (keywordText: string, expectedText = '') => ({
+        message: `Expected identifier ${expectedText ? `'${expectedText}' ` : ''}after '${keywordText}' keyword`,
         code: 1016,
         severity: DiagnosticSeverity.Error
     }),

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -765,9 +765,14 @@ export let DiagnosticMessages = {
         code: 1146,
         severity: DiagnosticSeverity.Error
     }),
-    typecastMStatementMustBeDeclaredAtStart: () => ({
-        message: `'typecast m' statement must be declared at the top of the file or beginning of function`,
+    typecastStatementMustBeDeclaredAtStart: () => ({
+        message: `'typecast' statement must be declared at the top of the file or beginning of function or namespace`,
         code: 1147,
+        severity: DiagnosticSeverity.Error
+    }),
+    invalidTypecastStatementApplication: (foundApplication: string) => ({
+        message: `'typecast' statement can only be applied to 'm', but was applied to '${foundApplication}'`,
+        code: 1148,
         severity: DiagnosticSeverity.Error
     })
 };

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -764,6 +764,11 @@ export let DiagnosticMessages = {
         message: `Member '${memberName}' is ${accessModifierNameFromFlag(accessModifierFlag)}${accessModifierAdditionalInfo(accessModifierFlag, definingClassName)}`, // TODO: Add scopes where it was defined
         code: 1146,
         severity: DiagnosticSeverity.Error
+    }),
+    typeCastMStatementMustBeDeclaredAtStart: () => ({
+        message: `'typecast m' statement must be declared at the top of the file or beginning of function`,
+        code: 1147,
+        severity: DiagnosticSeverity.Error
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -1,5 +1,5 @@
 import type { AALiteralExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, VariableExpression } from '../parser/Expression';
-import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement, TypeCastMStatement } from '../parser/Statement';
+import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement, TypecastMStatement } from '../parser/Statement';
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
 import type { Expression } from '../parser/AstNode';
@@ -53,8 +53,8 @@ export class CachedLookups {
         return this.getFromCache<Array<ImportStatement>>('importStatements');
     }
 
-    get typeCastMStatements(): TypeCastMStatement[] {
-        return this.getFromCache<Array<TypeCastMStatement>>('typeCastMStatements');
+    get typecastMStatements(): TypecastMStatement[] {
+        return this.getFromCache<Array<TypecastMStatement>>('typecastMStatements');
     }
 
     /**
@@ -164,7 +164,7 @@ export class CachedLookups {
         const assignmentStatements: AssignmentStatement[] = [];
         const libraryStatements: LibraryStatement[] = [];
         const importStatements: ImportStatement[] = [];
-        const typeCastMStatements: TypeCastMStatement[] = [];
+        const typecastMStatements: TypecastMStatement[] = [];
         const functionStatements: FunctionStatement[] = [];
         const functionExpressions: FunctionExpression[] = [];
 
@@ -257,8 +257,8 @@ export class CachedLookups {
             ImportStatement: s => {
                 importStatements.push(s);
             },
-            TypeCastMStatement: s => {
-                typeCastMStatements.push(s);
+            TypecastMStatement: s => {
+                typecastMStatements.push(s);
             },
             LibraryStatement: s => {
                 libraryStatements.push(s);
@@ -340,7 +340,7 @@ export class CachedLookups {
         this.cache.set('assignmentStatements', assignmentStatements);
         this.cache.set('libraryStatements', libraryStatements);
         this.cache.set('importStatements', importStatements);
-        this.cache.set('typeCastMStatements', typeCastMStatements);
+        this.cache.set('typecastMStatements', typecastMStatements);
         this.cache.set('functionStatements', functionStatements);
         this.cache.set('functionExpressions', functionExpressions);
         this.cache.set('propertyHints', propertyHints);

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -1,5 +1,5 @@
 import type { AALiteralExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, VariableExpression } from '../parser/Expression';
-import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement } from '../parser/Statement';
+import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement, TypeCastMStatement } from '../parser/Statement';
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
 import type { Expression } from '../parser/AstNode';
@@ -51,6 +51,10 @@ export class CachedLookups {
 
     get importStatements(): ImportStatement[] {
         return this.getFromCache<Array<ImportStatement>>('importStatements');
+    }
+
+    get typeCastMStatements(): TypeCastMStatement[] {
+        return this.getFromCache<Array<TypeCastMStatement>>('typeCastMStatements');
     }
 
     /**
@@ -160,6 +164,7 @@ export class CachedLookups {
         const assignmentStatements: AssignmentStatement[] = [];
         const libraryStatements: LibraryStatement[] = [];
         const importStatements: ImportStatement[] = [];
+        const typeCastMStatements: TypeCastMStatement[] = [];
         const functionStatements: FunctionStatement[] = [];
         const functionExpressions: FunctionExpression[] = [];
 
@@ -252,6 +257,9 @@ export class CachedLookups {
             ImportStatement: s => {
                 importStatements.push(s);
             },
+            TypeCastMStatement: s => {
+                typeCastMStatements.push(s);
+            },
             LibraryStatement: s => {
                 libraryStatements.push(s);
             },
@@ -332,6 +340,7 @@ export class CachedLookups {
         this.cache.set('assignmentStatements', assignmentStatements);
         this.cache.set('libraryStatements', libraryStatements);
         this.cache.set('importStatements', importStatements);
+        this.cache.set('typeCastMStatements', typeCastMStatements);
         this.cache.set('functionStatements', functionStatements);
         this.cache.set('functionExpressions', functionExpressions);
         this.cache.set('propertyHints', propertyHints);

--- a/src/astUtils/CachedLookups.ts
+++ b/src/astUtils/CachedLookups.ts
@@ -1,5 +1,5 @@
 import type { AALiteralExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, VariableExpression } from '../parser/Expression';
-import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement, TypecastMStatement } from '../parser/Statement';
+import type { AssignmentStatement, ClassStatement, ConstStatement, EnumStatement, FunctionStatement, ImportStatement, InterfaceStatement, LibraryStatement, NamespaceStatement, TypecastStatement } from '../parser/Statement';
 import { Cache } from '../Cache';
 import { WalkMode, createVisitor } from './visitors';
 import type { Expression } from '../parser/AstNode';
@@ -53,8 +53,8 @@ export class CachedLookups {
         return this.getFromCache<Array<ImportStatement>>('importStatements');
     }
 
-    get typecastMStatements(): TypecastMStatement[] {
-        return this.getFromCache<Array<TypecastMStatement>>('typecastMStatements');
+    get typecastStatements(): TypecastStatement[] {
+        return this.getFromCache<Array<TypecastStatement>>('typecastStatements');
     }
 
     /**
@@ -164,7 +164,7 @@ export class CachedLookups {
         const assignmentStatements: AssignmentStatement[] = [];
         const libraryStatements: LibraryStatement[] = [];
         const importStatements: ImportStatement[] = [];
-        const typecastMStatements: TypecastMStatement[] = [];
+        const typecastStatements: TypecastStatement[] = [];
         const functionStatements: FunctionStatement[] = [];
         const functionExpressions: FunctionExpression[] = [];
 
@@ -257,8 +257,8 @@ export class CachedLookups {
             ImportStatement: s => {
                 importStatements.push(s);
             },
-            TypecastMStatement: s => {
-                typecastMStatements.push(s);
+            TypecastStatement: s => {
+                typecastStatements.push(s);
             },
             LibraryStatement: s => {
                 libraryStatements.push(s);
@@ -340,7 +340,7 @@ export class CachedLookups {
         this.cache.set('assignmentStatements', assignmentStatements);
         this.cache.set('libraryStatements', libraryStatements);
         this.cache.set('importStatements', importStatements);
-        this.cache.set('typecastMStatements', typecastMStatements);
+        this.cache.set('typecastStatements', typecastStatements);
         this.cache.set('functionStatements', functionStatements);
         this.cache.set('functionExpressions', functionExpressions);
         this.cache.set('propertyHints', propertyHints);

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypecastMStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypecastStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypecastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -183,8 +183,8 @@ export function isCatchStatement(element: AstNode | undefined): element is Catch
 export function isThrowStatement(element: AstNode | undefined): element is ThrowStatement {
     return element?.kind === AstNodeKind.ThrowStatement;
 }
-export function isTypecastMStatement(element: AstNode | undefined): element is TypecastMStatement {
-    return element?.kind === AstNodeKind.TypecastMStatement;
+export function isTypecastStatement(element: AstNode | undefined): element is TypecastStatement {
+    return element?.kind === AstNodeKind.TypecastStatement;
 }
 
 // Expressions reflection

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypeCastMStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -182,6 +182,9 @@ export function isCatchStatement(element: AstNode | undefined): element is Catch
 }
 export function isThrowStatement(element: AstNode | undefined): element is ThrowStatement {
     return element?.kind === AstNodeKind.ThrowStatement;
+}
+export function isTypeCastMStatement(element: AstNode | undefined): element is TypeCastMStatement {
+    return element?.kind === AstNodeKind.TypeCastMStatement;
 }
 
 // Expressions reflection

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypeCastMStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypecastMStatement } from '../parser/Statement';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypecastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { TypedefProvider } from '../interfaces';
@@ -183,8 +183,8 @@ export function isCatchStatement(element: AstNode | undefined): element is Catch
 export function isThrowStatement(element: AstNode | undefined): element is ThrowStatement {
     return element?.kind === AstNodeKind.ThrowStatement;
 }
-export function isTypeCastMStatement(element: AstNode | undefined): element is TypeCastMStatement {
-    return element?.kind === AstNodeKind.TypeCastMStatement;
+export function isTypecastMStatement(element: AstNode | undefined): element is TypecastMStatement {
+    return element?.kind === AstNodeKind.TypecastMStatement;
 }
 
 // Expressions reflection
@@ -272,8 +272,8 @@ export function isTypedefProvider(element: any): element is TypedefProvider {
 export function isTypeExpression(element: any): element is TypeExpression {
     return element?.kind === AstNodeKind.TypeExpression;
 }
-export function isTypeCastExpression(element: any): element is TypeCastExpression {
-    return element?.kind === AstNodeKind.TypeCastExpression;
+export function isTypecastExpression(element: any): element is TypecastExpression {
+    return element?.kind === AstNodeKind.TypecastExpression;
 }
 export function isTypedArrayExpression(element: any): element is TypedArrayExpression {
     return element?.kind === AstNodeKind.TypedArrayExpression;

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypeCastMStatement } from '../parser/Statement';
-import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, TypeExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypecastMStatement } from '../parser/Statement';
+import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypecastExpression, TypeExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { Editor } from './Editor';
 import type { Statement, Expression, AstNode } from '../parser/AstNode';
@@ -127,7 +127,7 @@ export function createVisitor(
         LibraryStatement?: (statement: LibraryStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         NamespaceStatement?: (statement: NamespaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ImportStatement?: (statement: ImportStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
-        TypeCastMStatement?: (statement: TypeCastMStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        TypecastMStatement?: (statement: TypecastMStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceFieldStatement?: (statement: InterfaceFieldStatement, parent?: Statement) => Statement | void;
         InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
@@ -168,7 +168,7 @@ export function createVisitor(
         NullCoalescingExpression?: (expression: NullCoalescingExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
         RegexLiteralExpression?: (expression: RegexLiteralExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
         TypeExpression?: (expression: TypeExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
-        TypeCastExpression?: (expression: TypeCastExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
+        TypecastExpression?: (expression: TypecastExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
     }
 ) {
     return <WalkVisitor>((statement: Statement, parent?: Statement, owner?: any, key?: any): Statement | void => {

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypeCastMStatement } from '../parser/Statement';
 import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, TypeExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { Editor } from './Editor';
@@ -127,6 +127,7 @@ export function createVisitor(
         LibraryStatement?: (statement: LibraryStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         NamespaceStatement?: (statement: NamespaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ImportStatement?: (statement: ImportStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        TypeCastMStatement?: (statement: TypeCastMStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceFieldStatement?: (statement: InterfaceFieldStatement, parent?: Statement) => Statement | void;
         InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypecastMStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypecastStatement } from '../parser/Statement';
 import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypecastExpression, TypeExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { Editor } from './Editor';
@@ -127,7 +127,7 @@ export function createVisitor(
         LibraryStatement?: (statement: LibraryStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         NamespaceStatement?: (statement: NamespaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ImportStatement?: (statement: ImportStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
-        TypecastMStatement?: (statement: TypecastMStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        TypecastStatement?: (statement: TypecastStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceStatement?: (statement: InterfaceStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         InterfaceFieldStatement?: (statement: InterfaceFieldStatement, parent?: Statement) => Statement | void;
         InterfaceMethodStatement?: (statement: InterfaceMethodStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -353,7 +353,7 @@ describe('BrsFileValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart().message
+                DiagnosticMessages.typecastMStatementMustBeDeclaredAtStart().message
             ]);
         });
 
@@ -387,7 +387,7 @@ describe('BrsFileValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart().message
+                DiagnosticMessages.typecastMStatementMustBeDeclaredAtStart().message
             ]);
         });
 

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1,12 +1,19 @@
 import { expect } from '../../chai-config.spec';
 import type { BrsFile } from '../../files/BrsFile';
 import type { AALiteralExpression, DottedGetExpression } from '../../parser/Expression';
-import type { ClassStatement, FunctionStatement, NamespaceStatement, PrintStatement } from '../../parser/Statement';
+import type { AssignmentStatement, ClassStatement, FunctionStatement, NamespaceStatement, PrintStatement } from '../../parser/Statement';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
-import { expectDiagnostics, expectZeroDiagnostics } from '../../testHelpers.spec';
+import { expectDiagnostics, expectTypeToBe, expectZeroDiagnostics } from '../../testHelpers.spec';
 import { Program } from '../../Program';
 import { isClassStatement, isNamespaceStatement } from '../../astUtils/reflection';
 import util from '../../util';
+import { WalkMode, createVisitor } from '../../astUtils/visitors';
+import { SymbolTypeFlag } from '../../SymbolTypeFlag';
+import { ClassType } from '../../types/ClassType';
+import { FloatType } from '../../types/FloatType';
+import { IntegerType } from '../../types/IntegerType';
+import { InterfaceType } from '../../types/InterfaceType';
+import { StringType } from '../../types/StringType';
 
 describe('BrsFileValidator', () => {
     let program: Program;
@@ -318,5 +325,188 @@ describe('BrsFileValidator', () => {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('const'),
             range: util.createRange(4, 20, 4, 30)
         }]);
+    });
+
+    describe('typecast m', () => {
+        it('allows being at start of file', () => {
+            program.setFile('source/other.bs', `
+            `);
+
+            program.setFile('source/main.bs', `
+                import "other.bs"
+                typecast m as object
+
+                sub noop()
+                end sub
+
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('has diagnostic if not first in file', () => {
+            program.setFile('source/main.bs', `
+                sub noop()
+                end sub
+
+                typecast m as object
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart().message
+            ]);
+        });
+
+        it('allows being at start of function ', () => {
+            program.setFile('source/main.bs', `
+                interface Thing
+                    value as integer
+                end interface
+
+                sub noop()
+                    typecast m as Thing
+                    print m.value
+                end sub
+
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('has diagnostic when not at start of function', () => {
+            program.setFile('source/main.bs', `
+                interface Thing
+                    value as integer
+                end interface
+
+                sub noop()
+                    print m.value
+                    typecast m as Thing
+                end sub
+
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart().message
+            ]);
+        });
+
+        it('sets the type of m', () => {
+            program.setFile('source/types.bs', `
+                interface Thing1
+                    value as integer
+                end interface
+
+                interface Thing2
+                    value as string
+                end interface
+
+                interface Thing3
+                    value as float
+                end interface
+            `);
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                import "types.bs"
+                typecast m as Thing1
+
+                sub func1()
+                    x = m.value
+                    print x
+                end sub
+
+                sub func2()
+                    typecast m as Thing2
+                    x = m.value
+                    print x
+                end sub
+
+                sub func3()
+                    aa = {
+                        innerFunc: sub()
+                            typecast m as Thing3
+                            x = m.value
+                            print x
+                        end sub
+                    }
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            const assigns = [] as Array<AssignmentStatement>;
+
+            // find places in AST where "x" is assigned
+            file.ast.walk(createVisitor({
+                AssignmentStatement: (stmt) => {
+                    if (stmt.tokens.name.text.toLowerCase() === 'x') {
+                        assigns.push(stmt);
+                    }
+                }
+            }), { walkMode: WalkMode.visitAllRecursive });
+
+            // func1 - uses file level typecast
+            expectTypeToBe(assigns[0].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+            expect(assigns[0].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }).toString()).to.eq('Thing1');
+            expectTypeToBe(assigns[0].getSymbolTable().getSymbolType('x', { flags: SymbolTypeFlag.runtime }), IntegerType);
+
+            // func2 - uses func level typecast
+            expectTypeToBe(assigns[1].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+            expect(assigns[1].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }).toString()).to.eq('Thing2');
+            expectTypeToBe(assigns[1].getSymbolTable().getSymbolType('x', { flags: SymbolTypeFlag.runtime }), StringType);
+
+            // func3 - uses innerFunc level typecast
+            expectTypeToBe(assigns[2].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+            expect(assigns[2].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }).toString()).to.eq('Thing3');
+            expectTypeToBe(assigns[2].getSymbolTable().getSymbolType('x', { flags: SymbolTypeFlag.runtime }), FloatType);
+        });
+
+        it('should allow classes to override m typecast', () => {
+            program.setFile('source/types.bs', `
+                interface Thing1
+                    value as integer
+                end interface
+            `);
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                import "types.bs"
+                typecast m as Thing1
+
+                class TestKlass
+                    value as string
+
+                    sub method1()
+                        x = m.value
+                        print x
+                    end sub
+
+                    sub method2()
+                        typecast m as Thing1
+                        x = m.value
+                        print x
+                    end sub
+                end class
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            const assigns = [] as Array<AssignmentStatement>;
+
+            // find places in AST where "x" is assigned
+            file.ast.walk(createVisitor({
+                AssignmentStatement: (stmt) => {
+                    if (stmt.tokens.name.text.toLowerCase() === 'x') {
+                        assigns.push(stmt);
+                    }
+                }
+            }), { walkMode: WalkMode.visitAllRecursive });
+
+
+            // method1 - uses class 'm'
+            expectTypeToBe(assigns[0].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }), ClassType);
+            expect(assigns[0].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }).toString()).to.eq('TestKlass');
+            expectTypeToBe(assigns[0].getSymbolTable().getSymbolType('x', { flags: SymbolTypeFlag.runtime }), StringType);
+
+            // method2 - uses func level typecast
+            expectTypeToBe(assigns[1].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }), InterfaceType);
+            expect(assigns[1].getSymbolTable().getSymbolType('m', { flags: SymbolTypeFlag.runtime }).toString()).to.eq('Thing1');
+            expectTypeToBe(assigns[1].getSymbolTable().getSymbolType('x', { flags: SymbolTypeFlag.runtime }), IntegerType);
+        });
     });
 });

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isAALiteralExpression, isArrayType, isBody, isClassStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypeCastMStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isAALiteralExpression, isArrayType, isBody, isClassStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastMStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -7,7 +7,7 @@ import { TokenKind } from '../../lexer/TokenKind';
 import type { AstNode, Expression, Statement } from '../../parser/AstNode';
 import { CallExpression, type FunctionExpression, type LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, TypeCastMStatement, WhileStatement } from '../../parser/Statement';
+import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, TypecastMStatement, WhileStatement } from '../../parser/Statement';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import { ArrayDefaultTypeReferenceType } from '../../types/ReferenceType';
 import { AssociativeArrayType } from '../../types/AssociativeArrayType';
@@ -173,7 +173,7 @@ export class BrsFileValidator {
             ContinueStatement: (node) => {
                 this.validateContinueStatement(node);
             },
-            TypeCastMStatement: (node) => {
+            TypecastMStatement: (node) => {
                 node.parent.getSymbolTable().addSymbol('m', { definingNode: node }, node.getType({ flags: SymbolTypeFlag.typetime }), SymbolTypeFlag.runtime);
             }
         });
@@ -311,7 +311,7 @@ export class BrsFileValidator {
                     !isLibraryStatement(statement) &&
                     !isImportStatement(statement) &&
                     !isConstStatement(statement) &&
-                    !isTypeCastMStatement(statement)
+                    !isTypecastMStatement(statement)
                 ) {
                     this.event.file.addDiagnostic({
                         ...DiagnosticMessages.unexpectedStatementOutsideFunction(),
@@ -323,10 +323,10 @@ export class BrsFileValidator {
     }
 
     private validateTopOfFileStatements() {
-        let topOfFileIncludeStatements = [] as Array<LibraryStatement | ImportStatement | TypeCastMStatement>;
+        let topOfFileIncludeStatements = [] as Array<LibraryStatement | ImportStatement | TypecastMStatement>;
         for (let stmt of this.event.file.parser.ast.statements) {
             //if we found a non-library statement, this statement is not at the top of the file
-            if (isLibraryStatement(stmt) || isImportStatement(stmt) || isTypeCastMStatement(stmt)) {
+            if (isLibraryStatement(stmt) || isImportStatement(stmt) || isTypecastMStatement(stmt)) {
                 topOfFileIncludeStatements.push(stmt);
             } else {
                 //break out of the loop, we found all of our library statements
@@ -340,7 +340,7 @@ export class BrsFileValidator {
             // eslint-disable-next-line @typescript-eslint/dot-notation
             ...this.event.file['_cachedLookups'].importStatements,
             // eslint-disable-next-line @typescript-eslint/dot-notation
-            ...this.event.file['_cachedLookups'].typeCastMStatements
+            ...this.event.file['_cachedLookups'].typecastMStatements
         ];
         for (let result of statements) {
             //if this statement is not one of the top-of-file statements,
@@ -358,24 +358,24 @@ export class BrsFileValidator {
                         range: result.range,
                         file: this.event.file
                     });
-                } else if (isTypeCastMStatement(result)) {
+                } else if (isTypecastMStatement(result)) {
                     if (result.parent === this.event.file.ast) {
                         this.event.file.diagnostics.push({
-                            ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                            ...DiagnosticMessages.typecastMStatementMustBeDeclaredAtStart(),
                             range: result.range,
                             file: this.event.file
                         });
                     } else if (isFunctionExpression(result.parent?.parent)) {
                         if (result.parent.parent.body.statements[0] !== result) {
                             this.event.file.diagnostics.push({
-                                ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                                ...DiagnosticMessages.typecastMStatementMustBeDeclaredAtStart(),
                                 range: result.range,
                                 file: this.event.file
                             });
                         }
                     } else {
                         this.event.file.diagnostics.push({
-                            ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                            ...DiagnosticMessages.typecastMStatementMustBeDeclaredAtStart(),
                             range: result.range,
                             file: this.event.file
                         });

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isAALiteralExpression, isArrayType, isBody, isClassStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isAALiteralExpression, isArrayType, isBody, isClassStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypeCastMStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -7,7 +7,7 @@ import { TokenKind } from '../../lexer/TokenKind';
 import type { AstNode, Expression, Statement } from '../../parser/AstNode';
 import { CallExpression, type FunctionExpression, type LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
+import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, TypeCastMStatement, WhileStatement } from '../../parser/Statement';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import { ArrayDefaultTypeReferenceType } from '../../types/ReferenceType';
 import { AssociativeArrayType } from '../../types/AssociativeArrayType';
@@ -35,7 +35,7 @@ export class BrsFileValidator {
         this.flagTopLevelStatements();
         //only validate the file if it was actually parsed (skip files containing typedefs)
         if (!this.event.file.hasTypedef) {
-            this.validateImportStatements();
+            this.validateTopOfFileStatements();
         }
         unlinkGlobalSymbolTable();
     }
@@ -172,6 +172,9 @@ export class BrsFileValidator {
             },
             ContinueStatement: (node) => {
                 this.validateContinueStatement(node);
+            },
+            TypeCastMStatement: (node) => {
+                node.parent.getSymbolTable().addSymbol('m', { definingNode: node }, node.getType({ flags: SymbolTypeFlag.typetime }), SymbolTypeFlag.runtime);
             }
         });
 
@@ -307,7 +310,8 @@ export class BrsFileValidator {
                     !isInterfaceStatement(statement) &&
                     !isLibraryStatement(statement) &&
                     !isImportStatement(statement) &&
-                    !isConstStatement(statement)
+                    !isConstStatement(statement) &&
+                    !isTypeCastMStatement(statement)
                 ) {
                     this.event.file.addDiagnostic({
                         ...DiagnosticMessages.unexpectedStatementOutsideFunction(),
@@ -318,11 +322,11 @@ export class BrsFileValidator {
         }
     }
 
-    private validateImportStatements() {
-        let topOfFileIncludeStatements = [] as Array<LibraryStatement | ImportStatement>;
+    private validateTopOfFileStatements() {
+        let topOfFileIncludeStatements = [] as Array<LibraryStatement | ImportStatement | TypeCastMStatement>;
         for (let stmt of this.event.file.parser.ast.statements) {
             //if we found a non-library statement, this statement is not at the top of the file
-            if (isLibraryStatement(stmt) || isImportStatement(stmt)) {
+            if (isLibraryStatement(stmt) || isImportStatement(stmt) || isTypeCastMStatement(stmt)) {
                 topOfFileIncludeStatements.push(stmt);
             } else {
                 //break out of the loop, we found all of our library statements
@@ -334,7 +338,9 @@ export class BrsFileValidator {
             // eslint-disable-next-line @typescript-eslint/dot-notation
             ...this.event.file['_cachedLookups'].libraryStatements,
             // eslint-disable-next-line @typescript-eslint/dot-notation
-            ...this.event.file['_cachedLookups'].importStatements
+            ...this.event.file['_cachedLookups'].importStatements,
+            // eslint-disable-next-line @typescript-eslint/dot-notation
+            ...this.event.file['_cachedLookups'].typeCastMStatements
         ];
         for (let result of statements) {
             //if this statement is not one of the top-of-file statements,
@@ -352,6 +358,28 @@ export class BrsFileValidator {
                         range: result.range,
                         file: this.event.file
                     });
+                } else if (isTypeCastMStatement(result)) {
+                    if (result.parent === this.event.file.ast) {
+                        this.event.file.diagnostics.push({
+                            ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                            range: result.range,
+                            file: this.event.file
+                        });
+                    } else if (isFunctionExpression(result.parent?.parent)) {
+                        if (result.parent.parent.body.statements[0] !== result) {
+                            this.event.file.diagnostics.push({
+                                ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                                range: result.range,
+                                file: this.event.file
+                            });
+                        }
+                    } else {
+                        this.event.file.diagnostics.push({
+                            ...DiagnosticMessages.typeCastMStatementMustBeDeclaredAtStart(),
+                            range: result.range,
+                            file: this.event.file
+                        });
+                    }
                 }
             }
         }

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -14,7 +14,6 @@ import { AssociativeArrayType } from '../../types/AssociativeArrayType';
 import { DynamicType } from '../../types/DynamicType';
 import util from '../../util';
 import type { Range } from 'vscode-languageserver';
-import { isIdentifier } from '../../lexer/Token';
 
 export class BrsFileValidator {
     constructor(
@@ -392,7 +391,7 @@ export class BrsFileValidator {
             if (isBadTypecastObj) {
                 this.event.file.diagnostics.push({
                     ...DiagnosticMessages.invalidTypecastStatementApplication(util.getAllDottedGetPartsAsString(result.typecastExpression.obj)),
-                    range: result.range,
+                    range: result.typecastExpression.obj.range,
                     file: this.event.file
                 });
             }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -784,7 +784,7 @@ export class ScopeValidator {
     }
 
     private checkTypeChainForClassUsedAsVar(typeChain: TypeChainEntry[], containingNamespaceName: string) {
-        const ignoreKinds = [AstNodeKind.TypeCastExpression, AstNodeKind.NewExpression];
+        const ignoreKinds = [AstNodeKind.TypecastExpression, AstNodeKind.NewExpression];
         let lowerNameSoFar = '';
         let classUsedAsVar;
         let isFirst = true;

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -164,7 +164,7 @@ export enum TokenKind {
     EndInterface = 'EndInterface',
     Const = 'Const',
     Continue = 'Continue',
-    TypeCast = 'TypeCast',
+    Typecast = 'Typecast',
 
     //brighterscript source literals
     LineNumLiteral = 'LineNumLiteral',
@@ -325,7 +325,7 @@ export const Keywords: Record<string, TokenKind> = {
     'end interface': TokenKind.EndInterface,
     endinterface: TokenKind.EndInterface,
     const: TokenKind.Const,
-    typecast: TokenKind.TypeCast
+    typecast: TokenKind.Typecast
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -452,7 +452,7 @@ export const AllowedProperties = [
     TokenKind.EndInterface,
     TokenKind.Const,
     TokenKind.Continue,
-    TokenKind.TypeCast
+    TokenKind.Typecast
 ];
 
 /** List of TokenKind that are allowed as local var identifiers. */
@@ -489,7 +489,7 @@ export const AllowedLocalIdentifiers = [
     TokenKind.Const,
     TokenKind.Continue,
     TokenKind.In,
-    TokenKind.TypeCast
+    TokenKind.Typecast
 ];
 
 export const BrighterScriptSourceLiterals = [

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -164,6 +164,7 @@ export enum TokenKind {
     EndInterface = 'EndInterface',
     Const = 'Const',
     Continue = 'Continue',
+    TypeCast = 'TypeCast',
 
     //brighterscript source literals
     LineNumLiteral = 'LineNumLiteral',
@@ -323,7 +324,8 @@ export const Keywords: Record<string, TokenKind> = {
     throw: TokenKind.Throw,
     'end interface': TokenKind.EndInterface,
     endinterface: TokenKind.EndInterface,
-    const: TokenKind.Const
+    const: TokenKind.Const,
+    typecast: TokenKind.TypeCast
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -449,7 +451,8 @@ export const AllowedProperties = [
     TokenKind.Throw,
     TokenKind.EndInterface,
     TokenKind.Const,
-    TokenKind.Continue
+    TokenKind.Continue,
+    TokenKind.TypeCast
 ];
 
 /** List of TokenKind that are allowed as local var identifiers. */
@@ -485,7 +488,8 @@ export const AllowedLocalIdentifiers = [
     TokenKind.EndTry,
     TokenKind.Const,
     TokenKind.Continue,
-    TokenKind.In
+    TokenKind.In,
+    TokenKind.TypeCast
 ];
 
 export const BrighterScriptSourceLiterals = [

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -262,5 +262,6 @@ export enum AstNodeKind {
     Block = 'Block',
     TypeExpression = 'TypeExpression',
     TypeCastExpression = 'TypeCastExpression',
-    TypedArrayExpression = 'TypedArrayExpression'
+    TypedArrayExpression = 'TypedArrayExpression',
+    TypeCastMStatement = 'TypeCastMStatement'
 }

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -261,7 +261,7 @@ export enum AstNodeKind {
     ContinueStatement = 'ContinueStatement',
     Block = 'Block',
     TypeExpression = 'TypeExpression',
-    TypeCastExpression = 'TypeCastExpression',
+    TypecastExpression = 'TypecastExpression',
     TypedArrayExpression = 'TypedArrayExpression',
-    TypeCastMStatement = 'TypeCastMStatement'
+    TypecastMStatement = 'TypecastMStatement'
 }

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -263,5 +263,5 @@ export enum AstNodeKind {
     TypeExpression = 'TypeExpression',
     TypecastExpression = 'TypecastExpression',
     TypedArrayExpression = 'TypedArrayExpression',
-    TypecastMStatement = 'TypecastMStatement'
+    TypecastStatement = 'TypecastStatement'
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTypeCastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -746,7 +746,7 @@ export class GroupingExpression extends Expression {
     public readonly range: Range | undefined;
 
     transpile(state: BrsTranspileState) {
-        if (isTypeCastExpression(this.expression)) {
+        if (isTypecastExpression(this.expression)) {
             return this.expression.transpile(state);
         }
         return [
@@ -2179,7 +2179,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
     }
 }
 
-export class TypeCastExpression extends Expression {
+export class TypecastExpression extends Expression {
     constructor(options: {
         obj: Expression;
         as?: Token;
@@ -2198,7 +2198,7 @@ export class TypeCastExpression extends Expression {
         );
     }
 
-    public readonly kind = AstNodeKind.TypeCastExpression;
+    public readonly kind = AstNodeKind.TypecastExpression;
 
     public readonly obj: Expression;
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1,14 +1,14 @@
 import { expect, assert } from '../chai-config.spec';
 import { Lexer } from '../lexer/Lexer';
 import { ReservedWords, TokenKind } from '../lexer/TokenKind';
-import type { AAMemberExpression, BinaryExpression, TypeCastExpression, UnaryExpression } from './Expression';
+import type { AAMemberExpression, BinaryExpression, TypecastExpression, UnaryExpression } from './Expression';
 import { TernaryExpression, NewExpression, IndexedGetExpression, DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression, VariableExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
-import type { AssignmentStatement, ClassStatement, InterfaceStatement, ReturnStatement, TypeCastMStatement } from './Statement';
+import type { AssignmentStatement, ClassStatement, InterfaceStatement, ReturnStatement, TypecastMStatement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isClassStatement, isDottedGetExpression, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypeCastExpression, isTypeCastMStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isClassStatement, isDottedGetExpression, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastMStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import { expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics } from '../testHelpers.spec';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { Expression, Statement } from './AstNode';
@@ -1251,8 +1251,8 @@ describe('parser', () => {
             expect(fn.func.body.statements).to.exist;
             let assignment = fn.func.body.statements[0] as AssignmentStatement;
             expect(isAssignmentStatement(assignment)).to.be.true;
-            expect(isTypeCastExpression(assignment.value)).to.be.true;
-            expect(isCallExpression((assignment.value as TypeCastExpression).obj)).to.be.true;
+            expect(isTypecastExpression(assignment.value)).to.be.true;
+            expect(isCallExpression((assignment.value as TypecastExpression).obj)).to.be.true;
             expectTypeToBe(assignment.getType({ flags: SymbolTypeFlag.typetime }), IntegerType);
         });
 
@@ -1275,7 +1275,7 @@ describe('parser', () => {
             expect(isCallExpression(assignment.value)).to.be.true;
             expect(isDottedGetExpression(assignment.value.callee)).to.be.true;
             expect(isGroupingExpression(assignment.value.callee.obj)).to.be.true;
-            expect(isTypeCastExpression(assignment.value.callee.obj.expression)).to.be.true;
+            expect(isTypecastExpression(assignment.value.callee.obj.expression)).to.be.true;
             //grouping expression is an integer
             expectTypeToBe(assignment.value.callee.obj.getType({ flags: SymbolTypeFlag.typetime }), IntegerType);
         });
@@ -1298,8 +1298,8 @@ describe('parser', () => {
             expect(isPrintStatement(print)).to.be.true;
             expect(isCallExpression(print.expressions[0])).to.be.true;
             let fnCall = print.expressions[0] as CallExpression;
-            expect(isTypeCastExpression(fnCall.args[0])).to.be.true;
-            let arg = fnCall.args[0] as TypeCastExpression;
+            expect(isTypecastExpression(fnCall.args[0])).to.be.true;
+            let arg = fnCall.args[0] as TypecastExpression;
             //argument type is float
             expectTypeToBe(arg.getType({ flags: SymbolTypeFlag.typetime }), FloatType);
         });
@@ -1316,7 +1316,7 @@ describe('parser', () => {
             expect(fn.func.body.statements).to.exist;
             let print = fn.func.body.statements[0] as any;
             expect(isPrintStatement(print)).to.be.true;
-            expect(isTypeCastExpression(print.expressions[0])).to.be.true;
+            expect(isTypecastExpression(print.expressions[0])).to.be.true;
             //argument type is float
             expectTypeToBe(print.expressions[0].getType({ flags: SymbolTypeFlag.typetime }), StringType);
         });
@@ -1861,12 +1861,12 @@ describe('parser', () => {
     describe('typecast m', () => {
         it('allows typecast m statement ', () => {
             let { diagnostics, statements } = parse(`
-                typeCast m AS roAssociativeArray
+                typecast m AS roAssociativeArray
             `, ParseMode.BrighterScript);
             expectZeroDiagnostics(diagnostics);
-            expect(isTypeCastMStatement(statements[0])).to.be.true;
-            const stmt = statements[0] as TypeCastMStatement;
-            expect(stmt.tokens.typeCast.text).to.eq('typeCast');
+            expect(isTypecastMStatement(statements[0])).to.be.true;
+            const stmt = statements[0] as TypecastMStatement;
+            expect(stmt.tokens.typecast.text).to.eq('typecast');
             expect(stmt.tokens.m.text).to.eq('m');
             expect(stmt.tokens.as.text).to.eq('AS');
             expect(stmt.typeExpression.expression).to.exist;
@@ -1874,7 +1874,7 @@ describe('parser', () => {
 
         it('is disallowed in brightscript mode', () => {
             let { diagnostics } = parse(`
-                typeCast m AS roAssociativeArray
+                typecast m AS roAssociativeArray
             `, ParseMode.BrightScript);
             expectDiagnosticsIncludes(diagnostics, [
                 DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('typecast m statements')

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -4,11 +4,11 @@ import { ReservedWords, TokenKind } from '../lexer/TokenKind';
 import type { AAMemberExpression, BinaryExpression, TypecastExpression, UnaryExpression } from './Expression';
 import { TernaryExpression, NewExpression, IndexedGetExpression, DottedGetExpression, XmlAttributeGetExpression, CallfuncExpression, AnnotationExpression, CallExpression, FunctionExpression, VariableExpression } from './Expression';
 import { Parser, ParseMode } from './Parser';
-import type { AssignmentStatement, ClassStatement, InterfaceStatement, ReturnStatement, TypecastMStatement } from './Statement';
+import type { AssignmentStatement, ClassStatement, InterfaceStatement, ReturnStatement, TypecastStatement } from './Statement';
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isClassStatement, isDottedGetExpression, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastMStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isClassStatement, isDottedGetExpression, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import { expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics } from '../testHelpers.spec';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { Expression, Statement } from './AstNode';
@@ -1858,18 +1858,16 @@ describe('parser', () => {
         });
     });
 
-    describe('typecast m', () => {
-        it('allows typecast m statement ', () => {
+    describe('typecast statement', () => {
+        it('allows typecast statement ', () => {
             let { diagnostics, statements } = parse(`
-                typecast m AS roAssociativeArray
+                typeCAST m AS roAssociativeArray
             `, ParseMode.BrighterScript);
             expectZeroDiagnostics(diagnostics);
-            expect(isTypecastMStatement(statements[0])).to.be.true;
-            const stmt = statements[0] as TypecastMStatement;
-            expect(stmt.tokens.typecast.text).to.eq('typecast');
-            expect(stmt.tokens.m.text).to.eq('m');
-            expect(stmt.tokens.as.text).to.eq('AS');
-            expect(stmt.typeExpression.expression).to.exist;
+            expect(isTypecastStatement(statements[0])).to.be.true;
+            const stmt = statements[0] as TypecastStatement;
+            expect(stmt.tokens.typecast.text).to.eq('typeCAST');
+            expect(stmt.typecastExpression).to.exist;
         });
 
         it('is disallowed in brightscript mode', () => {
@@ -1877,7 +1875,7 @@ describe('parser', () => {
                 typecast m AS roAssociativeArray
             `, ParseMode.BrightScript);
             expectDiagnosticsIncludes(diagnostics, [
-                DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('typecast m statements')
+                DiagnosticMessages.bsFeatureNotSupportedInBrsFiles('typecast statements')
             ]);
         });
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -17,7 +17,6 @@ import { IntegerType } from '../types/IntegerType';
 import { FloatType } from '../types/FloatType';
 import { StringType } from '../types/StringType';
 import { ArrayType, UnionType } from '../types';
-import { AssociativeArrayType } from '../types/AssociativeArrayType';
 
 describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -55,7 +55,7 @@ import {
     ThrowStatement,
     TryCatchStatement,
     WhileStatement,
-    TypeCastMStatement
+    TypecastMStatement
 } from './Statement';
 import type { DiagnosticInfo } from '../DiagnosticMessages';
 import { DiagnosticMessages } from '../DiagnosticMessages';
@@ -83,7 +83,7 @@ import {
     TemplateStringExpression,
     TemplateStringQuasiExpression,
     TernaryExpression,
-    TypeCastExpression,
+    TypecastExpression,
     TypeExpression,
     TypedArrayExpression,
     UnaryExpression,
@@ -1031,8 +1031,8 @@ export class Parser {
             return this.importStatement();
         }
 
-        if (this.check(TokenKind.TypeCast) && this.checkNextText(TokenKind.Identifier, 'm')) {
-            return this.typeCastMStatement();
+        if (this.check(TokenKind.Typecast) && this.checkNextText(TokenKind.Identifier, 'm')) {
+            return this.typecastMStatement();
         }
 
         if (this.check(TokenKind.Stop)) {
@@ -1448,27 +1448,27 @@ export class Parser {
         return importStatement;
     }
 
-    private typeCastMStatement() {
+    private typecastMStatement() {
         this.warnIfNotBrighterScriptMode('typecast m statements');
-        const typeCastToken = this.advance();
+        const typecastToken = this.advance();
         if (!this.checkText(TokenKind.Identifier, 'm')) {
             this.diagnostics.push({
                 ...DiagnosticMessages.expectedIdentifierAfterKeyword('typecast', 'm'),
-                range: util.getRange(typeCastToken, this.peek())
+                range: util.getRange(typecastToken, this.peek())
             });
             throw this.lastDiagnosticAsError();
         }
         const mToken = this.advance();
         const [asToken, typeExpression] = this.consumeAsTokenAndTypeExpression();
 
-        let typeCastMStatement = new TypeCastMStatement({
-            typeCast: typeCastToken,
+        let typecastMStatement = new TypecastMStatement({
+            typecast: typecastToken,
             m: mToken,
             as: asToken,
             typeExpression: typeExpression
         });
 
-        return typeCastMStatement;
+        return typecastMStatement;
     }
 
     private annotationExpression() {
@@ -2274,11 +2274,11 @@ export class Parser {
         this.pendingAnnotations = parentAnnotations;
     }
 
-    private expression(findTypeCast = true): Expression {
+    private expression(findTypecast = true): Expression {
         let expression = this.anonymousFunction();
         let asToken: Token;
         let typeExpression: TypeExpression;
-        if (findTypeCast) {
+        if (findTypecast) {
             do {
                 if (this.check(TokenKind.As)) {
                     this.warnIfNotBrighterScriptMode('type cast');
@@ -2287,7 +2287,7 @@ export class Parser {
                     // myVal = foo() as dynamic as string
                     [asToken, typeExpression] = this.consumeAsTokenAndTypeExpression();
                     if (asToken && typeExpression) {
-                        expression = new TypeCastExpression({ obj: expression, as: asToken, typeExpression: typeExpression });
+                        expression = new TypecastExpression({ obj: expression, as: asToken, typeExpression: typeExpression });
                     }
                 } else {
                     break;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3468,7 +3468,7 @@ export class TypeCastMStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            this.typeExpression.walk(visitor, options);
+            walk(this, 'typeExpression', visitor, options);
         }
     }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3417,9 +3417,9 @@ export class ContinueStatement extends Statement {
 }
 
 
-export class TypeCastMStatement extends Statement {
+export class TypecastMStatement extends Statement {
     constructor(options: {
-        typeCast?: Token;
+        typecast?: Token;
         as?: Token;
         m?: Token;
         typeExpression: TypeExpression;
@@ -3427,13 +3427,13 @@ export class TypeCastMStatement extends Statement {
     ) {
         super();
         this.tokens = {
-            typeCast: options.typeCast,
+            typecast: options.typecast,
             as: options.as,
             m: options.m
         };
         this.typeExpression = options.typeExpression;
         this.range = util.createBoundingRange(
-            this.tokens.typeCast,
+            this.tokens.typecast,
             this.tokens.m,
             this.tokens.as,
             this.typeExpression
@@ -3441,14 +3441,14 @@ export class TypeCastMStatement extends Statement {
     }
 
     public readonly tokens: {
-        readonly typeCast?: Token;
+        readonly typecast?: Token;
         readonly m?: Token;
         readonly as?: Token;
     };
 
     public readonly typeExpression: TypeExpression;
 
-    public readonly kind = AstNodeKind.TypeCastMStatement;
+    public readonly kind = AstNodeKind.TypecastMStatement;
 
     public readonly range: Range;
 
@@ -3456,7 +3456,7 @@ export class TypeCastMStatement extends Statement {
         //the typecast statement is a comment just for debugging purposes
         return [
             `'`,
-            state.transpileToken(this.tokens.typeCast, 'typecast'),
+            state.transpileToken(this.tokens.typecast, 'typecast'),
             ' ',
             state.transpileToken(this.tokens.m, 'm'),
             ' ',
@@ -3473,7 +3473,7 @@ export class TypeCastMStatement extends Statement {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.typeCast?.leadingTrivia ?? [];
+        return this.tokens.typecast?.leadingTrivia ?? [];
     }
 
     getType(options: GetTypeOptions): BscType {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer/TokenKind';
-import type { BinaryExpression, DottedGetExpression, FunctionExpression, FunctionParameterExpression, LiteralExpression, TypeExpression } from './Expression';
+import type { BinaryExpression, DottedGetExpression, FunctionExpression, FunctionParameterExpression, LiteralExpression, TypeExpression, TypecastExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
 import type { Range } from 'vscode-languageserver';
@@ -3417,38 +3417,30 @@ export class ContinueStatement extends Statement {
 }
 
 
-export class TypecastMStatement extends Statement {
+export class TypecastStatement extends Statement {
     constructor(options: {
         typecast?: Token;
-        as?: Token;
-        m?: Token;
-        typeExpression: TypeExpression;
+        typecastExpression: TypecastExpression;
     }
     ) {
         super();
         this.tokens = {
-            typecast: options.typecast,
-            as: options.as,
-            m: options.m
+            typecast: options.typecast
         };
-        this.typeExpression = options.typeExpression;
+        this.typecastExpression = options.typecastExpression;
         this.range = util.createBoundingRange(
             this.tokens.typecast,
-            this.tokens.m,
-            this.tokens.as,
-            this.typeExpression
+            this.typecastExpression
         );
     }
 
     public readonly tokens: {
         readonly typecast?: Token;
-        readonly m?: Token;
-        readonly as?: Token;
     };
 
-    public readonly typeExpression: TypeExpression;
+    public readonly typecastExpression: TypecastExpression;
 
-    public readonly kind = AstNodeKind.TypecastMStatement;
+    public readonly kind = AstNodeKind.TypecastStatement;
 
     public readonly range: Range;
 
@@ -3458,17 +3450,17 @@ export class TypecastMStatement extends Statement {
             `'`,
             state.transpileToken(this.tokens.typecast, 'typecast'),
             ' ',
-            state.transpileToken(this.tokens.m, 'm'),
+            this.typecastExpression.obj.transpile(state),
             ' ',
-            state.transpileToken(this.tokens.as, 'as'),
+            state.transpileToken(this.typecastExpression.tokens.as, 'as'),
             ' ',
-            this.typeExpression.transpile(state)
+            this.typecastExpression.typeExpression.transpile(state)
         ];
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
-            walk(this, 'typeExpression', visitor, options);
+            walk(this, 'typecastExpression', visitor, options);
         }
     }
 
@@ -3477,6 +3469,6 @@ export class TypecastMStatement extends Statement {
     }
 
     getType(options: GetTypeOptions): BscType {
-        return this.typeExpression.getType(options);
+        return this.typecastExpression.getType(options);
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3415,3 +3415,68 @@ export class ContinueStatement extends Statement {
         return this.tokens.continue?.leadingTrivia ?? [];
     }
 }
+
+
+export class TypeCastMStatement extends Statement {
+    constructor(options: {
+        typeCast?: Token;
+        as?: Token;
+        m?: Token;
+        typeExpression: TypeExpression;
+    }
+    ) {
+        super();
+        this.tokens = {
+            typeCast: options.typeCast,
+            as: options.as,
+            m: options.m
+        };
+        this.typeExpression = options.typeExpression;
+        this.range = util.createBoundingRange(
+            this.tokens.typeCast,
+            this.tokens.m,
+            this.tokens.as,
+            this.typeExpression
+        );
+    }
+
+    public readonly tokens: {
+        readonly typeCast?: Token;
+        readonly m?: Token;
+        readonly as?: Token;
+    };
+
+    public readonly typeExpression: TypeExpression;
+
+    public readonly kind = AstNodeKind.TypeCastMStatement;
+
+    public readonly range: Range;
+
+    transpile(state: BrsTranspileState) {
+        //the typecast statement is a comment just for debugging purposes
+        return [
+            `'`,
+            state.transpileToken(this.tokens.typeCast, 'typecast'),
+            ' ',
+            state.transpileToken(this.tokens.m, 'm'),
+            ' ',
+            state.transpileToken(this.tokens.as, 'as'),
+            ' ',
+            this.typeExpression.transpile(state)
+        ];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        if (options.walkMode & InternalWalkMode.walkExpressions) {
+            this.typeExpression.walk(visitor, options);
+        }
+    }
+
+    getLeadingTrivia(): Token[] {
+        return this.tokens.typeCast?.leadingTrivia ?? [];
+    }
+
+    getType(options: GetTypeOptions): BscType {
+        return this.typeExpression.getType(options);
+    }
+}


### PR DESCRIPTION
Adds ability to add a single statement to beginning of file or function, and every usage of `m` in that or lower scopes will be typecast as the type given.

Syntax: 

```
typecast m as <type>
```

eg:
```
import "types.bs"
typecast m as Thing1

sub func1()
    x = m.value ' x is type of Thing1.value
    print x
end sub

sub func2()
    typecast m as Thing2 
    x = m.value  ' x is type of Thing2.value
    print x
end sub

sub func3()
    aa = {
        innerFunc: sub()
            typecast m as Thing3
            x = m.value  ' x is type of Thing3.value
            print x
        end sub
    }
end sub

class TestKlass
    value as string

    sub method1()
        x = m.value ' x is type of TestKlass.value
        print x
    end sub

    sub method2()
        typecast m as Thing1
        x = m.value  ' x is type of Thing1.value
        print x
    end sub
end class

```