### PR TITLE
Removes diagnostic on accessing unknown member of roAssociativeArray

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -3356,6 +3356,97 @@ describe('Scope', () => {
             });
         });
 
+
+        describe('roAssociativeArray type', () => {
+
+            it('allows accessing built-in member of AA', () => {
+                program.setFile<BrsFile>('source/aa.bs', `
+                    function getSize(aa as roAssociativeArray) as integer
+                        return aa.count()
+                    end function
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows assigning to prop of AA', () => {
+                program.setFile<BrsFile>('source/aa.bs', `
+                    sub addName(aa as roAssociativeArray)
+                        aa.name = "foo"
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows accessing random prop of typecasted AA', () => {
+                program.setFile<BrsFile>('source/aa.bs', `
+                    sub foo()
+                        print (m as roAssociativeArray).whatever.whatever
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows asscessing prop of AA through square brackets', () => {
+                program.setFile<BrsFile>('source/aa.bs', `
+                    sub addName(aa as roAssociativeArray)
+                        aa["whatEver"] = "hello"
+                        print aa["whatEver"]
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+        });
+
+        describe('roArray type', () => {
+
+            it('allows accessing built-in member of array', () => {
+                program.setFile<BrsFile>('source/array.bs', `
+                    function getSize(aa as roArray) as integer
+                        return aa.count()
+                    end function
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows assigning to prop of item in array', () => {
+                program.setFile<BrsFile>('source/array.bs', `
+                    sub addName(aa as roArray)
+                        aa[0].name = "foo"
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows accessing random prop item in array of typecasted array', () => {
+                program.setFile<BrsFile>('source/array.bs', `
+                    sub foo()
+                        print (m as roArray)[0].whatever
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows asscessing prop of AA through square brackets', () => {
+                program.setFile<BrsFile>('source/array.bs', `
+                    sub addName(myArray as roArray)
+                        myArray[0] = "hello"
+                        print myArray[0]
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+        });
+
         it('classes in namespaces that reference themselves without namespace work', () => {
             program.setFile<BrsFile>('source/class.bs', `
                 namespace Alpha

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -3,6 +3,7 @@ import { isInheritableType, isReferenceType } from '../astUtils/reflection';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { BscType } from './BscType';
 import type { ReferenceType } from './ReferenceType';
+import { DynamicType } from './DynamicType';
 
 export abstract class InheritableType extends BscType {
 
@@ -14,6 +15,12 @@ export abstract class InheritableType extends BscType {
     }
 
     getMemberType(memberName: string, options: GetTypeOptions) {
+        let hasRoAssociativeArrayAsAncestor = this.name.toLowerCase() === 'roassociativearray' || this.getAncestorTypeList()?.find(ancestorType => ancestorType.name.toLowerCase() === 'roassociativearray');
+
+        if (hasRoAssociativeArrayAsAncestor) {
+            return super.getMemberType(memberName, options) ?? DynamicType.instance;
+        }
+
         return super.getMemberType(memberName, { ...options, fullName: memberName, tableProvider: () => this.memberTable });
     }
 


### PR DESCRIPTION
Look ma, no diagnostics:

```
program.setFile<BrsFile>('source/aa.bs', `
    sub foo(someAA as roAssociativeArray)
          print someAA.whatever.whatever
    end sub
`);
program.validate();
expectZeroDiagnostics(program);
```