### PR TITLE
Typecast symbols are not merged to other namespaces

### DIFF
--- a/docs/typecasts.md
+++ b/docs/typecasts.md
@@ -38,6 +38,7 @@ Rules:
 - There can be a maximum of one `typecast` statement per block
 - Only runtime symbols can be typecast
 - Currently only `m` is supported
+- When used in a namespace, only the current namespace statement is affected - other namespace statements that contibute to the same namespaces do not have the typecast applied
 
 This is very usefuly for components, so that the actual type of Associative Array `m` can narrowed to provide better validation.
 

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -226,6 +226,7 @@ export class SymbolTable implements SymbolTypeGetter {
             options.data.description = data?.description;
             options.data.flags = foundFlags ?? options.flags;
             options.data.memberOfAncestor = data?.memberOfAncestor;
+            options.data.doNotMerge = data?.doNotMerge;
         }
         return resolvedType;
     }
@@ -237,6 +238,9 @@ export class SymbolTable implements SymbolTypeGetter {
     mergeSymbolTable(symbolTable: SymbolTable) {
         for (let [, value] of symbolTable.symbolMap) {
             for (const symbol of value) {
+                if (symbol.data?.doNotMerge) {
+                    continue;
+                }
                 this.addSymbol(
                     symbol.name,
                     symbol.data,
@@ -249,12 +253,12 @@ export class SymbolTable implements SymbolTypeGetter {
 
     mergeNamespaceSymbolTables(symbolTable: SymbolTable) {
         const disposables = [] as Array<() => void>;
-        //console.log(' :: mergeNamespaceSymbolTables:', this.name, '<-', symbolTable.name);
         for (let [_name, value] of symbolTable.symbolMap) {
-            //console.log(name, value.length);
             const symbol = value[0];
             if (symbol) {
-                //console.log(symbol.name, ' ~ ', symbol.type.toString());
+                if (symbol.data?.doNotMerge) {
+                    continue;
+                }
                 const existingRuntimeType = this.getSymbolType(symbol.name, { flags: symbol.flags });
 
                 if (isNamespaceType(existingRuntimeType) && isNamespaceType(symbol.type)) {
@@ -270,13 +274,10 @@ export class SymbolTable implements SymbolTypeGetter {
                 }
             }
         }
-        //console.log(' :: mergeNamespaceSymbolTables: checking siblings');
 
         for (let siblingTable of symbolTable.siblings) {
-            //console.log(' sibling', siblingTable.name);
             disposables.push(...this.mergeNamespaceSymbolTables(siblingTable));
         }
-        //console.log(' :: mergeNamespaceSymbolTables:', this.name, '<-', symbolTable.name, 'done');
         return disposables;
     }
 

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -175,7 +175,7 @@ export class BrsFileValidator {
                 this.validateContinueStatement(node);
             },
             TypecastStatement: (node) => {
-                node.parent.getSymbolTable().addSymbol('m', { definingNode: node }, node.getType({ flags: SymbolTypeFlag.typetime }), SymbolTypeFlag.runtime);
+                node.parent.getSymbolTable().addSymbol('m', { definingNode: node, doNotMerge: true }, node.getType({ flags: SymbolTypeFlag.typetime }), SymbolTypeFlag.runtime);
             }
         });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1305,7 +1305,7 @@ export class BrsFile implements BscFile {
             const typeTimeSymbols = symbolTable.table.getOwnSymbols(SymbolTypeFlag.typetime);
 
             for (const symbol of runTimeSymbols) {
-                if (!isAnyReferenceType(symbol.type)) {
+                if (!isAnyReferenceType(symbol.type) && symbol.name.toLowerCase() !== 'm') {
                     const symbolNameLower = symbolTable.namePrefixLower
                         ? `${symbolTable.namePrefixLower}.${symbol.name.toLowerCase()}`
                         : symbol.name.toLowerCase();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -821,11 +821,30 @@ export interface FileLink<T> {
 }
 
 export interface ExtraSymbolData {
+    /**
+     * What AST node defined this symbol?
+     */
     definingNode?: AstNode;
+    /**
+     * Description of this symbol
+     */
     description?: string;
-    completionPriority?: number; // the higher the number, the lower the priority
+    /**
+     * the higher the number, the lower the priority
+     */
+    completionPriority?: number;
+    /**
+     * Flags for this symbol
+     */
     flags?: SymbolTypeFlag;
-    memberOfAncestor?: boolean; // this symbol comes from an ancestor symbol table
+    /**
+     * this symbol comes from an ancestor symbol table
+     */
+    memberOfAncestor?: boolean;
+    /**
+     * Do not merge this symbol when merging symbol tables
+     */
+    doNotMerge?: boolean;
 }
 
 export interface GetTypeOptions {


### PR DESCRIPTION
In namespace statement with typecast:
![image](https://github.com/rokucommunity/brighterscript/assets/810290/13174370-9569-4778-af2a-07c28e4b627c)

in sibling namespace statement without typecast:
![image](https://github.com/rokucommunity/brighterscript/assets/810290/f1fe129d-1a3b-422b-84e8-f87f4d01df2e)
