### PR TITLE
Revert range and column caching

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1067,39 +1067,19 @@ export class Util {
     }
 
     /**
-     * A cache of `Range` objects. The key is a 52bit integer created from the 4 range integers and leveraging bitshifting.
-     * The whole point of this cache is to reduce garbage collection churn, so we didn't want to use string concatenation for the key
-     */
-    private rangeCache = new Map<number, Map<number, Range>>();
-
-    /**
      * Helper for creating `Range` objects. Prefer using this function because vscode-languageserver's `Range.create()` is significantly slower.
-     *
-     * This function caches the `Range` objects to reduce garbage collection churn.
-     *
-     * See this jsbench for why we chose this method: https://jsbench.me/r1lub4hjro
      */
     public createRange(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
-        // eslint-disable-next-line no-bitwise
-        const startKey = (startLine << 15) + startCharacter;
-        // eslint-disable-next-line no-bitwise
-        const endKey = (endLine << 15) + endCharacter;
-
-        let rangeMap = this.rangeCache.get(startKey);
-        if (!rangeMap) {
-            rangeMap = new Map();
-            this.rangeCache.set(startKey, rangeMap);
-        }
-
-        let range = rangeMap.get(endKey);
-        if (!range) {
-            range = {
-                start: this.createPosition(startLine, startCharacter),
-                end: this.createPosition(endLine, endCharacter)
-            };
-            rangeMap.set(endKey, range);
-        }
-        return range;
+        return {
+            start: {
+                line: startLine,
+                character: startCharacter
+            },
+            end: {
+                line: endLine,
+                character: endCharacter
+            }
+        };
     }
 
     /**
@@ -1175,32 +1155,13 @@ export class Util {
     }
 
     /**
-     * A cache of `Position` objects. The key is a 26bit integer created from line and character and leveraging bitshifting
-     * The whole point of this cache is to reduce garbage collection churn, so we didn't want to use string concatenation for the key
-     */
-    private positionCache = new Map<number, Position>();
-
-    /**
-     * Create a `Position` object. Prefer this over `Position.create` for performance reasons
+     * Create a `Position` object. Prefer this over `Position.create` for performance reasons.
      */
     public createPosition(line: number, character: number) {
-        if (line > 8191 || character > 8191) {
-            return {
-                line: line,
-                character: character
-            };
-        }
-        // eslint-disable-next-line no-bitwise
-        const key = (line << 16) + character;
-        let position = this.positionCache.get(key);
-        if (!position) {
-            position = {
-                line: line,
-                character: character
-            };
-            this.positionCache.set(key, position);
-        }
-        return position;
+        return {
+            line: line,
+            character: character
+        };
     }
 
     /**


### PR DESCRIPTION
Turns out #940 actually slowed down performance. It's faster to just make new `Range` and `Location` objects directly. V8 does a great job optimizing this flow.

Caching enabled on `local`:
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1afa40d8-6207-4539-a341-596859eb2d8b)

Caching disabled on `local`:
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/29593c8f-d293-4cb5-a2ca-1c0ad7796c3b)

