### PR TITLE
fix: resolve the stagingDir option relative to the bsconfig.json file

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -123,6 +123,26 @@ describe('util', () => {
             ].map(p => util.pathSepNormalize(p, '/')));
         });
 
+        it('resolves path relatively to config file', () => {
+            const mockConfig: BsConfig = {
+                outFile: 'out/app.zip',
+                rootDir: 'rootDir',
+                cwd: 'cwd',
+                stagingDir: 'stagingDir'
+            };
+            fsExtra.outputFileSync(s`${rootDir}/child.json`, JSON.stringify(mockConfig));
+            let config = util.loadConfigFile(s`${rootDir}/child.json`);
+            expect(config).to.deep.equal({
+                '_ancestors': [
+                    `${rootDir}/child.json`
+                ],
+                'cwd': `${rootDir}/cwd`,
+                'outFile': `${rootDir}/out/app.zip`,
+                'rootDir': `${rootDir}/rootDir`,
+                'stagingDir': `${rootDir}/stagingDir`
+            });
+        });
+
         it('removes duplicate plugins and undefined values', () => {
             const config: BsConfig = {
                 plugins: [

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -134,12 +134,12 @@ describe('util', () => {
             let config = util.loadConfigFile(s`${rootDir}/child.json`);
             expect(config).to.deep.equal({
                 '_ancestors': [
-                    `${rootDir}/child.json`
+                    s`${rootDir}/child.json`
                 ],
-                'cwd': `${rootDir}/cwd`,
-                'outFile': `${rootDir}/out/app.zip`,
-                'rootDir': `${rootDir}/rootDir`,
-                'stagingDir': `${rootDir}/stagingDir`
+                'cwd': s`${rootDir}/cwd`,
+                'outFile': s`${rootDir}/out/app.zip`,
+                'rootDir': s`${rootDir}/rootDir`,
+                'stagingDir': s`${rootDir}/stagingDir`
             });
         });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -234,6 +234,9 @@ export class Util {
             if (result.cwd) {
                 result.cwd = path.resolve(projectFileCwd, result.cwd);
             }
+            if (result.stagingDir) {
+                result.stagingDir = path.resolve(projectFileCwd, result.stagingDir);
+            }
             return result;
         }
     }


### PR DESCRIPTION
## Summary

fix: resolve the stagingDir option relative to the bsconfig.json file

## Details

Resolve `stagingDir` relative to the `bsconfig.json` file similar to the other paths. 

⚠️ This is a breaking change in behaviour of the bsconfig.json.

solves https://github.com/rokucommunity/brighterscript/issues/1141

## Repro steps

given the below two config files
1. **./node_modules/shared-config/bsconfig.json**
```json
  "rootDir": "../../src",
  "stagingDir": "../../build"
```

2. **./bsconfig.json**
```json
{
  "extends": "./node_modules/shared-config/bsconfig.json",
}
```

 **Expected result:**
  
```terminal 
$ rootDir: {cwd-dir}/src
$ stagingDir: {cwd-dir}/build
```

## How it was tested

unit test
