### PR TITLE
Fixes union type issues with unknown members

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -19,14 +19,16 @@ export let DiagnosticMessages = {
      *
      * @param name for local vars, it's the var name. for namespaced parts, it's the specific part that's unknown (`alpha.beta.charlie` would result in "cannot find name 'charlie')
      * @param fullName if a namespaced name, this is the full name `alpha.beta.charlie`, otherwise it's the same as `name`
+     * @param typeName if 'name' refers to a member, what is the the type it is a member of?
+     * @param typeDescriptor defaults to 'type' ... could also be 'namespace', etc.
      */
-    cannotFindName: (name: string, fullName?: string, typeName?: string) => ({
-        message: `Cannot find name '${name}'${typeName ? ' for type ' + typeName : ''}`,
+    cannotFindName: (name: string, fullName?: string, typeName?: string, typeDescriptor = 'type') => ({
+        message: `Cannot find name '${name}'${typeName ? ` for ${typeDescriptor} '${typeName}'` : ''}`,
         code: 1001,
         data: {
             name: name,
             fullName: fullName ?? name,
-            typeName: typeName
+            typeName: typeName ? typeName : undefined
         },
         severity: DiagnosticSeverity.Error
     }),

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -371,7 +371,7 @@ describe('Scope', () => {
             program.validate();
             expectDiagnostics(program, [
                 {
-                    message: DiagnosticMessages.cannotFindName('delta').message,
+                    message: DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace').message,
                     file: {
                         srcPath: buttonPrimary.srcPath
                     },
@@ -379,7 +379,7 @@ describe('Scope', () => {
                         message: `In component scope 'ButtonPrimary'`
                     }]
                 }, {
-                    message: DiagnosticMessages.cannotFindName('delta').message,
+                    message: DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace').message,
                     file: {
                         srcPath: buttonSecondary.srcPath
                     },
@@ -539,7 +539,7 @@ describe('Scope', () => {
             `);
             program.validate();
             expectDiagnostics(program, [{
-                ...DiagnosticMessages.cannotFindName('subname', 'Name1.subname')
+                ...DiagnosticMessages.cannotFindName('subname', 'Name1.subname', 'Name1', 'namespace')
             }]);
         });
 
@@ -1755,7 +1755,7 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('UnknownType').message
+                    DiagnosticMessages.cannotFindName('UnknownType', 'MyNamespace.UnknownType', 'MyNamespace', 'namespace').message
                 ]);
                 expect(program.getDiagnostics()[0]?.data?.fullName).to.eq('MyNamespace.UnknownType');
             });
@@ -1905,7 +1905,7 @@ describe('Scope', () => {
                 program.validate();
 
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('NSDoesNotExistC', 'NSExistsA.NSExistsB.NSDoesNotExistC').message
+                    DiagnosticMessages.cannotFindName('NSDoesNotExistC', 'NSExistsA.NSExistsB.NSDoesNotExistC', 'NSExistsA.NSExistsB', 'namespace').message
                 ]);
             });
 
@@ -2101,7 +2101,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('someProp').message
+                    DiagnosticMessages.cannotFindName('someProp', 'float.someProp', 'float').message
                 ]);
             });
 
@@ -2119,7 +2119,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('noMethod').message
+                    DiagnosticMessages.cannotFindName('noMethod', 'float.noMethod', 'float').message
                 ]);
             });
 
@@ -2176,7 +2176,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('name').message
+                    DiagnosticMessages.cannotFindName('name', 'iface.name', 'iFace').message
                 ]);
             });
 
@@ -2707,7 +2707,7 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 expectDiagnostics(program, [
-                    DiagnosticMessages.cannotFindName('legs').message
+                    DiagnosticMessages.cannotFindName('legs', '(Person or Pet).legs', '(Person or Pet)').message
                 ]);
                 const mainFnScope = mainFile.getFunctionScopeAtPosition(util.createPosition(2, 24));
                 const sourceScope = program.getScopeByName('source');

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -898,9 +898,6 @@ export class Scope {
                 this.linkSymbolTableDisposables.push(
                     ...this._allNamespaceTypeTable.mergeNamespaceSymbolTables(namespaceTypes)
                 );
-                /* this.linkSymbolTableDisposables.push(
-                     () => file.unlinkNamespaceSymbolTables()
-                 );*/
             }
         }
         for (const [_, nsContainer] of this.namespaceLookup) {

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1059,6 +1059,25 @@ describe('CompletionsProcessor', () => {
             }]);
         });
 
+        it('includes function parameters at the end of the function in namespace', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    function main(param)
+                        print
+                        myValue = 234
+                    end function
+                end namespace
+            `);
+
+            program.validate();
+            // print |
+            let completions = program.getCompletions(`${rootDir}/source/main.bs`, Position.create(3, 33));
+            expectCompletionsIncludes(completions, [{
+                label: 'param',
+                kind: CompletionItemKind.Variable
+            }]);
+        });
+
         it('treats class name as a function', () => {
             program.setFile('source/main.bs', `
                 class SomeKlass

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -687,7 +687,6 @@ describe('HoverProcessor', () => {
             const file = program.setFile('source/util.bs', `
                 sub test()
                     myVar = "hello" ' setting type to string
-                    myVar = myVar.trim()
                     print 1; myVar
                     myVar = "hello".len()  ' setting type to integer
                     myVar = sqr(33)  ' setting type to float
@@ -700,15 +699,15 @@ describe('HoverProcessor', () => {
             program.validate();
             expectZeroDiagnostics(program);
             // print 1; my|Var
-            let hover = program.getHover(file.srcPath, util.createPosition(4, 31))[0];
+            let hover = program.getHover(file.srcPath, util.createPosition(3, 31))[0];
             expect(hover?.contents).eql([fence(expectedHoverStr)]);
 
             // my|Var = "hello".len()
-            hover = program.getHover(file.srcPath, util.createPosition(5, 23))[0];
+            hover = program.getHover(file.srcPath, util.createPosition(4, 23))[0];
             expect(hover?.contents).eql([fence(expectedHoverStr)]);
 
             // print 2; my|Var
-            hover = program.getHover(file.srcPath, util.createPosition(7, 31))[0];
+            hover = program.getHover(file.srcPath, util.createPosition(6, 31))[0];
             expect(hover?.contents).eql([fence(expectedHoverStr)]);
         });
 

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -45,6 +45,7 @@ describe('HoverProcessor', () => {
                     end function
                 end sub
             `);
+            program.validate();
 
             //hover over the `name = 1` line
             let hover = program.getHover(file.srcPath, util.createPosition(2, 24))[0];
@@ -422,7 +423,10 @@ describe('HoverProcessor', () => {
             let commentSep = `\n***\n`;
             //th|ing = new MyKlass()
             let hover = program.getHover('source/main.bs', util.createPosition(2, 24))[0];
-            expect(hover?.contents).to.eql([`${fence('thing as MyKlass')}${commentSep}A sample class`]);
+            expect(hover?.contents).to.eql([`${fence('thing as MyKlass')}`]);
+            //thing = new MyK|lass()
+            hover = program.getHover('source/main.bs', util.createPosition(2, 37))[0];
+            expect(hover?.contents).to.eql([`${fence('class MyKlass')}${commentSep}A sample class`]);
             //use|Klass(thing)
             hover = program.getHover('source/main.bs', util.createPosition(3, 24))[0];
             expect(hover?.contents).to.eql([`${fence('sub useKlass(thing as MyKlass) as void')}${commentSep}Prints a MyKlass.name`]);
@@ -675,5 +679,95 @@ describe('HoverProcessor', () => {
             let hover = program.getHover(file.srcPath, util.createPosition(3, 35))[0];
             expect(hover?.contents).eql([fence('function roSGNodeWidget@.someFunc(input as string) as float')]);
         });
+    });
+
+    describe('multiple definition locations', () => {
+
+        it('shows correct type in all locations', () => {
+            const file = program.setFile('source/util.bs', `
+                sub test()
+                    myVar = "hello" ' setting type to string
+                    myVar = myVar.trim()
+                    print 1; myVar
+                    myVar = "hello".len()  ' setting type to integer
+                    myVar = sqr(33)  ' setting type to float
+                    print 2; myVar
+                end sub
+            `);
+
+            const expectedHoverStr = `myVar as string or integer or float`;
+
+            program.validate();
+            expectZeroDiagnostics(program);
+            // print 1; my|Var
+            let hover = program.getHover(file.srcPath, util.createPosition(4, 31))[0];
+            expect(hover?.contents).eql([fence(expectedHoverStr)]);
+
+            // my|Var = "hello".len()
+            hover = program.getHover(file.srcPath, util.createPosition(5, 23))[0];
+            expect(hover?.contents).eql([fence(expectedHoverStr)]);
+
+            // print 2; my|Var
+            hover = program.getHover(file.srcPath, util.createPosition(7, 31))[0];
+            expect(hover?.contents).eql([fence(expectedHoverStr)]);
+        });
+
+        it('reusing same variable for multiple types', () => {
+            const file = program.setFile('source/util.bs', `
+                namespace stringUtil
+                    function pad(x as string or integer) as string
+                        return "0"+x.toStr()
+                    end function
+                end namespace
+
+                ' Formats a timestamp into a user friendly string.
+                ' @param {Integer} time - The unix time stamp to format.
+                ' @param {String} meridiemStyle - A style key to be wrapped around the meridiem for MultiStyleLabels.
+                ' @return {String} - The formatted time
+                function formatTime(time as integer, meridiemStyle = "" as string) as string
+                    dateObj = createObject("roDateTime")
+                    deviceInfo = createObject("roDeviceInfo")
+                    dateObj.fromSeconds(time)
+                    hour = dateObj.getHours()
+                    minutes = dateObj.getMinutes()
+
+                    ' Get the Meridiem value
+                    if hour > 11 then
+                        meridiem = "pm"
+                    else
+                        meridiem = "am"
+                    end if
+
+                    if meridiemStyle <> "" then
+                        meridiem = "<" + meridiemStyle + ">" + meridiem + "</" + meridiemStyle + ">"
+                    end if
+
+                    minutes = stringUtil.pad(minutes)
+
+                    if deviceInfo.getClockFormat() = "24h" then
+                        hour = stringUtil.pad(hour)
+                        ' "22:01" | "01:01"
+                        return substitute("{0}:{1}", hour, minutes as string)
+                    else
+                        hour = hour mod 12
+                        if hour = 0 then hour = 12
+                        ' "10:01 AM" | "1:01 AM"
+                        return substitute("{0}:{1} {2}", hour, minutes as string, meridiem)
+                    end if
+                end function
+            `);
+            const expectedHourHoverStr = `hour as dynamic`;
+
+            program.validate();
+            expectZeroDiagnostics(program);
+            // ho|ur = stringUtil.pad(hour)
+            let hover = program.getHover(file.srcPath, util.createPosition(32, 27))[0];
+            expect(hover?.contents).eql([fence(expectedHourHoverStr)]);
+
+            // ho|ur = hour mod 12
+            hover = program.getHover(file.srcPath, util.createPosition(36, 27))[0];
+            expect(hover?.contents).eql([fence(expectedHourHoverStr)]);
+        });
+
     });
 });

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -1,4 +1,4 @@
-import { isAnyReferenceType, isAssignmentStatement, isBrsFile, isCallfuncExpression, isClassStatement, isDottedGetExpression, isEnumMemberStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isMemberField, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
+import { isAssignmentStatement, isBrsFile, isCallfuncExpression, isClassStatement, isDottedGetExpression, isEnumMemberStatement, isEnumStatement, isEnumType, isInheritableType, isInterfaceStatement, isMemberField, isNamespaceStatement, isNamespaceType, isNewExpression, isTypedFunctionType, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { ExtraSymbolData, Hover, ProvideHoverEvent, TypeChainEntry } from '../../interfaces';

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -51,7 +51,7 @@ export class BrsFileValidator {
                 if (isClassStatement(node.parent) && node.parent.hasParentClass()) {
                     const data: ExtraSymbolData = {};
                     const parentClassType = node.parent.parentClassName.getType({ flags: SymbolTypeFlag.typetime, data: data });
-                    node.func.body.symbolTable.addSymbol('super', data, parentClassType, SymbolTypeFlag.runtime);
+                    node.func.body.getSymbolTable().addSymbol('super', data, parentClassType, SymbolTypeFlag.runtime);
                 }
             },
             CallfuncExpression: (node) => {
@@ -141,8 +141,11 @@ export class BrsFileValidator {
                 }
             },
             FunctionExpression: (node) => {
-                if (!node.symbolTable.hasSymbol('m', SymbolTypeFlag.runtime) || node.findAncestor(isAALiteralExpression)) {
-                    node.symbolTable.addSymbol('m', undefined, new AssociativeArrayType(), SymbolTypeFlag.runtime);
+                const funcSymbolTable = node.getSymbolTable();
+                if (!funcSymbolTable?.hasSymbol('m', SymbolTypeFlag.runtime) || node.findAncestor(isAALiteralExpression)) {
+                    if (!isTypecastStatement(node.body?.statements?.[0])) {
+                        funcSymbolTable?.addSymbol('m', undefined, new AssociativeArrayType(), SymbolTypeFlag.runtime);
+                    }
                 }
                 this.validateFunctionParameterCount(node);
             },

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -151,10 +151,14 @@ export class BrsFileValidator {
             },
             FunctionParameterExpression: (node) => {
                 const paramName = node.tokens.name?.text;
-                // add param symbol at expression level, so it can be used as default value in other params
-                const symbolTable = node.findAncestor<FunctionExpression>(isFunctionExpression)?.getSymbolTable();
                 const nodeType = node.getType({ flags: SymbolTypeFlag.typetime });
-                symbolTable?.addSymbol(paramName, { definingNode: node }, nodeType, SymbolTypeFlag.runtime);
+                // add param symbol at expression level, so it can be used as default value in other params
+                const funcExpr = node.findAncestor<FunctionExpression>(isFunctionExpression);
+                const funcSymbolTable = funcExpr?.getSymbolTable();
+                funcSymbolTable?.addSymbol(paramName, { definingNode: node }, nodeType, SymbolTypeFlag.runtime);
+
+                //also add param symbol at block level, as it may be redefined, and if so, should show a union
+                funcExpr.body.getSymbolTable()?.addSymbol(paramName, { definingNode: node }, nodeType, SymbolTypeFlag.runtime);
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1708,6 +1708,19 @@ describe('ScopeValidator', () => {
                 DiagnosticMessages.cannotFindName('paramX').message
             ]);
         });
+
+        it('has diagnostic when trying to use a method on an union that does not exist in one type', () => {
+            program.setFile('source/main.bs', `
+                function typeHoverTest(x as string or integer)
+                    value = x.len()
+                    return value
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('len').message
+            ]);
+        });
     });
 
     describe('itemCannotBeUsedAsVariable', () => {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1571,7 +1571,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('unknown', 'Klass.unknown')
+                DiagnosticMessages.cannotFindName('unknown', 'Klass.unknown', 'Klass')
             ]);
         });
 
@@ -1584,7 +1584,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('length', 'string.length')
+                DiagnosticMessages.cannotFindName('length', 'string.length', 'string')
             ]);
         });
 
@@ -1718,8 +1718,19 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('len').message
+                DiagnosticMessages.cannotFindName('len', null, '(string or integer)').message
             ]);
+        });
+
+        it('does not have diagnostic when accessing unknown member of union in Brightscript mode', () => {
+            program.setFile('source/main.brs', `
+                function typeHoverTest(x as string)
+                    x = x.len()
+                    return x
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
         });
     });
 
@@ -1812,7 +1823,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('name', 'function.name')
+                DiagnosticMessages.cannotFindName('name', 'function.name', 'function')
             ]);
         });
 
@@ -1830,7 +1841,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('name', 'function.name')
+                DiagnosticMessages.cannotFindName('name', 'function.name', 'function')
             ]);
         });
 
@@ -2228,7 +2239,7 @@ describe('ScopeValidator', () => {
                 end class
             `);
             program.validate();
-            expectDiagnostics(program, [DiagnosticMessages.cannotFindName('getPi', 'Thing.getPi')]);
+            expectDiagnostics(program, [DiagnosticMessages.cannotFindName('getPi', 'Thing.getPi', 'Thing')]);
         });
 
         it('validates class constructors', () => {
@@ -2761,7 +2772,7 @@ describe('ScopeValidator', () => {
                 end namespace
             `);
             program.validate();
-            expectDiagnosticsIncludes(program, [DiagnosticMessages.cannotFindName('SomeEnum').message]);
+            expectDiagnosticsIncludes(program, [DiagnosticMessages.cannotFindName('SomeEnum', null, 'Alpha.Beta.Charlie', 'namespace').message]);
         });
 
         it('revalidates when a class defined in a different namespace changes', () => {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1709,6 +1709,19 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        it('has diagnostic when function default params reference variable from inside function', () => {
+            program.setFile('source/main.bs', `
+                function test(param1 as integer, param2 = paramX + 2)
+                    paramX = 3
+                    print param1; param2
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('paramX').message
+            ]);
+        });
+
         it('has diagnostic when trying to use a method on an union that does not exist in one type', () => {
             program.setFile('source/main.bs', `
                 function typeHoverTest(x as string or integer)
@@ -1722,9 +1735,21 @@ describe('ScopeValidator', () => {
             ]);
         });
 
-        it('does not have diagnostic when accessing unknown member of union in Brightscript mode', () => {
+        it('does not have diagnostic when accessing unknown member of union in Brightscript mode, when variable is a param', () => {
             program.setFile('source/main.brs', `
                 function typeHoverTest(x as string)
+                    x = x.len()
+                    return x
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('does not have diagnostic when accessing unknown member of union in Brightscript mode, when variable is defined in block', () => {
+            program.setFile('source/main.brs', `
+                function typeHoverTest()
+                    x = "hello"
                     x = x.len()
                     return x
                 end function

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -5,7 +5,7 @@ import { Cache } from '../../Cache';
 import type { DiagnosticInfo } from '../../DiagnosticMessages';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
-import type { BsDiagnostic, CallableContainer, ExtraSymbolData, FileReference, OnScopeValidateEvent, TypeChainEntry, TypeCompatibilityData } from '../../interfaces';
+import type { BsDiagnostic, CallableContainer, ExtraSymbolData, FileReference, GetTypeOptions, OnScopeValidateEvent, TypeChainEntry, TypeChainProcessResult, TypeCompatibilityData } from '../../interfaces';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import type { AssignmentStatement, ClassStatement, DottedSetStatement, EnumStatement, NamespaceStatement, ReturnStatement } from '../../parser/Statement';
 import util from '../../util';
@@ -28,6 +28,8 @@ import { globalCallableMap } from '../../globalCallables';
 import type { XmlScope } from '../../XmlScope';
 import type { XmlFile } from '../../files/XmlFile';
 import { SGFieldTypes } from '../../parser/SGTypes';
+import { DynamicType } from '../../types';
+import { BscTypeKind } from '../../types/BscTypeKind';
 
 /**
  * The lower-case names of all platform-included scenegraph nodes
@@ -144,7 +146,7 @@ export class ScopeValidator {
                         // Note: this also includes For statements
                         this.detectShadowedLocalVar(file, {
                             name: assignStmt.tokens.name.text,
-                            type: assignStmt.getType({ flags: SymbolTypeFlag.runtime }),
+                            type: this.getNodeTypeWrapper(file, assignStmt, { flags: SymbolTypeFlag.runtime }),
                             nameRange: assignStmt.tokens.name.range
                         });
                     },
@@ -154,14 +156,14 @@ export class ScopeValidator {
                     ForEachStatement: (forEachStmt) => {
                         this.detectShadowedLocalVar(file, {
                             name: forEachStmt.tokens.item.text,
-                            type: forEachStmt.getType({ flags: SymbolTypeFlag.runtime }),
+                            type: this.getNodeTypeWrapper(file, forEachStmt, { flags: SymbolTypeFlag.runtime }),
                             nameRange: forEachStmt.tokens.item.range
                         });
                     },
                     FunctionParameterExpression: (funcParam) => {
                         this.detectShadowedLocalVar(file, {
                             name: funcParam.tokens.name.text,
-                            type: funcParam.getType({ flags: SymbolTypeFlag.runtime }),
+                            type: this.getNodeTypeWrapper(file, funcParam, { flags: SymbolTypeFlag.runtime }),
                             nameRange: funcParam.tokens.name.range
                         });
                     }
@@ -397,7 +399,7 @@ export class ScopeValidator {
      */
     private validateFunctionCall(file: BrsFile, expression: CallExpression) {
         const getTypeOptions = { flags: SymbolTypeFlag.runtime, data: {} };
-        let funcType = expression?.callee?.getType(getTypeOptions);
+        let funcType = this.getNodeTypeWrapper(file, expression?.callee, getTypeOptions);
         if (funcType?.isResolvable() && isClassType(funcType)) {
             // We're calling a class - get the constructor
             funcType = funcType.getMemberType('new', getTypeOptions);
@@ -433,7 +435,7 @@ export class ScopeValidator {
             let paramIndex = 0;
             for (let arg of expression.args) {
                 const data = {} as ExtraSymbolData;
-                let argType = arg.getType({ flags: SymbolTypeFlag.runtime, data: data });
+                let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
 
                 const paramType = funcType.params[paramIndex]?.type;
                 if (!paramType) {
@@ -472,7 +474,7 @@ export class ScopeValidator {
         const getTypeOptions = { flags: SymbolTypeFlag.runtime };
         let funcType = returnStmt.findAncestor(isFunctionExpression).getType({ flags: SymbolTypeFlag.typetime });
         if (isTypedFunctionType(funcType)) {
-            const actualReturnType = returnStmt.value?.getType(getTypeOptions);
+            const actualReturnType = this.getNodeTypeWrapper(file, returnStmt?.value, getTypeOptions);
             const compatibilityData: TypeCompatibilityData = {};
 
             if (actualReturnType && !funcType.returnType.isTypeCompatible(actualReturnType, compatibilityData)) {
@@ -487,14 +489,14 @@ export class ScopeValidator {
     }
 
     /**
-     * Detect return statements with incompatible types vs. declared return type
+     * Detect assigned type different from expected member type
      */
     private validateDottedSetStatement(file: BrsFile, dottedSetStmt: DottedSetStatement) {
         const typeChainExpectedLHS = [] as TypeChainEntry[];
         const getTypeOpts = { flags: SymbolTypeFlag.runtime };
 
-        const expectedLHSType = dottedSetStmt?.getType({ ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
-        const actualRHSType = dottedSetStmt?.value?.getType(getTypeOpts);
+        const expectedLHSType = this.getNodeTypeWrapper(file, dottedSetStmt, { ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
+        const actualRHSType = this.getNodeTypeWrapper(file, dottedSetStmt?.value, getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
         const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
         // check if anything in typeChain is an AA - if so, just allow it
@@ -506,7 +508,7 @@ export class ScopeValidator {
         if (!expectedLHSType?.isResolvable()) {
             this.addMultiScopeDiagnostic({
                 file: file as BscFile,
-                ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
+                ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
                 range: typeChainScan.range
             });
             return;
@@ -541,8 +543,8 @@ export class ScopeValidator {
 
         const typeChainExpectedLHS = [];
         const getTypeOpts = { flags: SymbolTypeFlag.runtime };
-        const expectedLHSType = assignStmt.typeExpression.getType({ ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
-        const actualRHSType = assignStmt.value?.getType(getTypeOpts);
+        const expectedLHSType = this.getNodeTypeWrapper(file, assignStmt.typeExpression, { ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
+        const actualRHSType = this.getNodeTypeWrapper(file, assignStmt.value, getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
         if (!expectedLHSType || !expectedLHSType.isResolvable()) {
             this.addMultiScopeDiagnostic({
@@ -569,8 +571,8 @@ export class ScopeValidator {
             return;
         }
 
-        let leftType = binaryExpr.left.getType(getTypeOpts);
-        let rightType = binaryExpr.right.getType(getTypeOpts);
+        let leftType = this.getNodeTypeWrapper(file, binaryExpr.left, getTypeOpts);
+        let rightType = this.getNodeTypeWrapper(file, binaryExpr.right, getTypeOpts);
 
         if (!leftType.isResolvable() || !rightType.isResolvable()) {
             // Can not find the type. error handled elsewhere
@@ -622,7 +624,7 @@ export class ScopeValidator {
     private validateUnaryExpression(file: BrsFile, unaryExpr: UnaryExpression) {
         const getTypeOpts = { flags: SymbolTypeFlag.runtime };
 
-        let rightType = unaryExpr.right.getType(getTypeOpts);
+        let rightType = this.getNodeTypeWrapper(file, unaryExpr.right, getTypeOpts);
 
         if (!rightType.isResolvable()) {
             // Can not find the type. error handled elsewhere
@@ -688,7 +690,7 @@ export class ScopeValidator {
         // this will create a diagnostic if an invalid member is accessed
         const typeChain: TypeChainEntry[] = [];
         const typeData = {} as ExtraSymbolData;
-        let exprType = expression.getType({
+        let exprType = this.getNodeTypeWrapper(file, expression, {
             flags: symbolType,
             typeChain: typeChain,
             data: typeData
@@ -697,9 +699,9 @@ export class ScopeValidator {
         const hasValidDeclaration = this.hasValidDeclaration(expression, exprType, typeData?.definingNode);
 
         if (!this.isTypeKnown(exprType) && !hasValidDeclaration) {
-            if (expression.getType({ flags: oppositeSymbolType, isExistenceTest: true })?.isResolvable()) {
+            if (this.getNodeTypeWrapper(file, expression, { flags: oppositeSymbolType, isExistenceTest: true })?.isResolvable()) {
                 const oppoSiteTypeChain = [];
-                const invalidlyUsedResolvedType = expression.getType({ flags: oppositeSymbolType, typeChain: oppoSiteTypeChain, isExistenceTest: true });
+                const invalidlyUsedResolvedType = this.getNodeTypeWrapper(file, expression, { flags: oppositeSymbolType, typeChain: oppoSiteTypeChain, isExistenceTest: true });
                 const typeChainScan = util.processTypeChain(oppoSiteTypeChain);
                 if (isUsedAsType) {
                     this.addMultiScopeDiagnostic({
@@ -720,7 +722,7 @@ export class ScopeValidator {
                     const typeChainScan = util.processTypeChain(typeChain);
                     this.addMultiScopeDiagnostic({
                         file: file as BscFile,
-                        ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
+                        ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
                         range: typeChainScan.range
                     });
                 }
@@ -729,7 +731,7 @@ export class ScopeValidator {
                 const typeChainScan = util.processTypeChain(typeChain);
                 this.addMultiScopeDiagnostic({
                     file: file as BscFile,
-                    ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem),
+                    ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
                     range: typeChainScan.range
                 });
             }
@@ -880,7 +882,7 @@ export class ScopeValidator {
      * and make sure we can find a class with that name
      */
     private validateNewExpression(file: BrsFile, newExpression: NewExpression) {
-        const newExprType = newExpression.getType({ flags: SymbolTypeFlag.typetime });
+        const newExprType = this.getNodeTypeWrapper(file, newExpression, { flags: SymbolTypeFlag.typetime });
         if (isClassType(newExprType)) {
             return;
         }
@@ -1356,6 +1358,34 @@ export class ScopeValidator {
                 }
             }
         }
+    }
+
+
+    private getNodeTypeWrapper(file: BrsFile, node: AstNode, getTypeOpts: GetTypeOptions) {
+        const type = node?.getType(getTypeOpts);
+
+        if (file.parseMode === ParseMode.BrightScript) {
+            const typeChain = getTypeOpts.typeChain;
+            if (typeChain) {
+                const hasUnion = typeChain.reduce((hasUnion, tce) => {
+                    return hasUnion || isUnionType(tce.type);
+                }, false);
+                if (hasUnion) {
+                    return DynamicType.instance;
+                }
+            }
+            if (isUnionType(type)) {
+                return DynamicType.instance;
+            }
+        }
+        return type;
+    }
+
+    private getParentTypeDescriptor(typeChainResult: TypeChainProcessResult) {
+        if (typeChainResult.itemParentTypeKind === BscTypeKind.NamespaceType) {
+            return 'namespace';
+        }
+        return 'type';
     }
 
     private addDiagnostic(diagnostic: BsDiagnostic) {

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1560,7 +1560,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [{
-                ...DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird'),
+                ...DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird', 'Vertibrates', 'namespace'),
                 relatedInformation: [{
                     message: `In scope 'source'`
                 }]
@@ -1584,7 +1584,7 @@ describe('BrsFile BrighterScript classes', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird').message
+                DiagnosticMessages.cannotFindName('GroundedBird', 'Vertibrates.GroundedBird', 'Vertibrates', 'namespace').message
             ]);
         });
     });
@@ -1632,7 +1632,7 @@ describe('BrsFile BrighterScript classes', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.cannotFindName('AnimalNotDefined', 'NameA.NameB.AnimalNotDefined')
+            DiagnosticMessages.cannotFindName('AnimalNotDefined', 'NameA.NameB.AnimalNotDefined', 'NameA.NameB', 'namespace')
         ]);
     });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -912,7 +912,7 @@ export interface TypeChainProcessResult {
      */
     itemParentTypeName: string;
     /**
-     * The type kind of  the parent of the item of `itemName`
+     * The TypeKind of the parent of the item of `itemName`
      */
     itemParentTypeKind: BscTypeKind | string;
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -904,7 +904,7 @@ export interface TypeChainProcessResult {
      */
     itemName: string;
     /**
-     * The type kind of  the item of `itemName`
+     * The TypeKind of the item of `itemName`
      */
     itemTypeKind: BscTypeKind | string;
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ import type { SymbolTable } from './SymbolTable';
 import type { SymbolTypeFlag } from './SymbolTypeFlag';
 import { createToken } from './astUtils/creators';
 import { TokenKind } from './lexer/TokenKind';
+import type { BscTypeKind } from './types/BscTypeKind';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -903,9 +904,17 @@ export interface TypeChainProcessResult {
      */
     itemName: string;
     /**
+     * The type kind of  the item of `itemName`
+     */
+    itemTypeKind: BscTypeKind | string;
+    /**
      * The name of the parent of the item of `itemName`
      */
     itemParentTypeName: string;
+    /**
+     * The type kind of  the parent of the item of `itemName`
+     */
+    itemParentTypeKind: BscTypeKind | string;
     /**
      * The complete chain leading up to the item of `itemName`
      */

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -224,7 +224,15 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         this.parameters = options.parameters ?? [];
         this.body = options.body;
         this.returnTypeExpression = options.returnTypeExpression;
-
+        //if there's a body, and it doesn't have a SymbolTable, assign one
+        if (this.body) {
+            if (!this.body.symbolTable) {
+                this.body.symbolTable = new SymbolTable(`Block`, () => this.getSymbolTable());
+            } else {
+                this.body.symbolTable.pushParentProvider(() => this.getSymbolTable());
+            }
+            this.body.parent = this;
+        }
         this.symbolTable = new SymbolTable('FunctionExpression', () => this.parent?.getSymbolTable());
     }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -225,14 +225,6 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         this.body = options.body;
         this.returnTypeExpression = options.returnTypeExpression;
 
-        //if there's a body, and it doesn't have a SymbolTable, assign one
-        if (this.body) {
-            if (!this.body.symbolTable) {
-                this.body.symbolTable = new SymbolTable(`Block`, () => this.getSymbolTable());
-            } else {
-                this.body.symbolTable.pushParentProvider(() => this.getSymbolTable());
-            }
-        }
         this.symbolTable = new SymbolTable('FunctionExpression', () => this.parent?.getSymbolTable());
     }
 

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -41,14 +41,18 @@ export class UnionType extends BscType {
 
     getMemberType(name: string, options: GetTypeOptions) {
         const innerTypesMemberTypes = this.getMemberTypeFromInnerTypes(name, options);
-        if (!innerTypesMemberTypes) {
+        if (!innerTypesMemberTypes || innerTypesMemberTypes.includes(undefined)) {
             // We don't have any members of any inner types that match
             // so instead, create reference type that will
             return new ReferenceType(name, name, options.flags, () => {
                 return {
                     name: `UnionType MemberTable: '${this.__identifier}'`,
                     getSymbolType: (innerName: string, innerOptions: GetTypeOptions) => {
-                        return getUniqueType(findTypeUnion(this.getMemberTypeFromInnerTypes(name, options)), unionTypeFactory);
+                        const referenceTypeInnerMemberTypes = this.getMemberTypeFromInnerTypes(name, options);
+                        if (!innerTypesMemberTypes || innerTypesMemberTypes.includes(undefined)) {
+                            return undefined;
+                        }
+                        return getUniqueType(findTypeUnion(referenceTypeInnerMemberTypes), unionTypeFactory);
                     },
                     setCachedType: (innerName: string, innerCacheEntry: TypeCacheEntry, innerOptions: GetTypeOptions) => {
                         // TODO: is this even cachable? This is a NO-OP for now, and it shouldn't hurt anything

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ import type { CallExpression, CallfuncExpression, DottedGetExpression, FunctionP
 import { Logger, LogLevel } from './Logger';
 import { isToken, type Identifier, type Locatable, type Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
-import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isClassType, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLiteralString, isLongIntegerType, isNewExpression, isNumberType, isStringType, isTypeExpression, isTypedArrayExpression, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
+import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallfuncExpression, isClassType, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLiteralString, isLongIntegerType, isNewExpression, isNumberType, isStringType, isTypeExpression, isTypedArrayExpression, isUnionType, isVariableExpression, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
 import { SourceNode } from 'source-map';
 import * as requireRelative from 'require-relative';
@@ -2011,7 +2011,8 @@ export class Util {
             if (continueResolvingAllItems) {
                 parentTypeName = previousTypeName;
                 fullErrorName = previousTypeName ? `${previousTypeName}${dotSep}${chainItem.name}` : chainItem.name;
-                previousTypeName = chainItem.type?.toString() ?? '';
+                const typeString = isUnionType(chainItem.type) ? `(${chainItem.type?.toString()})` : chainItem.type?.toString();
+                previousTypeName = typeString ?? '';
                 itemName = chainItem.name;
                 containsDynamic = containsDynamic || (isDynamicType(chainItem.type) && !isAnyReferenceType(chainItem.type));
                 if (!chainItem.isResolved) {


### PR DESCRIPTION
- Adds extra detail to `cannotFindName` diagnostic to say what it cannot find the name in
- If a union type is in a Brighterscript file, it will act like a Dynamic type
- Removes functionExpression body symbol table, in favor of single symbol table that also includes the params. (I think this solves #1167)
