### PR TITLE
Fix crash when diagnostic is missing range

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -250,14 +250,21 @@ describe('ProgramBuilder', () => {
         it('does not crash when a diagnostic is missing range informtaion', () => {
             const file = builder.program.setFile('source/main.brs', ``);
             file.addDiagnostics([{
-                message: 'the message',
-                code: 'test1'
+                message: 'message 1',
+                code: 'test1',
+                file: file
             }, {
-                message: 'the message',
-                code: 'test1'
+                message: 'message 2',
+                code: 'test1',
+                file: file
             }] as any);
+            const stub = sinon.stub(diagnosticUtils, 'printDiagnostic').callsFake(() => { });
             //if this doesn't crash, then the test passes
             builder['printDiagnostics']();
+            expect(stub.getCalls().map(x => x.args[4].message)).to.eql([
+                'message 1',
+                'message 2'
+            ]);
         });
 
         it('prints no diagnostics when showDiagnosticsInConsole is false', () => {

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -247,6 +247,19 @@ describe('ProgramBuilder', () => {
 
     describe('printDiagnostics', () => {
 
+        it('does not crash when a diagnostic is missing range informtaion', () => {
+            const file = builder.program.setFile('source/main.brs', ``);
+            file.addDiagnostics([{
+                message: 'the message',
+                code: 'test1'
+            }, {
+                message: 'the message',
+                code: 'test1'
+            }] as any);
+            //if this doesn't crash, then the test passes
+            builder['printDiagnostics']();
+        });
+
         it('prints no diagnostics when showDiagnosticsInConsole is false', () => {
             builder.options.showDiagnosticsInConsole = false;
 

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -307,8 +307,8 @@ export class ProgramBuilder {
             //sort the diagnostics in line and column order
             let sortedDiagnostics = diagnosticsForFile.sort((a, b) => {
                 return (
-                    a.range.start.line - b.range.start.line ||
-                    a.range.start.character - b.range.start.character
+                    (a.range?.start.line ?? -1) - (b.range?.start.line ?? -1) ||
+                    (a.range?.start.character ?? -1) - (b.range?.start.character ?? -1)
                 );
             });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -128,14 +128,16 @@ export class BrsFile {
     }
 
     public addDiagnostic(diagnostic: Diagnostic & { file?: BscFile }) {
-        if (!diagnostic.file) {
-            diagnostic.file = this;
-        }
-        this.diagnostics.push(diagnostic as any);
+        this.addDiagnostics([diagnostic as BsDiagnostic]);
     }
 
     public addDiagnostics(diagnostics: BsDiagnostic[]) {
-        this.diagnostics.push(...diagnostics);
+        for (const diagnostic of diagnostics) {
+            if (!diagnostic.file) {
+                diagnostic.file = this;
+            }
+            this.diagnostics.push(diagnostic as any);
+        }
     }
 
     public commentFlags = [] as CommentFlag[];


### PR DESCRIPTION
Fix a crash when a diagnostic is trying to be printed, but has no range.