### PR TITLE
Adds `AstNode.getEndTrivia()`

### DIFF
--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -168,7 +168,20 @@ export abstract class AstNode {
         }
     }
 
+
+    /**
+     * Gets all the trivia (comments, whitespace) that is directly before the start of this node
+     * Note: this includes all trivia that might start on the line of the previous node
+     */
     public getLeadingTrivia(): Token[] {
+        return [];
+    }
+
+    /**
+     * Gets any trivia that is directly before the end of the node
+     * For example, this would return all trivia before a `end function` token of a FunctionExpression
+     */
+    public getEndTrivia(): Token[] {
         return [];
     }
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -259,6 +259,10 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         return this.tokens.functionType?.leadingTrivia ?? [];
     }
 
+    public getEndTrivia(): Token[] {
+        return this.tokens.endFunctionType?.leadingTrivia ?? [];
+    }
+
     /**
      * The range of the function, starting at the 'f' in function or 's' in sub (or the open paren if the keyword is missing),
      * and ending with the last n' in 'end function' or 'b' in 'end sub'
@@ -934,7 +938,11 @@ export class ArrayLiteralExpression extends Expression {
         return new ArrayType(...innerTypes);
     }
     getLeadingTrivia(): Token[] {
-        return this.tokens.open.leadingTrivia ?? [];
+        return this.tokens.open?.leadingTrivia ?? [];
+    }
+
+    getEndTrivia(): Token[] {
+        return this.tokens.close?.leadingTrivia ?? [];
     }
 }
 
@@ -1083,7 +1091,11 @@ export class AALiteralExpression extends Expression {
     }
 
     public getLeadingTrivia(): Token[] {
-        return this.tokens.open.leadingTrivia ?? [];
+        return this.tokens.open?.leadingTrivia ?? [];
+    }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.close?.leadingTrivia ?? [];
     }
 
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -564,6 +564,11 @@ export class IfStatement extends Statement {
     getLeadingTrivia(): Token[] {
         return this.tokens.if?.leadingTrivia ?? [];
     }
+
+    getEndTrivia(): Token[] {
+        return this.tokens.endIf?.leadingTrivia ?? [];
+    }
+
 }
 
 export class IncrementStatement extends Statement {
@@ -1060,6 +1065,10 @@ export class ForStatement extends Statement {
     getLeadingTrivia(): Token[] {
         return this.tokens.for?.leadingTrivia ?? [];
     }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endFor?.leadingTrivia ?? [];
+    }
 }
 
 export class ForEachStatement extends Statement {
@@ -1150,6 +1159,10 @@ export class ForEachStatement extends Statement {
     getLeadingTrivia(): Token[] {
         return this.tokens.forEach?.leadingTrivia ?? [];
     }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endFor?.leadingTrivia ?? [];
+    }
 }
 
 export class WhileStatement extends Statement {
@@ -1218,6 +1231,10 @@ export class WhileStatement extends Statement {
 
     getLeadingTrivia(): Token[] {
         return this.tokens.while?.leadingTrivia ?? [];
+    }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endWhile?.leadingTrivia ?? [];
     }
 }
 
@@ -1492,6 +1509,10 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
         return util.concatAnnotationLeadingTrivia(this, this.tokens.namespace?.leadingTrivia);
     }
 
+    public getEndTrivia(): Token[] {
+        return this.tokens.endNamespace?.leadingTrivia ?? [];
+    }
+
     public getNameParts() {
         let parts = util.getAllDottedGetParts(this.nameExpression);
 
@@ -1678,7 +1699,11 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
 
     public getLeadingTrivia(): Token[] {
         return util.concatAnnotationLeadingTrivia(this,
-            this.tokens.interface.leadingTrivia);
+            this.tokens.interface?.leadingTrivia);
+    }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endInterface?.leadingTrivia ?? [];
     }
 
 
@@ -2145,6 +2170,10 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
     public getLeadingTrivia(): Token[] {
         return util.concatAnnotationLeadingTrivia(this, this.tokens.class?.leadingTrivia);
+    }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endClass?.leadingTrivia ?? [];
     }
 
     public readonly memberMap = {} as Record<string, MemberStatement>;
@@ -2909,6 +2938,10 @@ export class TryCatchStatement extends Statement {
     public getLeadingTrivia(): Token[] {
         return this.tokens.try?.leadingTrivia ?? [];
     }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endTry?.leadingTrivia ?? [];
+    }
 }
 
 export class CatchStatement extends Statement {
@@ -3064,6 +3097,10 @@ export class EnumStatement extends Statement implements TypedefProvider {
 
     public getLeadingTrivia(): Token[] {
         return util.concatAnnotationLeadingTrivia(this, this.tokens.enum?.leadingTrivia);
+    }
+
+    public getEndTrivia(): Token[] {
+        return this.tokens.endEnum?.leadingTrivia ?? [];
     }
 
     /**


### PR DESCRIPTION
Solves #1181 

This allows access to the trivia at the end of a block when walking the AST