### PR TITLE
Logger nocolor

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -111,7 +111,7 @@ export class LanguageServer {
             void this.sendBusyStatus(status);
         });
 
-        //disable color for lsp logging
+        //disable logger colors when running in LSP mode
         logger.enableColor = false;
 
         //listen to all of the output log events and pipe them into the debug channel in the extension

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -111,6 +111,9 @@ export class LanguageServer {
             void this.sendBusyStatus(status);
         });
 
+        //disable color for lsp logging
+        logger.enableColor = false;
+
         //listen to all of the output log events and pipe them into the debug channel in the extension
         this.loggerSubscription = logger.subscribe((message) => {
             this.connection.tracer.log(message.argsText);


### PR DESCRIPTION
Prevent the ascii color characters for logs in LSP mode. This was accidentally introduced when we switched to the @rokucommuntiy logger.

**Before:**
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/60bb777b-fc7a-40ef-9545-0751eba67068)

**After:**
![image](https://github.com/rokucommunity/brighterscript/assets/2544493/e9f3a199-0a95-487b-931f-4eaac8616809)


