### PR TITLE
Component field can be set with strings

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -2350,18 +2350,54 @@ describe('ScopeValidator', () => {
         });
 
 
-        it('allows assigning string to font fields', () => {
-            program.setFile('source/util.bs', `
-                sub setLabelFont(label as roSGNodeLabel)
-                    label.font = "font:LargeSystemFont"
-                    label.font.size = 50
-                end sub
-            `);
-            program.validate();
-            //should have no errors
-            expectZeroDiagnostics(program);
-        });
+        describe('Component fields', () => {
+            it('allows assigning string to font fields', () => {
+                program.setFile('source/util.bs', `
+                    sub setLabelFont(label as roSGNodeLabel)
+                        label.font = "font:LargeSystemFont"
+                        label.font.size = 50
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
 
+            it('allows assigning strings to node fields', () => {
+                program.setFile('source/util.bs', `
+                    sub setPosterPosition(node as roSGNodePoster)
+                        node.translation = "[100, 200]"
+                        node.bitmapMargins = "this is not an aa" ' TODO: this *should* be a diagnostic
+                    end sub
+                `);
+                program.validate();
+                //should have no errors
+                expectZeroDiagnostics(program);
+            });
+
+            it('disallows assigning non-correct type to node fields', () => {
+                program.setFile('source/util.bs', `
+                    sub setId(node as roSgNode)
+                        node.id = 123
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.assignmentTypeMismatch('integer', 'string').message
+                ]);
+            });
+
+            it('allows assigning arrays to appropriate node fields', () => {
+                program.setFile('source/util.bs', `
+                    sub setPosition(node as roSGNodePoster)
+                        node.translation = [100, 200]
+                        node.bitmapMargins = {left: 0, right: 100, top: 0, bottom: 200}
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+        });
     });
 
     describe('operatorTypeMismatch', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -524,8 +524,10 @@ export class ScopeValidator {
 
         let accessibilityIsOk = this.checkMemberAccessibility(file, dottedSetStmt, typeChainExpectedLHS);
 
-        //special case for roSgNodeFont - these can accept string
-        if (isComponentType(expectedLHSType) && expectedLHSType.name.toLowerCase() === 'font') {
+        //Most Component fields can be set with strings
+        //TODO: be more precise about which fields can actually accept strings
+        //TODO: if RHS is a string literal, we can do more validation to make sure it's the correct type
+        if (isComponentType(dottedSetStmt.obj?.getType({ flags: SymbolTypeFlag.runtime }))) {
             if (isStringType(actualRHSType)) {
                 return;
             }


### PR DESCRIPTION
Addresses #1191 

Changes `assignementTypeMismatch` validation so that if LHS is a DottedSetStatement, and the `obj` is a ComponentType (ie. a SG Node), and RHS is a string, then do not show the validation diagnostic.
