### PR TITLE
Fix semantic token crash

### DIFF
--- a/src/SemanticTokenUtils.spec.ts
+++ b/src/SemanticTokenUtils.spec.ts
@@ -6,6 +6,21 @@ import util from './util';
 
 describe('SemanticTokenUtils', () => {
     describe('encodeSemanticTokens', () => {
+        it('eliminates items with no range', () => {
+            expectEncodeEquals(
+                encodeSemanticTokens([{
+                    range: util.createRange(1, 0, 1, 2),
+                    tokenType: SemanticTokenTypes.class
+                }, {
+                    range: undefined,
+                    tokenType: SemanticTokenTypes.parameter
+                }]),
+                [
+                    1, 0, 2, semanticTokensLegend.tokenTypes.indexOf(SemanticTokenTypes.class), 0
+                ]
+            );
+        });
+
         it('encodes single entry at start of line', () => {
             expectEncodeEquals(
                 encodeSemanticTokens([{

--- a/src/SemanticTokenUtils.ts
+++ b/src/SemanticTokenUtils.ts
@@ -59,6 +59,10 @@ export function encodeSemanticTokens(tokens: SemanticToken[]) {
     util.sortByRange(tokens);
     const builder = new SemanticTokensBuilder();
     for (const token of tokens) {
+        //skip tokens that have no range
+        if (!token?.range) {
+            continue;
+        }
         builder.push(
             token.range.start.line,
             token.range.start.character,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1729,6 +1729,14 @@ export class Util {
     public sortByRange<T extends Locatable>(locatables: T[]) {
         //sort the tokens by range
         return locatables.sort((a, b) => {
+            //handle undefined tokens
+            if (!a?.range) {
+                return 1;
+            }
+            if (!b?.range) {
+                return -1;
+            }
+
             //start line
             if (a.range.start.line < b.range.start.line) {
                 return -1;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1729,7 +1729,7 @@ export class Util {
     public sortByRange<T extends Locatable>(locatables: T[]) {
         //sort the tokens by range
         return locatables.sort((a, b) => {
-            //handle undefined tokens
+            //handle undefined tokens to prevent crashes
             if (!a?.range) {
                 return 1;
             }


### PR DESCRIPTION
Exclude semantic tokens that have no range (we wouldn't know where to colorize anyway...)

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1d5a7d72-3217-4f3b-be5a-43670c0640cf)
