### PR TITLE
Fix namespace crash

### DIFF
--- a/src/astUtils/Editor.ts
+++ b/src/astUtils/Editor.ts
@@ -291,4 +291,3 @@ class ManualChange<T> implements Change {
         this._undo?.(this);
     }
 }
-

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -16,7 +16,7 @@ import util, { standardizePath as s } from '../util';
 import { expectDiagnostics, expectHasDiagnostics, expectTypeToBe, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 import { ParseMode, Parser } from '../parser/Parser';
 import { ImportStatement } from '../parser/Statement';
-import { createToken } from '../astUtils/creators';
+import { createToken, createVariableExpression } from '../astUtils/creators';
 import * as fsExtra from 'fs-extra';
 import { URI } from 'vscode-uri';
 import undent from 'undent';
@@ -26,7 +26,7 @@ import { ClassType, EnumType, FloatType, InterfaceType } from '../types';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import * as fileUrl from 'file-url';
 import { isAALiteralExpression } from '../astUtils/reflection';
-import type { AALiteralExpression } from '../parser/Expression';
+import { VariableExpression, type AALiteralExpression } from '../parser/Expression';
 
 let sinon = sinonImport.createSandbox();
 
@@ -47,7 +47,6 @@ describe('BrsFile', () => {
         }
 
     }
-
 
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
@@ -5122,4 +5121,16 @@ describe('BrsFile', () => {
         }]);
     });
 
+    describe('calleeIsKnownNamespaceFunction', () => {
+        it('does not crash when namespace is missing', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub main()
+                    someNamespace.someFunc()
+                end sub
+            `);
+            expect(
+                file.calleeIsKnownNamespaceFunction(createVariableExpression('alpha'), 'beta')
+            ).to.be.false;
+        });
+    });
 });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -26,7 +26,7 @@ import { ClassType, EnumType, FloatType, InterfaceType } from '../types';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import * as fileUrl from 'file-url';
 import { isAALiteralExpression } from '../astUtils/reflection';
-import { VariableExpression, type AALiteralExpression } from '../parser/Expression';
+import type { AALiteralExpression } from '../parser/Expression';
 
 let sinon = sinonImport.createSandbox();
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -777,6 +777,9 @@ export class BrsFile implements BscFile {
                 let scopes = this.program.getScopesForFile(this);
                 for (let scope of scopes) {
                     let namespace = scope.namespaceLookup.get(namespaceName.toLowerCase());
+                    if (!namespace) {
+                        continue;
+                    }
                     if (namespace.functionStatements.has(lowerCalleeName)) {
                         return true;
                     }


### PR DESCRIPTION
Fix crash when trying to transpile a function on an unknown namespace.

![image](https://github.com/rokucommunity/brighterscript/assets/2544493/17a8772e-0eab-4f85-baca-b9e093a6288c)
