### PR TITLE
Temporarily disable test-related-projects until they support v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - run: npm run publish-coverage
-      - run: npm run test-related-projects
+      # disable this task until we have v1-suported versions of the projects to test
+      # - run: npm run test-related-projects
   npm-release:
     #only run this task if a tag starting with 'v' was used to trigger this (i.e. a tagged release)
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Disable the `test-related-projects` job until those projects support v1. These jobs currently take a long time because they're all failing with thousands of errors due to v1 incompatibility.