### PR TITLE
Fixes issue with setting `roSGNodeTargetSet.targetRects`

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -815,8 +815,11 @@ export const defaultMaximumTruncationLength = 160;
 
 export function typeCompatibilityMessage(actualTypeString: string, expectedTypeString: string, data: TypeCompatibilityData) {
     let message = '';
+    actualTypeString = data?.actualType?.toString() ?? actualTypeString;
+    expectedTypeString = data?.expectedType?.toString() ?? expectedTypeString;
+
     if (data?.missingFields?.length > 0) {
-        message = `\n    Type '${actualTypeString}' is missing the following members: ` + util.truncate({
+        message = `\n    Type '${actualTypeString}' is missing the following members of type '${expectedTypeString}': ` + util.truncate({
             leadingText: ``,
             trailingText: '',
             itemSeparator: ', ',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1004,6 +1004,9 @@ export interface TypeCompatibilityData {
     missingFields?: { name: string; expectedType: BscType }[];
     fieldMismatches?: { name: string; expectedType: BscType; actualType: BscType }[];
     depth?: number;
+    // override for diagnostic message - useful for Arrays with different default types
+    actualType?: BscType;
+    expectedType?: BscType;
 }
 
 export interface NamespaceContainer {

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -39,7 +39,12 @@ export class ArrayType extends BscType {
         } else if (isUnionTypeCompatible(this, targetType)) {
             return true;
         } else if (isArrayType(targetType)) {
-            return this.defaultType.isTypeCompatible(targetType.defaultType, data);
+            const compatible = this.defaultType.isTypeCompatible(targetType.defaultType, data);
+            if (data) {
+                data.actualType = targetType.defaultType;
+                data.expectedType = this.defaultType;
+            }
+            return compatible;
         } else if (this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data)) {
             return true;
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1311,6 +1311,9 @@ export class Util {
                 // remove "'" in "float's", etc.
                 arrayOfTypeName = arrayOfTypeName.substring(0, arrayOfTypeName.length - 1);
             }
+            if (arrayOfTypeName === 'rectangle') {
+                arrayOfTypeName = 'rect2d';
+            }
             let arrayType = this.getNodeFieldType(arrayOfTypeName, lookupTable);
             return new ArrayType(arrayType);
         } else if (typeDescriptorLower.startsWith('option ')) {


### PR DESCRIPTION
Fixes #1219

Reason this was a problem is because the scraper did not understand `array of rectangles` as a type.


I wish Roku would use actual types here! The interface type should have been `rect2dArray` ... oh well..


I also updated the diagnostic message for type incompatibility to be able to add a override for the extended message which is useful if assigning Arrays of different default types, and the inner type is incompatible.

Example:
```brighterscript
targetSet = createObject("roSGNode", "TargetSet")
targets = ["hello", "world"]
targetSet.targetRects = targets ' targetRects is an array of rectangles, which are AA's with x,y,width,height
```



Before


```
"Type 'Array<string>' is not compatible with type 'Array<roAssociativeArray>'
    Type 'Array<string>' is missing the following members: height, width, x, y, ifAssociativeArray, AddReplace, Append, Clear, Count, Delete, DoesExist, Items, Keys, Lookup, LookupCI, ...and 5 more"
```


Now:

```
"Type 'Array<string>' is not compatible with type 'Array<roAssociativeArray>'
    Type 'string' is missing the following members of type 'roAssociativeArray': height, width, x, y, ifAssociativeArray, AddReplace, Append, Clear, Count, Delete, DoesExist, Items, Keys, Lookup, LookupCI, ...and 5 more"
```


`