### PR TITLE
Remove block starting range

### DIFF
--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-multi-spaces */
 import type { CancellationToken } from 'vscode-languageserver';
-import { CancellationTokenSource, Range } from 'vscode-languageserver';
+import { CancellationTokenSource } from 'vscode-languageserver';
 import { expect } from '../chai-config.spec';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
@@ -252,7 +252,7 @@ describe('astUtils visitors', () => {
                 print: createToken(TokenKind.Print),
                 expressions: []
             });
-            const blockStatement = new Block({ statements: [], startingRange: Range.create(0, 0, 0, 0) });
+            const blockStatement = new Block({ statements: [] });
             visitor(printStatement, undefined);
             visitor(blockStatement, undefined);
             expect(printHandler.callCount).to.equal(1);
@@ -276,8 +276,7 @@ describe('astUtils visitors', () => {
                 statements: [
                     printStatement1,
                     new ReturnStatement({ return: createToken(TokenKind.Return) })
-                ],
-                startingRange: Range.create(0, 0, 0, 0)
+                ]
             });
             const visitor = createVisitor({
                 PrintStatement: () => printStatement2
@@ -300,8 +299,7 @@ describe('astUtils visitors', () => {
             });
 
             const block = new Block({
-                statements: [printStatement1],
-                startingRange: Range.create(0, 0, 0, 0)
+                statements: [printStatement1]
             });
 
             block.walk(createVisitor({

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -915,11 +915,7 @@ export class Parser {
             }
 
             if (!body) {
-                body = new Block({
-                    statements: [],
-                    startingRange: util.createBoundingRange(
-                        functionType, name, leftParen, ...params, rightParen, asToken, typeExpression, endFunctionType)
-                });
+                body = new Block({ statements: [] });
             }
 
             let func = new FunctionExpression({
@@ -2182,7 +2178,7 @@ export class Parser {
             }
         }
         this.exitAnnotationBlock(parentAnnotations);
-        return new Block({ statements: statements, startingRange: startingToken.range });
+        return new Block({ statements: statements });
     }
 
     private conditionalCompileConstStatement() {
@@ -2315,7 +2311,7 @@ export class Parser {
                 });
             }
         }
-        return new Block({ statements: statements, startingRange: startingRange });
+        return new Block({ statements: statements });
     }
 
     private expressionStatement(expr: Expression): ExpressionStatement | IncrementStatement {
@@ -2577,7 +2573,7 @@ export class Parser {
         }
 
         this.exitAnnotationBlock(parentAnnotations);
-        return new Block({ statements: statements, startingRange: startingToken.range });
+        return new Block({ statements: statements });
     }
 
     /**

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1825,7 +1825,6 @@ export class Parser {
         }
 
         const ifToken = this.advance();
-        const startingRange = ifToken.range;
 
         const condition = this.expression();
         let thenBranch: Block;
@@ -1947,7 +1946,7 @@ export class Parser {
                 } else {
                     //missing endif
                     this.diagnostics.push({
-                        ...DiagnosticMessages.expectedEndIfToCloseIfStatement(startingRange.start),
+                        ...DiagnosticMessages.expectedEndIfToCloseIfStatement(ifToken.range.start),
                         range: ifToken.range
                     });
                 }
@@ -1994,7 +1993,6 @@ export class Parser {
 
     private conditionalCompileStatement(): ConditionalCompileStatement {
         const hashIfToken = this.advance();
-        const startingRange = hashIfToken.range;
         let notToken: Token | undefined;
 
         if (this.check(TokenKind.Not)) {
@@ -2058,7 +2056,7 @@ export class Parser {
             } else {
                 //missing #endif
                 this.diagnostics.push({
-                    ...DiagnosticMessages.expectedHashEndIfToCloseHashIf(startingRange.start.line),
+                    ...DiagnosticMessages.expectedHashEndIfToCloseHashIf(hashIfToken.range.start.line),
                     range: hashIfToken.range
                 });
             }
@@ -2108,7 +2106,6 @@ export class Parser {
         const parentAnnotations = this.enterAnnotationBlock();
 
         this.consumeStatementSeparators(true);
-        let startingToken = this.peek();
         const unsafeTerminators = BlockTerminators;
         const conditionalEndTokens = [TokenKind.HashElse, TokenKind.HashElseIf, TokenKind.HashEndIf];
         const terminators = [...conditionalEndTokens, ...unsafeTerminators];
@@ -2285,7 +2282,6 @@ export class Parser {
             return undefined;
         }
         statements.push(statement);
-        const startingRange = statement.range;
 
         //look for colon statement separator
         let foundColon = false;
@@ -2523,8 +2519,6 @@ export class Parser {
         const parentAnnotations = this.enterAnnotationBlock();
 
         this.consumeStatementSeparators(true);
-        let startingToken = this.peek();
-
         const statements: Statement[] = [];
         const flatGlobalTerminators = this.globalTerminators.flat().flat();
         while (!this.isAtEnd() && !this.checkAny(TokenKind.EndSub, TokenKind.EndFunction, ...terminators, ...flatGlobalTerminators)) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -273,7 +273,7 @@ export class Block extends Statement {
             lastBitBefore = util.createBoundingRange(
                 this.parent.tokens.functionType,
                 this.parent.tokens.leftParen,
-                ...this.parent.parameters,
+                ...(this.parent.parameters ?? [])
                 this.parent.tokens.rightParen,
                 this.parent.tokens.as,
                 this.parent.returnTypeExpression

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -259,7 +259,6 @@ export class Block extends Statement {
     }
 
     public readonly statements: Statement[];
-    public readonly startingRange?: Range;
 
     public readonly kind = AstNodeKind.Block;
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -264,7 +264,7 @@ export class Block extends Statement {
 
     get range(): Range {
         if (this.statements.length > 0) {
-            return util.createBoundingRange(...(this.statements));
+            return util.createBoundingRange(...this.statements);
         }
         let lastBitBefore: Position;
         let firstBitAfter: Position;

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -273,7 +273,7 @@ export class Block extends Statement {
             lastBitBefore = util.createBoundingRange(
                 this.parent.tokens.functionType,
                 this.parent.tokens.leftParen,
-                ...(this.parent.parameters ?? [])
+                ...(this.parent.parameters ?? []),
                 this.parent.tokens.rightParen,
                 this.parent.tokens.as,
                 this.parent.returnTypeExpression

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -383,6 +383,16 @@ export function expectTypeToBe(someType: BscType, expectedTypeClass: any) {
     expect(someType?.constructor?.name).to.eq(expectedTypeClass.name);
 }
 
+/**
+ * Test that a range is waht was expected
+ */
+export function expectRangeToBe(actual: Range, expected: Range) {
+    expect(actual.start.line, 'start line').to.eq(expected.start.line);
+    expect(actual.start.character, 'start character').to.eq(expected.start.character);
+    expect(actual.end.line, 'end line').to.eq(expected.end.line);
+    expect(actual.end.character, 'end character').to.eq(expected.end.character);
+}
+
 export function stripConsoleColors(inputString) {
     // Regular expression to match ANSI escape codes for colors
     // eslint-disable-next-line no-control-regex

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -6,7 +6,7 @@ import type { BsConfig } from './BsConfig';
 import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import { tempDir, rootDir, expectTypeToBe } from './testHelpers.spec';
+import { tempDir, rootDir, expectTypeToBe, expectRangeToBe } from './testHelpers.spec';
 import { Program } from './Program';
 import type { BsDiagnostic } from './interfaces';
 import { TypeChainEntry } from './interfaces';
@@ -648,6 +648,29 @@ describe('util', () => {
             expect(plugins[0].name).to.eql('AwesomePlugin');
             //does not warn about factory pattern
             expect(stub.callCount).to.equal(0);
+        });
+    });
+
+    describe('range creation', () => {
+        it('createRangeFromPositions', () => {
+            const pos11 = { line: 1, character: 1 };
+            const pos99 = { line: 9, character: 9 };
+
+            expectRangeToBe(util.createRangeFromPositions(pos11, pos99), util.createRange(1, 1, 9, 9));
+            expectRangeToBe(util.createRangeFromPositions(null, pos99), util.createRange(9, 9, 9, 9));
+            expectRangeToBe(util.createRangeFromPositions(pos11, null), util.createRange(1, 1, 1, 1));
+        });
+
+
+        it('createBoundingRange', () => {
+            const range1 = util.createRange(1, 1, 2, 2);
+            const range2 = util.createRange(2, 2, 3, 3);
+            const range3 = util.createRange(100, 100, 100, 100);
+
+            expectRangeToBe(util.createBoundingRange(range1), util.createRange(1, 1, 2, 2));
+            expectRangeToBe(util.createBoundingRange(range1, range2), util.createRange(1, 1, 3, 3));
+            expectRangeToBe(util.createBoundingRange(range2, range1), util.createRange(1, 1, 3, 3));
+            expectRangeToBe(util.createBoundingRange(range2, range3, range1), util.createRange(1, 1, 100, 100));
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1088,7 +1088,12 @@ export class Util {
     /**
      * Create a `Range` from two `Position`s
      */
-    public createRangeFromPositions(startPosition: Position, endPosition: Position): Range {
+    public createRangeFromPositions(startPosition: Position, endPosition: Position): Range | undefined {
+        startPosition = startPosition ?? endPosition;
+        endPosition = endPosition ?? startPosition;
+        if (!startPosition && !endPosition) {
+            return undefined;
+        }
         return this.createRange(startPosition.line, startPosition.character, endPosition.line, endPosition.character);
     }
 


### PR DESCRIPTION
Removes the `startingRange` property on Blocks.

If a block is not empty, the range of a Block is the range of its statements

If the block is empty, the Block looks at its parent to see what the range should be, with specific logic for all the different types of nodes that can contain a block.