### PR TITLE
Allow updating leading trivia

### DIFF
--- a/src/bscPlugin/SignatureHelpUtil.ts
+++ b/src/bscPlugin/SignatureHelpUtil.ts
@@ -78,7 +78,7 @@ export class SignatureHelpUtil {
         const funcStartPosition = func.range.start;
 
         // Get function comments in reverse order
-        const trivia = func.getLeadingTrivia().reverse();
+        const trivia = util.concatAnnotationLeadingTrivia(func).reverse();
         let functionComments = [] as string[];
 
         for (const currentToken of trivia) {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -111,7 +111,7 @@ export class Lexer {
                 ? util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
                 : undefined,
             leadingWhitespace: this.leadingWhitespace,
-            leadingTrivia: this.leadingTrivia
+            leadingTrivia: this.leadingTrivia ?? []
         });
         this.leadingWhitespace = '';
         return this;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -256,11 +256,11 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     public functionStatement?: FunctionStatement;
 
     public getLeadingTrivia(): Token[] {
-        return this.tokens.functionType?.leadingTrivia ?? [];
+        return this.tokens.functionType?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
-        return this.tokens.endFunctionType?.leadingTrivia ?? [];
+        return this.tokens.endFunctionType?.leadingTrivia;
     }
 
     /**
@@ -515,7 +515,7 @@ export class FunctionParameterExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.name.leadingTrivia ?? [];
+        return this.tokens.name.leadingTrivia;
     }
 }
 
@@ -779,7 +779,7 @@ export class GroupingExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.leftParen?.leadingTrivia ?? [];
+        return this.tokens.leftParen?.leadingTrivia;
     }
 }
 
@@ -833,7 +833,7 @@ export class LiteralExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.value.leadingTrivia ?? [];
+        return this.tokens.value.leadingTrivia;
     }
 }
 
@@ -938,11 +938,11 @@ export class ArrayLiteralExpression extends Expression {
         return new ArrayType(...innerTypes);
     }
     getLeadingTrivia(): Token[] {
-        return this.tokens.open?.leadingTrivia ?? [];
+        return this.tokens.open?.leadingTrivia;
     }
 
     getEndTrivia(): Token[] {
-        return this.tokens.close?.leadingTrivia ?? [];
+        return this.tokens.close?.leadingTrivia;
     }
 }
 
@@ -991,7 +991,7 @@ export class AAMemberExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.key.leadingTrivia ?? [];
+        return this.tokens.key.leadingTrivia;
     }
 
 }
@@ -1091,11 +1091,11 @@ export class AALiteralExpression extends Expression {
     }
 
     public getLeadingTrivia(): Token[] {
-        return this.tokens.open?.leadingTrivia ?? [];
+        return this.tokens.open?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
-        return this.tokens.close?.leadingTrivia ?? [];
+        return this.tokens.close?.leadingTrivia;
     }
 
 }
@@ -1150,7 +1150,7 @@ export class UnaryExpression extends Expression {
     }
 
     public getLeadingTrivia(): Token[] {
-        return this.tokens.operator.leadingTrivia ?? [];
+        return this.tokens.operator.leadingTrivia;
     }
 }
 
@@ -1221,7 +1221,7 @@ export class VariableExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.name.leadingTrivia ?? [];
+        return this.tokens.name.leadingTrivia;
     }
 }
 
@@ -1337,7 +1337,7 @@ export class SourceLiteralExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.value.leadingTrivia ?? [];
+        return this.tokens.value.leadingTrivia;
     }
 }
 
@@ -1407,7 +1407,7 @@ export class NewExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.new.leadingTrivia ?? [];
+        return this.tokens.new.leadingTrivia;
     }
 }
 
@@ -1823,7 +1823,7 @@ export class AnnotationExpression extends Expression {
     }
 
     public getLeadingTrivia(): Token[] {
-        return this.tokens.at?.leadingTrivia ?? [];
+        return this.tokens.at?.leadingTrivia;
     }
 
     transpile(state: BrsTranspileState) {
@@ -2104,7 +2104,7 @@ export class RegexLiteralExpression extends Expression {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.regexLiteral?.leadingTrivia ?? [];
+        return this.tokens.regexLiteral?.leadingTrivia;
     }
 }
 

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -1660,13 +1660,20 @@ describe('parser', () => {
                 ' hello comment 1
                 ' hello comment 2
                 @annotation
+                ' hello comment 3
+                @otherAnnotation
                 sub sayHello(name as string = "world")
                 end sub
             `, ParseMode.BrighterScript);
             const funcStatements = statements.filter(isFunctionStatement);
             const helloTrivia = funcStatements[0].getLeadingTrivia();
-            expect(helloTrivia.length).to.be.greaterThan(0);
-            expect(helloTrivia.filter(t => t.kind === TokenKind.Comment).length).to.eq(2);
+            expect(helloTrivia.filter(t => t.kind === TokenKind.Comment).length).to.eq(0);
+            const helloAnnotationTrivia = funcStatements[0].annotations[0].getLeadingTrivia();
+            expect(helloAnnotationTrivia.length).to.be.greaterThan(0);
+            expect(helloAnnotationTrivia.filter(t => t.kind === TokenKind.Comment).length).to.eq(2);
+            const otherAnnotationTrivia = funcStatements[0].annotations[1].getLeadingTrivia();
+            expect(otherAnnotationTrivia.length).to.be.greaterThan(0);
+            expect(otherAnnotationTrivia.filter(t => t.kind === TokenKind.Comment).length).to.eq(1);
         });
 
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -185,7 +185,7 @@ export class AssignmentStatement extends Statement {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.name.leadingTrivia ?? [];
+        return this.tokens.name.leadingTrivia;
     }
 }
 
@@ -369,7 +369,7 @@ export class ExitForStatement extends Statement {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.exitFor?.leadingTrivia ?? [];
+        return this.tokens.exitFor?.leadingTrivia;
     }
 
 }
@@ -402,7 +402,7 @@ export class ExitWhileStatement extends Statement {
     }
 
     getLeadingTrivia(): Token[] {
-        return this.tokens.exitWhile?.leadingTrivia ?? [];
+        return this.tokens.exitWhile?.leadingTrivia;
     }
 }
 
@@ -446,7 +446,7 @@ export class FunctionStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.func.getLeadingTrivia());
+        return this.func.getLeadingTrivia();
     }
 
     transpile(state: BrsTranspileState) {
@@ -889,7 +889,7 @@ export class LabelStatement extends Statement {
     public readonly range: Range | undefined;
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.name.leadingTrivia);
+        return this.tokens.name.leadingTrivia;
     }
 
     transpile(state: BrsTranspileState) {
@@ -1565,11 +1565,11 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.namespace?.leadingTrivia);
+        return this.tokens.namespace?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
-        return this.tokens.endNamespace?.leadingTrivia ?? [];
+        return this.tokens.endNamespace?.leadingTrivia;
     }
 
     public getNameParts() {
@@ -1760,12 +1760,11 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this,
-            this.tokens.interface?.leadingTrivia);
+        return this.tokens.interface?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
-        return this.tokens.endInterface?.leadingTrivia ?? [];
+        return this.tokens.endInterface?.leadingTrivia;
     }
 
 
@@ -1946,7 +1945,7 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     };
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.optional?.leadingTrivia ?? this.tokens.name.leadingTrivia);
+        return this.tokens.optional?.leadingTrivia ?? this.tokens.name.leadingTrivia;
     }
 
     public get name() {
@@ -2071,7 +2070,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.optional?.leadingTrivia ?? this.tokens.functionType.leadingTrivia);
+        return this.tokens.optional?.leadingTrivia ?? this.tokens.functionType.leadingTrivia;
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -2233,7 +2232,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.class?.leadingTrivia);
+        return this.tokens.class?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
@@ -2671,7 +2670,7 @@ export class MethodStatement extends FunctionStatement {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.func.getLeadingTrivia());
+        return this.func.getLeadingTrivia();
     }
 
     transpile(state: BrsTranspileState) {
@@ -2886,7 +2885,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
     public readonly range: Range | undefined;
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.accessModifier?.leadingTrivia ?? this.tokens.optional?.leadingTrivia ?? this.tokens.name?.leadingTrivia ?? []);
+        return this.tokens.accessModifier?.leadingTrivia ?? this.tokens.optional?.leadingTrivia ?? this.tokens.name.leadingTrivia;
     }
 
     public get isOptional() {
@@ -3160,7 +3159,7 @@ export class EnumStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.enum?.leadingTrivia);
+        return this.tokens.enum?.leadingTrivia;
     }
 
     public getEndTrivia(): Token[] {
@@ -3341,7 +3340,7 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.name.leadingTrivia);
+        return this.tokens.name.leadingTrivia;
     }
 
     public transpile(state: BrsTranspileState): TranspileResult {
@@ -3417,7 +3416,7 @@ export class ConstStatement extends Statement implements TypedefProvider {
     }
 
     public getLeadingTrivia(): Token[] {
-        return util.concatAnnotationLeadingTrivia(this, this.tokens.const?.leadingTrivia);
+        return this.tokens.const?.leadingTrivia;
     }
 
     /**

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1110,7 +1110,7 @@ describe('util', () => {
                 end function
             `);
             const func = (statements[0] as FunctionStatement).func;
-            const docs = util.getTokenDocumentation(func);
+            const docs = util.getNodeDocumentation(func);
             expect(docs).to.eql('This is a comment.\nit has two lines');
         });
 
@@ -1126,7 +1126,7 @@ describe('util', () => {
                 end function
             `);
             const func = (statements[0] as FunctionStatement).func;
-            const docs = util.getTokenDocumentation(func);
+            const docs = util.getNodeDocumentation(func);
             expect(docs).to.eql('Add 1 to a number\n\n\n_@public_\n\n_@param_ {integer} the number to add to\n\n_@return_ {integer} the result');
         });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -639,7 +639,7 @@ export class Util {
         }
         const nodeTrivia = node?.getLeadingTrivia() ?? [];
         const leadingTrivia = isStatement(node)
-            ? [...(node.annotations?.map(anno => anno.getLeadingTrivia()).flat() ?? []), ...nodeTrivia]
+            ? [...(node.annotations?.map(anno => anno.getLeadingTrivia() ?? []).flat() ?? []), ...nodeTrivia]
             : nodeTrivia;
         const tokens = leadingTrivia?.filter(t => t.kind === TokenKind.Newline || t.kind === TokenKind.Comment);
         const comments = [] as Token[];
@@ -1644,7 +1644,7 @@ export class Util {
 
 
     public concatAnnotationLeadingTrivia(stmt: Statement): Token[] {
-        return [...(stmt.annotations?.map(anno => anno.getLeadingTrivia()).flat() ?? []), ...stmt.getLeadingTrivia()];
+        return [...(stmt.annotations?.map(anno => anno.getLeadingTrivia() ?? []).flat() ?? []), ...stmt.getLeadingTrivia()];
     }
 
     /**


### PR DESCRIPTION
- All AstNodes will return an editable array of tokens when calling `.getLeadingTrivia()`
- No longer concatenates leading trivia of annotations above a statement
- Refined utils functions that get node documentation to ensure all comments are included, and these concatenate leading trivia of associated annotations 


Addresses #1206