### PR TITLE
Removed `isInline` property from `IfStatement` 

### DIFF
--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -634,8 +634,8 @@ export class IfStatement extends Statement {
             ...(this.tokens.endIf?.leadingTrivia ?? [])
         ];
 
-        const hasNewlineOrColon = allLeadingTrivia.find(t => t.kind === TokenKind.Newline);
-        return !hasNewlineOrColon;
+        const hasNewline = allLeadingTrivia.find(t => t.kind === TokenKind.Newline);
+        return !hasNewline;
     }
 
     transpile(state: BrsTranspileState) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -386,6 +386,10 @@ export class Block extends Statement {
         return results;
     }
 
+    public getLeadingTrivia(): Token[] {
+        return this.statements[0]?.getLeadingTrivia() ?? [];
+    }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkStatements) {
             walkArray(this.statements, visitor, options, this);
@@ -587,13 +591,11 @@ export class IfStatement extends Statement {
         condition: Expression;
         thenBranch: Block;
         elseBranch?: IfStatement | Block;
-        isInline?: boolean;
     }) {
         super();
         this.condition = options.condition;
         this.thenBranch = options.thenBranch;
         this.elseBranch = options.elseBranch;
-        this.isInline = options.isInline;
 
         this.tokens = {
             if: options.if,
@@ -619,11 +621,22 @@ export class IfStatement extends Statement {
     public readonly condition: Expression;
     public readonly thenBranch: Block;
     public readonly elseBranch?: IfStatement | Block;
-    public readonly isInline?: boolean;
 
     public readonly kind = AstNodeKind.IfStatement;
 
     public readonly range: Range | undefined;
+
+    get isInline() {
+        const allLeadingTrivia = [
+            ...this.thenBranch.getLeadingTrivia(),
+            ...this.thenBranch.statements.map(s => s.getLeadingTrivia()).flat(),
+            ...(this.tokens.else?.leadingTrivia ?? []),
+            ...(this.tokens.endIf?.leadingTrivia ?? [])
+        ];
+
+        const hasNewlineOrColon = allLeadingTrivia.find(t => t.kind === TokenKind.Newline);
+        return !hasNewlineOrColon;
+    }
 
     transpile(state: BrsTranspileState) {
         let results = [] as TranspileResult;

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -6,7 +6,7 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, rangeMatch, token } from '../Parser.spec';
 import { isBlock, isFunctionStatement, isIfStatement } from '../../../astUtils/reflection';
 import type { Block, FunctionStatement, IfStatement } from '../../Statement';
-import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
+import { expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 
 describe('parser if statements', () => {

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -6,6 +6,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, rangeMatch, token } from '../Parser.spec';
 import { isBlock, isFunctionStatement, isIfStatement } from '../../../astUtils/reflection';
 import type { Block, FunctionStatement, IfStatement } from '../../Statement';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
+import { DiagnosticMessages } from '../../../DiagnosticMessages';
 
 describe('parser if statements', () => {
     it('allows empty if blocks', () => {
@@ -233,8 +235,147 @@ describe('parser if statements', () => {
                 if true then return else print 1
             `);
 
-            expect(diagnostics).to.be.lengthOf(0);
+            expectZeroDiagnostics(diagnostics);
             expect(statements).to.be.length.greaterThan(0);
+        });
+
+        it('colon used between inline else statements', () => {
+            const { statements, diagnostics } = Parser.parse(`
+                if x print 1 else print 2 : print 3
+            `);
+
+            expectZeroDiagnostics(diagnostics);
+            expect(statements).to.be.lengthOf(1);
+            const ifStatement = statements[0] as IfStatement;
+            expect(ifStatement.thenBranch.statements).to.be.lengthOf(1);
+            expect((ifStatement.elseBranch as Block).statements).to.be.lengthOf(2);
+        });
+
+        it('colon used between inline else if statements', () => {
+            const { statements, diagnostics } = Parser.parse(`
+                if x print 1 else if y print 2 : print 3
+            `);
+
+            expectZeroDiagnostics(diagnostics);
+            expect(statements).to.be.lengthOf(1);
+            const ifStatement = statements[0] as IfStatement;
+            expect(ifStatement.thenBranch.statements).to.be.lengthOf(1);
+            expect((ifStatement.elseBranch as IfStatement).thenBranch.statements).to.be.lengthOf(2);
+        });
+
+        it('colon used between all kinds of statements', () => {
+            const { statements, diagnostics } = Parser.parse(`
+                if x print 1 : print 1 else if y print 2 : print 2 : print 2 else print 3 : print 3: print 3: print 3
+            `);
+
+            expectZeroDiagnostics(diagnostics);
+            expect(statements).to.be.lengthOf(1);
+            const ifStatement = statements[0] as IfStatement;
+            expect(ifStatement.thenBranch.statements).to.be.lengthOf(2);
+            const elseIf = ifStatement.elseBranch as IfStatement;
+            expect(elseIf.thenBranch.statements).to.be.lengthOf(3);
+            expect((elseIf.elseBranch as Block).statements).to.be.lengthOf(4);
+        });
+
+        it('has diagnostic with extra else', () => {
+            const { diagnostics } = Parser.parse(`
+                if x=1 print 1 else print 2 else print 3
+            `);
+
+            expectDiagnosticsIncludes(diagnostics, [
+                DiagnosticMessages.expectedNewlineOrColon().message
+            ]);
+        });
+
+        it('nested inline if statements', () => {
+            const { statements, diagnostics } = Parser.parse(`
+                if x=1 print 1 else if x=2 print 2 : if y=1 print "y is 1" else print "y is not 1" else print 3: print 3: print 3
+            `);
+
+            expectZeroDiagnostics(diagnostics);
+            expect(statements).to.be.lengthOf(1);
+            const ifStatement = statements[0] as IfStatement;
+            expect(ifStatement.thenBranch.statements).to.be.lengthOf(1);
+            const elseIf = ifStatement.elseBranch as IfStatement;
+            expect(elseIf.thenBranch.statements).to.be.lengthOf(2);
+            expect(isIfStatement(elseIf.thenBranch.statements[1])).to.be.true;
+            const nestedInlineIf = elseIf.thenBranch.statements[1] as IfStatement;
+            expect(nestedInlineIf.thenBranch.statements).to.be.lengthOf(1);
+            expect((nestedInlineIf.elseBranch as Block).statements).to.be.lengthOf(1);
+            expect((elseIf.elseBranch as Block).statements).to.be.lengthOf(3);
+        });
+
+        describe('expected inline if', () => {
+
+            it('non-inline statement used in inline if', () => {
+                const { statements, diagnostics } = Parser.parse(`
+                    if true print 1 else
+                        print 1
+                    end if
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedInlineIfStatement().message
+                ]);
+                expect(statements.length).to.be.greaterThan(0);
+            });
+
+            it('non inline statement used in inline else if', () => {
+                const { statements, diagnostics } = Parser.parse(`
+                    if x print 1 else if y
+                        print 2
+                    end if
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedInlineIfStatement().message
+                ]);
+                expect(statements.length).to.be.greaterThan(0);
+            });
+
+            it('colon used after inline else', () => {
+                const { statements, diagnostics } = Parser.parse(`
+                    if x print 1 else : print 2 : print 3: end if
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedInlineIfStatement().message
+                ]);
+                expect(statements.length).to.be.greaterThan(0);
+            });
+
+            it('new line used in inline else', () => {
+                const { statements, diagnostics } = Parser.parse(`
+                    if x print 1 else
+                        print 2
+                        print 3
+                    end if
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedInlineIfStatement().message
+                ]);
+                expect(statements.length).to.be.greaterThan(0);
+            });
+
+
+            it('colon used after inline else if', () => {
+                const { diagnostics } = Parser.parse(`
+                    if x print 1 else if y : print 2
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedEndIfElseIfOrElseToTerminateThenBlock().message
+                ]);
+            });
+
+            it('new line used in inline else if', () => {
+                const { statements, diagnostics } = Parser.parse(`
+                    if x print 1 else if y
+                        print 2
+                    end if
+                `);
+                expectDiagnosticsIncludes(diagnostics, [
+                    DiagnosticMessages.expectedInlineIfStatement().message
+                ]);
+                expect(statements.length).to.be.greaterThan(0);
+            });
+
         });
     });
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -383,16 +383,6 @@ export function expectTypeToBe(someType: BscType, expectedTypeClass: any) {
     expect(someType?.constructor?.name).to.eq(expectedTypeClass.name);
 }
 
-/**
- * Test that a range is waht was expected
- */
-export function expectRangeToBe(actual: Range, expected: Range) {
-    expect(actual.start.line, 'start line').to.eq(expected.start.line);
-    expect(actual.start.character, 'start character').to.eq(expected.start.character);
-    expect(actual.end.line, 'end line').to.eq(expected.end.line);
-    expect(actual.end.character, 'end character').to.eq(expected.end.character);
-}
-
 export function stripConsoleColors(inputString) {
     // Regular expression to match ANSI escape codes for colors
     // eslint-disable-next-line no-control-regex


### PR DESCRIPTION
- It was changed to a getter, so that proper diagnostic could still be added if there was a problem.
- Added tests for inline conditional statements
- Added support for nested inline conditionals. (People must have a deathwish!)