### PR TITLE
Convert .range to .location

### DIFF
--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -92,7 +92,7 @@ describe('CommentFlagProcessor', () => {
             const tokens = Lexer.scan(`print "hi" 'bs:disable-line: 123456 999999   aaaab`).tokens;
             const token = tokens[2].leadingTrivia[1];
             expect(
-                processor['tokenize'](token.text, token.range)
+                processor['tokenize'](token.text, token.location.range)
             ).to.eql({
                 commentTokenText: `'`,
                 disableType: 'line',
@@ -112,7 +112,7 @@ describe('CommentFlagProcessor', () => {
         it('tokenizes bs:disable-line comment with codes', () => {
             const token = Lexer.scan(`'bs:disable-line:1 2 3`).tokens[0].leadingTrivia[0];
             expect(
-                processor['tokenize'](token.text, token.range)
+                processor['tokenize'](token.text, token.location?.range)
             ).to.eql({
                 commentTokenText: `'`,
                 disableType: 'line',
@@ -133,7 +133,7 @@ describe('CommentFlagProcessor', () => {
             const tokens = Lexer.scan(`' bs:disable-line:1`).tokens;
             const token = tokens[0].leadingTrivia[0];
             expect(
-                processor['tokenize'](token.text, token.range)
+                processor['tokenize'](token.text, token.location?.range)
             ).to.eql({
                 commentTokenText: `'`,
                 disableType: 'line',
@@ -148,7 +148,7 @@ describe('CommentFlagProcessor', () => {
             const tokens = Lexer.scan(`'\tbs:disable-line:1`).tokens;
             const token = tokens[0].leadingTrivia[0];
             expect(
-                processor['tokenize'](token.text, token.range)
+                processor['tokenize'](token.text, token.location?.range)
             ).to.eql({
                 commentTokenText: `'`,
                 disableType: 'line',

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -573,8 +573,8 @@ export class CrossScopeValidator {
                                 }
 
                                 const thatNodeKindName = otherIsGlobal ? 'Global Function' : util.getAstNodeFriendlyName(otherDupeNode) ?? 'Item';
-                                let thisNameRange = (dupeNode as any)?.tokens?.name?.range ?? dupeNode.range;
-                                let thatNameRange = (otherDupeNode as any)?.tokens?.name?.range ?? otherDupeNode?.range;
+                                let thisNameRange = (dupeNode as any)?.tokens?.name?.range ?? dupeNode.location?.range;
+                                let thatNameRange = (otherDupeNode as any)?.tokens?.name?.range ?? otherDupeNode?.location?.range;
 
                                 const relatedInformation = thatNameRange ? [{
                                     message: `${thatNodeKindName} declared here`,

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -19,6 +19,7 @@ import { ParseMode } from './parser/Parser';
 import { URI } from 'vscode-uri';
 import { globalFile } from './globalCallables';
 import type { DottedGetExpression, VariableExpression } from './parser/Expression';
+import type { InheritableType } from './types';
 
 
 interface FileSymbolPair {
@@ -97,9 +98,9 @@ export class ProvidedNode {
                     typesToTry.push(currentType.defaultMemberType);
                 }
                 if (isInheritableType(currentType)) {
-                    let inheritableType = currentType as any;
+                    let inheritableType = currentType;
                     while (inheritableType?.parentType) {
-                        let parentType = inheritableType.parentType;
+                        let parentType = inheritableType.parentType as BscType;
                         if (isReferenceType(inheritableType.parentType)) {
                             const fullName = inheritableType.parentType.fullName;
                             if (fullName.includes('.')) {
@@ -110,7 +111,7 @@ export class ProvidedNode {
                             }
                         }
                         typesToTry.push(parentType);
-                        inheritableType = parentType;
+                        inheritableType = parentType as InheritableType;
                     }
 
                 }

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -578,7 +578,7 @@ export class CrossScopeValidator {
 
                                 const relatedInformation = thatNameRange ? [{
                                     message: `${thatNodeKindName} declared here`,
-                                    location: util.createLocation(
+                                    location: util.createLocationFromRange(
                                         URI.file(otherDupe.file?.srcPath).toString(),
                                         thatNameRange
                                     )

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -110,7 +110,7 @@ export class DiagnosticManager {
                         message: `In component scope '${scope?.xmlFile?.componentName?.text}'`,
                         location: util.createLocationFromRange(
                             URI.file(scope.xmlFile.srcPath).toString(),
-                            scope?.xmlFile?.ast?.componentElement?.getAttribute('name')?.tokens?.value?.range ?? util.createRange(0, 0, 0, 10)
+                            scope?.xmlFile?.ast?.componentElement?.getAttribute('name')?.tokens?.value?.location?.range ?? util.createRange(0, 0, 0, 10)
                         )
                     });
                 } else {

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -108,7 +108,7 @@ export class DiagnosticManager {
                 if (isXmlScope(scope) && scope.xmlFile?.srcPath) {
                     relatedInformation.push({
                         message: `In component scope '${scope?.xmlFile?.componentName?.text}'`,
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(scope.xmlFile.srcPath).toString(),
                             scope?.xmlFile?.ast?.componentElement?.getAttribute('name')?.tokens?.value?.range ?? util.createRange(0, 0, 0, 10)
                         )
@@ -116,7 +116,7 @@ export class DiagnosticManager {
                 } else {
                     relatedInformation.push({
                         message: `In scope '${scope.name}'`,
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(diagnostic.file.srcPath).toString(),
                             diagnostic.range
                         )

--- a/src/FunctionScope.ts
+++ b/src/FunctionScope.ts
@@ -13,7 +13,7 @@ export class FunctionScope {
      * and ends after the final `n` in `end function` or `b` in end sub.
      */
     public get range() {
-        return this.func?.range;
+        return this.func?.location?.range;
     }
     /**
      * The scopes that are children of this scope

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -264,7 +264,7 @@ describe('Program', () => {
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
                 range: Range.create(1, 17, 1, 27),
                 relatedInformation: [{
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/components/component1.xml`).toString(),
                         Range.create(1, 17, 1, 27)
                     ),
@@ -274,7 +274,7 @@ describe('Program', () => {
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
                 range: Range.create(1, 17, 1, 27),
                 relatedInformation: [{
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/components/component2.xml`).toString(),
                         Range.create(1, 17, 1, 27)
                     ),

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -997,13 +997,13 @@ export class Program {
                     const { componentName } = xmlFile;
                     this.diagnostics.register({
                         ...DiagnosticMessages.duplicateComponentName(componentName.text),
-                        range: xmlFile.componentName.range,
+                        range: xmlFile.componentName.location?.range,
                         file: xmlFile,
                         relatedInformation: xmlFiles.filter(x => x !== xmlFile).map(x => {
                             return {
                                 location: util.createLocationFromRange(
                                     URI.file(xmlFile.srcPath ?? xmlFile.srcPath).toString(),
-                                    x.componentName.range
+                                    x.componentName.location?.range
                                 ),
                                 message: 'Also defined here'
                             };

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1001,7 +1001,7 @@ export class Program {
                         file: xmlFile,
                         relatedInformation: xmlFiles.filter(x => x !== xmlFile).map(x => {
                             return {
-                                location: util.createLocation(
+                                location: util.createLocationFromRange(
                                     URI.file(xmlFile.srcPath ?? xmlFile.srcPath).toString(),
                                     x.componentName.range
                                 ),

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -795,9 +795,10 @@ describe('Scope', () => {
                 `);
                 program.validate();
                 // only care about code and `roFontMetrics` match
-                expectDiagnostics(program, [
-                    DiagnosticMessages.unknownBrightScriptComponent('roFontMetrics')
-                ]);
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownBrightScriptComponent('roFontMetrics'),
+                    range: Range.create(2, 51, 2, 66)
+                }]);
             });
 
             it('infers the correct type', () => {

--- a/src/astUtils/reflection.spec.ts
+++ b/src/astUtils/reflection.spec.ts
@@ -194,7 +194,7 @@ describe('reflection', () => {
         const charCode: Token & { charCode: number } = {
             kind: TokenKind.EscapedCharCodeLiteral,
             text: '0',
-            range: undefined,
+            location: undefined,
             isReserved: false,
             charCode: 0,
             leadingWhitespace: '',

--- a/src/bscPlugin/CallExpressionInfo.ts
+++ b/src/bscPlugin/CallExpressionInfo.ts
@@ -91,7 +91,7 @@ export class CallExpressionInfo {
     }
 
     isPositionBetweenParentheses() {
-        let boundingRange = util.createBoundingRange(this.callExpression.tokens.openingParen, this.callExpression.tokens.closingParen);
+        let boundingRange = util.createBoundingRange(this.callExpression.tokens.openingParen?.location, this.callExpression.tokens.closingParen?.location);
         return util.rangeContains(boundingRange, this.position);
     }
 
@@ -151,7 +151,7 @@ export class CallExpressionInfo {
     private getParameterIndex() {
         for (let i = this.callExpression.args.length - 1; i > -1; i--) {
             let argExpression = this.callExpression.args[i];
-            let comparison = util.comparePositionToRange(this.position, argExpression.range);
+            let comparison = util.comparePositionToRange(this.position, argExpression.location?.range);
             if (comparison >= 0) {
                 return i + comparison;
             }

--- a/src/bscPlugin/SignatureHelpUtil.ts
+++ b/src/bscPlugin/SignatureHelpUtil.ts
@@ -75,7 +75,7 @@ export class SignatureHelpUtil {
             return undefined;
         }
         const func = statement.func;
-        const funcStartPosition = func.range.start;
+        const funcStartPosition = func.location?.range.start;
 
         // Get function comments in reverse order
         const trivia = func.getLeadingTrivia().reverse();
@@ -85,7 +85,7 @@ export class SignatureHelpUtil {
             if (!currentToken) {
                 break;
             }
-            if (currentToken.range.start.line + 1 < funcStartPosition.line) {
+            if (currentToken.location?.range.start.line + 1 < funcStartPosition.line) {
                 if (functionComments.length === 0) {
                     break;
                 }
@@ -121,7 +121,7 @@ export class SignatureHelpUtil {
             key += param.tokens.name.text;
         }
 
-        let label = util.getTextForRange(lines, util.createRangeFromPositions(func.tokens.functionType?.range.start, func.body.range.start)).trim();
+        let label = util.getTextForRange(lines, util.createRangeFromPositions(func.tokens.functionType?.location?.range.start, func.body.location?.range.start)).trim();
         if (namespaceName) {
             label = label.replace(/^(sub | function )/gim, `$1${namespaceName}.`);
         }
@@ -149,7 +149,4 @@ export class SignatureHelpUtil {
         }
         return sigHelp;
     }
-
-
 }
-

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -45,7 +45,7 @@ export class CodeActionsProcessor {
         // eslint-disable-next-line @typescript-eslint/dot-notation
         const importStatements = this.event.file['_cachedLookups'].importStatements;
         //find the position of the first import statement, or the top of the file if there is none
-        const insertPosition = importStatements[importStatements.length - 1]?.tokens.import?.range?.start ?? util.createPosition(0, 0);
+        const insertPosition = importStatements[importStatements.length - 1]?.tokens.import?.location?.range?.start ?? util.createPosition(0, 0);
 
         //find all files that reference this function
         for (const file of files) {
@@ -103,7 +103,7 @@ export class CodeActionsProcessor {
         const srcPath = this.event.file.srcPath;
         const { componentElement } = (this.event.file as XmlFile).parser.ast;
         //inject new attribute after the final attribute, or after the `<component` if there are no attributes
-        const pos = (componentElement.attributes[componentElement.attributes.length - 1] ?? componentElement.tokens.startTagName).range.end;
+        const pos = (componentElement.attributes[componentElement.attributes.length - 1] ?? componentElement.tokens.startTagName)?.location?.range.end;
         this.event.codeActions.push(
             codeActionUtil.createCodeAction({
                 title: `Extend "Group"`,

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -146,7 +146,7 @@ export class CompletionsProcessor {
     public getBrsFileCompletions(position: Position, file: BrsFile): CompletionItem[] {
         let result = [] as CompletionItem[];
         const currentTokenByFilePosition = file.getTokenAt(position);
-        const currentToken = currentTokenByFilePosition ?? file.getTokenAt(file.getClosestExpression(position)?.range.start);
+        const currentToken = currentTokenByFilePosition ?? file.getTokenAt(file.getClosestExpression(position)?.location?.range.start);
         if (!currentToken) {
             return [];
         }
@@ -171,12 +171,12 @@ export class CompletionsProcessor {
         if (this.isTokenAdjacentTo(file, currentToken, TokenKind.Dot)) {
             const dotToken = this.getAdjacentToken(file, currentToken, TokenKind.Dot);
             beforeDotToken = file.getTokenBefore(dotToken);
-            expression = file.getClosestExpression(beforeDotToken?.range.end);
+            expression = file.getClosestExpression(beforeDotToken?.location?.range.end);
             shouldLookForMembers = true;
         } else if (this.isTokenAdjacentTo(file, currentToken, TokenKind.Callfunc)) {
             const dotToken = this.getAdjacentToken(file, currentToken, TokenKind.Callfunc);
             beforeDotToken = file.getTokenBefore(dotToken);
-            expression = file.getClosestExpression(beforeDotToken?.range.end);
+            expression = file.getClosestExpression(beforeDotToken?.location?.range.end);
             shouldLookForCallFuncMembers = true;
         } else if (this.isTokenAdjacentTo(file, currentToken, TokenKind.As)) {
             if (file.parseMode === ParseMode.BrightScript) {
@@ -204,7 +204,7 @@ export class CompletionsProcessor {
             return [];
         }
 
-        const tokenBefore = file.getTokenBefore(file.getClosestToken(expression.range?.start));
+        const tokenBefore = file.getTokenBefore(file.getClosestToken(expression.location?.range?.start));
 
         // helper to check get correct symbol tables for look ups
         function getSymbolTableForLookups() {
@@ -507,12 +507,12 @@ export class CompletionsProcessor {
                     label: pkgPath,
                     textEdit: TextEdit.replace(
                         util.createRange(
-                            currentToken.range.start.line,
+                            currentToken.location?.range.start.line,
                             //+1 to step past the opening quote
-                            currentToken.range.start.character + (openingQuote ? 1 : 0),
-                            currentToken.range.end.line,
+                            currentToken.location?.range.start.character + (openingQuote ? 1 : 0),
+                            currentToken.location?.range.end.line,
                             //-1 to exclude the closing quotemark (or the end character if there is no closing quotemark)
-                            currentToken.range.end.character + (currentToken.text.endsWith('"') ? -1 : 0)
+                            currentToken.location?.range.end.character + (currentToken.text.endsWith('"') ? -1 : 0)
                         ),
                         pkgPath
                     ),
@@ -621,7 +621,7 @@ export class CompletionsProcessor {
 
         const nextNonComment = file.getNextTokenByPredicate(currentToken, (t: Token) => !AllowedTriviaTokens.includes(t.kind), 1);
         const firstComment = nextNonComment?.leadingTrivia.find(t => t.kind === TokenKind.Comment);
-        if (firstComment && util.comparePosition(position, firstComment?.range.start) >= 0) {
+        if (firstComment && util.comparePosition(position, firstComment?.location?.range.start) >= 0) {
             return true;
         }
         return false;

--- a/src/bscPlugin/definition/DefinitionProvider.ts
+++ b/src/bscPlugin/definition/DefinitionProvider.ts
@@ -58,7 +58,7 @@ export class DefinitionProvider {
                 this.event.definitions.push(
                     util.createLocationFromRange(
                         URI.file(constant.file.srcPath).toString(),
-                        constant.item.tokens.name.range
+                        constant.item.tokens.name?.location?.range
                     )
                 );
                 return;
@@ -70,7 +70,7 @@ export class DefinitionProvider {
                     this.event.definitions.push(
                         util.createLocationFromRange(
                             URI.file(enumLink.file.srcPath).toString(),
-                            enumLink.item.tokens.name.range
+                            enumLink.item.tokens.name.location?.range
                         )
                     );
                     return;
@@ -80,7 +80,7 @@ export class DefinitionProvider {
                     this.event.definitions.push(
                         util.createLocationFromRange(
                             URI.file(enumMemberLink.file.srcPath).toString(),
-                            enumMemberLink.item.tokens.name.range
+                            enumMemberLink.item.tokens.name.location?.range
                         )
                     );
                     return;
@@ -91,7 +91,7 @@ export class DefinitionProvider {
                     this.event.definitions.push(
                         util.createLocationFromRange(
                             URI.file(interfaceFileLink.file.srcPath).toString(),
-                            interfaceFileLink.item.tokens.name.range
+                            interfaceFileLink.item.tokens.name.location?.range
                         )
                     );
                     return;
@@ -102,7 +102,7 @@ export class DefinitionProvider {
                     this.event.definitions.push(
                         util.createLocationFromRange(
                             URI.file(classFileLink.file.srcPath).toString(),
-                            classFileLink.item.tokens.name.range
+                            classFileLink.item.tokens.name.location?.range
                         )
                     );
                     return;
@@ -112,7 +112,7 @@ export class DefinitionProvider {
 
         let textToSearchFor = token.text.toLowerCase();
 
-        const previousToken = file.getTokenAt({ line: token.range.start.line, character: token.range.start.character });
+        const previousToken = file.getTokenAt({ line: token.location?.range.start.line, character: token.location?.range.start.character });
 
         if (previousToken?.kind === TokenKind.Callfunc) {
             for (const scope of this.event.program.getScopes()) {
@@ -121,12 +121,12 @@ export class DefinitionProvider {
                     const apiFunc = scope.xmlFile.ast?.componentElement?.interfaceElement?.functions?.find(x => x.name.toLowerCase() === textToSearchFor); // eslint-disable-line @typescript-eslint/no-loop-func
                     if (apiFunc) {
                         this.event.definitions.push(
-                            util.createLocationFromRange(util.pathToUri(scope.xmlFile.srcPath), apiFunc.getAttribute('name').tokens.value.range)
+                            util.createLocationFromRange(util.pathToUri(scope.xmlFile.srcPath), apiFunc.getAttribute('name').tokens.value.location?.range)
                         );
                         const callable = scope.getAllCallables().find((c) => c.callable.name.toLowerCase() === textToSearchFor); // eslint-disable-line @typescript-eslint/no-loop-func
                         if (callable) {
                             this.event.definitions.push(
-                                util.createLocationFromRange(util.pathToUri((callable.callable.file as BrsFile).srcPath), callable.callable.functionStatement.tokens.name.range)
+                                util.createLocationFromRange(util.pathToUri((callable.callable.file as BrsFile).srcPath), callable.callable.functionStatement.tokens.name.location?.range)
                             );
                         }
                     }
@@ -138,12 +138,12 @@ export class DefinitionProvider {
         // eslint-disable-next-line @typescript-eslint/dot-notation
         let classToken = file['getTokenBefore'](token, TokenKind.Class);
         if (classToken) {
-            let cs = file.parser.ast.findChild<ClassStatement>((klass) => isClassStatement(klass) && klass.tokens.class.range === classToken.range);
+            let cs = file.parser.ast.findChild<ClassStatement>((klass) => isClassStatement(klass) && klass.tokens.class.location?.range === classToken.location?.range);
             if (cs?.parentClassName) {
                 const nameParts = cs.parentClassName.getNameParts();
                 let extendedClass = file.getClassFileLink(nameParts[nameParts.length - 1], nameParts.slice(0, -1).join('.'));
                 if (extendedClass) {
-                    this.event.definitions.push(util.createLocationFromRange(util.pathToUri(extendedClass.file.srcPath), extendedClass.item.range));
+                    this.event.definitions.push(util.createLocationFromRange(util.pathToUri(extendedClass.file.srcPath), extendedClass.item.location?.range));
                 }
             }
             return;
@@ -203,7 +203,7 @@ export class DefinitionProvider {
                     FunctionStatement: (statement: FunctionStatement) => {
                         if (statement.getName(file.parseMode).toLowerCase() === textToSearchFor) {
                             const uri = util.pathToUri(file.srcPath);
-                            this.event.definitions.push(util.createLocationFromRange(uri, statement.range));
+                            this.event.definitions.push(util.createLocationFromRange(uri, statement.location?.range));
                         }
                     }
                 }), {
@@ -230,7 +230,7 @@ export class DefinitionProvider {
                 const namespaceItemStatementHandler = (statement: ClassStatement | FunctionStatement) => {
                     if (!location && statement.tokens.name.text.toLowerCase() === endName) {
                         const uri = util.pathToUri(file.srcPath);
-                        location = util.createLocationFromRange(uri, statement.range);
+                        location = util.createLocationFromRange(uri, statement.location?.range);
                     }
                 };
 
@@ -259,7 +259,7 @@ export class DefinitionProvider {
             isXmlFile(file) &&
             file.parentComponent &&
             file.parentComponentName &&
-            util.rangeContains(file.parentComponentName.range, this.event.position)
+            util.rangeContains(file.parentComponentName.location?.range, this.event.position)
         ) {
             this.event.definitions.push({
                 range: util.createRange(0, 0, 0, 0),

--- a/src/bscPlugin/definition/DefinitionProvider.ts
+++ b/src/bscPlugin/definition/DefinitionProvider.ts
@@ -56,7 +56,7 @@ export class DefinitionProvider {
             const constant = scope?.getConstFileLink(fullName, containingNamespace);
             if (constant) {
                 this.event.definitions.push(
-                    util.createLocation(
+                    util.createLocationFromRange(
                         URI.file(constant.file.srcPath).toString(),
                         constant.item.tokens.name.range
                     )
@@ -68,7 +68,7 @@ export class DefinitionProvider {
                 const enumLink = scope.getEnumFileLink(fullName, containingNamespace);
                 if (enumLink) {
                     this.event.definitions.push(
-                        util.createLocation(
+                        util.createLocationFromRange(
                             URI.file(enumLink.file.srcPath).toString(),
                             enumLink.item.tokens.name.range
                         )
@@ -78,7 +78,7 @@ export class DefinitionProvider {
                 const enumMemberLink = scope.getEnumMemberFileLink(fullName, containingNamespace);
                 if (enumMemberLink) {
                     this.event.definitions.push(
-                        util.createLocation(
+                        util.createLocationFromRange(
                             URI.file(enumMemberLink.file.srcPath).toString(),
                             enumMemberLink.item.tokens.name.range
                         )
@@ -89,7 +89,7 @@ export class DefinitionProvider {
                 const interfaceFileLink = scope.getInterfaceFileLink(fullName, containingNamespace);
                 if (interfaceFileLink) {
                     this.event.definitions.push(
-                        util.createLocation(
+                        util.createLocationFromRange(
                             URI.file(interfaceFileLink.file.srcPath).toString(),
                             interfaceFileLink.item.tokens.name.range
                         )
@@ -100,7 +100,7 @@ export class DefinitionProvider {
                 const classFileLink = scope.getClassFileLink(fullName, containingNamespace);
                 if (classFileLink) {
                     this.event.definitions.push(
-                        util.createLocation(
+                        util.createLocationFromRange(
                             URI.file(classFileLink.file.srcPath).toString(),
                             classFileLink.item.tokens.name.range
                         )
@@ -121,12 +121,12 @@ export class DefinitionProvider {
                     const apiFunc = scope.xmlFile.ast?.componentElement?.interfaceElement?.functions?.find(x => x.name.toLowerCase() === textToSearchFor); // eslint-disable-line @typescript-eslint/no-loop-func
                     if (apiFunc) {
                         this.event.definitions.push(
-                            util.createLocation(util.pathToUri(scope.xmlFile.srcPath), apiFunc.getAttribute('name').tokens.value.range)
+                            util.createLocationFromRange(util.pathToUri(scope.xmlFile.srcPath), apiFunc.getAttribute('name').tokens.value.range)
                         );
                         const callable = scope.getAllCallables().find((c) => c.callable.name.toLowerCase() === textToSearchFor); // eslint-disable-line @typescript-eslint/no-loop-func
                         if (callable) {
                             this.event.definitions.push(
-                                util.createLocation(util.pathToUri((callable.callable.file as BrsFile).srcPath), callable.callable.functionStatement.tokens.name.range)
+                                util.createLocationFromRange(util.pathToUri((callable.callable.file as BrsFile).srcPath), callable.callable.functionStatement.tokens.name.range)
                             );
                         }
                     }
@@ -143,7 +143,7 @@ export class DefinitionProvider {
                 const nameParts = cs.parentClassName.getNameParts();
                 let extendedClass = file.getClassFileLink(nameParts[nameParts.length - 1], nameParts.slice(0, -1).join('.'));
                 if (extendedClass) {
-                    this.event.definitions.push(util.createLocation(util.pathToUri(extendedClass.file.srcPath), extendedClass.item.range));
+                    this.event.definitions.push(util.createLocationFromRange(util.pathToUri(extendedClass.file.srcPath), extendedClass.item.range));
                 }
             }
             return;
@@ -168,7 +168,7 @@ export class DefinitionProvider {
                 //we found a variable declaration with this token text!
                 if (varDeclaration.name.toLowerCase() === textToSearchFor) {
                     const uri = util.pathToUri(file.srcPath);
-                    this.event.definitions.push(util.createLocation(uri, varDeclaration.nameRange));
+                    this.event.definitions.push(util.createLocationFromRange(uri, varDeclaration.nameRange));
                 }
             }
             // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -176,7 +176,7 @@ export class DefinitionProvider {
                 for (const label of functionScope.labelStatements) {
                     if (label.name.toLocaleLowerCase() === textToSearchFor) {
                         const uri = util.pathToUri(file.srcPath);
-                        this.event.definitions.push(util.createLocation(uri, label.nameRange));
+                        this.event.definitions.push(util.createLocationFromRange(uri, label.nameRange));
                     }
                 }
             }
@@ -203,7 +203,7 @@ export class DefinitionProvider {
                     FunctionStatement: (statement: FunctionStatement) => {
                         if (statement.getName(file.parseMode).toLowerCase() === textToSearchFor) {
                             const uri = util.pathToUri(file.srcPath);
-                            this.event.definitions.push(util.createLocation(uri, statement.range));
+                            this.event.definitions.push(util.createLocationFromRange(uri, statement.range));
                         }
                     }
                 }), {
@@ -230,7 +230,7 @@ export class DefinitionProvider {
                 const namespaceItemStatementHandler = (statement: ClassStatement | FunctionStatement) => {
                     if (!location && statement.tokens.name.text.toLowerCase() === endName) {
                         const uri = util.pathToUri(file.srcPath);
-                        location = util.createLocation(uri, statement.range);
+                        location = util.createLocationFromRange(uri, statement.range);
                     }
                 };
 

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -70,7 +70,7 @@ export class HoverProcessor {
     }
 
     private getConstHover(token: Token, file: BrsFile, scope: Scope, expression: Expression) {
-        let containingNamespace = file.getNamespaceStatementForPosition(expression?.range?.start)?.getName(ParseMode.BrighterScript);
+        let containingNamespace = file.getNamespaceStatementForPosition(expression?.location?.range?.start)?.getName(ParseMode.BrighterScript);
         const fullName = util.getAllDottedGetParts(expression)?.map(x => x.text).join('.');
 
         //find a constant with this name
@@ -216,7 +216,7 @@ export class HoverProcessor {
             }
         }
         return {
-            range: token.range,
+            range: token?.location.range,
             contents: hoverContents
         };
     }

--- a/src/bscPlugin/references/ReferencesProvider.ts
+++ b/src/bscPlugin/references/ReferencesProvider.ts
@@ -41,12 +41,12 @@ export class ReferencesProvider {
                 file.ast.walk(createVisitor({
                     AssignmentStatement: (s) => {
                         if (s.tokens.name?.text?.toLowerCase() === searchFor) {
-                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), s.tokens.name.range));
+                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), s.tokens.name.location?.range));
                         }
                     },
                     VariableExpression: (e) => {
                         if (e.tokens.name.text.toLowerCase() === searchFor) {
-                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), e.range));
+                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), e.location?.range));
                         }
                     }
                 }), {

--- a/src/bscPlugin/references/ReferencesProvider.ts
+++ b/src/bscPlugin/references/ReferencesProvider.ts
@@ -41,12 +41,12 @@ export class ReferencesProvider {
                 file.ast.walk(createVisitor({
                     AssignmentStatement: (s) => {
                         if (s.tokens.name?.text?.toLowerCase() === searchFor) {
-                            this.event.references.push(util.createLocation(util.pathToUri(file.srcPath), s.tokens.name.range));
+                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), s.tokens.name.range));
                         }
                     },
                     VariableExpression: (e) => {
                         if (e.tokens.name.text.toLowerCase() === searchFor) {
-                            this.event.references.push(util.createLocation(util.pathToUri(file.srcPath), e.range));
+                            this.event.references.push(util.createLocationFromRange(util.pathToUri(file.srcPath), e.range));
                         }
                     }
                 }), {

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -91,8 +91,8 @@ export class BrsFileSemanticTokensProcessor {
 
     private addToken(locatable: Locatable, type: SemanticTokenTypes, modifiers: SemanticTokenModifiers[] = []) {
         //only keep a single token per range. Last-in wins
-        this.result.set(util.rangeToString(locatable.range), {
-            range: locatable.range,
+        this.result.set(util.rangeToString(locatable.location.range), {
+            range: locatable.location.range,
             tokenType: type,
             tokenModifiers: modifiers
         });

--- a/src/bscPlugin/symbols/symbolUtils.ts
+++ b/src/bscPlugin/symbols/symbolUtils.ts
@@ -98,57 +98,57 @@ function getSymbolsFromAstNode(node: AstNode): SymbolInfo[] {
     node.walk(createVisitor({
         FunctionStatement: (statement) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Function, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Function, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         ClassStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Class, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Class, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         FieldStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Field, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Field, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         MethodStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Method, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Method, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         InterfaceStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Interface, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Interface, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         InterfaceFieldStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Field, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Field, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         InterfaceMethodStatement: (statement, parent) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Method, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Method, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         ConstStatement: (statement) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Constant, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Constant, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         NamespaceStatement: (statement) => {
             if (statement.nameExpression) {
-                addSymbol(statement, statement.getNameParts().pop().text, SymbolKind.Namespace, statement.range, statement.nameExpression.range);
+                addSymbol(statement, statement.getNameParts().pop().text, SymbolKind.Namespace, statement.location?.range, statement.nameExpression.location?.range);
             }
         },
         EnumStatement: (statement) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.Enum, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.Enum, statement.location?.range, statement.tokens.name.location?.range);
             }
         },
         EnumMemberStatement: (statement) => {
             if (statement.tokens.name?.text) {
-                addSymbol(statement, statement.tokens.name.text, SymbolKind.EnumMember, statement.range, statement.tokens.name.range);
+                addSymbol(statement, statement.tokens.name.text, SymbolKind.EnumMember, statement.location?.range, statement.tokens.name.location?.range);
             }
         }
     }), {

--- a/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
@@ -124,7 +124,7 @@ export class BrsFilePreTranspileProcessor {
             return;
         }
 
-        let containingNamespace = this.event.file.getNamespaceStatementForPosition(expression.range.start)?.getName(ParseMode.BrighterScript);
+        let containingNamespace = this.event.file.getNamespaceStatementForPosition(expression.location?.range.start)?.getName(ParseMode.BrighterScript);
 
         const parts = util.splitExpression(expression);
         const processedNames: string[] = [];

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -7,7 +7,7 @@ import type { BrsFile } from '../../files/BrsFile';
 import type { BsDiagnostic, CallableContainer, ExtraSymbolData, FileReference, GetTypeOptions, OnScopeValidateEvent, TypeChainEntry, TypeChainProcessResult, TypeCompatibilityData } from '../../interfaces';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import type { AssignmentStatement, AugmentedAssignmentStatement, ClassStatement, DottedSetStatement, IncrementStatement, NamespaceStatement, ReturnStatement } from '../../parser/Statement';
-import util from '../../util';
+import { util } from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
 import type { Token } from '../../lexer/Token';
@@ -453,7 +453,7 @@ export class ScopeValidator {
             this.addMultiScopeDiagnostic({
                 file: file as BscFile,
                 ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
-                range: typeChainScan?.range
+                range: typeChainScan?.location?.range
             });
             return;
         }
@@ -708,13 +708,13 @@ export class ScopeValidator {
                         this.addMultiScopeDiagnostic({
                             file: file as BscFile,
                             ...DiagnosticMessages.cannotFindFunction(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
-                            range: typeChainScan?.range
+                            range: typeChainScan?.location?.range
                         });
                     } else {
                         this.addMultiScopeDiagnostic({
                             file: file as BscFile,
                             ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
-                            range: typeChainScan?.range
+                            range: typeChainScan?.location?.range
                         });
                     }
                 }
@@ -725,13 +725,13 @@ export class ScopeValidator {
                     this.addMultiScopeDiagnostic({
                         file: file as BscFile,
                         ...DiagnosticMessages.cannotFindFunction(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
-                        range: typeChainScan?.range
+                        range: typeChainScan?.location?.range
                     });
                 } else {
                     this.addMultiScopeDiagnostic({
                         file: file as BscFile,
                         ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
-                        range: typeChainScan?.range
+                        range: typeChainScan?.location?.range
                     });
                 }
 
@@ -784,7 +784,7 @@ export class ScopeValidator {
                 this.addMultiScopeDiagnostic({
                     file: file,
                     ...DiagnosticMessages.unknownEnumValue(lastTypeInfo?.name, typeChainScanForParent.fullChainName),
-                    range: lastTypeInfo?.range,
+                    range: lastTypeInfo?.location?.range,
                     relatedInformation: [{
                         message: 'Enum declared here',
                         location: util.createLocationFromRange(

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -787,7 +787,7 @@ export class ScopeValidator {
                     range: lastTypeInfo?.range,
                     relatedInformation: [{
                         message: 'Enum declared here',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(enumFileLink?.file.srcPath).toString(),
                             enumFileLink?.item?.tokens.name.range
                         )
@@ -967,7 +967,7 @@ export class ScopeValidator {
                         if (ownCallable.callable.nameRange !== callable.nameRange) {
                             related.push({
                                 message: `Function declared here`,
-                                location: util.createLocation(
+                                location: util.createLocationFromRange(
                                     URI.file(ownCallable.callable.file?.srcPath).toString(),
                                     thatNameRange
                                 )
@@ -1095,7 +1095,7 @@ export class ScopeValidator {
                     file: file,
                     relatedInformation: [{
                         message: 'Function declared here',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(callable[0].callable.file.srcPath).toString(),
                             callable[0].callable.nameRange
                         )
@@ -1108,7 +1108,7 @@ export class ScopeValidator {
                     file: file,
                     relatedInformation: [{
                         message: 'Function declared here',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(callable[0].callable.file.srcPath).toString(),
                             callable[0].callable.nameRange
                         )
@@ -1125,7 +1125,7 @@ export class ScopeValidator {
                     file: file,
                     relatedInformation: [{
                         message: 'Class declared here',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(classStmtLink.file.srcPath).toString(),
                             classStmtLink?.item.tokens.name.range
                         )
@@ -1152,7 +1152,7 @@ export class ScopeValidator {
                         range: param.tokens.name.range,
                         relatedInformation: [{
                             message: 'Namespace declared here',
-                            location: util.createLocation(
+                            location: util.createLocationFromRange(
                                 URI.file(namespace.file.srcPath).toString(),
                                 namespace.nameRange
                             )
@@ -1174,7 +1174,7 @@ export class ScopeValidator {
                     range: assignment.tokens.name.range,
                     relatedInformation: [{
                         message: 'Namespace declared here',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             URI.file(namespace.file.srcPath).toString(),
                             namespace.nameRange
                         )

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -14,7 +14,7 @@ import type { Token } from '../../lexer/Token';
 import { AstNodeKind } from '../../parser/AstNode';
 import type { AstNode } from '../../parser/AstNode';
 import type { Expression } from '../../parser/AstNode';
-import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression } from '../../parser/Expression';
+import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression } from '../../parser/Expression';
 import { CallExpression } from '../../parser/Expression';
 import { createVisitor } from '../../astUtils/visitors';
 import type { BscType } from '../../types/BscType';
@@ -263,7 +263,7 @@ export class ScopeValidator {
         if (callName !== 'createobject' || !isLiteralExpression(call?.args[0])) {
             return;
         }
-        const firstParamToken = (call?.args[0] as any)?.tokens?.value;
+        const firstParamToken = (call?.args[0] as LiteralExpression)?.tokens?.value;
         const firstParamStringValue = firstParamToken?.text?.replace(/"/g, '');
         if (!firstParamStringValue) {
             return;
@@ -272,7 +272,7 @@ export class ScopeValidator {
 
         //if this is a `createObject('roSGNode'` call, only support known sg node types
         if (firstParamStringValueLower === 'rosgnode' && isLiteralExpression(call?.args[1])) {
-            const componentName: Token = (call?.args[1] as any)?.tokens.value;
+            const componentName: Token = call?.args[1]?.tokens.value;
             //don't validate any components with a colon in their name (probably component libraries, but regular components can have them too).
             if (!componentName || componentName?.text?.includes(':')) {
                 return;
@@ -297,7 +297,7 @@ export class ScopeValidator {
             this.addDiagnostic({
                 file: file as BscFile,
                 ...DiagnosticMessages.unknownBrightScriptComponent(firstParamStringValue),
-                range: firstParamToken.location?.location?.range
+                range: firstParamToken.location?.range
             });
         } else {
             // This is valid brightscript component

--- a/src/bscPlugin/validation/XmlFileValidator.ts
+++ b/src/bscPlugin/validation/XmlFileValidator.ts
@@ -25,7 +25,7 @@ export class XmlFileValidator {
             //not a SG component
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingComponentDeclaration(),
-                range: rootElement.range,
+                range: rootElement.location?.range,
                 file: this.event.file
             });
             return;
@@ -35,14 +35,14 @@ export class XmlFileValidator {
         if (!componentElement.name) {
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingNameAttribute(),
-                range: componentElement.tokens.startTagName.range,
+                range: componentElement.tokens.startTagName.location?.range,
                 file: this.event.file
             });
         }
         if (!componentElement.extends) {
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingExtendsAttribute(),
-                range: componentElement.tokens.startTagName.range,
+                range: componentElement.tokens.startTagName.location?.range,
                 file: this.event.file
             });
         }

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1961,7 +1961,7 @@ describe('BrsFile', () => {
             function doTest(source: string, expected = source) {
                 const file = program.setFile<BrsFile>('source/main.bs', '');
                 //override the parser with our locationless parser
-                file['_parser'] = Parser.parse(source, { mode: ParseMode.BrighterScript, trackLocations: false });
+                file['_parser'] = Parser.parse(source, { mode: ParseMode.BrighterScript, trackLocations: false, srcPath: s`${rootDir}/source/main.brs` });
                 program.getScopesForFile(file).forEach(x => x['cache'].clear());
                 program.validate();
                 expectZeroDiagnostics(program);
@@ -2562,13 +2562,13 @@ describe('BrsFile', () => {
             await SourceMapConsumer.with(result.map.toString(), null, (consumer) => {
                 let tokenResult = tokens.map(token => ({
                     kind: token.kind,
-                    start: token.range.start
+                    start: token.location?.range.start
                 }));
                 let sourcemapResult = tokens.map(token => {
                     let originalPosition = consumer.originalPositionFor({
                         //convert token 0-based line to source-map 1-based line for the lookup
-                        line: token.range.start.line + 1,
-                        column: token.range.start.character
+                        line: token.location?.range.start.line + 1,
+                        column: token.location?.range.start.character
                     });
                     return {
                         kind: token.kind,

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -749,7 +749,7 @@ export class BrsFile implements BscFile {
      * Returns false if no namespace was found with that name
      */
     public calleeStartsWithNamespace(callee: Expression) {
-        let left = callee as any;
+        let left = callee as AstNode;
         while (isDottedGetExpression(left)) {
             left = left.obj;
         }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -876,12 +876,12 @@ export class BrsFile implements BscFile {
         //get class fields and members
         const statementHandler = (statement: MethodStatement) => {
             if (statement.getName(file.parseMode).toLowerCase() === textToSearchFor) {
-                results.push(util.createLocation(util.pathToUri(file.srcPath), statement.range));
+                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.range));
             }
         };
         const fieldStatementHandler = (statement: FieldStatement) => {
             if (statement.tokens.name.text.toLowerCase() === textToSearchFor) {
-                results.push(util.createLocation(util.pathToUri(file.srcPath), statement.range));
+                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.range));
             }
         };
         file.parser.ast.walk(createVisitor({

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -360,7 +360,8 @@ export class BrsFile implements BscFile {
             //tokenize the input file
             let lexer = this.program.logger.time('debug', ['lexer.lex', chalk.green(this.srcPath)], () => {
                 return Lexer.scan(fileContents, {
-                    includeWhitespace: false
+                    includeWhitespace: false,
+                    srcPath: this.srcPath
                 });
             });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -187,7 +187,7 @@ export class BrsFile implements BscFile {
                 //register import statements
                 if (isImportStatement(statement) && statement.tokens.path) {
                     result.push({
-                        filePathRange: statement.tokens.path.range,
+                        filePathRange: statement.tokens.path.location?.range,
                         destPath: util.getPkgPathFromTarget(this.destPath, statement.filePath),
                         sourceFile: this,
                         text: statement.tokens.path.text
@@ -226,7 +226,7 @@ export class BrsFile implements BscFile {
      */
     public getTokenAt(position: Position) {
         for (let token of this.parser.tokens) {
-            if (util.rangeContains(token.range, position)) {
+            if (util.rangeContains(token.location?.range, position)) {
                 return token;
             }
         }
@@ -237,7 +237,7 @@ export class BrsFile implements BscFile {
      */
     public getCurrentOrNextTokenAt(position: Position) {
         for (let token of this.parser.tokens) {
-            if (util.comparePositionToRange(position, token.range) < 0) {
+            if (util.comparePositionToRange(position, token.location?.range) < 0) {
                 return token;
             }
         }
@@ -252,7 +252,7 @@ export class BrsFile implements BscFile {
         this.ast.walk((node) => {
             const latestContainer = containingNode;
             //bsc walks depth-first
-            if (util.rangeContains(node.range, position)) {
+            if (util.rangeContains(node.location?.range, position)) {
                 containingNode = node;
             }
             //we had a match before, and don't now. this means we've finished walking down the whole way, and found our match
@@ -368,6 +368,7 @@ export class BrsFile implements BscFile {
 
             this.program.logger.time(LogLevel.debug, ['parser.parse', chalk.green(this.srcPath)], () => {
                 this._parser = Parser.parse(lexer.tokens, {
+                    srcPath: this.srcPath,
                     mode: this.parseMode,
                     logger: this.program.logger,
                     bsConsts: getBsConst(this.program.getManifest())
@@ -449,7 +450,7 @@ export class BrsFile implements BscFile {
         for (let lexerToken of tokens) {
             for (let triviaToken of lexerToken.leadingTrivia ?? []) {
                 if (triviaToken.kind === TokenKind.Comment) {
-                    processor.tryAdd(triviaToken.text, triviaToken.range);
+                    processor.tryAdd(triviaToken.text, triviaToken.location?.range);
                 }
             }
         }
@@ -489,8 +490,8 @@ export class BrsFile implements BscFile {
             //add every parameter
             for (let param of func.parameters) {
                 scope.variableDeclarations.push({
-                    nameRange: param.tokens.name.range,
-                    lineIndex: param.tokens.name.range?.start.line,
+                    nameRange: param.tokens.name.location?.range,
+                    lineIndex: param.tokens.name.location?.range?.start.line,
                     name: param.tokens.name.text,
                     getType: () => {
                         return param.getType({ flags: SymbolTypeFlag.typetime });
@@ -502,8 +503,8 @@ export class BrsFile implements BscFile {
             func.body?.walk(createVisitor({
                 ForEachStatement: (stmt) => {
                     scope.variableDeclarations.push({
-                        nameRange: stmt.tokens.item.range,
-                        lineIndex: stmt.tokens.item.range?.start.line,
+                        nameRange: stmt.tokens.item.location?.range,
+                        lineIndex: stmt.tokens.item.location?.range?.start.line,
                         name: stmt.tokens.item.text,
                         getType: () => DynamicType.instance //TODO: Infer types from array
                     });
@@ -511,8 +512,8 @@ export class BrsFile implements BscFile {
                 LabelStatement: (stmt) => {
                     const { name: identifier } = stmt.tokens;
                     scope.labelStatements.push({
-                        nameRange: identifier.range,
-                        lineIndex: identifier.range?.start.line,
+                        nameRange: identifier.location?.range,
+                        lineIndex: identifier.location?.range?.start.line,
                         name: identifier.text
                     });
                 }
@@ -540,8 +541,8 @@ export class BrsFile implements BscFile {
             if (scope) {
                 const variableName = statement.tokens.name;
                 scope.variableDeclarations.push({
-                    nameRange: variableName.range,
-                    lineIndex: variableName.range?.start.line,
+                    nameRange: variableName.location?.range,
+                    lineIndex: variableName.location?.range?.start.line,
                     name: variableName.text,
                     getType: () => {
                         return statement.getType({ flags: SymbolTypeFlag.runtime });
@@ -582,10 +583,10 @@ export class BrsFile implements BscFile {
                 callables.push({
                     isSub: statement.func.tokens.functionType?.text.toLowerCase() === 'sub',
                     name: statement.tokens.name?.text,
-                    nameRange: statement.tokens.name?.range,
+                    nameRange: statement.tokens.name?.location?.range,
                     file: this,
                     params: params,
-                    range: statement.func.range,
+                    range: statement.func.location?.range,
                     type: funcType,
                     getName: statement.getName.bind(statement),
                     hasNamespace: !!statement.findAncestor<NamespaceStatement>(isNamespaceStatement),
@@ -633,7 +634,7 @@ export class BrsFile implements BscFile {
         if (position) {
             return this.cache.getOrAdd(`namespaceStatementForPosition-${position.line}:${position.character}`, () => {
                 for (const statement of this._cachedLookups.namespaceStatements) {
-                    if (util.rangeContains(statement.range, position)) {
+                    if (util.rangeContains(statement.location?.range, position)) {
                         return statement;
                     }
                 }
@@ -821,11 +822,11 @@ export class BrsFile implements BscFile {
         let tokens = this.parser.tokens;
         for (let i = 0; i < tokens.length; i++) {
             let token = tokens[i];
-            if (util.rangeContains(token.range, position)) {
+            if (util.rangeContains(token.location?.range, position)) {
                 return token;
             }
             //if the position less than this token range, then this position touches no token,
-            if (util.positionIsGreaterThanRange(position, token.range) === false) {
+            if (util.positionIsGreaterThanRange(position, token.location?.range) === false) {
                 let t = tokens[i - 1];
                 //return the token or the first token
                 return t ? t : tokens[0];
@@ -876,12 +877,12 @@ export class BrsFile implements BscFile {
         //get class fields and members
         const statementHandler = (statement: MethodStatement) => {
             if (statement.getName(file.parseMode).toLowerCase() === textToSearchFor) {
-                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.range));
+                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.location?.range));
             }
         };
         const fieldStatementHandler = (statement: FieldStatement) => {
             if (statement.tokens.name.text.toLowerCase() === textToSearchFor) {
-                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.range));
+                results.push(util.createLocationFromRange(util.pathToUri(file.srcPath), statement.location?.range));
             }
         };
         file.parser.ast.walk(createVisitor({
@@ -968,7 +969,7 @@ export class BrsFile implements BscFile {
             const astTranspile = this.ast.transpile(state);
             const trailingComments = [];
             if (util.hasLeadingComments(this.parser.eofToken)) {
-                if (util.isLeadingCommentOnSameLine(this.ast.statements[this.ast.statements.length - 1], this.parser.eofToken)) {
+                if (util.isLeadingCommentOnSameLine(this.ast.statements[this.ast.statements.length - 1]?.location, this.parser.eofToken)) {
                     trailingComments.push(' ');
                 } else {
                     trailingComments.push('\n');
@@ -1305,7 +1306,7 @@ export class BrsFile implements BscFile {
                         fullNameLower: lowerLoopName,
                         parentNameLower: parentNameLower,
                         nameParts: nameParts.slice(0, i),
-                        nameRange: namespaceStatement.nameExpression.range,
+                        nameRange: namespaceStatement.nameExpression.location?.range,
                         lastPartName: part.text,
                         lastPartNameLower: lowerPartName,
                         functionStatements: new Map(),

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -464,7 +464,7 @@ describe('XmlFile', () => {
                     </component>
                 `
             );
-            expect(file.parentComponentName.range).to.eql(Range.create(1, 38, 1, 47));
+            expect(file.parentComponentName.location?.range).to.eql(Range.create(1, 38, 1, 47));
         });
 
         it('works for multi-line', () => {
@@ -480,7 +480,7 @@ describe('XmlFile', () => {
                     </component>
                 `
             );
-            expect(file.parentComponentName.range).to.eql(Range.create(2, 13, 2, 22));
+            expect(file.parentComponentName.location?.range).to.eql(Range.create(2, 13, 2, 22));
         });
 
         it('does not throw when unable to find extends', () => {

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -255,7 +255,10 @@ export class XmlFile implements BscFile {
     public parse(fileContents: string) {
         this.fileContents = fileContents;
 
-        this.parser.parse(this.destPath, fileContents);
+        this.parser.parse(fileContents, {
+            srcPath: this.srcPath,
+            destPath: this.destPath
+        });
         const diagnostics = this.parser.diagnostics.map(diagnostic => ({
             ...diagnostic,
             file: this

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -9,7 +9,7 @@ import { IntegerType } from './types/IntegerType';
 import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';
 import { VoidType } from './types/VoidType';
-import util from './util';
+import { util } from './util';
 import { UnionType } from './types/UnionType';
 
 export let globalFile = new BrsFile({ srcPath: 'global', destPath: 'global', program: null });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -949,7 +949,7 @@ export class TypeChainEntry {
     }
 
     get range() {
-        return this._range ?? this.astNode?.range;
+        return this._range ?? this.astNode?.location?.range;
     }
 
     public readonly name: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -934,7 +934,7 @@ export class TypeChainEntry {
         name: string;
         type: BscType;
         data: ExtraSymbolData;
-        range?: Range;
+        location?: Location;
         separatorToken?: Token;
         astNode: AstNode;
     }) {
@@ -942,20 +942,20 @@ export class TypeChainEntry {
         // make a copy of this data
         this.data = { ...options.data };
         this.type = options.type;
-        this._range = options.range;
+        this._location = options.location;
         this.separatorToken = options.separatorToken ?? createToken(TokenKind.Dot);
         this.astNode = options.astNode;
         this.isResolved = this.type?.isResolvable();
     }
 
-    get range() {
-        return this._range ?? this.astNode?.location?.range;
+    get location(): Location {
+        return this._location ?? this.astNode?.location;
     }
 
     public readonly name: string;
     public readonly type: BscType;
     public readonly data: ExtraSymbolData;
-    private readonly _range: Range;
+    private readonly _location: Location;
     public readonly separatorToken: Token;
     public isResolved: boolean;
     public astNode: AstNode;
@@ -989,7 +989,7 @@ export interface TypeChainProcessResult {
     /**
      * the range of the first unresolved item
      */
-    range: Range;
+    location: Location;
     /**
      * Does the chain contain a dynamic type?
      */

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -169,12 +169,12 @@ describe('lexer', () => {
 
     it('computes range properly both with and without whitespace', () => {
         let withoutWhitespace = Lexer.scan(`sub Main()\n    bob = true\nend sub`).tokens
-            .map(x => rangeToArray(x.range));
+            .map(x => rangeToArray(x.location?.range));
 
         let withWhitespace = Lexer.scan(`sub Main()\n    bob = true\nend sub`).tokens
             //filter out the whitespace...we only care that it was computed during the scan
             .filter(x => x.kind !== TokenKind.Whitespace)
-            .map(x => rangeToArray(x.range));
+            .map(x => rangeToArray(x.location?.range));
 
         /*eslint-disable */
         let expectedLocations = [
@@ -278,7 +278,7 @@ describe('lexer', () => {
                 end sub
             `, {
                 includeWhitespace: true
-            }).tokens.map(x => [...rangeToArray(x.range), x.text]);
+            }).tokens.map(x => [...rangeToArray(x.location?.range), x.text]);
 
             expect(tokens).to.eql([
                 [0, 0, 0, 1, '\n'],
@@ -316,7 +316,7 @@ describe('lexer', () => {
                 //ignore the Eof token
                 .filter(x => x.kind !== TokenKind.Eof);
 
-            expect(tokens.map(x => x.range)).to.eql([
+            expect(tokens.map(x => x.location?.range)).to.eql([
                 Range.create(0, 0, 0, 3), // sub
                 Range.create(0, 3, 0, 4), // \n
                 Range.create(1, 0, 1, 3), // sub
@@ -722,7 +722,7 @@ describe('lexer', () => {
             );
             expect(tokens.map(x => {
                 return {
-                    range: x.range,
+                    range: x.location?.range,
                     kind: x.kind
                 };
             })).to.eql([
@@ -1162,7 +1162,7 @@ describe('lexer', () => {
     describe('location tracking', () => {
         it('tracks starting and ending locations including whitespace', () => {
             let { tokens } = Lexer.scan(`sub foo()\n    print "bar"\r\nend sub`, { includeWhitespace: true });
-            expect(tokens.map(t => t.range)).to.eql([
+            expect(tokens.map(t => t.location?.range)).to.eql([
                 Range.create(0, 0, 0, 3), // sub
                 Range.create(0, 3, 0, 4), // <space>
                 Range.create(0, 4, 0, 7), // foo
@@ -1181,7 +1181,7 @@ describe('lexer', () => {
 
         it('tracks starting and ending locations excluding whitespace', () => {
             let { tokens } = Lexer.scan(`sub foo()\n    print "bar"\r\nend sub`, { includeWhitespace: false });
-            expect(tokens.map(t => t.range)).to.eql([
+            expect(tokens.map(t => t.location?.range)).to.eql([
                 Range.create(0, 0, 0, 3), // sub
                 Range.create(0, 4, 0, 7), // foo
                 Range.create(0, 7, 0, 8), // (
@@ -1226,7 +1226,7 @@ describe('lexer', () => {
         ]);
 
         //verify the location of `rem`
-        expect(tokens.map(t => [t.range.start.character, t.range.end.character])).to.eql([
+        expect(tokens.map(t => [t.location?.range.start.character, t.location?.range.end.character])).to.eql([
             [0, 6], // person
             [6, 7], // .
             [7, 10], // rem

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -2,7 +2,7 @@
 import { TokenKind, ReservedWords, Keywords, PreceedingRegexTypes, AllowedTriviaTokens } from './TokenKind';
 import type { Token } from './Token';
 import { isAlpha, isDecimalDigit, isAlphaNumeric, isHexDigit } from './Characters';
-import type { Range, Diagnostic } from 'vscode-languageserver';
+import type { Location, Range, Diagnostic } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import util from '../util';
 
@@ -107,8 +107,8 @@ export class Lexer {
             kind: TokenKind.Eof,
             isReserved: false,
             text: '',
-            range: this.options.trackLocations
-                ? util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
+            location: this.options.trackLocations
+                ? util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1, this.options.srcPath)
                 : undefined,
             leadingWhitespace: this.leadingWhitespace,
             leadingTrivia: this.leadingTrivia
@@ -1067,7 +1067,7 @@ export class Lexer {
             kind: kind,
             text: text,
             isReserved: ReservedWords.has(text.toLowerCase()),
-            range: this.rangeOf(),
+            location: this.locationOf(),
             leadingWhitespace: this.leadingWhitespace,
             leadingTrivia: []
         };
@@ -1095,13 +1095,21 @@ export class Lexer {
         this.columnBegin = this.columnEnd;
     }
 
+    private rangeOf(): Range {
+        if (this.options.trackLocations) {
+            return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
+        } else {
+            return undefined;
+        }
+    }
+
     /**
      * Creates a `Range` at the lexer's current position
      * @returns the range of `text`
      */
-    private rangeOf(): Range {
+    private locationOf(): Location {
         if (this.options.trackLocations) {
-            return util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd);
+            return util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd, this.options?.srcPath);
         } else {
             return undefined;
         }
@@ -1119,4 +1127,8 @@ export interface ScanOptions {
      * @default true
      */
     trackLocations?: boolean;
+    /**
+     * Path to the file where this source code originated
+     */
+    srcPath?: string;
 }

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -68,6 +68,11 @@ export class Lexer {
     private leadingTrivia: Token[] = [];
 
     /**
+     * URI of the file being scanned (if available)
+     */
+    private uri?: string;
+
+    /**
      * A convenience function, equivalent to `new Lexer().scan(toScan)`, that converts a string
      * containing BrightScript code to an array of `Token` objects that will later be used to build
      * an abstract syntax tree.
@@ -99,6 +104,7 @@ export class Lexer {
         this.columnEnd = 0;
         this.tokens = [];
         this.diagnostics = [];
+        this.uri = util.pathToUri(options?.srcPath);
         while (!this.isAtEnd()) {
             this.scanToken();
         }
@@ -108,7 +114,7 @@ export class Lexer {
             isReserved: false,
             text: '',
             location: this.options.trackLocations
-                ? util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1, this.options.srcPath)
+                ? util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1, this.uri)
                 : undefined,
             leadingWhitespace: this.leadingWhitespace,
             leadingTrivia: this.leadingTrivia
@@ -1109,7 +1115,7 @@ export class Lexer {
      */
     private locationOf(): Location {
         if (this.options.trackLocations) {
-            return util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd, this.options?.srcPath);
+            return util.createLocation(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd, this.uri);
         } else {
             return undefined;
         }

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -38,7 +38,6 @@ export interface Token {
  */
 export interface Locatable {
     location: Location;
-    [key: string]: any;
 }
 
 /**

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -1,18 +1,27 @@
 import { TokenKind } from './TokenKind';
-import type { Range } from 'vscode-languageserver';
+import type { Location } from 'vscode-languageserver';
 
 /**
  * Represents a chunk of BrightScript scanned by the lexer.
  */
 export interface Token {
-    /** The type of token this represents. */
+    /**
+     * The type of token this represents.
+     */
     kind: TokenKind;
-    /** The text found in the original BrightScript source, if any. */
+    /**
+     * The text found in the original BrightScript source, if any.
+     */
     text: string;
-    /** True if this token's `text` is a reserved word, otherwise `false`. */
+    /**
+     * True if this token's `text` is a reserved word, otherwise `false`.
+     *
+     */
     isReserved?: boolean;
-    /** Where the token was found. */
-    range: Range;
+    /**
+     * Where the token was found.
+     */
+    location: Location;
     /**
      * Any leading whitespace found prior to this token. Excludes newline characters.
      */
@@ -28,7 +37,7 @@ export interface Token {
  * Any object that has a range
  */
 export interface Locatable {
-    range: Range;
+    location: Location;
     [key: string]: any;
 }
 

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -1,6 +1,6 @@
 import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
-import type { Position, Range } from 'vscode-languageserver';
+import type { Location, Position } from 'vscode-languageserver';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { InternalWalkMode } from '../astUtils/visitors';
 import type { SymbolTable } from '../SymbolTable';
@@ -20,7 +20,7 @@ export abstract class AstNode {
     /**
      *  The starting and ending location of the node.
      */
-    public abstract range?: Range | undefined;
+    public abstract location?: Location | undefined;
 
     public abstract transpile(state: BrsTranspileState): TranspileResult;
 
@@ -136,7 +136,7 @@ export abstract class AstNode {
     public findChildAtPosition<TNodeType extends AstNode = AstNode>(position: Position, options?: WalkOptions): TNodeType | undefined {
         return this.findChild<TNodeType>((node) => {
             //if the current node includes this range, keep that node
-            if (util.rangeContains(node.range, position)) {
+            if (util.rangeContains(node?.location.range, position)) {
                 return node.findChildAtPosition(position, options) ?? node;
             }
         }, options);

--- a/src/parser/BrsTranspileState.ts
+++ b/src/parser/BrsTranspileState.ts
@@ -1,4 +1,4 @@
-import type { Range } from 'vscode-languageserver';
+import type { Location } from 'vscode-languageserver';
 import { Editor } from '../astUtils/Editor';
 import type { BrsFile } from '../files/BrsFile';
 import type { ClassStatement, ConditionalCompileStatement } from './Statement';
@@ -22,7 +22,7 @@ export class BrsTranspileState extends TranspileState {
      * Used to assist blocks in knowing when to add a comment statement to the same line as the first line of the parent
      */
     lineage = [] as Array<{
-        range?: Range;
+        location?: Location;
     }>;
 
     /**

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -581,7 +581,7 @@ export class DottedGetExpression extends Expression {
             name: this.tokens.name?.text,
             type: result,
             data: options.data,
-            range: this.tokens.name?.location?.range ?? this.location?.range,
+            location: this.tokens.name?.location ?? this.location,
             astNode: this
         }));
         if (result ||
@@ -1503,7 +1503,7 @@ export class CallfuncExpression extends Expression {
                     name: this.tokens.methodName.text,
                     type: funcType,
                     data: options.data,
-                    range: this.tokens.methodName.location?.range,
+                    location: this.tokens.methodName.location,
                     separatorToken: createToken(TokenKind.Callfunc),
                     astNode: this
                 }));

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -31,6 +31,7 @@ import { createToken } from '../astUtils/creators';
 import { TypedFunctionType } from '../types';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { FunctionType } from '../types/FunctionType';
+import type { BaseFunctionType } from '../types/BaseFunctionType';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -191,8 +192,8 @@ export class CallExpression extends Expression {
         if (isCallableType(calleeType) && (!isReferenceType(calleeType.returnType) || calleeType.returnType?.isResolvable())) {
             return calleeType.returnType;
         }
-        if (!isReferenceType(calleeType) && (calleeType as any)?.returnType?.isResolvable()) {
-            return (calleeType as any).returnType;
+        if (!isReferenceType(calleeType) && (calleeType as BaseFunctionType)?.returnType?.isResolvable()) {
+            return (calleeType as BaseFunctionType).returnType;
         }
         return new TypePropertyReferenceType(calleeType, 'returnType');
     }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -2,7 +2,7 @@
 import type { Token, Identifier } from '../lexer/Token';
 import { TokenKind } from '../lexer/TokenKind';
 import type { Block, FunctionStatement, NamespaceStatement } from './Statement';
-import type { Range } from 'vscode-languageserver';
+import type { Location } from 'vscode-languageserver';
 import util from '../util';
 import type { BrsTranspileState } from './BrsTranspileState';
 import { ParseMode } from './Parser';
@@ -46,7 +46,7 @@ export class BinaryExpression extends Expression {
         };
         this.left = options.left;
         this.right = options.right;
-        this.range = util.createBoundingRange(this.left, this.tokens.operator, this.right);
+        this.location = util.createBoundingLocation(this.left, this.tokens.operator, this.right);
     }
     readonly tokens: {
         readonly operator: Token;
@@ -57,7 +57,7 @@ export class BinaryExpression extends Expression {
 
     public readonly kind = AstNodeKind.BinaryExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState): TranspileResult {
         return [
@@ -123,7 +123,7 @@ export class CallExpression extends Expression {
         };
         this.callee = options.callee;
         this.args = options.args ?? [];
-        this.range = util.createBoundingRange(this.callee, this.tokens.openingParen, ...this.args, this.tokens.closingParen);
+        this.location = util.createBoundingLocation(this.callee, this.tokens.openingParen, ...this.args, this.tokens.closingParen);
     }
 
     readonly callee: Expression;
@@ -138,7 +138,7 @@ export class CallExpression extends Expression {
 
     public readonly kind = AstNodeKind.CallExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState, nameOverride?: string) {
         let result: TranspileResult = [];
@@ -267,8 +267,8 @@ export class FunctionExpression extends Expression implements TypedefProvider {
      * The range of the function, starting at the 'f' in function or 's' in sub (or the open paren if the keyword is missing),
      * and ending with the last n' in 'end function' or 'b' in 'end sub'
      */
-    public get range() {
-        return util.createBoundingRange(
+    public get location(): Location {
+        return util.createBoundingLocation(
             this.tokens.functionType,
             this.tokens.leftParen,
             ...this.parameters,
@@ -453,8 +453,8 @@ export class FunctionParameterExpression extends Expression {
         return paramType;
     }
 
-    public get range(): Range | undefined {
-        return util.createBoundingRange(
+    public get location(): Location | undefined {
+        return util.createBoundingLocation(
             this.tokens.name,
             this.tokens.as,
             this.typeExpression,
@@ -535,7 +535,7 @@ export class DottedGetExpression extends Expression {
         };
         this.obj = options.obj;
 
-        this.range = util.createBoundingRange(this.obj, this.tokens.dot, this.tokens.name);
+        this.location = util.createBoundingLocation(this.obj, this.tokens.dot, this.tokens.name);
     }
 
     readonly tokens: {
@@ -546,7 +546,7 @@ export class DottedGetExpression extends Expression {
 
     public readonly kind = AstNodeKind.DottedGetExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         //if the callee starts with a namespace name, transpile the name
@@ -581,7 +581,7 @@ export class DottedGetExpression extends Expression {
             name: this.tokens.name?.text,
             type: result,
             data: options.data,
-            range: this.tokens.name?.range ?? this.range,
+            range: this.tokens.name?.location?.range ?? this.location?.range,
             astNode: this
         }));
         if (result ||
@@ -617,7 +617,7 @@ export class XmlAttributeGetExpression extends Expression {
         super();
         this.obj = options.obj;
         this.tokens = { at: options.at, name: options.name };
-        this.range = util.createBoundingRange(this.obj, this.tokens.at, this.tokens.name);
+        this.location = util.createBoundingLocation(this.obj, this.tokens.at, this.tokens.name);
     }
 
     public readonly kind = AstNodeKind.XmlAttributeGetExpression;
@@ -629,7 +629,7 @@ export class XmlAttributeGetExpression extends Expression {
 
     public readonly obj: Expression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         return [
@@ -669,7 +669,7 @@ export class IndexedGetExpression extends Expression {
         };
         this.obj = options.obj;
         this.indexes = options.indexes;
-        this.range = util.createBoundingRange(this.obj, this.tokens.openingSquare, this.tokens.questionDot, this.tokens.openingSquare, ...this.indexes, this.tokens.closingSquare);
+        this.location = util.createBoundingLocation(this.obj, this.tokens.openingSquare, this.tokens.questionDot, this.tokens.openingSquare, ...this.indexes, this.tokens.closingSquare);
     }
 
     public readonly kind = AstNodeKind.IndexedGetExpression;
@@ -686,7 +686,7 @@ export class IndexedGetExpression extends Expression {
         readonly questionDot?: Token; //  ? or ?.
     };
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         const result = [];
@@ -744,7 +744,7 @@ export class GroupingExpression extends Expression {
             leftParen: options.leftParen
         };
         this.expression = options.expression;
-        this.range = util.createBoundingRange(this.tokens.leftParen, this.expression, this.tokens.rightParen);
+        this.location = util.createBoundingLocation(this.tokens.leftParen, this.expression, this.tokens.rightParen);
     }
 
     public readonly tokens: {
@@ -755,7 +755,7 @@ export class GroupingExpression extends Expression {
 
     public readonly kind = AstNodeKind.GroupingExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         if (isTypecastExpression(this.expression)) {
@@ -799,8 +799,8 @@ export class LiteralExpression extends Expression {
 
     public readonly kind = AstNodeKind.LiteralExpression;
 
-    public get range() {
-        return this.tokens.value.range;
+    public get location() {
+        return this.tokens.value.location;
     }
 
     public getType(options?: GetTypeOptions) {
@@ -847,7 +847,7 @@ export class EscapedCharCodeLiteralExpression extends Expression {
     }) {
         super();
         this.tokens = { value: options.value };
-        this.range = this.tokens.value.range;
+        this.location = this.tokens.value.location;
     }
 
     public readonly kind = AstNodeKind.EscapedCharCodeLiteralExpression;
@@ -856,7 +856,7 @@ export class EscapedCharCodeLiteralExpression extends Expression {
         readonly value: Token & { charCode: number };
     };
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     transpile(state: BrsTranspileState) {
         return [
@@ -881,7 +881,7 @@ export class ArrayLiteralExpression extends Expression {
             close: options.close
         };
         this.elements = options.elements;
-        this.range = util.createBoundingRange(this.tokens.open, ...this.elements, this.tokens.close);
+        this.location = util.createBoundingLocation(this.tokens.open, ...this.elements, this.tokens.close);
     }
 
     public readonly elements: Array<Expression>;
@@ -893,7 +893,7 @@ export class ArrayLiteralExpression extends Expression {
 
     public readonly kind = AstNodeKind.ArrayLiteralExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         let result: TranspileResult = [];
@@ -961,12 +961,12 @@ export class AAMemberExpression extends Expression {
             comma: options.comma
         };
         this.value = options.value;
-        this.range = util.createBoundingRange(this.tokens.key, this.tokens.colon, this.value);
+        this.location = util.createBoundingLocation(this.tokens.key, this.tokens.colon, this.value);
     }
 
     public readonly kind = AstNodeKind.AAMemberExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public readonly tokens: {
         readonly key: Token;
@@ -1008,7 +1008,7 @@ export class AALiteralExpression extends Expression {
             close: options.close
         };
         this.elements = options.elements;
-        this.range = util.createBoundingRange(this.tokens.open, ...this.elements, this.tokens.close);
+        this.location = util.createBoundingLocation(this.tokens.open, ...this.elements, this.tokens.close);
     }
 
     public readonly elements: Array<AAMemberExpression>;
@@ -1019,7 +1019,7 @@ export class AALiteralExpression extends Expression {
 
     public readonly kind = AstNodeKind.AALiteralExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         let result: TranspileResult = [];
@@ -1110,12 +1110,12 @@ export class UnaryExpression extends Expression {
             operator: options.operator
         };
         this.right = options.right;
-        this.range = util.createBoundingRange(this.tokens.operator, this.right);
+        this.location = util.createBoundingLocation(this.tokens.operator, this.right);
     }
 
     public readonly kind = AstNodeKind.UnaryExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public readonly tokens: {
         readonly operator: Token;
@@ -1162,7 +1162,7 @@ export class VariableExpression extends Expression {
         this.tokens = {
             name: options.name
         };
-        this.range = this.tokens.name?.range;
+        this.location = this.tokens.name?.location;
     }
 
     public readonly tokens: {
@@ -1171,7 +1171,7 @@ export class VariableExpression extends Expression {
 
     public readonly kind = AstNodeKind.VariableExpression;
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     public getName(parseMode?: ParseMode) {
         return this.tokens.name.text;
@@ -1233,10 +1233,10 @@ export class SourceLiteralExpression extends Expression {
         this.tokens = {
             value: options.value
         };
-        this.range = this.tokens.value?.range;
+        this.location = this.tokens.value?.location;
     }
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     public readonly kind = AstNodeKind.SourceLiteralExpression;
 
@@ -1284,8 +1284,8 @@ export class SourceLiteralExpression extends Expression {
     private getClosestLineNumber() {
         let node: AstNode = this;
         while (node) {
-            if (node.range) {
-                return node.range.start.line + 1;
+            if (node.location?.range) {
+                return node.location.range.start.line + 1;
             }
             node = node.parent;
         }
@@ -1356,12 +1356,12 @@ export class NewExpression extends Expression {
             new: options.new
         };
         this.call = options.call;
-        this.range = util.createBoundingRange(this.tokens.new, this.call);
+        this.location = util.createBoundingLocation(this.tokens.new, this.call);
     }
 
     public readonly kind = AstNodeKind.NewExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public readonly tokens: {
         readonly new?: Token;
@@ -1430,7 +1430,7 @@ export class CallfuncExpression extends Expression {
         this.callee = options.callee;
         this.args = options.args ?? [];
 
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.callee,
             this.tokens.operator,
             this.tokens.methodName,
@@ -1452,7 +1452,7 @@ export class CallfuncExpression extends Expression {
 
     public readonly kind = AstNodeKind.CallfuncExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
@@ -1503,7 +1503,7 @@ export class CallfuncExpression extends Expression {
                     name: this.tokens.methodName.text,
                     type: funcType,
                     data: options.data,
-                    range: this.tokens.methodName.range,
+                    range: this.tokens.methodName.location?.range,
                     separatorToken: createToken(TokenKind.Callfunc),
                     astNode: this
                 }));
@@ -1541,7 +1541,7 @@ export class TemplateStringQuasiExpression extends Expression {
     }) {
         super();
         this.expressions = options.expressions;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             ...this.expressions
         );
     }
@@ -1549,7 +1549,7 @@ export class TemplateStringQuasiExpression extends Expression {
     public readonly expressions: Array<LiteralExpression | EscapedCharCodeLiteralExpression>;
     public readonly kind = AstNodeKind.TemplateStringQuasiExpression;
 
-    readonly range: Range | undefined;
+    readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState, skipEmptyStrings = true) {
         let result = [] as TranspileResult;
@@ -1590,7 +1590,7 @@ export class TemplateStringExpression extends Expression {
         };
         this.quasis = options.quasis;
         this.expressions = options.expressions;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.tokens.openingBacktick,
             this.quasis[0],
             this.quasis[this.quasis.length - 1],
@@ -1607,7 +1607,7 @@ export class TemplateStringExpression extends Expression {
     public readonly quasis: TemplateStringQuasiExpression[];
     public readonly expressions: Expression[];
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public getType(options: GetTypeOptions) {
         return StringType.instance;
@@ -1698,7 +1698,7 @@ export class TaggedTemplateStringExpression extends Expression {
         this.quasis = options.quasis;
         this.expressions = options.expressions;
 
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.tokens.tagName,
             this.tokens.openingBacktick,
             this.quasis[0],
@@ -1718,7 +1718,7 @@ export class TaggedTemplateStringExpression extends Expression {
     public readonly quasis: TemplateStringQuasiExpression[];
     public readonly expressions: Expression[];
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
@@ -1799,8 +1799,8 @@ export class AnnotationExpression extends Expression {
         readonly name: Token;
     };
 
-    public get range(): Range | undefined {
-        return util.createBoundingRange(
+    public get location(): Location | undefined {
+        return util.createBoundingLocation(
             this.tokens.at,
             this.tokens.name,
             this.call
@@ -1858,7 +1858,7 @@ export class TernaryExpression extends Expression {
         this.test = options.test;
         this.consequent = options.consequent;
         this.alternate = options.alternate;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.test,
             this.tokens.questionMark,
             this.consequent,
@@ -1869,7 +1869,7 @@ export class TernaryExpression extends Expression {
 
     public readonly kind = AstNodeKind.TernaryExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public readonly tokens: {
         readonly questionMark?: Token;
@@ -1965,7 +1965,7 @@ export class NullCoalescingExpression extends Expression {
         };
         this.consequent = options.consequent;
         this.alternate = options.alternate;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.consequent,
             this.tokens.questionQuestion,
             this.alternate
@@ -1974,7 +1974,7 @@ export class NullCoalescingExpression extends Expression {
 
     public readonly kind = AstNodeKind.NullCoalescingExpression;
 
-    public readonly range: Range | undefined;
+    public readonly location: Location | undefined;
 
     public readonly tokens: {
         readonly questionQuestion?: Token;
@@ -2070,8 +2070,8 @@ export class RegexLiteralExpression extends Expression {
         readonly regexLiteral: Token;
     };
 
-    public get range() {
-        return this.tokens?.regexLiteral?.range;
+    public get location(): Location {
+        return this.tokens?.regexLiteral?.location;
     }
 
     public transpile(state: BrsTranspileState): TranspileResult {
@@ -2159,7 +2159,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
     }) {
         super();
         this.expression = options.expression;
-        this.range = this.expression?.range;
+        this.location = this.expression?.location;
     }
 
     public readonly kind = AstNodeKind.TypeExpression;
@@ -2169,7 +2169,7 @@ export class TypeExpression extends Expression implements TypedefProvider {
      */
     public readonly expression: Expression;
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     public transpile(state: BrsTranspileState): TranspileResult {
         return [this.getType({ flags: SymbolTypeFlag.typetime }).toTypeString()];
@@ -2212,7 +2212,7 @@ export class TypecastExpression extends Expression {
         };
         this.obj = options.obj;
         this.typeExpression = options.typeExpression;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.obj,
             this.tokens.as,
             this.typeExpression
@@ -2229,7 +2229,7 @@ export class TypecastExpression extends Expression {
 
     public typeExpression?: TypeExpression;
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     public transpile(state: BrsTranspileState): TranspileResult {
         return this.obj.transpile(state);
@@ -2266,7 +2266,7 @@ export class TypedArrayExpression extends Expression {
             rightBracket: options.rightBracket
         };
         this.innerType = options.innerType;
-        this.range = util.createBoundingRange(
+        this.location = util.createBoundingLocation(
             this.innerType,
             this.tokens.leftBracket,
             this.tokens.rightBracket
@@ -2282,7 +2282,7 @@ export class TypedArrayExpression extends Expression {
 
     public readonly kind = AstNodeKind.TypedArrayExpression;
 
-    public readonly range: Range;
+    public readonly location: Location;
 
     public transpile(state: BrsTranspileState): TranspileResult {
         return [this.getType({ flags: SymbolTypeFlag.typetime }).toTypeString()];

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -9,7 +9,7 @@ import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement 
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { isAliasStatement, isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isClassStatement, isConditionalCompileConstStatement, isConditionalCompileErrorStatement, isConditionalCompileStatement, isDottedGetExpression, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
-import { expectDiagnostics, expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics } from '../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics, rootDir } from '../testHelpers.spec';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { Expression, Statement } from './AstNode';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
@@ -17,6 +17,7 @@ import { IntegerType } from '../types/IntegerType';
 import { FloatType } from '../types/FloatType';
 import { StringType } from '../types/StringType';
 import { ArrayType, UnionType } from '../types';
+import { standardizePath as s } from '../util';
 
 describe('parser', () => {
     it('emits empty object when empty token list is provided', () => {
@@ -2293,6 +2294,7 @@ export function parse(text: string, mode?: ParseMode, bsConsts: Record<string, b
         bsConstMap.set(constName.toLowerCase(), bsConsts[constName]);
     }
     return Parser.parse(tokens, {
+        srcPath: s`${rootDir}/source/main.brs`,
         mode: mode!,
         bsConsts: bsConstMap
     });
@@ -2317,6 +2319,5 @@ function expectCommentWithText(stat: Statement, text: string) {
 }
 
 export function failStatementType(stat: Statement, type: string) {
-    assert.fail(`Statement ${stat.constructor.name} line ${stat.range.start.line} is not a ${type}`);
+    assert.fail(`Statement ${stat.constructor.name} line ${stat.location?.range.start.line} is not a ${type}`);
 }
-

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2208,7 +2208,7 @@ export class Parser {
             if (assignment.tokens.as || assignment.typeExpression) {
                 this.diagnostics.push({
                     ...DiagnosticMessages.unexpectedToken(assignment.tokens.as?.text || assignment.typeExpression?.getName(ParseMode.BrighterScript)),
-                    range: assignment.tokens.as?.location?.range ?? assignment.typeExpression?.location.range
+                    range: assignment.tokens.as?.location?.range ?? assignment.typeExpression?.location?.range
                 });
                 this.lastDiagnosticAsError();
             }
@@ -2580,7 +2580,7 @@ export class Parser {
         }
 
         this.exitAnnotationBlock(parentAnnotations);
-        return new Block({ statements: statements, startingRange: startingToken.location.range });
+        return new Block({ statements: statements, startingRange: startingToken.location?.range });
     }
 
     /**

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -79,8 +79,7 @@ describe('SGParser', () => {
 
     it('does not crash when missing tag name', () => {
         const parser = new SGParser();
-        parser.parse(
-            'pkg:/components/ParentScene.xml', trim`
+        parser.parse(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
             <!-- a standalone less-than symbol used to cause issues -->
@@ -93,8 +92,7 @@ describe('SGParser', () => {
 
     it('Adds error when an unexpected tag is found in xml', () => {
         const parser = new SGParser();
-        parser.parse(
-            'pkg:/components/ParentScene.xml', trim`
+        parser.parse(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <interface>
@@ -116,8 +114,7 @@ describe('SGParser', () => {
 
     it('Adds error when a leaf tag is found to have children', () => {
         const parser = new SGParser();
-        parser.parse(
-            'pkg:/components/ParentScene.xml', trim`
+        parser.parse(trim`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <interface>
@@ -143,7 +140,7 @@ describe('SGParser', () => {
 
     it('Adds error when whitespace appears before the prolog', () => {
         const parser = new SGParser();
-        parser.parse('path/to/component/ChildScene.xml', /* not trimmed */`
+        parser.parse(/* not trimmed */`
             <?xml version="1.0" encoding="utf-8" ?>
             <component name="ChildScene" extends="ParentScene">
                 <script type="text/brightscript" uri="ChildScene.brs" />

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -350,7 +350,7 @@ export default class SGParser {
      * @param startOffset the offset to start the new token. If negative, subtracts from token.length
      * @param length the length of the text to keep. If negative, subtracts from token.length
      */
-    public createPartialToken(token: IToken, startOffset: number, length?: number) {
+    public createPartialToken(token: IToken, startOffset: number, length?: number): SGToken {
         if (startOffset < 0) {
             startOffset = token.image.length + startOffset;
         }
@@ -363,13 +363,13 @@ export default class SGParser {
         return {
             text: token.image.substring(startOffset, startOffset + length),
             //xmltools startLine is 1-based, we need 0-based which is why we subtract 1 below
-            range: util.createRange(
+            location: util.createLocation(
                 token.startLine - 1,
                 token.startColumn - 1 + startOffset,
                 token.endLine - 1,
-                token.startColumn - 1 + (startOffset + length)
+                token.startColumn - 1 + (startOffset + length),
+                this.options.srcPath
             )
-
         };
     }
 

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -1,5 +1,5 @@
 import { SourceNode } from 'source-map';
-import type { Range } from 'vscode-languageserver';
+import type { Location } from 'vscode-languageserver';
 import { createSGAttribute, createSGInterface, createSGInterfaceField, createSGInterfaceFunction, createSGToken } from '../astUtils/creators';
 import type { FileReference, TranspileResult } from '../interfaces';
 import util from '../util';
@@ -7,7 +7,7 @@ import type { TranspileState } from './TranspileState';
 
 export interface SGToken {
     text: string;
-    range?: Range;
+    location?: Location;
 }
 
 export class SGAttribute {
@@ -59,9 +59,9 @@ export class SGAttribute {
         }
     }
 
-    public get range() {
-        if (!this._range) {
-            this._range = util.createBoundingRange(
+    public get location(): Location {
+        if (!this._location) {
+            this._location = util.createBoundingLocation(
                 this.tokens.key,
                 this.tokens.equals,
                 this.tokens.openingQuote,
@@ -69,9 +69,9 @@ export class SGAttribute {
                 this.tokens.closingQuote
             );
         }
-        return this._range;
+        return this._location;
     }
-    private _range = null as Range;
+    private _location = null as Location;
 
     public transpile(state: TranspileState) {
         const result: TranspileResult = [
@@ -154,9 +154,9 @@ export class SGElement {
      */
     public readonly elements = [] as SGElement[];
 
-    public get range() {
-        if (!this._range) {
-            this._range = util.createBoundingRange(
+    public get location() {
+        if (!this._location) {
+            this._location = util.createBoundingLocation(
                 this.tokens.startTagOpen,
                 this.tokens.startTagName,
                 this.attributes?.[this.attributes?.length - 1],
@@ -167,9 +167,9 @@ export class SGElement {
                 this.tokens.endTagClose
             );
         }
-        return this._range;
+        return this._location;
     }
-    private _range = null as Range;
+    private _location = null as Location;
 
     /**
      * Is this a self-closing tag?
@@ -308,7 +308,7 @@ export class SGElement {
         } else {
             // it is possible that the original tag isSelfClosing, but new elements have been added to it
             // in that case, create a new startTagClose token for transpilation.
-            const startTagClose = this.isSelfClosing ? createSGToken('>', this.tokens.startTagClose.range) : this.tokens.startTagClose;
+            const startTagClose = this.isSelfClosing ? createSGToken('>', this.tokens.startTagClose.location) : this.tokens.startTagClose;
             const chunks: TranspileResult = [
                 state.transpileToken(startTagClose, '>'),
                 state.newline

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -180,7 +180,7 @@ export class AssignmentStatement extends Statement {
 
         // Note: compound assignments (eg. +=) are internally dealt with via the RHS being a BinaryExpression
         // so this.value will be a BinaryExpression, and BinaryExpressions can figure out their own types
-        options.typeChain?.push(new TypeChainEntry({ name: this.tokens.name.text, type: variableType, data: options.data, range: this.tokens.name?.location?.range, astNode: this }));
+        options.typeChain?.push(new TypeChainEntry({ name: this.tokens.name.text, type: variableType, data: options.data, location: this.tokens.name?.location, astNode: this }));
         return variableType;
     }
 
@@ -1360,7 +1360,7 @@ export class DottedSetStatement extends Statement {
         options.typeChain?.push(new TypeChainEntry({
             name: this.tokens.name?.text,
             type: result, data: options.data,
-            range: this.tokens.name?.location?.range,
+            location: this.tokens.name?.location,
             astNode: this
         }));
         return result;

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -65,6 +65,21 @@ export class TranspileState {
 
     public newline = '\n';
 
+    private getSource(locatable: RangeLike) {
+        let srcPath = (locatable as { location: Location })?.location?.uri ?? (locatable as Location).uri;
+        if (srcPath) {
+            //if a sourceRoot is specified, use that instead of the rootDir
+            if (this.options.sourceRoot) {
+                srcPath = srcPath.replace(
+                    this.options.rootDir,
+                    this.options.sourceRoot
+                );
+            }
+        } else {
+            return this.srcPath;
+        }
+    }
+
     /**
      * Shorthand for creating a new source node
      */
@@ -75,7 +90,7 @@ export class TranspileState {
             range ? range.start.line + 1 : null,
             //range and SourceNode character are both 0-based, so no conversion necessary
             range ? range.start.character : null,
-            this.srcPath,
+            this.getSource(locatable),
             code
         );
     }
@@ -91,7 +106,7 @@ export class TranspileState {
             token.location?.range ? token.location.range.start.line + 1 : null,
             //range and SourceNode character are both 0-based, so no conversion necessary
             token.location?.range ? token.location.range.start.character : null,
-            this.srcPath,
+            this.getSource(token),
             token.text
         );
     }
@@ -131,7 +146,6 @@ export class TranspileState {
         return leadingCommentsSourceNodes;
     }
 
-
     /**
      * Create a SourceNode from a token, accounting for missing range and multi-line text
      * Adds all leading trivia for the token
@@ -162,7 +176,7 @@ export class TranspileState {
                         token.location.range.start.line + i + 1,
                         //SourceNode column is 0-based, and this starts at the beginning of the line
                         0,
-                        this.srcPath,
+                        this.getSource(token),
                         lines[i]
                     )
                 );

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -68,6 +68,7 @@ export class TranspileState {
     private getSource(locatable: RangeLike) {
         let srcPath = (locatable as { location: Location })?.location?.uri ?? (locatable as Location).uri;
         if (srcPath) {
+            srcPath = util.uriToPath(srcPath);
             //if a sourceRoot is specified, use that instead of the rootDir
             if (this.options.sourceRoot) {
                 srcPath = srcPath.replace(
@@ -75,6 +76,7 @@ export class TranspileState {
                     this.options.sourceRoot
                 );
             }
+            return srcPath;
         } else {
             return this.srcPath;
         }

--- a/src/parser/tests/Parser.spec.ts
+++ b/src/parser/tests/Parser.spec.ts
@@ -1,6 +1,5 @@
 import type { Token } from '../../lexer/Token';
 import { TokenKind, ReservedWords } from '../../lexer/TokenKind';
-import type { Range } from 'vscode-languageserver';
 
 /* A set of utilities to be used while writing tests for the BRS parser. */
 
@@ -12,7 +11,7 @@ export function token(kind: TokenKind, text?: string): Token {
         kind: kind,
         text: text!,
         isReserved: ReservedWords.has((text ?? '').toLowerCase()),
-        range: null,
+        location: null,
         leadingWhitespace: '',
         leadingTrivia: []
     };
@@ -23,16 +22,6 @@ export function token(kind: TokenKind, text?: string): Token {
  */
 export function identifier(text: string) {
     return token(TokenKind.Identifier, text);
-}
-
-/**
- * Test whether a range matches a group of elements with a `range`
- */
-export function rangeMatch(range: Range, elements: ({ range?: Range })[]): boolean {
-    return range.start.line === elements[0].range.start.line &&
-        range.start.character === elements[0].range.start.character &&
-        range.end.line === elements[elements.length - 1].range.end.line &&
-        range.end.character === elements[elements.length - 1].range.end.character;
 }
 
 /** An end-of-file token. */

--- a/src/parser/tests/controlFlow/For.spec.ts
+++ b/src/parser/tests/controlFlow/For.spec.ts
@@ -7,6 +7,7 @@ import type { FunctionStatement } from '../../Statement';
 import type { ForStatement } from '../../Statement';
 import { LiteralExpression } from '../../Expression';
 import { isFunctionStatement } from '../../../astUtils/reflection';
+import util from '../../../util';
 
 describe('parser for loops', () => {
     it('accepts a \'step\' clause', () => {
@@ -106,52 +107,49 @@ describe('parser for loops', () => {
                 kind: TokenKind.For,
                 text: 'for',
                 isReserved: true,
-                range: Range.create(0, 0, 0, 3),
+                location: util.createLocation(0, 0, 0, 3),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'i',
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5),
+                location: util.createLocation(0, 4, 0, 5),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
                 isReserved: false,
-                range: Range.create(0, 6, 0, 7),
+                location: util.createLocation(0, 6, 0, 7),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '0',
                 isReserved: false,
-                range: Range.create(0, 8, 0, 9),
+                location: util.createLocation(0, 8, 0, 9),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.To,
                 text: 'to',
                 isReserved: false,
-                range: {
-                    start: { line: 0, character: 10 },
-                    end: { line: 0, character: 12 }
-                },
+                location: util.createLocation(0, 10, 0, 12),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '10',
                 isReserved: false,
-                range: Range.create(0, 13, 0, 15),
+                location: util.createLocation(0, 13, 0, 15),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
                 isReserved: false,
-                range: Range.create(0, 15, 0, 16),
+                location: util.createLocation(0, 15, 0, 16),
                 leadingTrivia: []
             },
             // loop body isn't significant for location tracking, so helper functions are safe
@@ -164,7 +162,7 @@ describe('parser for loops', () => {
                 kind: TokenKind.EndFor,
                 text: 'end for',
                 isReserved: false,
-                range: Range.create(2, 0, 2, 8),
+                location: util.createLocation(2, 0, 2, 8),
                 leadingTrivia: []
             },
             EOF
@@ -172,7 +170,7 @@ describe('parser for loops', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).to.deep.include(
+        expect(statements[0].location.range).to.deep.include(
             Range.create(0, 0, 2, 8)
         );
     });

--- a/src/parser/tests/controlFlow/ForEach.spec.ts
+++ b/src/parser/tests/controlFlow/ForEach.spec.ts
@@ -6,6 +6,7 @@ import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { ForEachStatement } from '../../Statement';
 import { VariableExpression } from '../../Expression';
+import util from '../../../util';
 
 describe('parser foreach loops', () => {
     it('requires a name and target', () => {
@@ -66,35 +67,35 @@ describe('parser foreach loops', () => {
                 kind: TokenKind.ForEach,
                 text: 'for each',
                 isReserved: true,
-                range: Range.create(0, 0, 0, 8),
+                location: util.createLocation(0, 0, 0, 8),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10),
+                location: util.createLocation(0, 9, 0, 10),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'in',
                 isReserved: true,
-                range: Range.create(0, 11, 0, 13),
+                location: util.createLocation(0, 11, 0, 13),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'b',
                 isReserved: false,
-                range: Range.create(0, 14, 0, 15),
+                location: util.createLocation(0, 14, 0, 15),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
                 isReserved: false,
-                range: Range.create(0, 15, 0, 16),
+                location: util.createLocation(0, 15, 0, 16),
                 leadingTrivia: []
             },
             // loop body isn't significant for location tracking, so helper functions are safe
@@ -107,7 +108,7 @@ describe('parser foreach loops', () => {
                 kind: TokenKind.EndFor,
                 text: 'end for',
                 isReserved: false,
-                range: Range.create(2, 0, 2, 7),
+                location: util.createLocation(2, 0, 2, 7),
                 leadingTrivia: []
             },
             EOF
@@ -115,7 +116,7 @@ describe('parser foreach loops', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).deep.include(
+        expect(statements[0].location.range).deep.include(
             Range.create(0, 0, 2, 7)
         );
     });

--- a/src/parser/tests/controlFlow/If.spec.ts
+++ b/src/parser/tests/controlFlow/If.spec.ts
@@ -3,9 +3,10 @@ import * as assert from 'assert';
 import { Parser } from '../../Parser';
 import { Lexer } from '../../../lexer/Lexer';
 import { TokenKind } from '../../../lexer/TokenKind';
-import { EOF, identifier, rangeMatch, token } from '../Parser.spec';
+import { EOF, identifier, token } from '../Parser.spec';
 import { isBlock, isFunctionStatement, isIfStatement } from '../../../astUtils/reflection';
 import type { Block, FunctionStatement, IfStatement } from '../../Statement';
+import util from '../../../util';
 
 describe('parser if statements', () => {
     it('allows empty if blocks', () => {
@@ -617,12 +618,15 @@ describe('parser if statements', () => {
         expect(diagnostics).to.be.lengthOf(0);
 
         const then1 = (statements[0] as IfStatement).thenBranch;
-        expect(rangeMatch(then1.range, then1.statements)).to.be.true;
+        expect(then1.location).to.eql(util.createBoundingLocation(...then1.statements));
+
         const then2 = (statements[1] as IfStatement).thenBranch;
-        expect(rangeMatch(then2.range, then2.statements)).to.be.true;
+        expect(then2.location).to.eql(util.createBoundingLocation(...then2.statements));
+
         const else1 = (statements[2] as IfStatement).elseBranch as Block;
-        expect(rangeMatch(else1.range, else1.statements)).to.be.true;
+        expect(else1.location).to.eql(util.createBoundingLocation(...else1.statements));
+
         const else2 = (statements[3] as IfStatement).elseBranch as Block;
-        expect(rangeMatch(else2.range, else2.statements)).to.be.true;
+        expect(else2.location).to.eql(util.createBoundingLocation(...else2.statements));
     });
 });

--- a/src/parser/tests/controlFlow/While.spec.ts
+++ b/src/parser/tests/controlFlow/While.spec.ts
@@ -6,6 +6,7 @@ import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import type { FunctionStatement } from '../../Statement';
 import { isFunctionStatement } from '../../../astUtils/reflection';
+import util from '../../../util';
 
 describe('parser while statements', () => {
 
@@ -79,21 +80,21 @@ describe('parser while statements', () => {
                 kind: TokenKind.While,
                 text: 'while',
                 isReserved: true,
-                range: Range.create(0, 0, 0, 5),
+                location: util.createLocation(0, 0, 0, 5),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.True,
                 text: 'true',
                 isReserved: true,
-                range: Range.create(0, 6, 0, 10),
+                location: util.createLocation(0, 6, 0, 10),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
                 isReserved: false,
-                range: Range.create(0, 10, 0, 11),
+                location: util.createLocation(0, 10, 0, 11),
                 leadingTrivia: []
             },
             // loop body isn't significant for location tracking, so helper functions are safe
@@ -106,7 +107,7 @@ describe('parser while statements', () => {
                 kind: TokenKind.EndWhile,
                 text: 'end while',
                 isReserved: false,
-                range: Range.create(2, 0, 2, 9),
+                location: util.createLocation(2, 0, 2, 9),
                 leadingTrivia: []
             },
             EOF
@@ -114,7 +115,7 @@ describe('parser while statements', () => {
 
         expect(diagnostics[0]?.message).not.to.exist;
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).deep.include(
+        expect(statements[0].location.range).deep.include(
             Range.create(0, 0, 2, 9)
         );
     });

--- a/src/parser/tests/expression/Additive.spec.ts
+++ b/src/parser/tests/expression/Additive.spec.ts
@@ -4,6 +4,7 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { util } from '../../../util';
 
 describe('parser additive expressions', () => {
     it('parses left-associative addition chains', () => {
@@ -48,50 +49,58 @@ describe('parser additive expressions', () => {
             {
                 kind: TokenKind.Identifier,
                 text: '_',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 2)
+                location: util.createLocation(0, 2, 0, 2)
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '1',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                location: util.createLocation(0, 4, 0, 5)
             },
             {
                 kind: TokenKind.Plus,
                 text: '+',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 6, 0, 7)
+                location: util.createLocation(0, 6, 0, 7)
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '2',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 8, 0, 9)
+                location: util.createLocation(0, 8, 0, 9)
             },
             {
                 kind: TokenKind.Plus,
                 text: '+',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 10, 0, 11)
+                location: util.createLocation(0, 10, 0, 11)
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '3',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 12, 0, 13)
+                location: util.createLocation(0, 12, 0, 13)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 13, 0, 14)
+                location: util.createLocation(0, 13, 0, 14)
             }
         ]) as any;
 

--- a/src/parser/tests/expression/Additive.spec.ts
+++ b/src/parser/tests/expression/Additive.spec.ts
@@ -5,6 +5,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { util } from '../../../util';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import type { AssignmentStatement } from '../../Statement';
 
 describe('parser additive expressions', () => {
     it('parses left-associative addition chains', () => {
@@ -45,7 +47,7 @@ describe('parser additive expressions', () => {
         // ^^ columns ^^
         //
         // _ = 1 + 2 + 3
-        let { statements, diagnostics } = Parser.parse(<any>[
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: '_',
@@ -102,11 +104,10 @@ describe('parser additive expressions', () => {
                 isReserved: false,
                 location: util.createLocation(0, 13, 0, 14)
             }
-        ]) as any;
+        ]);
 
-        expect(diagnostics[0]?.message).to.not.exist;
-        expect(statements).to.be.lengthOf(1);
-        expect(statements[0].value.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).to.deep.include(
             Range.create(0, 4, 0, 13)
         );
     });

--- a/src/parser/tests/expression/ArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/ArrayLiterals.spec.ts
@@ -4,7 +4,7 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
-import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { isArrayLiteralExpression, isAssignmentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
 import type { AssignmentStatement } from '../../Statement';
@@ -225,7 +225,7 @@ describe('parser array literals', () => {
          * 4|
          * 5| ]
          */
-        let { statements, diagnostics } = Parser.parse([
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
@@ -317,14 +317,13 @@ describe('parser array literals', () => {
                 isReserved: false,
                 location: util.createLocation(5, 1, 5, 2)
             }
-        ]) as any;
+        ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(2);
-        expect(statements[0].value.range).deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).deep.include(
             Range.create(0, 4, 0, 9)
         );
-        expect(statements[1].value.range).deep.include(
+        expect((parser.ast.statements[1] as AssignmentStatement).value.location.range).deep.include(
             Range.create(2, 4, 5, 1)
         );
     });

--- a/src/parser/tests/expression/ArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/ArrayLiterals.spec.ts
@@ -9,6 +9,7 @@ import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { isArrayLiteralExpression, isAssignmentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
 import type { AssignmentStatement } from '../../Statement';
 import type { ArrayLiteralExpression } from '../../Expression';
+import { util } from '../../../util';
 
 describe('parser array literals', () => {
     describe('empty arrays', () => {
@@ -224,84 +225,97 @@ describe('parser array literals', () => {
          * 4|
          * 5| ]
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 3)
+                location: util.createLocation(0, 2, 0, 3)
             },
             {
                 kind: TokenKind.LeftSquareBracket,
                 text: '[',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                location: util.createLocation(0, 4, 0, 5)
             },
             {
                 kind: TokenKind.RightSquareBracket,
                 text: ']',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 8, 0, 9)
+                location: util.createLocation(0, 8, 0, 9)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10)
+                location: util.createLocation(0, 9, 0, 10)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 0, 1, 1)
+                location: util.createLocation(1, 0, 1, 1)
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'b',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 0, 2, 1)
+                location: util.createLocation(2, 0, 2, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 2, 2, 3)
+                location: util.createLocation(2, 2, 2, 3)
             },
             {
                 kind: TokenKind.LeftSquareBracket,
                 text: '[',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 4, 2, 5)
+                location: util.createLocation(2, 4, 2, 5)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(3, 0, 3, 1)
+                location: util.createLocation(3, 0, 3, 1)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(4, 0, 4, 1)
+                location: util.createLocation(4, 0, 4, 1)
             },
             {
                 kind: TokenKind.RightSquareBracket,
                 text: ']',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(5, 0, 5, 1)
+                location: util.createLocation(5, 0, 5, 1)
             },
             {
                 kind: TokenKind.Eof,
                 text: '',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(5, 1, 5, 2)
+                location: util.createLocation(5, 1, 5, 2)
             }
         ]) as any;
 

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -9,6 +9,7 @@ import type { AALiteralExpression, AAMemberExpression } from '../../Expression';
 import { isAALiteralExpression, isAssignmentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
 import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
+import { util } from '../../../util';
 
 describe('parser associative array literals', () => {
     describe('empty associative arrays', () => {
@@ -259,84 +260,97 @@ describe('parser associative array literals', () => {
          * 5|
          * 6| }
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 3)
+                location: util.createLocation(0, 2, 0, 3)
             },
             {
                 kind: TokenKind.LeftCurlyBrace,
                 text: '{',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                location: util.createLocation(0, 4, 0, 5)
             },
             {
                 kind: TokenKind.RightCurlyBrace,
                 text: '}',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 8, 0, 9)
+                location: util.createLocation(0, 8, 0, 9)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10)
+                location: util.createLocation(0, 9, 0, 10)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 0, 1, 1)
+                location: util.createLocation(1, 0, 1, 1)
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'b',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 0, 2, 1)
+                location: util.createLocation(2, 0, 2, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 2, 2, 3)
+                location: util.createLocation(2, 2, 2, 3)
             },
             {
                 kind: TokenKind.LeftCurlyBrace,
                 text: '{',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 4, 2, 5)
+                location: util.createLocation(2, 4, 2, 5)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(3, 0, 3, 1)
+                location: util.createLocation(3, 0, 3, 1)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(4, 0, 4, 1)
+                location: util.createLocation(4, 0, 4, 1)
             },
             {
                 kind: TokenKind.RightCurlyBrace,
                 text: '}',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(5, 0, 5, 1)
+                location: util.createLocation(5, 0, 5, 1)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(5, 1, 5, 2)
+                location: util.createLocation(5, 1, 5, 2)
             }
         ]) as any;
 

--- a/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
+++ b/src/parser/tests/expression/AssociativeArrayLiterals.spec.ts
@@ -7,7 +7,7 @@ import { Range } from 'vscode-languageserver';
 import type { AssignmentStatement } from '../../Statement';
 import type { AALiteralExpression, AAMemberExpression } from '../../Expression';
 import { isAALiteralExpression, isAssignmentStatement, isDottedGetExpression, isLiteralExpression } from '../../../astUtils/reflection';
-import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { util } from '../../../util';
 
@@ -260,7 +260,7 @@ describe('parser associative array literals', () => {
          * 5|
          * 6| }
          */
-        let { statements, diagnostics } = Parser.parse([
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
@@ -352,14 +352,13 @@ describe('parser associative array literals', () => {
                 isReserved: false,
                 location: util.createLocation(5, 1, 5, 2)
             }
-        ]) as any;
+        ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(2);
-        expect(statements[0].value.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).to.deep.include(
             Range.create(0, 4, 0, 9)
         );
-        expect(statements[1].value.range).to.deep.include(
+        expect((parser.ast.statements[1] as AssignmentStatement).value.location.range).to.deep.include(
             Range.create(2, 4, 5, 1)
         );
     });

--- a/src/parser/tests/expression/Boolean.spec.ts
+++ b/src/parser/tests/expression/Boolean.spec.ts
@@ -5,6 +5,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { util } from '../../../util';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import type { AssignmentStatement } from '../../Statement';
 
 describe('parser boolean expressions', () => {
 
@@ -43,7 +45,7 @@ describe('parser boolean expressions', () => {
          *  +----------------------
          * 0| a = true and false
          */
-        let { statements, diagnostics } = Parser.parse([
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
@@ -86,11 +88,10 @@ describe('parser boolean expressions', () => {
                 isReserved: false,
                 location: util.createLocation(0, 18, 0, 19)
             }
-        ]) as any;
+        ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(1);
-        expect(statements[0].value.range).deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).deep.include(
             Range.create(0, 4, 0, 18)
         );
     });

--- a/src/parser/tests/expression/Boolean.spec.ts
+++ b/src/parser/tests/expression/Boolean.spec.ts
@@ -4,6 +4,7 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { util } from '../../../util';
 
 describe('parser boolean expressions', () => {
 
@@ -42,42 +43,48 @@ describe('parser boolean expressions', () => {
          *  +----------------------
          * 0| a = true and false
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 3)
+                location: util.createLocation(0, 2, 0, 3)
             },
             {
                 kind: TokenKind.True,
                 text: 'true',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 4, 0, 8)
+                location: util.createLocation(0, 4, 0, 8)
             },
             {
                 kind: TokenKind.And,
                 text: 'and',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 9, 0, 12)
+                location: util.createLocation(0, 9, 0, 12)
             },
             {
                 kind: TokenKind.False,
                 text: 'false',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 13, 0, 18)
+                location: util.createLocation(0, 13, 0, 18)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 18, 0, 19)
+                location: util.createLocation(0, 18, 0, 19)
             }
         ]) as any;
 

--- a/src/parser/tests/expression/Call.spec.ts
+++ b/src/parser/tests/expression/Call.spec.ts
@@ -9,6 +9,7 @@ import type { ExpressionStatement, FunctionStatement } from '../../Statement';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
 import { isAssignmentStatement, isCallExpression, isDottedGetExpression, isDottedSetStatement, isExpressionStatement, isIndexedGetExpression, isReturnStatement } from '../../../astUtils/reflection';
+import { util } from '../../../util';
 
 describe('parser call expressions', () => {
     it('parses named function calls', () => {
@@ -148,48 +149,55 @@ describe('parser call expressions', () => {
          *  +----------------------
          * 0| foo("bar", "baz")
          */
-        const { statements, diagnostics } = Parser.parse(<any>[
+        const { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'foo',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 3)
+                location: util.createLocation(0, 0, 0, 3)
             },
             {
                 kind: TokenKind.LeftParen,
                 text: '(',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 3, 0, 4)
+                location: util.createLocation(0, 3, 0, 4)
             },
             {
                 kind: TokenKind.StringLiteral,
                 text: `"bar"`,
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 9)
+                location: util.createLocation(0, 4, 0, 9)
             },
             {
                 kind: TokenKind.Comma,
                 text: ',',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10)
+                location: util.createLocation(0, 9, 0, 10)
             },
             {
                 kind: TokenKind.StringLiteral,
                 text: `"baz"`,
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 11, 0, 16)
+                location: util.createLocation(0, 11, 0, 16)
             },
             {
                 kind: TokenKind.RightParen,
                 text: ')',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 16, 0, 17)
+                location: util.createLocation(0, 16, 0, 17)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 17, 0, 18)
+                location: util.createLocation(0, 17, 0, 18)
             }
         ]);
 

--- a/src/parser/tests/expression/Call.spec.ts
+++ b/src/parser/tests/expression/Call.spec.ts
@@ -14,7 +14,7 @@ describe('parser call expressions', () => {
     it('parses named function calls', () => {
         const { statements, diagnostics } = Parser.parse([
             identifier('RebootSystem'),
-            { kind: TokenKind.LeftParen, text: '(', range: null as any, leadingTrivia: [] },
+            { kind: TokenKind.LeftParen, text: '(', location: null as any, leadingTrivia: [] },
             token(TokenKind.RightParen, ')'),
             EOF
         ]);
@@ -65,7 +65,7 @@ describe('parser call expressions', () => {
     it('allows closing parentheses on separate line', () => {
         const { statements, diagnostics } = Parser.parse([
             identifier('RebootSystem'),
-            { kind: TokenKind.LeftParen, text: '(', range: null as any, leadingTrivia: [] },
+            { kind: TokenKind.LeftParen, text: '(', location: null as any, leadingTrivia: [] },
             token(TokenKind.Newline, '\\n'),
             token(TokenKind.Newline, '\\n'),
             token(TokenKind.RightParen, ')'),
@@ -128,9 +128,9 @@ describe('parser call expressions', () => {
     it('accepts arguments', () => {
         const { statements, diagnostics } = Parser.parse([
             identifier('add'),
-            { kind: TokenKind.LeftParen, text: '(', range: null as any, leadingTrivia: [] },
+            { kind: TokenKind.LeftParen, text: '(', location: null as any, leadingTrivia: [] },
             token(TokenKind.IntegerLiteral, '1'),
-            { kind: TokenKind.Comma, text: ',', range: null as any, leadingTrivia: [] },
+            { kind: TokenKind.Comma, text: ',', location: null as any, leadingTrivia: [] },
             token(TokenKind.IntegerLiteral, '2'),
             token(TokenKind.RightParen, ')'),
             EOF
@@ -195,7 +195,7 @@ describe('parser call expressions', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).to.deep.include(
+        expect(statements[0].location?.range).to.deep.include(
             Range.create(0, 0, 0, 17)
         );
     });

--- a/src/parser/tests/expression/Function.spec.ts
+++ b/src/parser/tests/expression/Function.spec.ts
@@ -5,6 +5,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { util } from '../../../util';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import type { AssignmentStatement } from '../../Statement';
 
 describe('parser', () => {
 
@@ -397,7 +399,7 @@ describe('parser', () => {
          * 1|
          * 2| end sub
          */
-        let { statements, diagnostics } = Parser.parse([
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: '_',
@@ -454,11 +456,10 @@ describe('parser', () => {
                 isReserved: false,
                 location: util.createLocation(2, 7, 2, 8)
             }
-        ]) as any;
+        ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(1);
-        expect(statements[0].value.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).to.deep.include(
             Range.create(0, 4, 2, 7)
         );
     });

--- a/src/parser/tests/expression/Function.spec.ts
+++ b/src/parser/tests/expression/Function.spec.ts
@@ -4,6 +4,7 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { util } from '../../../util';
 
 describe('parser', () => {
 
@@ -396,54 +397,62 @@ describe('parser', () => {
          * 1|
          * 2| end sub
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: '_',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 3)
+                location: util.createLocation(0, 2, 0, 3)
             },
             {
                 kind: TokenKind.Sub,
                 text: 'sub',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 4, 0, 7)
+                location: util.createLocation(0, 4, 0, 7)
             },
             {
                 kind: TokenKind.LeftParen,
                 text: '(',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 11, 0, 12)
+                location: util.createLocation(0, 11, 0, 12)
             },
             {
                 kind: TokenKind.RightParen,
                 text: ')',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 12, 0, 13)
+                location: util.createLocation(0, 12, 0, 13)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 13, 0, 14)
+                location: util.createLocation(0, 13, 0, 14)
             },
             {
                 kind: TokenKind.EndSub,
                 text: 'end sub',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 0, 2, 7)
+                location: util.createLocation(2, 0, 2, 7)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 7, 2, 8)
+                location: util.createLocation(2, 7, 2, 8)
             }
         ]) as any;
 

--- a/src/parser/tests/expression/Indexing.spec.ts
+++ b/src/parser/tests/expression/Indexing.spec.ts
@@ -7,7 +7,7 @@ import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import type { IndexedSetStatement } from '../../Statement';
 import { AssignmentStatement } from '../../Statement';
-import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../../../testHelpers.spec';
 import { isAssignmentStatement, isDottedGetExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isVariableExpression } from '../../../astUtils/reflection';
 import type { DottedGetExpression, IndexedGetExpression, VariableExpression } from '../../Expression';
 import { WalkMode } from '../../../astUtils/visitors';
@@ -98,7 +98,7 @@ describe('parser indexing', () => {
              * 0| a = foo.bar
              * 1| b = foo[2]
              */
-            let { statements, diagnostics } = Parser.parse([
+            const parser = Parser.parse([
                 {
                     kind: TokenKind.Identifier,
                     text: 'a',
@@ -192,9 +192,8 @@ describe('parser indexing', () => {
                 }
             ]);
 
-            expect(diagnostics).to.be.lengthOf(0);
-            expect(statements).to.be.lengthOf(2);
-            expect(statements.map(s => (s as any).value.range)).to.deep.equal([
+            expectZeroDiagnostics(parser);
+            expect(parser.ast.statements.map(s => (s as AssignmentStatement).value.location.range)).to.deep.equal([
                 Range.create(0, 4, 0, 11),
                 Range.create(1, 4, 1, 10)
             ]);

--- a/src/parser/tests/expression/Indexing.spec.ts
+++ b/src/parser/tests/expression/Indexing.spec.ts
@@ -11,6 +11,7 @@ import { expectDiagnostics, expectDiagnosticsIncludes } from '../../../testHelpe
 import { isAssignmentStatement, isDottedGetExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isVariableExpression } from '../../../astUtils/reflection';
 import type { DottedGetExpression, IndexedGetExpression, VariableExpression } from '../../Expression';
 import { WalkMode } from '../../../astUtils/visitors';
+import { util } from '../../../util';
 
 
 describe('parser indexing', () => {
@@ -97,84 +98,97 @@ describe('parser indexing', () => {
              * 0| a = foo.bar
              * 1| b = foo[2]
              */
-            let { statements, diagnostics } = Parser.parse(<any>[
+            let { statements, diagnostics } = Parser.parse([
                 {
                     kind: TokenKind.Identifier,
                     text: 'a',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 0, 0, 1)
+                    location: util.createLocation(0, 0, 0, 1)
                 },
                 {
                     kind: TokenKind.Equal,
                     text: '=',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 2, 0, 3)
+                    location: util.createLocation(0, 2, 0, 3)
                 },
                 {
                     kind: TokenKind.Identifier,
                     text: 'foo',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 4, 0, 7)
+                    location: util.createLocation(0, 4, 0, 7)
                 },
                 {
                     kind: TokenKind.Dot,
                     text: '.',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 7, 0, 8)
+                    location: util.createLocation(0, 7, 0, 8)
                 },
                 {
                     kind: TokenKind.Identifier,
                     text: 'bar',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 8, 0, 11)
+                    location: util.createLocation(0, 8, 0, 11)
                 },
                 {
                     kind: TokenKind.Newline,
                     text: '\n',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(0, 11, 0, 12)
+                    location: util.createLocation(0, 11, 0, 12)
                 },
                 {
                     kind: TokenKind.Identifier,
                     text: 'b',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 0, 1, 1)
+                    location: util.createLocation(1, 0, 1, 1)
                 },
                 {
                     kind: TokenKind.Equal,
                     text: '=',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 2, 1, 3)
+                    location: util.createLocation(1, 2, 1, 3)
                 },
                 {
                     kind: TokenKind.Identifier,
                     text: 'bar',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 4, 1, 7)
+                    location: util.createLocation(1, 4, 1, 7)
                 },
                 {
                     kind: TokenKind.LeftSquareBracket,
                     text: '[',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 7, 1, 8)
+                    location: util.createLocation(1, 7, 1, 8)
                 },
                 {
                     kind: TokenKind.IntegerLiteral,
                     text: '2',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 8, 1, 9)
+                    location: util.createLocation(1, 8, 1, 9)
                 },
                 {
                     kind: TokenKind.RightSquareBracket,
                     text: ']',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 9, 1, 10)
+                    location: util.createLocation(1, 9, 1, 10)
                 },
                 {
                     kind: TokenKind.Eof,
                     text: '\0',
+                    leadingTrivia: [],
                     isReserved: false,
-                    range: Range.create(1, 10, 1, 11)
+                    location: util.createLocation(1, 10, 1, 11)
                 }
             ]);
 

--- a/src/parser/tests/expression/PrefixUnary.spec.ts
+++ b/src/parser/tests/expression/PrefixUnary.spec.ts
@@ -4,6 +4,9 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import type { AssignmentStatement } from '../../Statement';
+import { util } from '../../../util';
 
 describe('parser prefix unary expressions', () => {
 
@@ -74,42 +77,46 @@ describe('parser prefix unary expressions', () => {
          *  +----------------------
          * 1| _false = not true
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: '_false',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 6)
+                location: util.createLocation(0, 0, 0, 6)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 7, 0, 8)
+                location: util.createLocation(0, 7, 0, 8)
             },
             {
                 kind: TokenKind.Not,
                 text: 'not',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 9, 0, 12)
+                location: util.createLocation(0, 9, 0, 12)
             },
             {
                 kind: TokenKind.True,
                 text: 'true',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 13, 0, 17)
+                location: util.createLocation(0, 13, 0, 17)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 17, 0, 18)
+                location: util.createLocation(0, 17, 0, 18)
             }
         ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(1);
-        expect((statements[0] as any).value.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect((parser.ast.statements[0] as AssignmentStatement).value.location.range).to.deep.include(
             Range.create(0, 9, 0, 17)
         );
     });

--- a/src/parser/tests/expression/Primary.spec.ts
+++ b/src/parser/tests/expression/Primary.spec.ts
@@ -4,6 +4,8 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { util } from '../../../util';
+import type { AssignmentStatement } from '../../Statement';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
 
 describe('parser primary expressions', () => {
 
@@ -60,7 +62,7 @@ describe('parser primary expressions', () => {
          * 1| b = "foo"
          * 2| c = ( 0 )
          */
-        let { statements, diagnostics } = Parser.parse([
+        let parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
@@ -159,17 +161,17 @@ describe('parser primary expressions', () => {
                 isReserved: false,
                 location: util.createLocation(1, 9, 1, 10) //TODO are these numbers right?
             }
-        ]) as any;
+        ]);
+        const statements = parser.ast.statements as AssignmentStatement[];
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(3);
-        expect(statements[0].value.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect(statements[0].value.location.range).to.deep.include(
             Range.create(0, 4, 0, 5)
         );
-        expect(statements[1].value.range).to.deep.include(
+        expect(statements[1].value.location.range).to.deep.include(
             Range.create(1, 4, 1, 9)
         );
-        expect(statements[2].value.range).to.deep.include(
+        expect(statements[2].value.location.range).to.deep.include(
             Range.create(2, 4, 2, 9)
         );
     });

--- a/src/parser/tests/expression/Primary.spec.ts
+++ b/src/parser/tests/expression/Primary.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from '../../../chai-config.spec';
-
 import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { util } from '../../../util';
 
 describe('parser primary expressions', () => {
 
@@ -60,90 +60,104 @@ describe('parser primary expressions', () => {
          * 1| b = "foo"
          * 2| c = ( 0 )
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'a',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 1)
+                location: util.createLocation(0, 0, 0, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 2, 0, 3)
+                location: util.createLocation(0, 2, 0, 3)
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '5',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                location: util.createLocation(0, 4, 0, 5)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 5, 0, 6)
+                location: util.createLocation(0, 5, 0, 6)
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'b',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 0, 1, 1)
+                location: util.createLocation(1, 0, 1, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 2, 1, 3)
+                location: util.createLocation(1, 2, 1, 3)
             },
             {
                 kind: TokenKind.StringLiteral,
                 text: `"foo"`,
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 4, 1, 9)
+                location: util.createLocation(1, 4, 1, 9)
             },
             {
                 kind: TokenKind.Newline,
                 text: '\n',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 9, 1, 10)
+                location: util.createLocation(1, 9, 1, 10)
             },
             {
                 kind: TokenKind.Identifier,
                 text: 'c',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 0, 2, 1)
+                location: util.createLocation(2, 0, 2, 1)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 2, 2, 3)
+                location: util.createLocation(2, 2, 2, 3)
             },
             {
                 kind: TokenKind.LeftParen,
                 text: '(',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 4, 2, 5)
+                location: util.createLocation(2, 4, 2, 5)
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 6, 2, 7)
+                location: util.createLocation(2, 6, 2, 7)
             },
             {
                 kind: TokenKind.RightParen,
                 text: ')',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(2, 8, 2, 9)
+                location: util.createLocation(2, 8, 2, 9)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(1, 9, 1, 10) //TODO are these numbers right?
+                location: util.createLocation(1, 9, 1, 10) //TODO are these numbers right?
             }
         ]) as any;
 

--- a/src/parser/tests/expression/TemplateStringExpression.spec.ts
+++ b/src/parser/tests/expression/TemplateStringExpression.spec.ts
@@ -20,7 +20,7 @@ describe('TemplateStringExpression', () => {
             it('generates correct locations for quasis', () => {
                 let { tokens } = Lexer.scan('print `0xAAAAAA${"0xBBBBBB"}0xCCCCCC`');
                 expect(
-                    tokens.filter(x => /"?0x/.test(x.text)).map(x => x.range)
+                    tokens.filter(x => /"?0x/.test(x.text)).map(x => x.location?.range)
                 ).to.eql([
                     util.createRange(0, 7, 0, 15), // 0xAAAAAA
                     util.createRange(0, 17, 0, 27), // "0xBBBBBB"
@@ -34,7 +34,7 @@ describe('TemplateStringExpression', () => {
                 tokens.shift();
                 expect(
                     //compute the length of the token char spread
-                    tokens.filter(x => x.text !== '').map(x => [x.range.end.character - x.range.start.character, x.text])
+                    tokens.filter(x => x.text !== '').map(x => [x.location.range.end.character - x.location.range.start.character, x.text])
                 ).to.eql([
                     '`',
                     '${',
@@ -368,6 +368,6 @@ describe('TemplateStringExpression', () => {
             end function
         `);
         const ann = parser.ast.statements[0].annotations![0];
-        expect(ann.range).to.eql(util.createRange(1, 12, 3, 14));
+        expect(ann.location?.range).to.eql(util.createRange(1, 12, 3, 14));
     });
 });

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -1,5 +1,5 @@
 import { expectCompletionsIncludes, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
-import { util } from '../../../util';
+import { util, standardizePath as s } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
 import { ParseMode, Parser } from '../../Parser';
@@ -41,7 +41,7 @@ describe('ConstStatement', () => {
     });
 
     it('supports basic structure', () => {
-        parser.parse('const API_KEY = "abc"', { mode: ParseMode.BrighterScript });
+        parser.parse('const API_KEY = "abc"', { mode: ParseMode.BrighterScript, srcPath: s`${rootDir}/source/main.bs` });
         expectZeroDiagnostics(parser);
         const statement = parser.ast.statements[0] as ConstStatement;
         expect(statement.tokens.const?.kind).to.eql(TokenKind.Const);
@@ -53,7 +53,7 @@ describe('ConstStatement', () => {
         expect(value).to.be.instanceof(LiteralExpression);
         expect(value.tokens.value?.text).to.eql('"abc"');
         //ensure range is correct
-        expect(statement.range).to.eql(util.createRange(0, 0, 0, 21));
+        expect(statement.location?.range).to.eql(util.createRange(0, 0, 0, 21));
     });
 
     it('produces typedef', async () => {

--- a/src/parser/tests/statement/Declaration.spec.ts
+++ b/src/parser/tests/statement/Declaration.spec.ts
@@ -4,6 +4,8 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
+import { util } from '../../../util';
 
 describe('parser variable declarations', () => {
     it('allows newlines before assignments', () => {
@@ -84,36 +86,39 @@ describe('parser variable declarations', () => {
          *  +------------------
          * 0| foo = invalid
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        const parser = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'foo',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 0, 0, 3)
+                location: util.createLocation(0, 0, 0, 3)
             },
             {
                 kind: TokenKind.Equal,
                 text: '=',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5)
+                location: util.createLocation(0, 4, 0, 5)
             },
             {
                 kind: TokenKind.Invalid,
                 text: 'invalid',
+                leadingTrivia: [],
                 isReserved: true,
-                range: Range.create(0, 6, 0, 13)
+                location: util.createLocation(0, 6, 0, 13)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
+                leadingTrivia: [],
                 isReserved: false,
-                range: Range.create(0, 13, 0, 14)
+                location: util.createLocation(0, 13, 0, 14)
             }
         ]);
 
-        expect(diagnostics).to.be.lengthOf(0);
-        expect(statements).to.be.lengthOf(1);
-        expect(statements[0].location.range).to.deep.include(
+        expectZeroDiagnostics(parser);
+        expect(parser.ast.statements[0].location?.range).to.deep.include(
             Range.create(0, 0, 0, 13)
         );
     });

--- a/src/parser/tests/statement/Declaration.spec.ts
+++ b/src/parser/tests/statement/Declaration.spec.ts
@@ -113,7 +113,7 @@ describe('parser variable declarations', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).to.deep.include(
+        expect(statements[0].location.range).to.deep.include(
             Range.create(0, 0, 0, 13)
         );
     });

--- a/src/parser/tests/statement/Dim.spec.ts
+++ b/src/parser/tests/statement/Dim.spec.ts
@@ -73,5 +73,5 @@ function validatePass(text: string, dimStatementIndex: number, identifierText: s
     expect(dimStatement.dimensions).to.exist;
     expect(dimStatement.dimensions!.length).to.equal(dimensionsCount);
     expect(dimStatement.tokens.closingSquare).to.exist;
-    expect(dimStatement.range).to.exist;
+    expect(dimStatement.location).to.exist;
 }

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -226,14 +226,14 @@ describe('EnumStatement', () => {
             expectDiagnosticsIncludes(program, [{
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/main.bs`).toString(),
                         util.createRange(5, 21, 5, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/main.bs`).toString(),
                         util.createRange(1, 21, 1, 30)
                     ),
@@ -242,14 +242,14 @@ describe('EnumStatement', () => {
             }, {
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/main.bs`).toString(),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/main.bs`).toString(),
                         util.createRange(5, 21, 5, 30)
                     ),
@@ -273,14 +273,14 @@ describe('EnumStatement', () => {
             expectDiagnosticsIncludes(program, [{
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/lib.bs`).toString(),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
-                    location: util.createLocation(
+                    location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/source/main.bs`).toString(),
                         util.createRange(1, 21, 1, 30)
                     ),

--- a/src/parser/tests/statement/Function.spec.ts
+++ b/src/parser/tests/statement/Function.spec.ts
@@ -5,6 +5,7 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { isFunctionStatement } from '../../../astUtils/reflection';
 import type { FunctionStatement } from '../../Statement';
+import { expectZeroDiagnostics } from '../../../testHelpers.spec';
 
 describe('parser', () => {
 
@@ -372,7 +373,7 @@ describe('parser', () => {
                 EOF
             ]);
 
-            expect(diagnostics).to.be.lengthOf(0);
+            expectZeroDiagnostics(diagnostics);
             expect(statements).to.length.greaterThan(0);
         });
 

--- a/src/parser/tests/statement/Increment.spec.ts
+++ b/src/parser/tests/statement/Increment.spec.ts
@@ -5,6 +5,7 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
+import util from '../../../util';
 
 describe('parser postfix unary expressions', () => {
     it('parses postfix \'++\' for variables', () => {
@@ -103,24 +104,27 @@ describe('parser postfix unary expressions', () => {
          *  +--------------
          * 0| someNumber++
          */
-        let { statements, diagnostics } = Parser.parse(<any>[
+        let { statements, diagnostics } = Parser.parse([
             {
                 kind: TokenKind.Identifier,
                 text: 'someNumber',
                 isReserved: false,
-                range: Range.create(0, 0, 0, 10)
+                leadingTrivia: [],
+                location: util.createLocation(0, 0, 0, 10)
             },
             {
                 kind: TokenKind.PlusPlus,
                 text: '++',
                 isReserved: false,
-                range: Range.create(0, 10, 0, 12)
+                leadingTrivia: [],
+                location: util.createLocation(0, 10, 0, 12)
             },
             {
                 kind: TokenKind.Eof,
                 text: '\0',
                 isReserved: false,
-                range: Range.create(0, 12, 0, 13)
+                leadingTrivia: [],
+                location: util.createLocation(0, 12, 0, 13)
             }
         ]);
 

--- a/src/parser/tests/statement/Increment.spec.ts
+++ b/src/parser/tests/statement/Increment.spec.ts
@@ -126,7 +126,7 @@ describe('parser postfix unary expressions', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).deep.include(
+        expect(statements[0].location?.range).deep.include(
             Range.create(0, 0, 0, 12)
         );
     });

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -6,6 +6,7 @@ import { Range } from 'vscode-languageserver';
 import { Program } from '../../../Program';
 import { rootDir } from '../../../testHelpers.spec';
 import { getTestTranspile } from '../../../testHelpers.spec';
+import util from '../../../util';
 
 describe('parser print statements', () => {
 
@@ -79,7 +80,7 @@ describe('parser print statements', () => {
                 kind: TokenKind.Print,
                 text: 'print',
                 isReserved: true,
-                range: Range.create(0, 0, 0, 5),
+                location: util.createLocation(0, 0, 0, 5),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -87,7 +88,7 @@ describe('parser print statements', () => {
                 kind: TokenKind.StringLiteral,
                 text: `"foo"`,
                 isReserved: false,
-                range: Range.create(0, 6, 0, 11),
+                location: util.createLocation(0, 6, 0, 11),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -95,7 +96,7 @@ describe('parser print statements', () => {
                 kind: TokenKind.Eof,
                 text: '\0',
                 isReserved: false,
-                range: Range.create(0, 11, 0, 12),
+                location: util.createLocation(0, 11, 0, 12),
                 leadingWhitespace: '',
                 leadingTrivia: []
             }
@@ -103,7 +104,7 @@ describe('parser print statements', () => {
 
         expect(diagnostics).to.be.lengthOf(0);
         expect(statements).to.be.lengthOf(1);
-        expect(statements[0].range).to.deep.include(Range.create(0, 0, 0, 11));
+        expect(statements[0].location?.range).to.deep.include(Range.create(0, 0, 0, 11));
     });
 
     describe('transpile', () => {

--- a/src/parser/tests/statement/ReturnStatement.spec.ts
+++ b/src/parser/tests/statement/ReturnStatement.spec.ts
@@ -5,6 +5,7 @@ import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import type { FunctionStatement } from '../../Statement';
 import { Range } from 'vscode-languageserver';
+import util from '../../../util';
 
 describe('parser return statements', () => {
     it('parses void returns', () => {
@@ -51,7 +52,7 @@ describe('parser return statements', () => {
             token(TokenKind.Newline, '\\n'),
             token(TokenKind.Return, 'return'),
             identifier('RebootSystem'),
-            { kind: TokenKind.LeftParen, text: '(', range: null as any, leadingTrivia: [] },
+            { kind: TokenKind.LeftParen, text: '(', location: null as any, leadingTrivia: [] },
             token(TokenKind.RightParen, ')'),
             token(TokenKind.Newline, '\\n'),
             token(TokenKind.EndFunction, 'end function'),
@@ -81,14 +82,14 @@ describe('parser return statements', () => {
                 kind: TokenKind.Return,
                 text: 'return',
                 isReserved: true,
-                range: Range.create(1, 2, 1, 8),
+                location: util.createLocation(1, 2, 1, 8),
                 leadingTrivia: []
             },
             {
                 kind: TokenKind.IntegerLiteral,
                 text: '5',
                 isReserved: false,
-                range: Range.create(1, 9, 1, 10),
+                location: util.createLocation(1, 9, 1, 10),
                 leadingTrivia: []
             },
             token(TokenKind.Newline, '\\n'),
@@ -97,7 +98,7 @@ describe('parser return statements', () => {
         ]);
 
         expect(diagnostics).to.be.lengthOf(0);
-        expect((statements[0] as FunctionStatement).func.body.statements[0]?.range).to.exist.and.to.deep.include(
+        expect((statements[0] as FunctionStatement).func.body.statements[0]?.location?.range).to.exist.and.to.deep.include(
             Range.create(1, 2, 1, 10)
         );
     });

--- a/src/parser/tests/statement/Set.spec.ts
+++ b/src/parser/tests/statement/Set.spec.ts
@@ -4,6 +4,7 @@ import { Parser } from '../../Parser';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { EOF, identifier, token } from '../Parser.spec';
 import { Range } from 'vscode-languageserver';
+import util from '../../../util';
 
 describe('parser indexed assignment', () => {
     describe('dotted', () => {
@@ -131,7 +132,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Identifier,
                 text: 'arr',
                 isReserved: false,
-                range: Range.create(0, 0, 0, 3),
+                location: util.createLocation(0, 0, 0, 3),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -139,7 +140,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.LeftSquareBracket,
                 text: '[',
                 isReserved: false,
-                range: Range.create(0, 3, 0, 4),
+                location: util.createLocation(0, 3, 0, 4),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -147,7 +148,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.IntegerLiteral,
                 text: '0',
                 isReserved: false,
-                range: Range.create(0, 4, 0, 5),
+                location: util.createLocation(0, 4, 0, 5),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -155,7 +156,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.RightSquareBracket,
                 text: ']',
                 isReserved: false,
-                range: Range.create(0, 5, 0, 6),
+                location: util.createLocation(0, 5, 0, 6),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -163,7 +164,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Equal,
                 text: '=',
                 isReserved: false,
-                range: Range.create(0, 7, 0, 8),
+                location: util.createLocation(0, 7, 0, 8),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -171,7 +172,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.IntegerLiteral,
                 text: '1',
                 isReserved: false,
-                range: Range.create(0, 9, 0, 10),
+                location: util.createLocation(0, 9, 0, 10),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -179,7 +180,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Newline,
                 text: '\n',
                 isReserved: false,
-                range: Range.create(0, 10, 0, 11),
+                location: util.createLocation(0, 10, 0, 11),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -187,7 +188,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Identifier,
                 text: 'obj',
                 isReserved: false,
-                range: Range.create(1, 0, 1, 3),
+                location: util.createLocation(1, 0, 1, 3),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -195,7 +196,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Dot,
                 text: '.',
                 isReserved: false,
-                range: Range.create(1, 3, 1, 4),
+                location: util.createLocation(1, 3, 1, 4),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -203,7 +204,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Identifier,
                 text: 'a',
                 isReserved: false,
-                range: Range.create(1, 4, 1, 5),
+                location: util.createLocation(1, 4, 1, 5),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -211,7 +212,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Equal,
                 text: '=',
                 isReserved: false,
-                range: Range.create(1, 6, 1, 7),
+                location: util.createLocation(1, 6, 1, 7),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -219,7 +220,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.IntegerLiteral,
                 text: '5',
                 isReserved: false,
-                range: Range.create(1, 8, 1, 9),
+                location: util.createLocation(1, 8, 1, 9),
                 leadingWhitespace: '',
                 leadingTrivia: []
             },
@@ -227,7 +228,7 @@ describe('parser indexed assignment', () => {
                 kind: TokenKind.Eof,
                 text: '\0',
                 isReserved: false,
-                range: Range.create(1, 10, 1, 11),
+                location: util.createLocation(1, 10, 1, 11),
                 leadingWhitespace: '',
                 leadingTrivia: []
             }
@@ -235,7 +236,7 @@ describe('parser indexed assignment', () => {
 
         expect(diagnostics).to.be.empty;
         expect(statements).to.be.lengthOf(2);
-        expect(statements.map(s => s.range)).to.deep.equal([
+        expect(statements.map(s => s.location?.range)).to.deep.equal([
             Range.create(0, 0, 0, 10),
             Range.create(1, 0, 1, 9)
         ]);

--- a/src/types/BuiltInInterfaceAdder.ts
+++ b/src/types/BuiltInInterfaceAdder.ts
@@ -7,7 +7,7 @@ import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import type { BscType } from './BscType';
 import { isArrayType, isAssociativeArrayType, isBooleanType, isCallableType, isComponentType, isDoubleType, isEnumMemberType, isFloatType, isIntegerType, isInterfaceType, isInvalidType, isLongIntegerType, isStringType } from '../astUtils/reflection';
 import type { ComponentType } from './ComponentType';
-import util from '../util';
+import { util } from '../util';
 import type { UnionType } from './UnionType';
 
 

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -149,15 +149,14 @@ export abstract class InheritableType extends BscType {
     }
 
     protected isAncestorUnresolvedReferenceType() {
-        let p = this as InheritableType;
+        let p = this as InheritableType | ReferenceType;
         while (p) {
             if (isReferenceType(p) && !p.isResolvable()) {
                 return true;
             }
-            p = (p as any).parentType;
+            p = (p as InheritableType).parentType;
 
         }
         return false;
     }
 }
-

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -921,7 +921,7 @@ describe('util', () => {
                 }, 'u/r/i').relatedInformation
             ).to.eql([{
                 message: 'Alpha',
-                location: util.createLocation(
+                location: util.createLocationFromRange(
                     'u/r/i', util.createRange(1, 2, 3, 4)
                 )
             }]);
@@ -935,7 +935,7 @@ describe('util', () => {
                     range: util.createRange(1, 2, 3, 4),
                     relatedInformation: [{
                         message: 'Alpha',
-                        location: util.createLocation(
+                        location: util.createLocationFromRange(
                             'uri', util.createRange(2, 3, 4, 5)
                         )
                     }, {
@@ -945,7 +945,7 @@ describe('util', () => {
                 }, undefined as any).relatedInformation
             ).to.eql([{
                 message: 'Alpha',
-                location: util.createLocation(
+                location: util.createLocationFromRange(
                     'uri', util.createRange(2, 3, 4, 5)
                 )
             }]);

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -851,16 +851,16 @@ describe('util', () => {
 
     it('sortByRange', () => {
         const front = {
-            range: util.createRange(1, 1, 1, 2)
+            location: util.createLocation(1, 1, 1, 2)
         };
         const middle = {
-            range: util.createRange(1, 3, 1, 4)
+            location: util.createLocation(1, 3, 1, 4)
         };
         const back = {
-            range: util.createRange(1, 5, 1, 6)
+            location: util.createLocation(1, 5, 1, 6)
         };
         expect(
-            util.sortByRange([middle, front, back])
+            util.sortByRange([middle?.location, front?.location, back?.location])
         ).to.eql([
             front, middle, back
         ]);
@@ -954,9 +954,9 @@ describe('util', () => {
     describe('processTypeChain', () => {
         it('should  find the correct details in a list of type resolutions', () => {
             const nodes = [
-                createVariableExpression('Alpha', util.createRange(1, 1, 2, 2)),
-                createVariableExpression('Beta', util.createRange(2, 2, 3, 3)),
-                createVariableExpression('CharlieProp', util.createRange(3, 3, 4, 4))
+                createVariableExpression('Alpha', util.createLocation(1, 1, 2, 2)),
+                createVariableExpression('Beta', util.createLocation(2, 2, 3, 3)),
+                createVariableExpression('CharlieProp', util.createLocation(3, 3, 4, 4))
             ];
 
             const chain = [
@@ -975,8 +975,8 @@ describe('util', () => {
 
         it('respects the separatorToken', () => {
             const nodes = [
-                createVariableExpression('Custom', util.createRange(1, 1, 2, 2)),
-                createVariableExpression('someCallFunc', util.createRange(2, 2, 3, 3))
+                createVariableExpression('Custom', util.createLocation(1, 1, 2, 2)),
+                createVariableExpression('someCallFunc', util.createLocation(2, 2, 3, 3))
             ];
             const chain = [
                 new TypeChainEntry({ name: 'roSGNodeCustom', type: new ComponentType('Custom'), data: { flags: SymbolTypeFlag.runtime }, astNode: nodes[0] }),

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from './chai-config.spec';
 import * as path from 'path';
-import util, { standardizePath as s } from './util';
+import { util, standardizePath as s } from './util';
 import { Position, Range } from 'vscode-languageserver';
 import type { BsConfig } from './BsConfig';
 import * as fsExtra from 'fs-extra';
@@ -851,16 +851,16 @@ describe('util', () => {
 
     it('sortByRange', () => {
         const front = {
-            location: util.createLocation(1, 1, 1, 2)
+            range: util.createRange(1, 1, 1, 2)
         };
         const middle = {
-            location: util.createLocation(1, 3, 1, 4)
+            range: util.createRange(1, 3, 1, 4)
         };
         const back = {
-            location: util.createLocation(1, 5, 1, 6)
+            range: util.createRange(1, 5, 1, 6)
         };
         expect(
-            util.sortByRange([middle?.location, front?.location, back?.location])
+            util.sortByRange([middle, front, back])
         ).to.eql([
             front, middle, back
         ]);
@@ -970,7 +970,7 @@ describe('util', () => {
             expect(result.fullChainName).to.eql('AlphaNamespace.BetaProp.CharlieProp');
             expect(result.itemParentTypeName).to.eql('Beta');
             expect(result.fullNameOfItem).to.eql('Beta.CharlieProp');
-            expect(result.range).to.eql(util.createRange(3, 3, 4, 4));
+            expect(result.location.range).to.eql(util.createRange(3, 3, 4, 4));
         });
 
         it('respects the separatorToken', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -744,14 +744,37 @@ export class Util {
         return subject;
     }
 
+    /**
+     * Does the string appear to be a uri (i.e. does it start with `file:`)
+     */
+    private isUriLike(filePath: string) {
+        return filePath?.indexOf('file:') === 0;// eslint-disable-line @typescript-eslint/prefer-string-starts-ends-with
+    }
+
+    /**
+     * Given a file path, convert it to a URI string
+     */
+    public pathToUri(filePath: string) {
+        if (!filePath) {
+            return filePath;
+        } else if (this.isUriLike(filePath)) {
+            return filePath;
+        } else {
+            return URI.file(filePath).toString();
+        }
+    }
 
     /**
      * Given a URI, convert that to a regular fs path
      */
     public uriToPath(uri: string) {
+        //if this doesn't look like a URI, then assume it's already a path
+        if (this.isUriLike(uri) === false) {
+            return uri;
+        }
         let parsedPath = URI.parse(uri).fsPath;
 
-        //Uri annoyingly coverts all drive letters to lower case...so this will bring back whatever case it came in as
+        //Uri annoyingly converts all drive letters to lower case...so this will bring back whatever case it came in as
         let match = /\/\/\/([a-z]:)/i.exec(uri);
         if (match) {
             let originalDriveCasing = match[1];
@@ -806,13 +829,6 @@ export class Util {
             }
         }
         return true;
-    }
-
-    /**
-     * Given a file path, convert it to a URI string
-     */
-    public pathToUri(filePath: string) {
-        return URI.file(filePath).toString();
     }
 
     /**
@@ -1084,7 +1100,7 @@ export class Util {
      */
     public createLocationFromRange(uri: string, range: Range): Location {
         return {
-            uri: uri,
+            uri: util.pathToUri(uri),
             range: range
         };
     }
@@ -1094,7 +1110,7 @@ export class Util {
      */
     public createLocation(startLine: number, startCharacter: number, endLine: number, endCharacter: number, uri?: string): Location {
         return {
-            uri: uri,
+            uri: util.pathToUri(uri),
             range: {
                 start: {
                     line: startLine,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1062,10 +1062,29 @@ export class Util {
     /**
      * Helper for creating `Location` objects. Prefer using this function because vscode-languageserver's `Location.create()` is significantly slower at scale
      */
-    public createLocation(uri: string, range: Range): Location {
+    public createLocationFromRange(uri: string, range: Range): Location {
         return {
             uri: uri,
             range: range
+        };
+    }
+
+    /**
+     * Helper for creating `Location` objects by passing each range value in directly. Prefer using this function because vscode-languageserver's `Location.create()` is significantly slower at scale
+     */
+    public createLocation(startLine: number, startCharacter: number, endLine: number, endCharacter: number, uri: string): Location {
+        return {
+            uri: uri,
+            range: {
+                start: {
+                    line: startLine,
+                    character: startCharacter
+                },
+                end: {
+                    line: endLine,
+                    character: endCharacter
+                }
+            }
         };
     }
 
@@ -1686,7 +1705,7 @@ export class Util {
             relatedInformation = relatedInformation.slice(0, MAX_RELATED_INFOS_COUNT);
             relatedInformation.push({
                 message: `...and ${relatedInfoLength - MAX_RELATED_INFOS_COUNT} more`,
-                location: util.createLocation('   ', util.createRange(0, 0, 0, 0))
+                location: util.createLocationFromRange('   ', util.createRange(0, 0, 0, 0))
             });
         }
         let result = {
@@ -1700,7 +1719,7 @@ export class Util {
                 if (!clone.location) {
                     // use the fallback location if available
                     if (relatedInformationFallbackLocation) {
-                        clone.location = util.createLocation(relatedInformationFallbackLocation, diagnostic.range);
+                        clone.location = util.createLocationFromRange(relatedInformationFallbackLocation, diagnostic.range);
                     } else {
                         //remove this related information so it doesn't bring crash the language server
                         return undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1796,7 +1796,7 @@ export class Util {
      */
     public getFirstLocatableAt(locatables: Locatable[], position: Position) {
         for (let token of locatables) {
-            if (util.rangeContains(token.range, position)) {
+            if (util.rangeContains(token.location?.range, position)) {
                 return token;
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1142,7 +1142,9 @@ export class Util {
 
         for (let locatable of locatables) {
             let range: Range;
-            if ('location' in locatable) {
+            if (!locatable) {
+                continue;
+            } else if ('location' in locatable) {
                 range = locatable.location?.range;
                 if (!uri) {
                     uri = locatable.location?.uri;
@@ -2089,7 +2091,7 @@ export class Util {
         let itemTypeKind = '';
         let parentTypeKind = '';
         let astNode: AstNode;
-        let errorRange: Range;
+        let errorLocation: Location;
         let containsDynamic = false;
         let continueResolvingAllItems = true;
         for (let i = 0; i < typeChain.length; i++) {
@@ -2138,7 +2140,7 @@ export class Util {
                 astNode = chainItem.astNode;
                 containsDynamic = containsDynamic || (isDynamicType(chainItem.type) && !isAnyReferenceType(chainItem.type));
                 if (!chainItem.isResolved) {
-                    errorRange = chainItem.range;
+                    errorLocation = chainItem.location;
                     continueResolvingAllItems = false;
                 }
             }
@@ -2150,7 +2152,7 @@ export class Util {
             itemParentTypeKind: parentTypeKind,
             fullNameOfItem: fullErrorName,
             fullChainName: fullChainName,
-            range: errorRange,
+            location: errorLocation,
             containsDynamic: containsDynamic,
             astNode: astNode
         };
@@ -2333,7 +2335,7 @@ export function standardizePath(stringParts, ...expressions: any[]) {
 }
 
 /**
- * An item that can be coerced into a range
+ * An item that can be coerced into a `Range`
  */
 export type RangeLike = { location?: Location } | Location | { range?: Range } | Range | undefined;
 

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -57,7 +57,7 @@ export class BsClassValidator {
                             this.diagnostics.push({
                                 ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
                                 file: classStatement.file,
-                                range: expression.range
+                                range: expression.location?.range
                             });
                         }
                         if (isCallExpression(parent) && expressionNameLower === 'super') {
@@ -76,7 +76,7 @@ export class BsClassValidator {
                     this.diagnostics.push({
                         ...DiagnosticMessages.classConstructorMissingSuperCall(),
                         file: classStatement.file,
-                        range: newMethod.range
+                        range: newMethod.location?.range
                     });
                 }
             }
@@ -98,7 +98,7 @@ export class BsClassValidator {
                         ...DiagnosticMessages.circularReferenceDetected(
                             Array.from(names.values()).concat(className), this.scope.name),
                         file: cls.file,
-                        range: cls.tokens.name.range
+                        range: cls.tokens.name.location?.range
                     });
                     break;
                 }
@@ -134,7 +134,7 @@ export class BsClassValidator {
                         this.diagnostics.push({
                             ...DiagnosticMessages.duplicateIdentifier(memberName.text),
                             file: classStatement.file,
-                            range: memberName.range
+                            range: memberName.location?.range
                         });
                     }
 
@@ -152,7 +152,7 @@ export class BsClassValidator {
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
                                 file: classStatement.file,
-                                range: member.range
+                                range: member.location?.range
                             });
                         }
 
@@ -176,7 +176,7 @@ export class BsClassValidator {
                                         ancestorMemberType.toString()
                                     ),
                                     file: classStatement.file,
-                                    range: member.range
+                                    range: member.location?.range
                                 });
                             }
                         }
@@ -195,7 +195,7 @@ export class BsClassValidator {
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
                                 file: classStatement.file,
-                                range: member.range
+                                range: member.location?.range
                             });
                         }
 
@@ -214,7 +214,7 @@ export class BsClassValidator {
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
                                 file: classStatement.file,
-                                range: member.range
+                                range: member.location?.range
                             });
                         }
                     }


### PR DESCRIPTION
Convert all `.range` properties to `.location`. This allows all tokens to know what file they came from. This is a fairly significant breaking change. 

TODO

- [x] convert all `.range` to `.location`
- [x] add unit tests ensuring sourcemaps properly track tokens from multiple files
- [x] ensure transpiled output is the same for a few large projects