### PR TITLE
Fixes completions when file in multiple scopes

### DIFF
--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -22,6 +22,7 @@ import type { ClassStatement, FunctionStatement, NamespaceStatement, AliasStatem
 import type { Token } from '../../lexer/Token';
 import { createIdentifier } from '../../astUtils/creators';
 import type { FunctionExpression } from '../../parser/Expression';
+import { LogLevel } from '../../Logger';
 
 export class CompletionsProcessor {
     constructor(
@@ -32,43 +33,45 @@ export class CompletionsProcessor {
 
     public process() {
         let file = this.event.file;
+        this.event.program.logger.time(LogLevel.log, ['Processing completions'], () => {
+            //find the scopes for this file
+            let scopesForFile = this.event.program.getScopesForFile(file);
 
-        //find the scopes for this file
-        let scopesForFile = this.event.program.getScopesForFile(file);
+            //if there are no scopes, include the global scope so we at least get the built-in functions
+            scopesForFile = scopesForFile.length > 0 ? scopesForFile : [this.event.program.globalScope];
 
-        //if there are no scopes, include the global scope so we at least get the built-in functions
-        scopesForFile = scopesForFile.length > 0 ? scopesForFile : [this.event.program.globalScope];
+            //get the completions from all scopes for this file
+            let completionResults: CompletionItem[] = [];
+            let globalResults: CompletionItem[] = [];
 
-        //get the completions from all scopes for this file
-        let completionResults: CompletionItem[] = [];
-        let globalResults: CompletionItem[] = [];
-        if (isXmlFile(file)) {
-            completionResults = this.getXmlFileCompletions(this.event.position, file);
-        } else if (isBrsFile(file)) {
-            //handle script import completions
-            let scriptImport = util.getScriptImportAtPosition(file.ownScriptImports, this.event.position);
-            if (scriptImport) {
-                this.event.completions.push(...this.getScriptImportCompletions(file.program, file.pkgPath, scriptImport));
-                return;
+            if (isXmlFile(file)) {
+                completionResults = this.getXmlFileCompletions(this.event.position, file);
+            } else if (isBrsFile(file)) {
+                //handle script import completions
+                let scriptImport = util.getScriptImportAtPosition(file.ownScriptImports, this.event.position);
+                if (scriptImport) {
+                    this.event.completions.push(...this.getScriptImportCompletions(file.program, file.pkgPath, scriptImport));
+                    return;
+                }
+                const results = this.getBrsFileCompletions(this.event.position, file);
+                completionResults = results.scoped;
+                globalResults = results.global;
             }
-            const results = this.getBrsFileCompletions(this.event.position, file);
-            completionResults = results.scoped;
-            globalResults = results.global;
-        }
 
-        this.event.completions.push(...globalResults);
+            this.event.completions.push(...globalResults);
 
-        let allCompletions = completionResults.flat();
+            let allCompletions = completionResults.flat();
 
-        //only keep completions common to every scope for this file
-        let keyCounts = new Map<string, number>();
-        for (let completion of allCompletions) {
-            let key = `${completion.label}-${completion.kind}`;
-            keyCounts.set(key, keyCounts.has(key) ? keyCounts.get(key) + 1 : 1);
-            if (keyCounts.get(key) === scopesForFile.length) {
-                this.event.completions.push(completion);
+            //only keep completions common to every scope for this file
+            let keyCounts = new Map<string, number>();
+            for (let completion of allCompletions) {
+                let key = `${completion.label}-${completion.kind}`;
+                keyCounts.set(key, keyCounts.has(key) ? keyCounts.get(key) + 1 : 1);
+                if (keyCounts.get(key) === scopesForFile.length) {
+                    this.event.completions.push(completion);
+                }
             }
-        }
+        });
     }
 
 
@@ -242,17 +245,24 @@ export class CompletionsProcessor {
             return symbolTableToUse;
         }
 
-        let notMembers = !(shouldLookForMembers || shouldLookForCallFuncMembers);
+        const areMembers = (shouldLookForMembers || shouldLookForCallFuncMembers);
+        const notMembers = !areMembers;
+        const isAfterNew = tokenBefore?.kind === TokenKind.New;
         const shouldLookInNamespace: NamespaceStatement = notMembers && expression.findAncestor(isNamespaceStatement);
 
         const containingClassStmt = expression.findAncestor<ClassStatement>(isClassStatement);
         const containingNamespace = expression.findAncestor<NamespaceStatement>(isNamespaceStatement);
         const containingNamespaceName = containingNamespace?.getName(ParseMode.BrighterScript);
         const containingFunctionExpression = expression.findAncestor<FunctionExpression>(isFunctionExpression);
+        const tokenIsLiteralString = (tokenKind === TokenKind.StringLiteral || tokenKind === TokenKind.TemplateStringQuasi);
 
-        let globalSymbols: BscSymbol[] = this.event.program?.globalScope.symbolTable.getOwnSymbols(symbolTableLookupFlag) ?? [];
-        if (symbolTableLookupFlag === SymbolTypeFlag.runtime) {
-            globalSymbols.push(...this.getGlobalValues());
+        const globalCompletions: CompletionItem[] = [];
+        if (!tokenIsLiteralString && notMembers && !isAfterNew && this.event.program?.globalScope) {
+            let globalSymbols: BscSymbol[] = this.event.program.globalScope.symbolTable.getOwnSymbols(symbolTableLookupFlag) ?? [];
+            if (symbolTableLookupFlag === SymbolTypeFlag.runtime) {
+                globalSymbols.push(...this.getGlobalValues());
+            }
+            globalCompletions.push(...this.getSymbolsCompletion(globalSymbols));
         }
 
         for (const scope of this.event.scopes) {
@@ -264,7 +274,7 @@ export class CompletionsProcessor {
             const symbolTable = getSymbolTableForLookups();
             let currentSymbols: BscSymbol[] = [];
 
-            if (shouldLookForMembers || shouldLookForCallFuncMembers) {
+            if (areMembers) {
                 currentSymbols = symbolTable?.getAllSymbols(symbolTableLookupFlag) ?? [];
                 const tokenType = expression.getType({ flags: SymbolTypeFlag.runtime });
                 if (isClassType(tokenType)) {
@@ -299,22 +309,18 @@ export class CompletionsProcessor {
                         currentSymbols.push(...nameSpaceTypeSofar.getMemberTable().getAllSymbols(symbolTableLookupFlag));
                     }
                 }
-                currentSymbols.push(...globalSymbols);
                 currentSymbols.push(...this.getScopeSymbolCompletions(file, scope, symbolTableLookupFlag));
             }
 
             let ignoreAllPropertyNames = false;
 
-            // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-            switch (tokenBefore?.kind) {
-                case TokenKind.New:
-                    //we are after a new keyword; so we can only be namespaces that have a class or classes at this point
-                    currentSymbols = currentSymbols.filter(symbol => isClassType(symbol.type) || this.isNamespaceTypeWithMemberType(symbol.type, isClassType));
-                    ignoreAllPropertyNames = true;
-                    break;
+            if (isAfterNew) {
+                //we are after a new keyword; so we can only be namespaces that have a class or classes at this point
+                currentSymbols = currentSymbols.filter(symbol => isClassType(symbol.type) || this.isNamespaceTypeWithMemberType(symbol.type, isClassType));
+                ignoreAllPropertyNames = true;
             }
 
-            result.push(...this.getSymbolsCompletion(currentSymbols, shouldLookForMembers || shouldLookForCallFuncMembers));
+            result.push(...this.getSymbolsCompletion(currentSymbols, areMembers));
             if (shouldLookForMembers && currentSymbols.length === 0 && !ignoreAllPropertyNames) {
                 // could not find members of actual known types.. just try everything
                 result.push(...this.getPropertyNameCompletions(scope),
@@ -325,7 +331,7 @@ export class CompletionsProcessor {
             }
             scope.unlinkSymbolTable();
         }
-        return { global: [], scoped: result };
+        return { global: globalCompletions, scoped: result };
     }
 
     private getScopeSymbolCompletions(file: BrsFile, scope: Scope, symbolTableLookupFlag: SymbolTypeFlag) {


### PR DESCRIPTION
There was a bug that if a file was in multiple scopes, global completions and completions for the same file were only included once, that is not for every scope. However, there's also a process that filters out completions that don't work for every scope.

This is not the most performant code, because it has to link every scope, as well as do symbol tables checks for every scope, but it works.

![image](https://github.com/rokucommunity/brighterscript/assets/810290/eb781047-7da6-43a2-b58e-e8153243e6da)


Addresses: #1235