### PR TITLE
Remove `file` prop from `BsDiagnostic`

### DIFF
--- a/src/CodeActionUtil.ts
+++ b/src/CodeActionUtil.ts
@@ -1,6 +1,7 @@
 import type { Diagnostic, Position, Range, WorkspaceEdit } from 'vscode-languageserver';
 import { CodeActionKind, CodeAction, TextEdit } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+import type { BsDiagnostic } from './interfaces';
 
 export class CodeActionUtil {
 
@@ -31,9 +32,9 @@ export class CodeActionUtil {
         return action;
     }
 
-    public serializableDiagnostics(diagnostics: Diagnostic[] | undefined) {
-        return diagnostics?.map(({ range, severity, code, source, message, relatedInformation }) => ({
-            range: range,
+    public serializableDiagnostics(diagnostics: BsDiagnostic[] | undefined): Diagnostic[] {
+        return diagnostics?.map(({ location, severity, code, source, message, relatedInformation }) => ({
+            range: location?.range,
             severity: severity,
             source: source,
             code: code,
@@ -47,7 +48,7 @@ export { CodeActionKind };
 
 export interface CodeActionShorthand {
     title: string;
-    diagnostics?: Diagnostic[];
+    diagnostics?: BsDiagnostic[];
     kind?: CodeActionKind;
     isPreferred?: boolean;
     changes: Array<InsertChange | ReplaceChange>;

--- a/src/CodeActionUtil.ts
+++ b/src/CodeActionUtil.ts
@@ -1,7 +1,7 @@
 import type { Diagnostic, Position, Range, WorkspaceEdit } from 'vscode-languageserver';
 import { CodeActionKind, CodeAction, TextEdit } from 'vscode-languageserver';
-import { URI } from 'vscode-uri';
 import type { BsDiagnostic } from './interfaces';
+import util from './util';
 
 export class CodeActionUtil {
 
@@ -10,7 +10,7 @@ export class CodeActionUtil {
             changes: {}
         } as WorkspaceEdit;
         for (const change of obj.changes) {
-            const uri = URI.file(change.filePath).toString();
+            const uri = util.pathToUri(change.filePath);
 
             //create the edit changes array for this uri
             if (!edit.changes![uri]) {

--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -86,8 +86,7 @@ export class CommentFlagProcessor {
                 } else {
                     this.diagnostics.push({
                         ...DiagnosticMessages.unknownDiagnosticCode(codeInt),
-                        file: this.file,
-                        range: codeToken.range
+                        location: util.createLocationFromFileRange(this.file, codeToken.range)
                     });
                 }
             }

--- a/src/CrossScopeValidator.spec.ts
+++ b/src/CrossScopeValidator.spec.ts
@@ -6,6 +6,7 @@ import type { BrsFile } from './files/BrsFile';
 import { trim, expectZeroDiagnostics, expectDiagnostics, expectDiagnosticsIncludes } from './testHelpers.spec';
 import { expect } from 'chai';
 import { SymbolTypeFlag } from './SymbolTypeFlag';
+import util from './util';
 
 describe('CrossScopeValidator', () => {
     let sinon = sinonImport.createSandbox();
@@ -1153,15 +1154,11 @@ describe('CrossScopeValidator', () => {
             expectDiagnostics(program, [
                 {
                     message: DiagnosticMessages.cannotFindName('fontName', 'TextOptions.fontName', 'TextOptions').message,
-                    file: {
-                        srcPath: button1.srcPath
-                    }
+                    location: { uri: util.pathToUri(button1.srcPath) }
                 },
                 {
                     message: DiagnosticMessages.cannotFindName('fontName', 'TextOptions.fontName', 'TextOptions').message,
-                    file: {
-                        srcPath: button2.srcPath
-                    }
+                    location: { uri: util.pathToUri(button2.srcPath) }
                 }
             ]);
         });
@@ -1221,15 +1218,11 @@ describe('CrossScopeValidator', () => {
             expectDiagnostics(program, [
                 {
                     message: DiagnosticMessages.mismatchArgumentCount(1, 0).message,
-                    file: {
-                        srcPath: button1.srcPath
-                    }
+                    location: { uri: util.pathToUri(button1.srcPath) }
                 },
                 {
                     message: DiagnosticMessages.mismatchArgumentCount(1, 0).message,
-                    file: {
-                        srcPath: button2.srcPath
-                    }
+                    location: { uri: util.pathToUri(button2.srcPath) }
                 }
             ]);
         });
@@ -1397,15 +1390,11 @@ describe('CrossScopeValidator', () => {
             expectDiagnostics(program, [
                 {
                     message: DiagnosticMessages.cannotFindName('getValue', 'alpha.beta.getValue', 'alpha.beta', 'namespace').message,
-                    file: {
-                        srcPath: button1.srcPath
-                    }
+                    location: { uri: util.pathToUri(button1.srcPath) }
                 },
                 {
                     message: DiagnosticMessages.cannotFindName('getValue').message,
-                    file: {
-                        srcPath: button2.srcPath
-                    }
+                    location: { uri: util.pathToUri(button2.srcPath) }
                 }
             ]);
         });
@@ -1451,9 +1440,7 @@ describe('CrossScopeValidator', () => {
                 expectDiagnostics(program, [
                     {
                         message: DiagnosticMessages.cannotFindFunction('someFunc', 'alpha.beta.someFunc', 'alpha.beta', 'namespace').message,
-                        file: {
-                            srcPath: widgetFile.srcPath
-                        }
+                        location: { uri: util.pathToUri(widgetFile.srcPath) }
                     }
                 ]);
 

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -2,7 +2,6 @@ import type { BsDiagnostic } from './interfaces';
 import { DiagnosticCollection } from './DiagnosticCollection';
 import type { Project } from './LanguageServer';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { BscFile } from './files/BscFile';
 import util from './util';
 import { expect } from './chai-config.spec';
 
@@ -93,9 +92,10 @@ describe('DiagnosticCollection', () => {
     });
 
     function removeDiagnostic(srcPath: string, message: string) {
+        const fileUri = util.pathToUri(srcPath);
         for (let i = 0; i < diagnostics.length; i++) {
             const diagnostic = diagnostics[i];
-            if (diagnostic.file.srcPath === srcPath && diagnostic.message === message) {
+            if (diagnostic.location.uri === fileUri && diagnostic.message === message) {
                 diagnostics.splice(i, 1);
                 return;
             }
@@ -105,12 +105,10 @@ describe('DiagnosticCollection', () => {
 
     function addDiagnostics(srcPath: string, messages: string[]) {
         const newDiagnostics: BsDiagnostic[] = [];
+        const fileUri = util.pathToUri(srcPath);
         for (const message of messages) {
             newDiagnostics.push({
-                file: {
-                    srcPath: srcPath
-                } as BscFile,
-                range: util.createRange(0, 0, 0, 0),
+                location: { uri: fileUri, range: util.createRange(0, 0, 0, 0) },
                 //the code doesn't matter as long as the messages are different, so just enforce unique messages for this test files
                 code: 123,
                 message: message

--- a/src/DiagnosticCollection.spec.ts
+++ b/src/DiagnosticCollection.spec.ts
@@ -25,11 +25,16 @@ describe('DiagnosticCollection', () => {
         const patch = collection.getPatch(projects);
         //convert the patch into our test structure
         const actual = {};
-        for (const filePath in patch) {
-            actual[filePath] = patch[filePath].map(x => x.message);
+        for (const fileUri in patch) {
+            actual[fileUri] = patch[fileUri].map(x => x.message);
+        }
+        const expectedWithUris = {};
+        for (const fileSrc in expected) {
+            const fileUri = util.pathToUri(fileSrc);
+            expectedWithUris[fileUri] = expected[fileSrc];
         }
 
-        expect(actual).to.eql(expected);
+        expect(actual).to.eql(expectedWithUris);
     }
 
     it('does not crash for diagnostics with missing locations', () => {

--- a/src/DiagnosticCollection.ts
+++ b/src/DiagnosticCollection.ts
@@ -30,18 +30,18 @@ export class DiagnosticCollection {
         const keys = {};
         //build the full current set of diagnostics by file
         for (let diagnostic of diagnostics) {
-            const srcPath = diagnostic.file.srcPath ?? diagnostic.file.srcPath;
+            const fileUri = diagnostic.location.uri;
             //ensure the file entry exists
-            if (!result[srcPath]) {
-                result[srcPath] = [];
+            if (!result[fileUri]) {
+                result[fileUri] = [];
             }
-            const diagnosticMap = result[srcPath];
+            const diagnosticMap = result[fileUri];
 
             //fall back to a default range if missing
-            const range = diagnostic?.range ?? util.createRange(0, 0, 0, 0);
+            const range = diagnostic?.location?.range ?? util.createRange(0, 0, 0, 0);
 
             diagnostic.key =
-                srcPath.toLowerCase() + '-' +
+                fileUri.toLowerCase() + '-' +
                 diagnostic.code + '-' +
                 range.start.line + '-' +
                 range.start.character + '-' +

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from './chai-config.spec';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
 import type { BsDiagnostic } from './interfaces';
-import { standardizePath as s } from './util';
+import util, { standardizePath as s } from './util';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 let rootDir = s`${process.cwd()}/rootDir`;
@@ -270,8 +270,8 @@ describe('DiagnosticFilterer', () => {
 
 function getDiagnostic(code: number | string, srcPath: string) {
     return {
-        file: {
-            srcPath: s`${srcPath}`
+        location: {
+            uri: util.pathToUri(s`${srcPath}`)
         },
         code: code
     } as BsDiagnostic;

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -261,8 +261,8 @@ describe('DiagnosticFilterer', () => {
         ]);
         expect(stub.callCount).to.eql(2);
         expect(stub.getCalls().map(x => x.args[1])).to.eql([
-            s`${rootDir.toLowerCase()}/source/common1.brs`,
-            s`${rootDir.toLowerCase()}/source/common2.brs`
+            util.pathToUri(s`${rootDir.toLowerCase()}/source/common1.brs`),
+            util.pathToUri(s`${rootDir.toLowerCase()}/source/common2.brs`)
         ]);
     });
 

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -260,9 +260,9 @@ describe('DiagnosticFilterer', () => {
             getDiagnostic(4, s`${rootDir}/source/Common2.brs`)
         ]);
         expect(stub.callCount).to.eql(2);
-        expect(stub.getCalls().map(x => x.args[1])).to.eql([
-            util.pathToUri(s`${rootDir.toLowerCase()}/source/common1.brs`),
-            util.pathToUri(s`${rootDir.toLowerCase()}/source/common2.brs`)
+        expect(stub.getCalls().map(x => x.args[1].toLowerCase())).to.eql([
+            util.pathToUri(s`${rootDir.toLowerCase()}/source/common1.brs`).toLowerCase(),
+            util.pathToUri(s`${rootDir.toLowerCase()}/source/common2.brs`).toLowerCase()
         ]);
     });
 

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -2,7 +2,7 @@ import type { BsDiagnostic } from './interfaces';
 import * as path from 'path';
 import * as minimatch from 'minimatch';
 import type { BsConfig } from './BsConfig';
-import { standardizePath as s } from './util';
+import util, { standardizePath as s } from './util';
 
 interface DiagnosticWithSuppression {
     diagnostic: BsDiagnostic;
@@ -73,17 +73,17 @@ export class DiagnosticFilterer {
         this.byFile = {};
 
         for (let diagnostic of diagnostics) {
-            const srcPath = diagnostic?.file?.srcPath ?? diagnostic?.file?.srcPath;
+            const fileUri = diagnostic?.location?.uri;
             //skip diagnostics that have issues
-            if (!srcPath) {
+            if (!fileUri) {
                 continue;
             }
-            const lowerSrcPath = srcPath.toLowerCase();
+            const lowerFileUri = fileUri.toLowerCase();
             //make a new array for this file if one does not yet exist
-            if (!this.byFile[lowerSrcPath]) {
-                this.byFile[lowerSrcPath] = [];
+            if (!this.byFile[lowerFileUri]) {
+                this.byFile[lowerFileUri] = [];
             }
-            this.byFile[lowerSrcPath].push({
+            this.byFile[lowerFileUri].push({
                 diagnostic: diagnostic,
                 isSuppressed: false
             });
@@ -99,8 +99,9 @@ export class DiagnosticFilterer {
             let src = s(
                 path.isAbsolute(filter.src) ? filter.src : `${this.rootDir}/${filter.src}`
             );
+            let uri = util.pathToUri(src);
 
-            matchedFilePaths = minimatch.match(Object.keys(this.byFile), src, {
+            matchedFilePaths = minimatch.match(Object.keys(this.byFile), uri, {
                 nocase: true
             });
 

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -73,7 +73,7 @@ export class DiagnosticFilterer {
         this.byFile = {};
 
         for (let diagnostic of diagnostics) {
-            const fileUri = diagnostic?.location?.uri;
+            const fileUri = diagnostic?.location?.uri ?? 'invalid-uri';
             //skip diagnostics that have issues
             if (!fileUri) {
                 continue;

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -104,7 +104,7 @@ export class DiagnosticFilterer {
             const byFileSrcs = Object.keys(this.byFile).map(uri => URI.parse(uri).fsPath);
             matchedFileUris = minimatch.match(byFileSrcs, src, {
                 nocase: true
-            }).map(src => util.pathToUri(src));
+            }).map(src => util.pathToUri(src).toLowerCase());
 
             //there is no src; this applies to all files
         } else {
@@ -121,16 +121,16 @@ export class DiagnosticFilterer {
         //if the filter is negative, we're turning diagnostics on
         //if the filter is not negative we're turning diagnostics off
         const isSuppressing = !filter.isNegative;
-
+        const lowerFileUri = fileUri.toLowerCase();
         //if there is no code, set isSuppressed on every diagnostic in this file
         if (!filter.codes) {
-            this.byFile[fileUri].forEach(diagnostic => {
+            this.byFile[lowerFileUri].forEach(diagnostic => {
                 diagnostic.isSuppressed = isSuppressing;
             });
 
             //set isSuppressed for any diagnostics with matching codes
         } else {
-            let fileDiagnostics = this.byFile[fileUri];
+            let fileDiagnostics = this.byFile[lowerFileUri];
             for (const diagnostic of fileDiagnostics) {
                 if (filter.codes.includes(diagnostic.diagnostic.code!)) {
                     diagnostic.isSuppressed = isSuppressing;

--- a/src/DiagnosticManager.spec.ts
+++ b/src/DiagnosticManager.spec.ts
@@ -1,0 +1,31 @@
+import type { BrsFile } from './files/BrsFile';
+import type { BsDiagnostic } from './interfaces';
+import { Program } from './Program';
+import util from './util';
+
+
+describe('DiagnosticManager', () => {
+    describe('diagnosticIsSuppressed', () => {
+        it('does not crash when diagnostic is missing location information', () => {
+            const program = new Program({});
+            const file = program.setFile('source/main.brs', '') as BrsFile;
+            const diagnostic: BsDiagnostic = {
+                message: 'crash',
+                //important part of the test. range must be missing
+                location: { uri: util.getFileUri(file), range: undefined }
+            };
+
+            file.commentFlags.push({
+                affectedRange: util.createRange(1, 2, 3, 4),
+                codes: [1, 2, 3],
+                file: file,
+                range: util.createRange(1, 2, 3, 4)
+            });
+            program.diagnostics.register(diagnostic);
+
+            program.diagnostics.isDiagnosticSuppressed(diagnostic);
+
+            //test passes if there's no crash
+        });
+    });
+});

--- a/src/DiagnosticManager.spec.ts
+++ b/src/DiagnosticManager.spec.ts
@@ -12,7 +12,7 @@ describe('DiagnosticManager', () => {
             const diagnostic: BsDiagnostic = {
                 message: 'crash',
                 //important part of the test. range must be missing
-                location: { uri: util.getFileUri(file), range: undefined }
+                location: { uri: util.pathToUri(file?.srcPath), range: undefined }
             };
 
             file.commentFlags.push({

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -1,5 +1,4 @@
 import type { DiagnosticContext, BsDiagnostic, DiagnosticContextPair } from './interfaces';
-import { URI } from 'vscode-uri';
 import type { AstNode } from './parser/AstNode';
 import type { Scope } from './Scope';
 import { util } from './util';
@@ -111,7 +110,7 @@ export class DiagnosticManager {
                     relatedInformation.push({
                         message: `In component scope '${scope?.xmlFile?.componentName?.text}'`,
                         location: util.createLocationFromRange(
-                            URI.file(scope.xmlFile.srcPath).toString(),
+                            util.pathToUri(scope.xmlFile?.srcPath),
                             scope?.xmlFile?.ast?.componentElement?.getAttribute('name')?.tokens?.value?.location?.range ?? util.createRange(0, 0, 0, 10)
                         )
                     });

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -126,9 +126,10 @@ export class DiagnosticManager {
             diagnostic.relatedInformation = relatedInformation;
             results.push(diagnostic);
         }
-        return results.filter((x) => {
+        const filteredResults = results.filter((x) => {
             return !this.isDiagnosticSuppressed(x);
         });
+        return filteredResults;
     }
 
     /**
@@ -136,7 +137,7 @@ export class DiagnosticManager {
      */
     public isDiagnosticSuppressed(diagnostic: BsDiagnostic) {
         const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
-        const file = this.program?.getFile(diagnostic.location.uri);
+        const file = this.program?.getFile(diagnostic.location?.uri);
 
         for (let flag of file?.commentFlags ?? []) {
             //this diagnostic is affected by this flag
@@ -257,12 +258,12 @@ export class DiagnosticManager {
 
 
     private getDiagnosticKey(diagnostic: BsDiagnostic) {
-        return `${diagnostic.location.uri} ${util.rangeToString(diagnostic.location.range)} - ${diagnostic.code} - ${diagnostic.message}`;
+        return `${diagnostic.location?.uri ?? 'No uri'} ${util.rangeToString(diagnostic.location?.range)} - ${diagnostic.code} - ${diagnostic.message}`;
     }
 
     private mergeRelatedInformation(target: DiagnosticRelatedInformation[], source: DiagnosticRelatedInformation[]) {
         function getRiKey(relatedInfo: DiagnosticRelatedInformation) {
-            return `${relatedInfo.message} - ${relatedInfo.location.uri} - ${util.rangeToString(relatedInfo.location.range)}`.toLowerCase();
+            return `${relatedInfo.message} - ${relatedInfo.location?.uri} - ${util.rangeToString(relatedInfo.location?.range)}`.toLowerCase();
         }
 
         const existingKeys = target.map(ri => getRiKey(ri));

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -5,7 +5,6 @@ import type { Scope } from './Scope';
 import { util } from './util';
 import { Cache } from './Cache';
 import { isBsDiagnostic, isXmlScope } from './astUtils/reflection';
-import type { BscFile } from './files/BscFile';
 import type { DiagnosticRelatedInformation } from 'vscode-languageserver-protocol';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
 import { DiagnosticSeverityAdjuster } from './DiagnosticSeverityAdjuster';
@@ -13,6 +12,7 @@ import type { FinalizedBsConfig } from './BsConfig';
 import chalk from 'chalk';
 import type { Logger } from './logging';
 import { LogLevel, createLogger } from './logging';
+import type { Program } from './Program';
 
 /**
  * Manages all diagnostics for a program.
@@ -36,6 +36,8 @@ export class DiagnosticManager {
     public logger: Logger;
 
     public options: FinalizedBsConfig;
+
+    public program: Program;
 
     /**
      * Registers a diagnostic (or multiple diagnostics) for a program.
@@ -116,10 +118,7 @@ export class DiagnosticManager {
                 } else {
                     relatedInformation.push({
                         message: `In scope '${scope.name}'`,
-                        location: util.createLocationFromRange(
-                            URI.file(diagnostic.file.srcPath).toString(),
-                            diagnostic.range
-                        )
+                        location: diagnostic.location
                     });
                 }
 
@@ -128,8 +127,27 @@ export class DiagnosticManager {
             results.push(diagnostic);
         }
         return results.filter((x) => {
-            return !util.diagnosticIsSuppressed(x);
+            return !this.isDiagnosticSuppressed(x);
         });
+    }
+
+    /**
+     * Determine whether this diagnostic should be supressed or not, based on brs comment-flags
+     */
+    public isDiagnosticSuppressed(diagnostic: BsDiagnostic) {
+        const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
+        const file = this.program?.getFile(diagnostic.location.uri);
+
+        for (let flag of file?.commentFlags ?? []) {
+            //this diagnostic is affected by this flag
+            if (diagnostic.location.range && util.rangeContains(flag.affectedRange, diagnostic.location.range.start)) {
+                //if the flag acts upon this diagnostic's code
+                if (flag.codes === null || (diagnosticCode !== undefined && flag.codes.includes(diagnosticCode))) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private filterDiagnostics(diagnostics: BsDiagnostic[]) {
@@ -146,9 +164,9 @@ export class DiagnosticManager {
     }
 
     public clearForFile(fileSrcPath: string) {
-        const fileSrcPathLower = fileSrcPath.toLowerCase();
+        const fileSrcPathUri = util.pathToUri(fileSrcPath).toLowerCase();
         for (const [key, cachedData] of this.diagnosticsCache.entries()) {
-            if (cachedData.diagnostic.file.srcPath.toLowerCase() === fileSrcPathLower) {
+            if (cachedData.diagnostic.location.uri.toLowerCase() === fileSrcPathUri) {
                 this.diagnosticsCache.delete(key);
             }
         }
@@ -204,7 +222,7 @@ export class DiagnosticManager {
         const needToMatch = {
             tag: !!filter.tag,
             scope: !!filter.scope,
-            file: !!filter.file,
+            fileUri: !!filter.fileUri,
             segment: !!filter.segment
         };
 
@@ -218,8 +236,8 @@ export class DiagnosticManager {
                 if (isMatch && needToMatch.scope) {
                     isMatch = context.scope === filter.scope;
                 }
-                if (isMatch && needToMatch.file) {
-                    isMatch = cachedData.diagnostic.file === filter.file;
+                if (isMatch && needToMatch.fileUri) {
+                    isMatch = cachedData.diagnostic.location?.uri === filter.fileUri;
                 }
                 if (isMatch && needToMatch.segment) {
                     isMatch = context.segment === filter.segment;
@@ -239,7 +257,7 @@ export class DiagnosticManager {
 
 
     private getDiagnosticKey(diagnostic: BsDiagnostic) {
-        return `${diagnostic.file?.srcPath} - ${diagnostic.code} - ${diagnostic.message} - ${util.rangeToString(diagnostic.range)}`;
+        return `${diagnostic.location.uri} ${util.rangeToString(diagnostic.location.range)} - ${diagnostic.code} - ${diagnostic.message}`;
     }
 
     private mergeRelatedInformation(target: DiagnosticRelatedInformation[], source: DiagnosticRelatedInformation[]) {
@@ -262,6 +280,6 @@ export class DiagnosticManager {
 interface DiagnosticContextFilter {
     tag?: string;
     scope?: Scope;
-    file?: BscFile;
+    fileUri?: string;
     segment?: AstNode;
 }

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -883,4 +883,4 @@ export interface DiagnosticInfo {
 export type DiagnosticMessageType<K extends keyof D, D extends Record<string, (...args: any) => any> = typeof DiagnosticMessages> =
     ReturnType<D[K]> &
     //include the missing properties from BsDiagnostic
-    Pick<BsDiagnostic, 'range' | 'file' | 'relatedInformation' | 'tags'>;
+    Pick<BsDiagnostic, 'code' | 'location' | 'relatedInformation' | 'tags'>;

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -16,7 +16,6 @@ import { expectZeroDiagnostics, trim } from './testHelpers.spec';
 import { isBrsFile, isLiteralString } from './astUtils/reflection';
 import { createVisitor, WalkMode } from './astUtils/visitors';
 import { tempDir, rootDir } from './testHelpers.spec';
-import { URI } from 'vscode-uri';
 import { BusyStatusTracker } from './BusyStatusTracker';
 import type { BscFile } from './files/BscFile';
 
@@ -1146,7 +1145,7 @@ describe('LanguageServer', () => {
             `;
         };
 
-        const uri = URI.file(s`${rootDir}/source/sgnode.bs`).toString();
+        const uri = util.pathToUri(s`${rootDir}/source/sgnode.bs`);
 
         fsExtra.outputFileSync(s`${rootDir}/source/sgnode.bs`, getContents());
         server.run();

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -196,8 +196,8 @@ describe('LanguageServer', () => {
                 builder: {
                     getDiagnostics: () => {
                         return [{
-                            file: {
-                                srcPath: s`${rootDir}/source/main.brs`
+                            location: {
+                                uri: util.pathToUri(s`${rootDir}/source/main.brs`)
                             },
                             code: 1000,
                             range: Range.create(1, 2, 3, 4)
@@ -209,8 +209,8 @@ describe('LanguageServer', () => {
                 builder: {
                     getDiagnostics: () => {
                         return [{
-                            file: {
-                                srcPath: s`${rootDir}/source/main.brs`
+                            location: {
+                                uri: util.pathToUri(s`${rootDir}/source/main.brs`)
                             },
                             code: 1000,
                             range: Range.create(1, 2, 3, 4)

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1306,7 +1306,6 @@ export class LanguageServer {
             const patch = this.diagnosticCollection.getPatch(this.projects);
 
             for (let fileUri in patch) {
-                // const uri = URI.file(filePath).toString();
                 const diagnostics = patch[fileUri].map(d => util.toDiagnostic(d, fileUri));
 
                 await this.connection.sendDiagnostics({

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1305,12 +1305,12 @@ export class LanguageServer {
             //Get only the changes to diagnostics since the last time we sent them to the client
             const patch = this.diagnosticCollection.getPatch(this.projects);
 
-            for (let filePath in patch) {
-                const uri = URI.file(filePath).toString();
-                const diagnostics = patch[filePath].map(d => util.toDiagnostic(d, uri));
+            for (let fileUri in patch) {
+                // const uri = URI.file(filePath).toString();
+                const diagnostics = patch[fileUri].map(d => util.toDiagnostic(d, fileUri));
 
                 await this.connection.sendDiagnostics({
-                    uri: uri,
+                    uri: fileUri,
                     diagnostics: diagnostics
                 });
             }

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -457,7 +457,7 @@ export class LanguageServer {
      * anytime the program wants to load a file, check with our in-memory document cache first
      */
     private documentFileResolver(srcPath: string) {
-        let pathUri = URI.file(srcPath).toString();
+        let pathUri = util.pathToUri(srcPath);
         let document = this.documents.get(pathUri);
         if (document) {
             return document.getText();
@@ -469,7 +469,7 @@ export class LanguageServer {
         if (workspacePath.startsWith('file:')) {
             scopeUri = URI.parse(workspacePath).toString();
         } else {
-            scopeUri = URI.file(workspacePath).toString();
+            scopeUri = util.pathToUri(workspacePath);
         }
         let config = {
             configFile: undefined

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -599,7 +599,7 @@ export class LanguageServer {
         if (configFilePath && path.basename(configFilePath) === 'brsconfig.json') {
             builder.addDiagnostic(configFilePath, {
                 ...DiagnosticMessages.brsConfigJsonIsDeprecated(),
-                range: util.createRange(0, 0, 0, 0)
+                location: util.createLocationFromRange(util.pathToUri(configFilePath), util.createRange(0, 0, 0, 0))
             });
             return this.sendDiagnostics();
         }

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -7,7 +7,6 @@ import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
 import { Program } from './Program';
 import { standardizePath as s, util } from './util';
-import { URI } from 'vscode-uri';
 import type { FunctionStatement, PrintStatement } from './parser/Statement';
 import { EmptyStatement } from './parser/Statement';
 import { expectDiagnostics, expectHasDiagnostics, expectTypeToBe, expectZeroDiagnostics, trim, trimMap } from './testHelpers.spec';
@@ -252,7 +251,7 @@ describe('Program', () => {
                 src: s`${rootDir}/source/main.brs`,
                 dest: s`${rootDir}/source/maindest.brs`
             }, '');
-            expect(program.getFile(util.getFileUri(file))).to.exist;
+            expect(program.getFile(util.pathToUri(file?.srcPath))).to.exist;
         });
     });
 
@@ -281,12 +280,14 @@ describe('Program', () => {
                 </component>
             `);
             program.validate();
+            // the duplicate of component1.xml, which is in component2.xml is first
+            // the duplicate of component2.xml, which is in component1.xml is second
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
                 location: { range: Range.create(1, 17, 1, 27) },
                 relatedInformation: [{
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/components/component1.xml`).toString(),
+                        util.pathToUri(s`${rootDir}/components/component2.xml`),
                         Range.create(1, 17, 1, 27)
                     ),
                     message: 'Also defined here'
@@ -296,7 +297,7 @@ describe('Program', () => {
                 location: { range: Range.create(1, 17, 1, 27) },
                 relatedInformation: [{
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/components/component2.xml`).toString(),
+                        util.pathToUri(s`${rootDir}/components/component1.xml`),
                         Range.create(1, 17, 1, 27)
                     ),
                     message: 'Also defined here'

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -63,9 +63,8 @@ describe('Program', () => {
     it('allows diagnostics to be set on AssetFile', () => {
         const file = program.setFile<AssetFile>('manifest', ``);
         program.diagnostics.register({
-            file: file,
             message: 'Manifest is totally bogus',
-            range: util.createRange(0, 0, 0, 10),
+            location: util.createLocationFromFileRange(file, util.createRange(0, 0, 0, 10)),
             code: 10
         });
         program.validate();
@@ -232,6 +231,28 @@ describe('Program', () => {
             expect(beforeFileParse.callCount).to.equal(2);
             expect(afterFileParse.callCount).to.equal(2);
             expect(afterFileValidate.callCount).to.equal(2);
+        });
+    });
+
+    describe('getFile', () => {
+        it('can get a file from the srcPath', () => {
+            const file = program.setFile({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`${rootDir}/source/maindest.brs`
+            }, '');
+            expect(program.getFile(s`${rootDir}/source/main.brs`)).to.exist;
+            expect(program.getFile(s`${rootDir}\\source\\main.brs`)).to.exist;
+            expect(program.getFile(s`${rootDir}/SOURCE/MAIN.brs`, true)).to.exist;
+
+            expect(program.getFile(file.srcPath)).to.exist;
+        });
+
+        it('can get a file from the uri', () => {
+            const file = program.setFile({
+                src: s`${rootDir}/source/main.brs`,
+                dest: s`${rootDir}/source/maindest.brs`
+            }, '');
+            expect(program.getFile(util.getFileUri(file))).to.exist;
         });
     });
 

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -283,7 +283,7 @@ describe('Program', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
-                range: Range.create(1, 17, 1, 27),
+                location: { range: Range.create(1, 17, 1, 27) },
                 relatedInformation: [{
                     location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/components/component1.xml`).toString(),
@@ -293,7 +293,7 @@ describe('Program', () => {
                 }]
             }, {
                 ...DiagnosticMessages.duplicateComponentName('Component1'),
-                range: Range.create(1, 17, 1, 27),
+                location: { range: Range.create(1, 17, 1, 27) },
                 relatedInformation: [{
                     location: util.createLocationFromRange(
                         URI.file(s`${rootDir}/components/component2.xml`).toString(),
@@ -711,7 +711,7 @@ describe('Program', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.referencedFileDoesNotExist(),
-                range: Range.create(2, 42, 2, 72)
+                location: { range: Range.create(2, 42, 2, 72) }
             }]);
         });
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1001,10 +1001,7 @@ export class Program {
                         location: xmlFile.componentName.location,
                         relatedInformation: xmlFiles.filter(x => x !== xmlFile).map(x => {
                             return {
-                                location: util.createLocationFromRange(
-                                    URI.file(xmlFile.srcPath ?? xmlFile.srcPath).toString(),
-                                    x.componentName.location?.range
-                                ),
+                                location: x.componentName.location,
                                 message: 'Also defined here'
                             };
                         })
@@ -1309,7 +1306,7 @@ export class Program {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(srcPath);
         if (file) {
-            const fileUri = util.getFileUri(file);
+            const fileUri = util.pathToUri(file?.srcPath);
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
                 .getDiagnostics()

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1039,7 +1039,7 @@ export class Program {
                 (normalizePath ? util.standardizePath(filePath) : filePath).toLowerCase()
             ] as T;
         } else if (util.isUriLike(filePath)) {
-            const path = URI.parse(filePath).path;
+            const path = URI.parse(filePath).fsPath;
             return this.files[
                 (normalizePath ? util.standardizePath(path) : path).toLowerCase()
             ] as T;
@@ -1308,8 +1308,8 @@ export class Program {
     public getCodeActions(srcPath: string, range: Range) {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(srcPath);
-        const fileUri = util.getFileUri(file);
         if (file) {
+            const fileUri = util.getFileUri(file);
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
                 .getDiagnostics()

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -79,9 +79,10 @@ export class Program {
         this.plugins = plugins || new PluginInterface([], { logger: this.logger });
         this.diagnostics = diagnosticsManager || new DiagnosticManager();
 
-        // initialize teh diagnostics Manager
+        // initialize the diagnostics Manager
         this.diagnostics.logger = this.logger;
         this.diagnostics.options = this.options;
+        this.diagnostics.program = this;
 
         //inject the bsc plugin as the first plugin in the stack.
         this.plugins.addFirst(new BscPlugin());
@@ -997,8 +998,7 @@ export class Program {
                     const { componentName } = xmlFile;
                     this.diagnostics.register({
                         ...DiagnosticMessages.duplicateComponentName(componentName.text),
-                        range: xmlFile.componentName.location?.range,
-                        file: xmlFile,
+                        location: xmlFile.componentName.location,
                         relatedInformation: xmlFiles.filter(x => x !== xmlFile).map(x => {
                             return {
                                 location: util.createLocationFromRange(
@@ -1037,6 +1037,11 @@ export class Program {
         } else if (/^(?:(?:virtual:[\/\\])|(?:\w:)|(?:[\/\\]))/gmi.exec(filePath)) {
             return this.files[
                 (normalizePath ? util.standardizePath(filePath) : filePath).toLowerCase()
+            ] as T;
+        } else if (util.isUriLike(filePath)) {
+            const path = URI.parse(filePath).path;
+            return this.files[
+                (normalizePath ? util.standardizePath(path) : path).toLowerCase()
             ] as T;
         } else {
             return this.destMap.get(
@@ -1303,14 +1308,15 @@ export class Program {
     public getCodeActions(srcPath: string, range: Range) {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(srcPath);
+        const fileUri = util.getFileUri(file);
         if (file) {
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
                 .getDiagnostics()
                 //only keep diagnostics related to this file
-                .filter(x => x.file === file)
+                .filter(x => x.location.uri === fileUri)
                 //only keep diagnostics that touch this range
-                .filter(x => util.rangesIntersectOrTouch(x.range, range));
+                .filter(x => util.rangesIntersectOrTouch(x.location.range, range));
 
             const scopes = this.getScopesForFile(file);
 

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -330,12 +330,10 @@ describe('ProgramBuilder', () => {
         it('prints diagnostic, when file is present in project', () => {
             builder.options.showDiagnosticsInConsole = true;
 
-            let diagnostics = createBsDiagnostic('p1', ['m1']);
-            let f1 = diagnostics[0].file as BrsFile;
-            f1.fileContents = `l1\nl2\nl3`;
-            sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
+            let diagnostics = createBsDiagnostics('p1', ['m1']);
+            builder.program.setFile('p1', `l1\nl2\nl3`);
 
-            sinon.stub(builder.program, 'getFile').returns(f1);
+            sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
             let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
@@ -348,13 +346,9 @@ describe('ProgramBuilder', () => {
     it('prints diagnostic, when file has no lines', () => {
         builder.options.showDiagnosticsInConsole = true;
 
-        let diagnostics = createBsDiagnostic('p1', ['m1']);
-        let f1 = diagnostics[0].file as BrsFile;
-        (f1.fileContents as any) = null;
+        let diagnostics = createBsDiagnostics('p1', ['m1']);
+        builder.program.setFile('p1', null);
         sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
-
-        sinon.stub(builder.program, 'getFile').returns(f1);
-
         let printStub = sinon.stub(diagnosticUtils, 'printDiagnostic');
 
         builder['printDiagnostics']();
@@ -365,7 +359,7 @@ describe('ProgramBuilder', () => {
     it('prints diagnostic, when no file present', () => {
         builder.options.showDiagnosticsInConsole = true;
 
-        let diagnostics = createBsDiagnostic('p1', ['m1']);
+        let diagnostics = createBsDiagnostics('p1', ['m1']);
         sinon.stub(builder, 'getDiagnostics').returns(diagnostics);
 
         sinon.stub(builder.program, 'getFile').returns(null as any);
@@ -427,12 +421,11 @@ describe('ProgramBuilder', () => {
     });
 });
 
-function createBsDiagnostic(filePath: string, messages: string[]): BsDiagnostic[] {
+function createBsDiagnostics(filePath: string, messages: string[]): BsDiagnostic[] {
     let file = new BrsFile({ srcPath: filePath, destPath: filePath, program: null });
     let diagnostics = [];
     for (let message of messages) {
         let d = createDiagnostic(file, 1, message);
-        d.file = file;
         diagnostics.push(d);
     }
     return diagnostics;
@@ -447,11 +440,10 @@ function createDiagnostic(
     endCol = 99999,
     severity: DiagnosticSeverity = DiagnosticSeverity.Error
 ) {
-    const diagnostic = {
+    const diagnostic: BsDiagnostic = {
         code: code,
         message: message,
-        range: util.createRange(startLine, startCol, endLine, endCol),
-        file: file,
+        location: util.createLocationFromFileRange(file, util.createRange(startLine, startCol, endLine, endCol)),
         severity: severity
     };
     return diagnostic;

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -189,6 +189,7 @@ describe('ProgramBuilder', () => {
                 project: s`${rootDir}/bsconfig.json`,
                 username: 'john'
             });
+            // TODO: this is not run - builder.run throws a diagnostic
             expect(builder.program.options.username).to.equal('rokudev');
         });
 
@@ -289,17 +290,15 @@ describe('ProgramBuilder', () => {
     describe('printDiagnostics', () => {
 
         it('does not crash when a diagnostic is missing range informtaion', () => {
-            const file = builder.program.setFile('source/main.brs', ``);
+            builder.program.setFile('source/main.brs', ``);
             builder.diagnostics.register([{
                 message: 'message 1',
-                code: 'test1',
-                file: file
+                code: 'test1'
             }, {
                 message: 'message 2',
-                code: 'test1',
-                file: file
+                code: 'test1'
             }] as any);
-            const stub = sinon.stub(diagnosticUtils, 'printDiagnostic').callsFake(() => { });
+            const stub = sinon.stub(diagnosticUtils, 'printDiagnostic').callsFake((...args) => { });
             //if this doesn't crash, then the test passes
             builder['printDiagnostics']();
             expect(stub.getCalls().map(x => x.args[4].message)).to.eql([

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -100,7 +100,7 @@ export class ProgramBuilder {
             this.loadRequires();
             this.loadPlugins();
         } catch (e: any) {
-            if (e?.file && e.message && e.code) {
+            if (e?.location && e.message && e.code) {
                 let err = e as BsDiagnostic;
                 this.diagnostics.register(err);
             } else {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -15,7 +15,6 @@ import * as fsExtra from 'fs-extra';
 import * as requireRelative from 'require-relative';
 import { Throttler } from './Throttler';
 import type { BrsFile } from './files/BrsFile';
-import { URI } from 'vscode-uri';
 import { DiagnosticManager } from './DiagnosticManager';
 
 /**
@@ -316,7 +315,7 @@ export class ProgramBuilder {
                 );
             });
 
-            let filePath = URI.parse(fileUri).fsPath;
+            let filePath = util.uriToPath(fileUri);
             if (!emitFullPaths) {
                 filePath = path.relative(cwd, filePath);
             }
@@ -329,7 +328,7 @@ export class ProgramBuilder {
                 //default the severity to error if undefined
                 let severity = typeof diagnostic.severity === 'number' ? diagnostic.severity : DiagnosticSeverity.Error;
                 let relatedInformation = (util.toDiagnostic(diagnostic, diagnostic.source)?.relatedInformation ?? []).map(x => {
-                    let relatedInfoFilePath = URI.parse(x.location?.uri).fsPath;
+                    let relatedInfoFilePath = util.uriToPath(x.location?.uri);
                     if (!emitFullPaths) {
                         relatedInfoFilePath = path.relative(cwd, relatedInfoFilePath);
                     }

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -185,7 +185,7 @@ describe('Scope', () => {
         expectDiagnostics(program, [{
             //sub test(|lineHeight| as integer)
             message: DiagnosticMessages.parameterMayNotHaveSameNameAsNamespace('lineHeight').message,
-            range: util.createRange(2, 25, 2, 35)
+            location: { range: util.createRange(2, 25, 2, 35) }
         }]);
     });
 
@@ -202,11 +202,11 @@ describe('Scope', () => {
         expectDiagnostics(program, [
             {
                 ...DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('namea'),
-                range: util.createRange(4, 16, 4, 21)
+                location: { range: util.createRange(4, 16, 4, 21) }
             },
             {
                 ...DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('NAMEA'),
-                range: util.createRange(5, 16, 5, 21)
+                location: { range: util.createRange(5, 16, 5, 21) }
             }
         ]);
     });
@@ -371,16 +371,16 @@ describe('Scope', () => {
             expectDiagnostics(program, [
                 {
                     ...DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace'),
-                    file: {
-                        srcPath: buttonPrimary.srcPath
+                    location: {
+                        uri: util.getFileUri(buttonPrimary)
                     },
                     relatedInformation: [{
                         message: `In component scope 'ButtonPrimary'`
                     }]
                 }, {
                     ...DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace'),
-                    file: {
-                        srcPath: buttonSecondary.srcPath
+                    location: {
+                        uri: util.getFileUri(buttonSecondary)
                     },
                     relatedInformation: [{
                         message: `In component scope 'ButtonSecondary'`
@@ -435,10 +435,10 @@ describe('Scope', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.cannotFindName('Charlie'),
-                range: util.createRange(6, 32, 6, 39)
+                location: { range: util.createRange(6, 32, 6, 39) }
             }, {
                 ...DiagnosticMessages.itemCannotBeUsedAsVariable('namespace'),
-                range: util.createRange(7, 32, 7, 50)
+                location: { range: util.createRange(7, 32, 7, 50) }
             }]);
         });
 
@@ -457,7 +457,7 @@ describe('Scope', () => {
             expectDiagnostics(program, [{
                 //|lineHeight| = 1
                 message: DiagnosticMessages.variableMayNotHaveSameNameAsNamespace('lineHeight').message,
-                range: util.createRange(3, 24, 3, 34)
+                location: { range: util.createRange(3, 24, 3, 34) }
             }]);
         });
 
@@ -480,7 +480,7 @@ describe('Scope', () => {
             expectDiagnostics(program, [{
                 //print |lineHeight|
                 message: DiagnosticMessages.cannotFindName('lineHeight').message,
-                range: util.createRange(3, 30, 3, 40)
+                location: { range: util.createRange(3, 30, 3, 40) }
             }]);
         });
 
@@ -797,7 +797,7 @@ describe('Scope', () => {
                 // only care about code and `roFontMetrics` match
                 expectDiagnostics(program, [{
                     ...DiagnosticMessages.unknownBrightScriptComponent('roFontMetrics'),
-                    range: Range.create(2, 51, 2, 66)
+                    location: { range: Range.create(2, 51, 2, 66) }
                 }]);
             });
 
@@ -930,7 +930,7 @@ describe('Scope', () => {
                 program.validate();
                 expectDiagnostics(program, [{
                     ...DiagnosticMessages.localVarFunctionShadowsParentFunction('stdlib'),
-                    range: Range.create(2, 24, 2, 27)
+                    location: { range: Range.create(2, 24, 2, 27) }
                 }]);
             });
 
@@ -972,7 +972,7 @@ describe('Scope', () => {
                 program.validate();
                 expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarFunctionShadowsParentFunction('scope').message,
-                    range: Range.create(2, 24, 2, 32)
+                    location: { range: Range.create(2, 24, 2, 32) }
                 }]);
             });
 
@@ -989,7 +989,7 @@ describe('Scope', () => {
                 program.validate();
                 expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarShadowedByScopedFunction().message,
-                    range: Range.create(2, 24, 2, 32)
+                    location: { range: Range.create(2, 24, 2, 32) }
                 }]);
             });
 
@@ -1005,7 +1005,7 @@ describe('Scope', () => {
                 program.validate();
                 expectDiagnostics(program, [{
                     message: DiagnosticMessages.localVarShadowedByScopedFunction().message,
-                    range: Range.create(1, 29, 1, 37)
+                    location: { range: Range.create(1, 29, 1, 37) }
                 }]);
             });
 
@@ -1023,7 +1023,7 @@ describe('Scope', () => {
                     DiagnosticMessages.nameCollision('Function', 'Global Function', 'Str').message,
                     {
                         message: DiagnosticMessages.scopeFunctionShadowedByBuiltInFunction().message,
-                        range: Range.create(4, 29, 4, 32)
+                        location: { range: Range.create(4, 29, 4, 32) }
                     }]);
             });
         });

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -372,7 +372,7 @@ describe('Scope', () => {
                 {
                     ...DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace'),
                     location: {
-                        uri: util.getFileUri(buttonPrimary)
+                        uri: util.pathToUri(buttonPrimary?.srcPath)
                     },
                     relatedInformation: [{
                         message: `In component scope 'ButtonPrimary'`
@@ -380,7 +380,7 @@ describe('Scope', () => {
                 }, {
                     ...DiagnosticMessages.cannotFindName('delta', 'constants.alpha.delta', 'constants.alpha', 'namespace'),
                     location: {
-                        uri: util.getFileUri(buttonSecondary)
+                        uri: util.pathToUri(buttonSecondary?.srcPath)
                     },
                     relatedInformation: [{
                         message: `In component scope 'ButtonSecondary'`

--- a/src/XmlScope.spec.ts
+++ b/src/XmlScope.spec.ts
@@ -118,21 +118,21 @@ describe('XmlScope', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.xmlFunctionNotFound('func2'),
-                range: Range.create(4, 24, 4, 29)
+                location: { range: Range.create(4, 24, 4, 29) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
-                range: Range.create(5, 9, 5, 17)
+                location: { range: Range.create(5, 9, 5, 17) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
-                range: Range.create(6, 9, 6, 17)
+                location: { range: Range.create(6, 9, 6, 17) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('function', 'name'),
-                range: Range.create(7, 9, 7, 17)
+                location: { range: Range.create(7, 9, 7, 17) }
             }, { // syntax error expecting '=' but found '/>'
                 code: DiagnosticMessages.xmlGenericParseError('').code
             }, { // onChange function
                 ...DiagnosticMessages.xmlFunctionNotFound('func4'),
-                range: Range.create(8, 51, 8, 56)
+                location: { range: Range.create(8, 51, 8, 56) }
             }]);
         });
 
@@ -161,22 +161,22 @@ describe('XmlScope', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.xmlInvalidFieldType('no'),
-                range: Range.create(4, 33, 4, 35)
+                location: { range: Range.create(4, 33, 4, 35) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'type'),
-                range: Range.create(5, 9, 5, 14)
+                location: { range: Range.create(5, 9, 5, 14) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
-                range: Range.create(6, 9, 6, 14)
+                location: { range: Range.create(6, 9, 6, 14) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
-                range: Range.create(8, 9, 8, 14)
+                location: { range: Range.create(8, 9, 8, 14) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'id'),
-                range: Range.create(9, 9, 9, 14)
+                location: { range: Range.create(9, 9, 9, 14) }
             }, {
                 ...DiagnosticMessages.xmlTagMissingAttribute('field', 'type'),
-                range: Range.create(9, 9, 9, 14)
+                location: { range: Range.create(9, 9, 9, 14) }
             }, { // syntax error expecting '=' but found '/>'
                 code: DiagnosticMessages.xmlGenericParseError('').code
             }]);

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '../../chai-config.spec';
-import { URI } from 'vscode-uri';
 import type { Range } from 'vscode-languageserver';
 import { Program } from '../../Program';
 import { expectCodeActions, trim } from '../../testHelpers.spec';
@@ -93,7 +92,7 @@ describe('CodeActionsProcessor', () => {
                 util.createRange(1, 5, 1, 5)
             );
             expect(
-                codeActions[0].edit!.changes![URI.file(s`${rootDir}/components/comp1.xml`).toString()][0].range
+                codeActions[0].edit!.changes![util.pathToUri(s`${rootDir}/components/comp1.xml`)][0].range
             ).to.eql(
                 util.createRange(1, 51, 1, 51)
             );

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -1,4 +1,3 @@
-import type { Diagnostic } from 'vscode-languageserver';
 import { CodeActionKind } from 'vscode-languageserver';
 import { codeActionUtil } from '../../CodeActionUtil';
 import type { DiagnosticMessageType } from '../../DiagnosticMessages';
@@ -6,7 +5,7 @@ import { DiagnosticCodeMap } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile } from '../../files/BscFile';
 import type { XmlFile } from '../../files/XmlFile';
-import type { OnGetCodeActionsEvent } from '../../interfaces';
+import type { BsDiagnostic, OnGetCodeActionsEvent } from '../../interfaces';
 import { ParseMode } from '../../parser/Parser';
 import { util } from '../../util';
 import { isBrsFile } from '../../astUtils/reflection';
@@ -35,7 +34,7 @@ export class CodeActionsProcessor {
     /**
      * Generic import suggestion function. Shouldn't be called directly from the main loop, but instead called by more specific diagnostic handlers
      */
-    private suggestImports(diagnostic: Diagnostic, key: string, files: BscFile[]) {
+    private suggestImports(diagnostic: BsDiagnostic, key: string, files: BscFile[]) {
         //skip if we already have this suggestion
         if (this.suggestedImports.has(key) || !isBrsFile(this.event.file)) {
             return;
@@ -69,7 +68,8 @@ export class CodeActionsProcessor {
 
     private suggestCannotFindName(diagnostic: DiagnosticMessageType<'cannotFindName'>) {
         //skip if not a BrighterScript file
-        if ((diagnostic.file as BrsFile).parseMode !== ParseMode.BrighterScript) {
+        const file = this.event.program.getFile(diagnostic.location?.uri);
+        if (!file || (file as BrsFile).parseMode !== ParseMode.BrighterScript) {
             return;
         }
         const lowerName = (diagnostic.data.fullName ?? diagnostic.data.name).toLowerCase();
@@ -88,7 +88,8 @@ export class CodeActionsProcessor {
 
     private suggestClassImports(diagnostic: DiagnosticMessageType<'classCouldNotBeFound'>) {
         //skip if not a BrighterScript file
-        if ((diagnostic.file as BrsFile).parseMode !== ParseMode.BrighterScript) {
+        const file = this.event.program.getFile(diagnostic.location?.uri);
+        if (!file || (file as BrsFile).parseMode !== ParseMode.BrighterScript) {
             return;
         }
         const lowerClassName = diagnostic.data.className.toLowerCase();

--- a/src/bscPlugin/definition/DefinitionProvider.spec.ts
+++ b/src/bscPlugin/definition/DefinitionProvider.spec.ts
@@ -4,7 +4,6 @@ import { standardizePath as s, util } from '../../util';
 let rootDir = s`${process.cwd()}/rootDir`;
 import { createSandbox } from 'sinon';
 import { DefinitionProvider } from './DefinitionProvider';
-import { URI } from 'vscode-uri';
 const sinon = createSandbox();
 
 describe('DefinitionProvider', () => {
@@ -53,10 +52,10 @@ describe('DefinitionProvider', () => {
             //   m.customButton@.click|CustomButon()
             program.getDefinition(brsFile.srcPath, util.createPosition(2, 37))
         ).to.eql([{
-            uri: URI.file(customButtonXml.srcPath).toString(),
+            uri: util.pathToUri(customButtonXml.srcPath),
             range: util.createRange(4, 36, 4, 53)
         }, {
-            uri: URI.file(customButtonBrs.srcPath).toString(),
+            uri: util.pathToUri(customButtonBrs.srcPath),
             range: util.createRange(1, 21, 1, 38)
         }]);
     });
@@ -90,7 +89,7 @@ describe('DefinitionProvider', () => {
         expect(
             program.getDefinition(main.srcPath, util.createPosition(4, 24))
         ).to.eql([{
-            uri: URI.file(main.srcPath).toString(),
+            uri: util.pathToUri(main.srcPath),
             range: util.createRange(2, 16, 2, 22)
         }]);
     });

--- a/src/bscPlugin/definition/DefinitionProvider.ts
+++ b/src/bscPlugin/definition/DefinitionProvider.ts
@@ -6,7 +6,6 @@ import type { Location } from 'vscode-languageserver-protocol';
 import type { ClassStatement, FunctionStatement, NamespaceStatement } from '../../parser/Statement';
 import { ParseMode } from '../../parser/Parser';
 import util from '../../util';
-import { URI } from 'vscode-uri';
 import { WalkMode, createVisitor } from '../../astUtils/visitors';
 import type { Token } from '../../lexer/Token';
 import type { XmlFile } from '../../files/XmlFile';
@@ -56,10 +55,7 @@ export class DefinitionProvider {
             const constant = scope?.getConstFileLink(fullName, containingNamespace);
             if (constant) {
                 this.event.definitions.push(
-                    util.createLocationFromRange(
-                        URI.file(constant.file.srcPath).toString(),
-                        constant.item.tokens.name?.location?.range
-                    )
+                    constant.item.tokens.name?.location
                 );
                 return;
             }
@@ -68,20 +64,14 @@ export class DefinitionProvider {
                 const enumLink = scope.getEnumFileLink(fullName, containingNamespace);
                 if (enumLink) {
                     this.event.definitions.push(
-                        util.createLocationFromRange(
-                            URI.file(enumLink.file.srcPath).toString(),
-                            enumLink.item.tokens.name.location?.range
-                        )
+                        enumLink.item.tokens.name.location
                     );
                     return;
                 }
                 const enumMemberLink = scope.getEnumMemberFileLink(fullName, containingNamespace);
                 if (enumMemberLink) {
                     this.event.definitions.push(
-                        util.createLocationFromRange(
-                            URI.file(enumMemberLink.file.srcPath).toString(),
-                            enumMemberLink.item.tokens.name.location?.range
-                        )
+                        enumMemberLink.item.tokens.name.location
                     );
                     return;
                 }
@@ -89,10 +79,7 @@ export class DefinitionProvider {
                 const interfaceFileLink = scope.getInterfaceFileLink(fullName, containingNamespace);
                 if (interfaceFileLink) {
                     this.event.definitions.push(
-                        util.createLocationFromRange(
-                            URI.file(interfaceFileLink.file.srcPath).toString(),
-                            interfaceFileLink.item.tokens.name.location?.range
-                        )
+                        interfaceFileLink.item.tokens.name.location
                     );
                     return;
                 }
@@ -100,10 +87,7 @@ export class DefinitionProvider {
                 const classFileLink = scope.getClassFileLink(fullName, containingNamespace);
                 if (classFileLink) {
                     this.event.definitions.push(
-                        util.createLocationFromRange(
-                            URI.file(classFileLink.file.srcPath).toString(),
-                            classFileLink.item.tokens.name.location?.range
-                        )
+                        classFileLink.item.tokens.name.location
                     );
                     return;
                 }

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -128,10 +128,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('class'),
-            range: util.createRange(2, 16, 2, 27)
+            location: { range: util.createRange(2, 16, 2, 27) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('class'),
-            range: util.createRange(5, 20, 5, 30)
+            location: { range: util.createRange(5, 20, 5, 30) }
         }]);
     });
 
@@ -171,10 +171,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('enum'),
-            range: util.createRange(2, 16, 2, 26)
+            location: { range: util.createRange(2, 16, 2, 26) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('enum'),
-            range: util.createRange(6, 20, 6, 29)
+            location: { range: util.createRange(6, 20, 6, 29) }
         }]);
     });
 
@@ -209,10 +209,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('function'),
-            range: util.createRange(2, 16, 2, 30)
+            location: { range: util.createRange(2, 16, 2, 30) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('function'),
-            range: util.createRange(5, 20, 5, 33)
+            location: { range: util.createRange(5, 20, 5, 33) }
         }]);
     });
 
@@ -247,10 +247,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('namespace'),
-            range: util.createRange(2, 16, 2, 31)
+            location: { range: util.createRange(2, 16, 2, 31) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('namespace'),
-            range: util.createRange(5, 20, 5, 34)
+            location: { range: util.createRange(5, 20, 5, 34) }
         }]);
     });
 
@@ -290,10 +290,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('interface'),
-            range: util.createRange(2, 16, 2, 31)
+            location: { range: util.createRange(2, 16, 2, 31) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('interface'),
-            range: util.createRange(6, 20, 6, 34)
+            location: { range: util.createRange(6, 20, 6, 34) }
         }]);
     });
 
@@ -323,10 +323,10 @@ describe('BrsFileValidator', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('const'),
-            range: util.createRange(2, 16, 2, 27)
+            location: { range: util.createRange(2, 16, 2, 27) }
         }, {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel('const'),
-            range: util.createRange(4, 20, 4, 30)
+            location: { range: util.createRange(4, 20, 4, 30) }
         }]);
     });
 

--- a/src/bscPlugin/validation/ProgramValidator.ts
+++ b/src/bscPlugin/validation/ProgramValidator.ts
@@ -32,8 +32,7 @@ export class ProgramValidator {
 
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.fileNotReferencedByAnyOtherFile(),
-                file: file,
-                range: util.createRange(0, 0, 0, Number.MAX_VALUE)
+                location: util.createLocationFromFileRange(file, util.createRange(0, 0, 0, Number.MAX_VALUE))
             }, { tags: [ProgramValidatorDiagnosticsTag] });
         }
     }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,4 +1,3 @@
-import { URI } from 'vscode-uri';
 import { DiagnosticTag, type Range } from 'vscode-languageserver';
 import { isAliasStatement, isAssignmentStatement, isAssociativeArrayType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isComponentType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isStringType, isTypedFunctionType, isUnionType, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import type { DiagnosticInfo } from '../../DiagnosticMessages';
@@ -762,7 +761,7 @@ export class ScopeValidator {
                     relatedInformation: [{
                         message: 'Enum declared here',
                         location: util.createLocationFromRange(
-                            URI.file(enumFileLink?.file.srcPath).toString(),
+                            util.pathToUri(enumFileLink?.file.srcPath),
                             enumFileLink?.item?.tokens.name.location?.range
                         )
                     }]
@@ -939,7 +938,7 @@ export class ScopeValidator {
                             related.push({
                                 message: `Function declared here`,
                                 location: util.createLocationFromRange(
-                                    URI.file(ownCallable.callable.file?.srcPath).toString(),
+                                    util.pathToUri(ownCallable.callable.file?.srcPath),
                                     thatNameRange
                                 )
                             });
@@ -1074,7 +1073,7 @@ export class ScopeValidator {
                     relatedInformation: [{
                         message: 'Function declared here',
                         location: util.createLocationFromRange(
-                            URI.file(callable[0].callable.file.srcPath).toString(),
+                            util.pathToUri(callable[0].callable.file.srcPath),
                             callable[0].callable.nameRange
                         )
                     }]
@@ -1090,7 +1089,7 @@ export class ScopeValidator {
                     relatedInformation: [{
                         message: 'Class declared here',
                         location: util.createLocationFromRange(
-                            URI.file(classStmtLink.file.srcPath).toString(),
+                            util.pathToUri(classStmtLink.file.srcPath),
                             classStmtLink?.item.tokens.name.location?.range
                         )
                     }]
@@ -1100,7 +1099,7 @@ export class ScopeValidator {
     }
 
     private detectVariableNamespaceCollisions(file: BrsFile) {
-        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.getFileUri(file), tag: ScopeValidatorDiagnosticTag.NamespaceCollisions });
+        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.pathToUri(file?.srcPath), tag: ScopeValidatorDiagnosticTag.NamespaceCollisions });
 
         //find all function parameters
         // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -1116,7 +1115,7 @@ export class ScopeValidator {
                         relatedInformation: [{
                             message: 'Namespace declared here',
                             location: util.createLocationFromRange(
-                                URI.file(namespace.file.srcPath).toString(),
+                                util.pathToUri(namespace.file.srcPath),
                                 namespace.nameRange
                             )
                         }]
@@ -1137,7 +1136,7 @@ export class ScopeValidator {
                     relatedInformation: [{
                         message: 'Namespace declared here',
                         location: util.createLocationFromRange(
-                            URI.file(namespace.file.srcPath).toString(),
+                            util.pathToUri(namespace.file.srcPath),
                             namespace.nameRange
                         )
                     }]
@@ -1150,7 +1149,7 @@ export class ScopeValidator {
         if (!scope.xmlFile.parser.ast?.componentElement?.interfaceElement) {
             return;
         }
-        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.getFileUri(scope.xmlFile), tag: ScopeValidatorDiagnosticTag.XMLInterface });
+        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.pathToUri(scope.xmlFile?.srcPath), tag: ScopeValidatorDiagnosticTag.XMLInterface });
 
         const iface = scope.xmlFile.parser.ast.componentElement.interfaceElement;
         const callableContainerMap = scope.getCallableContainerMap();
@@ -1206,7 +1205,7 @@ export class ScopeValidator {
      * Detect when a child has imported a script that an ancestor also imported
      */
     private diagnosticDetectDuplicateAncestorScriptImports(scope: XmlScope) {
-        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.getFileUri(scope.xmlFile), tag: ScopeValidatorDiagnosticTag.XMLImports });
+        this.event.program.diagnostics.clearByFilter({ scope: this.event.scope, fileUri: util.pathToUri(scope.xmlFile?.srcPath), tag: ScopeValidatorDiagnosticTag.XMLImports });
         if (scope.xmlFile.parentComponent) {
             //build a lookup of pkg paths -> FileReference so we can more easily look up collisions
             let parentScriptImports = scope.xmlFile.getAncestorScriptTagImports();

--- a/src/bscPlugin/validation/XmlFileValidator.ts
+++ b/src/bscPlugin/validation/XmlFileValidator.ts
@@ -25,8 +25,7 @@ export class XmlFileValidator {
             //not a SG component
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingComponentDeclaration(),
-                range: rootElement.location?.range,
-                file: this.event.file
+                location: rootElement.location
             });
             return;
         }
@@ -35,15 +34,13 @@ export class XmlFileValidator {
         if (!componentElement.name) {
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingNameAttribute(),
-                range: componentElement.tokens.startTagName.location?.range,
-                file: this.event.file
+                location: componentElement.tokens.startTagName.location
             });
         }
         if (!componentElement.extends) {
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.xmlComponentMissingExtendsAttribute(),
-                range: componentElement.tokens.startTagName.location?.range,
-                file: this.event.file
+                location: componentElement.tokens.startTagName.location
             });
         }
 
@@ -56,8 +53,7 @@ export class XmlFileValidator {
         if (explicitCodebehindScriptTag) {
             this.event.program.diagnostics.register({
                 ...DiagnosticMessages.unnecessaryCodebehindScriptImport(),
-                file: this.event.file,
-                range: explicitCodebehindScriptTag.filePathRange
+                location: util.createLocationFromFileRange(this.event.file, explicitCodebehindScriptTag.filePathRange)
             });
         }
     }

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -4,7 +4,6 @@ import * as diagnosticUtils from './diagnosticUtils';
 import { Range, DiagnosticSeverity } from 'vscode-languageserver';
 import { util } from './util';
 import chalk from 'chalk';
-import { AssetFile } from './files/AssetFile';
 import { createSandbox } from 'sinon';
 import undent from 'undent';
 import type { BsDiagnostic } from './interfaces';

--- a/src/diagnosticUtils.spec.ts
+++ b/src/diagnosticUtils.spec.ts
@@ -27,16 +27,15 @@ describe('diagnosticUtils', () => {
             //print a diagnostic that has an AssetFile. It should not explode
             diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, './temp/file.brs', [], {
                 message: 'Bad thing happened',
-                range: null, //important...this needs to be null for the test to pass,
-                code: 1234,
-                file: new AssetFile({ srcPath: 'src', destPath: 'dest' })
+                location: null, //important...this needs to be null for the test to pass,
+                code: 1234
             } as any);
         });
         it('does not crash when range is undefined', () => {
             //print a diagnostic that doesn't have a range...it should not explode
             diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, './temp/file.brs', [], {
                 message: 'Bad thing happened',
-                range: null, //important...this needs to be null for the test to pass,
+                location: null, //important...this needs to be null for the test to pass,
                 code: 1234
             } as any);
         });
@@ -45,7 +44,7 @@ describe('diagnosticUtils', () => {
             //print a diagnostic that doesn't have a range...it should not explode
             diagnosticUtils.printDiagnostic(options, DiagnosticSeverity.Error, undefined, [], {
                 message: 'Bad thing happened',
-                range: Range.create(0, 0, 2, 2),
+                location: Range.create(0, 0, 2, 2),
                 code: 1234
             } as any);
         });
@@ -252,7 +251,7 @@ describe('diagnosticUtils', () => {
 
         function testGetDiagnosticLine(range: Range, squigglyText: string, lineLength = 20) {
             expect(
-                diagnosticUtils.getDiagnosticLine({ range: range } as any, '1'.repeat(lineLength), color)
+                diagnosticUtils.getDiagnosticLine({ location: { range: range } } as any, '1'.repeat(lineLength), color)
             ).to.eql([
                 chalk.bgWhite(' ' + chalk.black((range.start.line + 1).toString()) + ' ') + ' ' + '1'.repeat(lineLength),
                 chalk.bgWhite(' ' + chalk.white(' '.repeat((range.start.line + 1).toString().length)) + ' ') + ' ' + squigglyText.padEnd(lineLength, ' ')

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -76,7 +76,7 @@ export function printDiagnostic(
         chalk.cyan(filePath ?? '<unknown file>') +
         ':' +
         chalk.yellow(
-            diagnostic.location.range
+            diagnostic.location?.range
                 ? (diagnostic.location.range.start.line + 1) + ':' + (diagnostic.location.range.start.character + 1)
                 : 'line?:col?'
         ) +
@@ -91,7 +91,7 @@ export function printDiagnostic(
 
     //Get the line referenced by the diagnostic. if we couldn't find a line,
     // default to an empty string so it doesn't crash the error printing below
-    let diagnosticLine = lines[diagnostic.location.range?.start?.line ?? -1] ?? '';
+    let diagnosticLine = lines[diagnostic.location?.range?.start?.line ?? -1] ?? '';
     console.log(
         getDiagnosticLine(diagnostic, diagnosticLine, typeColor[severity])
     );
@@ -127,7 +127,7 @@ export function getDiagnosticLine(diagnostic: BsDiagnostic, diagnosticLine: stri
     let result = '';
 
     //only print the line information if we have some
-    if (diagnostic.location.range && diagnosticLine) {
+    if (diagnostic.location?.range && diagnosticLine) {
         const lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.location.range.start.line + 1).toString()) + ' ') + ' ';
         const blankLineNumberText = chalk.bgWhite(' ' + chalk.white(' '.repeat((diagnostic.location.range.start.line + 1).toString().length)) + ' ') + ' ';
 

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -76,8 +76,8 @@ export function printDiagnostic(
         chalk.cyan(filePath ?? '<unknown file>') +
         ':' +
         chalk.yellow(
-            diagnostic.range
-                ? (diagnostic.range.start.line + 1) + ':' + (diagnostic.range.start.character + 1)
+            diagnostic.location.range
+                ? (diagnostic.location.range.start.line + 1) + ':' + (diagnostic.location.range.start.character + 1)
                 : 'line?:col?'
         ) +
         ' - ' +
@@ -91,7 +91,7 @@ export function printDiagnostic(
 
     //Get the line referenced by the diagnostic. if we couldn't find a line,
     // default to an empty string so it doesn't crash the error printing below
-    let diagnosticLine = lines[diagnostic.range?.start?.line ?? -1] ?? '';
+    let diagnosticLine = lines[diagnostic.location.range?.start?.line ?? -1] ?? '';
     console.log(
         getDiagnosticLine(diagnostic, diagnosticLine, typeColor[severity])
     );
@@ -127,14 +127,14 @@ export function getDiagnosticLine(diagnostic: BsDiagnostic, diagnosticLine: stri
     let result = '';
 
     //only print the line information if we have some
-    if (diagnostic.range && diagnosticLine) {
-        const lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.range.start.line + 1).toString()) + ' ') + ' ';
-        const blankLineNumberText = chalk.bgWhite(' ' + chalk.white(' '.repeat((diagnostic.range.start.line + 1).toString().length)) + ' ') + ' ';
+    if (diagnostic.location.range && diagnosticLine) {
+        const lineNumberText = chalk.bgWhite(' ' + chalk.black((diagnostic.location.range.start.line + 1).toString()) + ' ') + ' ';
+        const blankLineNumberText = chalk.bgWhite(' ' + chalk.white(' '.repeat((diagnostic.location.range.start.line + 1).toString().length)) + ' ') + ' ';
 
         //remove tabs in favor of spaces to make diagnostic printing more consistent
-        let leadingText = diagnosticLine.slice(0, diagnostic.range.start.character);
+        let leadingText = diagnosticLine.slice(0, diagnostic.location.range.start.character);
         let leadingTextNormalized = leadingText.replace(/\t/g, '    ');
-        let actualText = diagnosticLine.slice(diagnostic.range.start.character, diagnostic.range.end.character);
+        let actualText = diagnosticLine.slice(diagnostic.location.range.start.character, diagnostic.location.range.end.character);
         let actualTextNormalized = actualText.replace(/\t/g, '    ');
         let startIndex = leadingTextNormalized.length;
         let endIndex = leadingTextNormalized.length + actualTextNormalized.length;

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -211,10 +211,10 @@ describe('BrsFile BrighterScript classes', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
-                range: Range.create(9, 24, 9, 25)
+                location: { range: Range.create(9, 24, 9, 25) }
             }, {
                 ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
-                range: Range.create(9, 33, 9, 34)
+                location: { range: Range.create(9, 33, 9, 34) }
             }]);
         });
     });
@@ -1348,16 +1348,16 @@ describe('BrsFile BrighterScript classes', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.duplicateIdentifier('name'),
-            range: Range.create(3, 23, 3, 27)
+            location: { range: Range.create(3, 23, 3, 27) }
         }, {
             ...DiagnosticMessages.duplicateIdentifier('name'),
-            range: Range.create(4, 27, 4, 31)
+            location: { range: Range.create(4, 27, 4, 31) }
         }, {
             ...DiagnosticMessages.duplicateIdentifier('age'),
-            range: Range.create(8, 27, 8, 30)
+            location: { range: Range.create(8, 27, 8, 30) }
         }, {
             ...DiagnosticMessages.duplicateIdentifier('age'),
-            range: Range.create(10, 23, 10, 26)
+            location: { range: Range.create(10, 23, 10, 26) }
         }]);
     });
 
@@ -1508,7 +1508,7 @@ describe('BrsFile BrighterScript classes', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.cannotFindName('Animal'),
-                range: Range.create(1, 35, 1, 41)
+                location: { range: Range.create(1, 35, 1, 41) }
             }]);
         });
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -18,7 +18,6 @@ import type { FunctionStatement } from '../parser/Statement';
 import { ImportStatement } from '../parser/Statement';
 import { createToken, createVariableExpression } from '../astUtils/creators';
 import * as fsExtra from 'fs-extra';
-import { URI } from 'vscode-uri';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
@@ -1338,7 +1337,7 @@ describe('BrsFile', () => {
                 end function
             `);
             expectHasDiagnostics(program);
-            expect(program.getDiagnostics()[0].location.uri).to.equal(util.getFileUri(file));
+            expect(program.getDiagnostics()[0].location.uri).to.equal(util.pathToUri(file?.srcPath));
             expect(program.getDiagnostics()[0].location.range.start.line).to.equal(1);
         });
 
@@ -4001,7 +4000,7 @@ describe('BrsFile', () => {
             program.validate();
             //print alpha.beta.char|lie
             expect(program.getDefinition(file.srcPath, Position.create(2, 41))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(5, 26, 5, 33)
             }]);
         });
@@ -4020,7 +4019,7 @@ describe('BrsFile', () => {
             program.validate();
             //print alpha.beta.char|lie
             expect(program.getDefinition(file.srcPath, Position.create(2, 40))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(5, 25, 5, 31)
             }]);
         });
@@ -4037,7 +4036,7 @@ describe('BrsFile', () => {
             program.validate();
             // sub test(selectedMovie as Mo|vie)
             expect(program.getDefinition(file.srcPath, Position.create(1, 44))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(4, 26, 4, 31)
             }]);
         });
@@ -4056,7 +4055,7 @@ describe('BrsFile', () => {
             program.validate();
             //sub test(selectedMovie as interfaces.Mo|vie)
             expect(program.getDefinition(file.srcPath, Position.create(1, 55))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(5, 30, 5, 35)
             }]);
         });
@@ -4073,7 +4072,7 @@ describe('BrsFile', () => {
             program.validate();
             //sub test(selectedMovie as Mo|vie)
             expect(program.getDefinition(file.srcPath, Position.create(1, 44))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(4, 22, 4, 27)
             }]);
         });
@@ -4092,7 +4091,7 @@ describe('BrsFile', () => {
             program.validate();
             //sub test(selectedMovie as classes.Mo|vie)
             expect(program.getDefinition(file.srcPath, Position.create(1, 52))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(5, 26, 5, 31)
             }]);
         });
@@ -4123,7 +4122,7 @@ describe('BrsFile', () => {
             program.validate();
             //print alpha.beta.char|lie
             expect(program.getDefinition(file.srcPath, Position.create(2, 48))).to.eql([{
-                uri: URI.file(file.srcPath).toString(),
+                uri: util.pathToUri(file.srcPath),
                 range: util.createRange(6, 24, 6, 31)
             }]);
         });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -411,9 +411,8 @@ describe('BrsFile', () => {
                 `) as BrsFile;
                 program.diagnostics.register({
                     code: 'LINT1005',
-                    file: file,
                     message: 'Something is not right',
-                    range: util.createRange(2, 16, 2, 26)
+                    location: util.createLocationFromFileRange(file, util.createRange(2, 16, 2, 26))
                 });
                 expectZeroDiagnostics(program);
             });
@@ -1339,8 +1338,8 @@ describe('BrsFile', () => {
                 end function
             `);
             expectHasDiagnostics(program);
-            expect(program.getDiagnostics()[0].file).to.equal(file);
-            expect(program.getDiagnostics()[0].range.start.line).to.equal(1);
+            expect(program.getDiagnostics()[0].location.uri).to.equal(util.getFileUri(file));
+            expect(program.getDiagnostics()[0].location.range.start.line).to.equal(1);
         });
 
         it('supports using the `next` keyword in a for loop', () => {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -117,7 +117,7 @@ describe('BrsFile', () => {
     });
 
     it('flags namespaces used as variables', () => {
-        program.setFile('source/main.bs', `
+        const file = program.setFile('source/main.bs', `
             sub main()
                 alpha.beta.charlie.test()
                 print alpha
@@ -137,13 +137,13 @@ describe('BrsFile', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.itemCannotBeUsedAsVariable('namespace'),
-            range: util.createRange(3, 22, 3, 27)
+            location: util.createLocationFromFileRange(file, util.createRange(3, 22, 3, 27))
         }, {
             ...DiagnosticMessages.itemCannotBeUsedAsVariable('namespace'),
-            range: util.createRange(4, 22, 4, 32)
+            location: util.createLocationFromFileRange(file, util.createRange(4, 22, 4, 32))
         }, {
             ...DiagnosticMessages.itemCannotBeUsedAsVariable('namespace'),
-            range: util.createRange(5, 22, 5, 40)
+            location: util.createLocationFromFileRange(file, util.createRange(5, 22, 5, 40))
         }]);
     });
 
@@ -418,7 +418,7 @@ describe('BrsFile', () => {
             });
 
             it('adds diagnostics for unknown numeric diagnostic codes', () => {
-                program.setFile('source/main.brs', `
+                const file = program.setFile('source/main.brs', `
                     sub main()
                         print "hi" 'bs:disable-line: 123456 999999   aaaab
                     end sub
@@ -427,10 +427,10 @@ describe('BrsFile', () => {
                 program.validate();
                 expectDiagnostics(program, [{
                     ...DiagnosticMessages.unknownDiagnosticCode(123456),
-                    range: Range.create(2, 53, 2, 59)
+                    location: util.createLocationFromFileRange(file, Range.create(2, 53, 2, 59))
                 }, {
                     ...DiagnosticMessages.unknownDiagnosticCode(999999),
-                    range: Range.create(2, 60, 2, 66)
+                    location: util.createLocationFromFileRange(file, Range.create(2, 60, 2, 66))
                 }]);
             });
 
@@ -455,7 +455,7 @@ describe('BrsFile', () => {
             });
 
             it('works for specific codes', () => {
-                program.setFile('source/main.brs', `
+                const file = program.setFile('source/main.brs', `
                     sub main()
                         'should not have any errors
                         DoSomething(1) 'bs:disable-line:1002
@@ -469,7 +469,7 @@ describe('BrsFile', () => {
                 program.validate();
 
                 expectDiagnostics(program, [{
-                    range: Range.create(5, 24, 5, 35)
+                    location: util.createLocationFromFileRange(file, Range.create(5, 24, 5, 35))
                 }]);
             });
 
@@ -4130,7 +4130,7 @@ describe('BrsFile', () => {
     });
 
     it('catches mismatched `end` keywords for functions', () => {
-        program.setFile('source/main.brs', `
+        const file = program.setFile('source/main.brs', `
             function speak()
             end sub
             sub walk()
@@ -4139,10 +4139,10 @@ describe('BrsFile', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.mismatchedEndCallableKeyword('function', 'sub'),
-            range: util.createRange(2, 12, 2, 19)
+            location: util.createLocationFromFileRange(file, util.createRange(2, 12, 2, 19))
         }, {
             ...DiagnosticMessages.mismatchedEndCallableKeyword('sub', 'function'),
-            range: util.createRange(4, 12, 4, 24)
+            location: util.createLocationFromFileRange(file, util.createRange(4, 12, 4, 24))
         }]);
     });
 
@@ -5224,7 +5224,7 @@ describe('BrsFile', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.tooManyCallableParameters(64, 63),
-            range: util.createRange(1, 638, 1, 641)
+            location: { range: util.createRange(1, 638, 1, 641) }
         }]);
     });
 
@@ -5236,10 +5236,10 @@ describe('BrsFile', () => {
         program.validate();
         expectDiagnostics(program, [{
             ...DiagnosticMessages.tooManyCallableParameters(65, 63),
-            range: util.createRange(1, 638, 1, 641)
+            location: { range: util.createRange(1, 638, 1, 641) }
         }, {
             ...DiagnosticMessages.tooManyCallableParameters(65, 63),
-            range: util.createRange(1, 648, 1, 651)
+            location: { range: util.createRange(1, 648, 1, 651) }
         }]);
     });
 
@@ -5268,7 +5268,7 @@ describe('BrsFile', () => {
             {
                 ...DiagnosticMessages.itemIsDeprecated(),
                 // url.|setPort|(80)
-                range: util.createRange(3, 20, 3, 27)
+                location: { range: util.createRange(3, 20, 3, 27) }
             }
         ]);
     });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -345,7 +345,7 @@ export class BrsFile implements BscFile {
      * @param fileContents the raw source code to parse
      */
     public parse(fileContents: string) {
-        const diagnostics = [];
+        const diagnostics = [] as Array<BsDiagnostic>;
 
         try {
             this.fileContents = fileContents;
@@ -382,15 +382,11 @@ export class BrsFile implements BscFile {
                 ...this._parser.diagnostics as BsDiagnostic[]
             );
 
-            //attach this file to every diagnostic
-            for (let diagnostic of diagnostics) {
-                diagnostic.file = this;
-            }
+
         } catch (e) {
             this._parser = new Parser();
             diagnostics.push({
-                file: this,
-                range: util.createRange(0, 0, 0, Number.MAX_VALUE),
+                location: util.createLocationFromFileRange(this, util.createRange(0, 0, 0, Number.MAX_VALUE)),
                 ...DiagnosticMessages.genericParserMessage('Critical error parsing file: ' + JSON.stringify(serializeError(e)))
             });
         }

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -159,16 +159,13 @@ describe('XmlFile', () => {
                     <script type="text/brightscript" uri="ChildScene.brs" />
                 </component>`
             );
-            const diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(2);
-            expect(diagnostics[0]).to.deep.include({ // expecting opening tag but got prolog
+            expectDiagnostics(program, [{ // expecting opening tag but got prolog
                 code: DiagnosticMessages.xmlGenericParseError('').code,
-                range: Range.create(1, 16, 1, 22)
-            });
-            expect(diagnostics[1]).to.deep.include({
+                location: { range: Range.create(1, 16, 1, 22) }
+            }, {
                 ...DiagnosticMessages.xmlGenericParseError('Syntax error: whitespace found before the XML prolog'),
-                range: Range.create(0, 0, 1, 16)
-            });
+                location: { range: Range.create(0, 0, 1, 16) }
+            }]);
         });
 
         it('Adds error when an unknown tag is found in xml', () => {
@@ -182,16 +179,13 @@ describe('XmlFile', () => {
                     <unexpectedToo />
                 </component>
             `);
-            const diagnostics = program.getDiagnostics();
-            expect(diagnostics).to.be.lengthOf(2);
-            expect(diagnostics[0]).to.deep.include({
+            expectDiagnostics(program, [{
                 ...DiagnosticMessages.xmlUnexpectedTag('unexpected'),
-                range: Range.create(3, 9, 3, 19)
-            });
-            expect(diagnostics[1]).to.deep.include({
+                location: { range: Range.create(3, 9, 3, 19) }
+            }, {
                 ...DiagnosticMessages.xmlUnexpectedTag('unexpectedToo'),
-                range: Range.create(5, 5, 5, 18)
-            });
+                location: { range: Range.create(5, 5, 5, 18) }
+            }]);
         });
 
         it('Adds error when no component is declared in xml', () => {
@@ -200,7 +194,7 @@ describe('XmlFile', () => {
             expectDiagnostics(program, [
                 {
                     ...DiagnosticMessages.xmlUnexpectedTag('script'),
-                    range: Range.create(0, 1, 0, 7)
+                    location: { range: Range.create(0, 1, 0, 7) }
                 },
                 DiagnosticMessages.xmlComponentMissingComponentDeclaration()
             ]);
@@ -216,7 +210,7 @@ describe('XmlFile', () => {
             program.validate();
             expectDiagnosticsIncludes(program, [{
                 message: DiagnosticMessages.xmlComponentMissingNameAttribute().message,
-                range: Range.create(1, 1, 1, 10)
+                location: { range: Range.create(1, 1, 1, 10) }
             }]);
         });
 

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -7,7 +7,7 @@ import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { BsDiagnostic, FileReference } from '../interfaces';
 import { Program } from '../Program';
 import { XmlFile } from './XmlFile';
-import { standardizePath as s } from '../util';
+import util, { standardizePath as s } from '../util';
 import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 import { ProgramBuilder } from '../ProgramBuilder';
 import { LogLevel } from '../logging';
@@ -232,7 +232,7 @@ describe('XmlFile', () => {
             expect(diagnostics[0].code).to.equal(DiagnosticMessages.xmlGenericParseError('').code); //unexpected character '1'
             expect(diagnostics[1]).to.deep.include(<BsDiagnostic>{
                 code: DiagnosticMessages.xmlComponentMissingNameAttribute().code,
-                range: Range.create(1, 1, 1, 10)
+                location: util.createLocationFromFileRange(file, Range.create(1, 1, 1, 10))
             });
         });
 
@@ -1045,9 +1045,8 @@ describe('XmlFile', () => {
                 for (const file of event.files) {
                     if (isXmlFile(file)) {
                         program.diagnostics.register({
-                            file: file,
                             message: 'Test diagnostic',
-                            range: Range.create(0, 0, 0, 0),
+                            location: util.createLocationFromFileRange(file, Range.create(0, 0, 0, 0)),
                             code: 9999
                         });
                     }

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -259,10 +259,7 @@ export class XmlFile implements BscFile {
             srcPath: this.srcPath,
             destPath: this.destPath
         });
-        /*const diagnostics = this.parser.diagnostics.map(diagnostic => ({
-            ...diagnostic,
-            file: this
-        }));*/
+
         this.program?.diagnostics.register(this.parser.diagnostics);
         this.getCommentFlags(this.parser.tokens as any[]);
     }

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -259,11 +259,11 @@ export class XmlFile implements BscFile {
             srcPath: this.srcPath,
             destPath: this.destPath
         });
-        const diagnostics = this.parser.diagnostics.map(diagnostic => ({
+        /*const diagnostics = this.parser.diagnostics.map(diagnostic => ({
             ...diagnostic,
             file: this
-        }));
-        this.program?.diagnostics.register(diagnostics);
+        }));*/
+        this.program?.diagnostics.register(this.parser.diagnostics);
         this.getCommentFlags(this.parser.tokens as any[]);
     }
 

--- a/src/files/tests/optionalChaning.spec.ts
+++ b/src/files/tests/optionalChaning.spec.ts
@@ -116,7 +116,7 @@ describe('optional chaining', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(2, 20, 2, 24)
+                location: { range: util.createRange(2, 20, 2, 24) }
             }]);
         });
 
@@ -129,7 +129,7 @@ describe('optional chaining', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(2, 20, 2, 29)
+                location: { range: util.createRange(2, 20, 2, 29) }
             }]);
         });
 
@@ -143,7 +143,7 @@ describe('optional chaining', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(3, 20, 3, 27)
+                location: { range: util.createRange(3, 20, 3, 27) }
             }]);
         });
 
@@ -157,7 +157,7 @@ describe('optional chaining', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(3, 20, 3, 30)
+                location: { range: util.createRange(3, 20, 3, 30) }
             }]);
         });
 
@@ -172,10 +172,10 @@ describe('optional chaining', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(3, 20, 3, 39)
+                location: { range: util.createRange(3, 20, 3, 39) }
             }, {
                 ...DiagnosticMessages.noOptionalChainingInLeftHandSideOfAssignment(),
-                range: util.createRange(4, 20, 4, 33)
+                location: { range: util.createRange(4, 20, 4, 33) }
             }]);
         });
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Range, Diagnostic, CodeAction, Position, CompletionItem, Location, DocumentSymbol, WorkspaceSymbol } from 'vscode-languageserver-protocol';
+import type { Range, CodeAction, Position, CompletionItem, Location, DocumentSymbol, WorkspaceSymbol, DiagnosticSeverity, CodeDescription, DiagnosticTag, DiagnosticRelatedInformation } from 'vscode-languageserver-protocol';
 import type { Scope } from './Scope';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
@@ -23,10 +23,53 @@ import { TokenKind } from './lexer/TokenKind';
 import type { BscTypeKind } from './types/BscTypeKind';
 import { createToken } from './astUtils/creators';
 
-export interface BsDiagnostic extends Diagnostic {
-    file: BscFile;
+export interface BsDiagnostic {
     /**
-     * A generic data container where additional details of the diagnostic can be stored. These are stripped out before being sent to a languageclient, and not printed to the console.
+     * The location at which the message applies
+     */
+    location: Location;
+    /**
+     * The diagnostic's severity. Can be omitted. If omitted it is up to the
+     * client to interpret diagnostics as error, warning, info or hint.
+     */
+    severity?: DiagnosticSeverity;
+    /**
+     * The diagnostic's code, which usually appear in the user interface.
+     */
+    code?: number | string;
+    /**
+     * An optional property to describe the error code.
+     * Requires the code field (above) to be present/not null.
+     *
+     * @since 3.16.0
+     */
+    codeDescription?: CodeDescription;
+    /**
+     * A human-readable string describing the source of this
+     * diagnostic, e.g. 'typescript' or 'super lint'. It usually
+     * appears in the user interface.
+     */
+    source?: string;
+    /**
+     * The diagnostic's message. It usually appears in the user interface
+     */
+    message: string;
+    /**
+     * Additional metadata about the diagnostic.
+     *
+     * @since 3.15.0
+     */
+    tags?: DiagnosticTag[];
+    /**
+     * An array of related diagnostic information, e.g. when symbol-names within
+     * a scope collide all definitions can be marked via this property.
+     */
+    relatedInformation?: DiagnosticRelatedInformation[];
+    /**
+     * A data entry field that is preserved between a `textDocument/publishDiagnostics`
+     * notification and `textDocument/codeAction` request.
+     *
+     * @since 3.16.0
      */
     data?: any;
 }

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -151,7 +151,7 @@ describe('parser', () => {
                 sub main()
                     call()a
                 end sub
-            `).diagnostics.map(x => rangeToArray(x.range))).to.eql([
+            `).diagnostics.map(x => rangeToArray(x.location.range))).to.eql([
                 [2, 26, 2, 27],
                 [2, 27, 2, 28]
             ]);
@@ -167,7 +167,7 @@ describe('parser', () => {
                 DiagnosticMessages.expectedStatementOrFunctionCallButReceivedExpression().message
             );
 
-            expect(diagnostics[0]?.range).to.eql(
+            expect(diagnostics[0]?.location.range).to.eql(
                 Range.create(3, 20, 3, 32)
             );
         });

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '../chai-config.spec';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import { getTestTranspile, trim } from '../testHelpers.spec';
+import { expectDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
 import SGParser from './SGParser';
 import { createSandbox } from 'sinon';
 import { Program } from '../Program';
@@ -102,14 +102,13 @@ describe('SGParser', () => {
             </component>
         `);
         expect(parser.diagnostics).to.be.lengthOf(2);
-        expect(parser.diagnostics[0]).to.deep.include({
+        expectDiagnostics(parser, [{
             ...DiagnosticMessages.xmlUnexpectedTag('unexpected'),
-            range: Range.create(3, 9, 3, 19)
-        });
-        expect(parser.diagnostics[1]).to.deep.include({
+            location: { range: Range.create(3, 9, 3, 19) }
+        }, {
             ...DiagnosticMessages.xmlUnexpectedTag('unexpectedToo'),
-            range: Range.create(5, 5, 5, 18)
-        });
+            location: { range: Range.create(5, 5, 5, 18) }
+        }]);
     });
 
     it('Adds error when a leaf tag is found to have children', () => {
@@ -127,15 +126,13 @@ describe('SGParser', () => {
                 </script>
             </component>
         `);
-        expect(parser.diagnostics).to.be.lengthOf(2);
-        expect(parser.diagnostics[0]).to.deep.include({
+        expectDiagnostics(parser, [{
             ...DiagnosticMessages.xmlUnexpectedChildren('field'),
-            range: Range.create(3, 9, 3, 14)
-        });
-        expect(parser.diagnostics[1]).to.deep.include({
+            location: { range: Range.create(3, 9, 3, 14) }
+        }, {
             ...DiagnosticMessages.xmlUnexpectedChildren('script'),
-            range: Range.create(7, 5, 7, 11)
-        });
+            location: { range: Range.create(7, 5, 7, 11) }
+        }]);
     });
 
     it('Adds error when whitespace appears before the prolog', () => {
@@ -146,14 +143,12 @@ describe('SGParser', () => {
                 <script type="text/brightscript" uri="ChildScene.brs" />
             </component>`
         );
-        expect(parser.diagnostics).to.be.lengthOf(2);
-        expect(parser.diagnostics[0]).to.deep.include({ // expecting opening tag but got prolog
+        expectDiagnostics(parser, [{ // expecting opening tag but got prolog
             code: DiagnosticMessages.xmlGenericParseError('').code,
-            range: Range.create(1, 12, 1, 18)
-        });
-        expect(parser.diagnostics[1]).to.deep.include({
+            location: { range: Range.create(1, 12, 1, 18) }
+        }, {
             ...DiagnosticMessages.xmlGenericParseError('Syntax error: whitespace found before the XML prolog'),
-            range: Range.create(0, 0, 1, 12)
-        });
+            location: { range: Range.create(0, 0, 1, 12) }
+        }]);
     });
 });

--- a/src/parser/tests/expression/Call.spec.ts
+++ b/src/parser/tests/expression/Call.spec.ts
@@ -37,7 +37,7 @@ describe('parser call expressions', () => {
         expect(ast.statements).to.be.length.greaterThan(0);
 
         //ALL of the diagnostics should be on the `DoThin` line
-        let lineNumbers = diagnostics.map(x => x.range.start.line);
+        let lineNumbers = diagnostics.map(x => x.location.range.start.line);
         for (let lineNumber of lineNumbers) {
             expect(lineNumber).to.equal(2);
         }
@@ -60,7 +60,7 @@ describe('parser call expressions', () => {
         ]);
         expect(ast.statements).to.be.length.greaterThan(0);
         //the error should be BEFORE the `name = "bob"` statement
-        expect(diagnostics[0].range.end.character).to.be.lessThan(25);
+        expect(diagnostics[0].location.range.end.character).to.be.lessThan(25);
     });
 
     it('allows closing parentheses on separate line', () => {

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -320,7 +320,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.duplicateIdentifier('name'),
-                range: util.createRange(3, 20, 3, 24)
+                location: { range: util.createRange(3, 20, 3, 24) }
             }]);
         });
 
@@ -334,7 +334,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.enumValueMustBeType('integer'),
-                range: util.createRange(3, 24, 3, 27)
+                location: { range: util.createRange(3, 24, 3, 27) }
             }]);
         });
 
@@ -348,7 +348,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.enumValueMustBeType('string'),
-                range: util.createRange(3, 24, 3, 25)
+                location: { range: util.createRange(3, 24, 3, 25) }
             }]);
         });
 
@@ -362,7 +362,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.enumValueIsRequired('string'),
-                range: util.createRange(3, 20, 3, 21)
+                location: { range: util.createRange(3, 20, 3, 21) }
             }]);
         });
 
@@ -397,7 +397,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.enumValueMustBeType('integer'),
-                range: util.createRange(2, 33, 2, 35)
+                location: { range: util.createRange(2, 33, 2, 35) }
             }]);
         });
 
@@ -422,7 +422,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.enumValueIsRequired('string'),
-                range: util.createRange(2, 20, 2, 21)
+                location: { range: util.createRange(2, 20, 2, 21) }
             }]);
         });
 
@@ -441,10 +441,10 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.unknownEnumValue('DOWN', 'Direction'),
-                range: util.createRange(7, 36, 7, 40)
+                location: { range: util.createRange(7, 36, 7, 40) }
             }, {
                 ...DiagnosticMessages.unknownEnumValue('down', 'Direction'),
-                range: util.createRange(8, 36, 8, 40)
+                location: { range: util.createRange(8, 36, 8, 40) }
             }]);
         });
 
@@ -465,10 +465,10 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [{
                 ...DiagnosticMessages.unknownEnumValue('DOWN', 'Enums.Direction'),
-                range: util.createRange(2, 42, 2, 46)
+                location: { range: util.createRange(2, 42, 2, 46) }
             }, {
                 ...DiagnosticMessages.unknownEnumValue('down', 'Enums.Direction'),
-                range: util.createRange(3, 42, 3, 46)
+                location: { range: util.createRange(3, 42, 3, 46) }
             }]);
         });
     });

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -11,7 +11,6 @@ import type { BrsFile } from '../../../files/BrsFile';
 import { CancellationTokenSource } from 'vscode-languageserver-protocol';
 import { WalkMode } from '../../../astUtils/visitors';
 import { isEnumStatement } from '../../../astUtils/reflection';
-import { URI } from 'vscode-uri';
 import { rootDir } from '../../../testHelpers.spec';
 
 const sinon = createSandbox();
@@ -227,14 +226,14 @@ describe('EnumStatement', () => {
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/main.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/main.bs`),
                         util.createRange(5, 21, 5, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/main.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/main.bs`),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: `In scope 'source'`
@@ -243,14 +242,14 @@ describe('EnumStatement', () => {
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/main.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/main.bs`),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/main.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/main.bs`),
                         util.createRange(5, 21, 5, 30)
                     ),
                     message: `In scope 'source'`
@@ -274,14 +273,14 @@ describe('EnumStatement', () => {
                 ...DiagnosticMessages.nameCollision('Enum', 'Enum', 'Direction'),
                 relatedInformation: [{
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/lib.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/lib.bs`),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: 'Enum declared here'
                 },
                 {
                     location: util.createLocationFromRange(
-                        URI.file(s`${rootDir}/source/main.bs`).toString(),
+                        util.pathToUri(s`${rootDir}/source/main.bs`),
                         util.createRange(1, 21, 1, 30)
                     ),
                     message: `In scope 'source'`

--- a/src/parser/tests/statement/Misc.spec.ts
+++ b/src/parser/tests/statement/Misc.spec.ts
@@ -37,7 +37,7 @@ describe('parser', () => {
             let { diagnostics } = Parser.parse(tokens);
             expect(diagnostics).to.be.lengthOf(1);
             //specifically check for the error location, because the identifier location was wrong in the past
-            expect(diagnostics[0].range).to.deep.include(
+            expect(diagnostics[0].location.range).to.deep.include(
                 Range.create(1, 4, 1, 8)
             );
         });

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,7 +1,7 @@
 import type { BsDiagnostic } from './interfaces';
 import * as assert from 'assert';
 import chalk from 'chalk';
-import type { CodeDescription, CompletionItem, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, integer, Range } from 'vscode-languageserver';
+import type { CodeDescription, CompletionItem, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, integer, Range } from 'vscode-languageserver';
 import { createSandbox } from 'sinon';
 import { expect } from './chai-config.spec';
 import type { CodeActionShorthand } from './CodeActionUtil';
@@ -21,7 +21,7 @@ export const stagingDir = s`${tempDir}/stagingDir`;
 
 export const trim = undent;
 
-type DiagnosticCollection = { getDiagnostics(): Array<Diagnostic> } | { diagnostics?: Diagnostic[] } | Diagnostic[];
+type DiagnosticCollection = { getDiagnostics(): Array<BsDiagnostic>; getFile?: (path: string, normalize: boolean) => BscFile } | { diagnostics?: BsDiagnostic[] } | BsDiagnostic[];
 
 function getDiagnostics(arg: DiagnosticCollection): BsDiagnostic[] {
     if (Array.isArray(arg)) {
@@ -39,10 +39,10 @@ function sortDiagnostics(diagnostics: BsDiagnostic[]) {
     return diagnostics.sort(
         firstBy<BsDiagnostic>('code')
             .thenBy<BsDiagnostic>('message')
-            .thenBy<BsDiagnostic>((a, b) => (a.range?.start?.line ?? 0) - (b.range?.start?.line ?? 0))
-            .thenBy<BsDiagnostic>((a, b) => (a.range?.start?.character ?? 0) - (b.range?.start?.character ?? 0))
-            .thenBy<BsDiagnostic>((a, b) => (a.range?.end?.line ?? 0) - (b.range?.end?.line ?? 0))
-            .thenBy<BsDiagnostic>((a, b) => (a.range?.end?.character ?? 0) - (b.range?.end?.character ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.location.range?.start?.line ?? 0) - (b.location.range?.start?.line ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.location.range?.start?.character ?? 0) - (b.location.range?.start?.character ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.location.range?.end?.line ?? 0) - (b.location.range?.end?.line ?? 0))
+            .thenBy<BsDiagnostic>((a, b) => (a.location.range?.end?.character ?? 0) - (b.location.range?.end?.character ?? 0))
     );
 }
 
@@ -79,7 +79,7 @@ function cloneDiagnostic(actualDiagnosticInput: BsDiagnostic, expectedDiagnostic
     const actualDiagnostic = cloneObject(
         actualDiagnosticInput,
         expectedDiagnostic,
-        ['message', 'code', 'range', 'severity', 'relatedInformation']
+        ['message', 'code', 'location', 'severity', 'relatedInformation']
     );
     //deep clone relatedInformation if available
     if (actualDiagnostic.relatedInformation) {
@@ -90,14 +90,6 @@ function cloneDiagnostic(actualDiagnosticInput: BsDiagnostic, expectedDiagnostic
                 ['location', 'message']
             ) as any;
         }
-    }
-    //deep clone file info if available
-    if (actualDiagnostic.file) {
-        actualDiagnostic.file = cloneObject(
-            actualDiagnostic.file,
-            expectedDiagnostic?.file,
-            ['srcPath', 'destPath', 'pkgPath']
-        ) as any;
     }
     return actualDiagnostic;
 }
@@ -177,9 +169,11 @@ export function expectZeroDiagnostics(arg: DiagnosticCollection) {
         for (const diagnostic of diagnostics) {
             //escape any newlines
             diagnostic.message = diagnostic.message.replace(/\r/g, '\\r').replace(/\n/g, '\\n');
-            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.file?.srcPath ?? ''}#(${diagnostic.range?.start.line}:${diagnostic.range?.start.character})-(${diagnostic.range?.end.line}:${diagnostic.range?.end.character})`;
+            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.location?.uri ?? ''}#(${diagnostic.location.range?.start.line}:${diagnostic.location.range?.start.character})-(${diagnostic.location.range?.end.line}:${diagnostic.location.range?.end.character})`;
             //print the line containing the error (if we can find it)srcPath
-            const line = (diagnostic.file as BrsFile)?.fileContents?.split(/\r?\n/g)?.[diagnostic.range?.start.line];
+            const file = (arg as any).getFile(diagnostic.location.uri);
+
+            const line = (file as BrsFile)?.fileContents?.split(/\r?\n/g)?.[diagnostic.location.range?.start.line];
             if (line) {
                 message += '\n' + getDiagnosticLine(diagnostic, line, chalk.red);
             }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -7,8 +7,6 @@ import * as fsExtra from 'fs-extra';
 import { createSandbox } from 'sinon';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { tempDir, rootDir, expectTypeToBe } from './testHelpers.spec';
-import { Program } from './Program';
-import type { BsDiagnostic } from './interfaces';
 import { TypeChainEntry } from './interfaces';
 import { NamespaceType } from './types/NamespaceType';
 import { ClassType } from './types/ClassType';
@@ -21,7 +19,6 @@ import { createDottedIdentifier, createVariableExpression } from './astUtils/cre
 import { Parser } from './parser/Parser';
 import type { FunctionStatement } from './parser/Statement';
 import { ComponentType } from './types/ComponentType';
-import type { BrsFile } from './files/BrsFile';
 
 const sinon = createSandbox();
 
@@ -70,31 +67,6 @@ describe('util', () => {
             expect(
                 util.getAllDottedGetPartsAsString(createDottedIdentifier(['alpha', 'beta']))
             ).to.eql('alpha.beta');
-        });
-    });
-
-    describe('diagnosticIsSuppressed', () => {
-        it('does not crash when diagnostic is missing location information', () => {
-            const program = new Program({});
-            const file = program.setFile('source/main.brs', '') as BrsFile;
-            const diagnostic: BsDiagnostic = {
-                file: file,
-                message: 'crash',
-                //important part of the test. range must be missing
-                range: undefined as any
-            };
-
-            file.commentFlags.push({
-                affectedRange: util.createRange(1, 2, 3, 4),
-                codes: [1, 2, 3],
-                file: file,
-                range: util.createRange(1, 2, 3, 4)
-            });
-            program.diagnostics.register(diagnostic);
-
-            util.diagnosticIsSuppressed(diagnostic);
-
-            //test passes if there's no crash
         });
     });
 
@@ -935,8 +907,7 @@ describe('util', () => {
             expect(
                 util.toDiagnostic({
                     ...DiagnosticMessages.cannotFindName('someVar'),
-                    file: undefined as any,
-                    range: util.createRange(1, 2, 3, 4),
+                    location: { uri: null, range: util.createRange(1, 2, 3, 4) },
                     relatedInformation: [{
                         message: 'Alpha',
                         location: undefined as any
@@ -954,8 +925,7 @@ describe('util', () => {
             expect(
                 util.toDiagnostic({
                     ...DiagnosticMessages.cannotFindName('someVar'),
-                    file: undefined as any,
-                    range: util.createRange(1, 2, 3, 4),
+                    location: { uri: null, range: util.createRange(1, 2, 3, 4) },
                     relatedInformation: [{
                         message: 'Alpha',
                         location: util.createLocationFromRange(

--- a/src/util.ts
+++ b/src/util.ts
@@ -750,13 +750,6 @@ export class Util {
     }
 
     /**
-     * Gets a URI string for a file's srcPath
-     */
-    public getFileUri(file: BscFile) {
-        return this.pathToUri(file?.srcPath);
-    }
-
-    /**
      * Given a file path, convert it to a URI string
      */
     public pathToUri(filePath: string) {
@@ -1098,7 +1091,7 @@ export class Util {
      * Helper for creating `Location` objects from a file and range
      */
     public createLocationFromFileRange(file: BscFile, range: Range): Location {
-        return this.createLocationFromRange(util.getFileUri(file), range);
+        return this.createLocationFromRange(this.pathToUri(file?.srcPath), range);
     }
 
     /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,6 +47,7 @@ import { AssociativeArrayType } from './types/AssociativeArrayType';
 import { ComponentType } from './types/ComponentType';
 import { FunctionType } from './types/FunctionType';
 import type { AssignmentStatement } from './parser/Statement';
+import type { BscFile } from './files/BscFile';
 
 export class Util {
     public clearConsole() {
@@ -204,10 +205,10 @@ export class Util {
                 let err = parseErrors[0];
                 let diagnostic = {
                     ...DiagnosticMessages.bsConfigJsonHasSyntaxErrors(printParseErrorCode(parseErrors[0].error)),
-                    file: {
-                        srcPath: configFilePath
-                    },
-                    range: this.getRangeFromOffsetLength(projectFileContents, err.offset, err.length)
+                    location: {
+                        uri: this.pathToUri(configFilePath),
+                        range: this.getRangeFromOffsetLength(projectFileContents, err.offset, err.length)
+                    }
                 } as BsDiagnostic;
                 throw diagnostic; //eslint-disable-line @typescript-eslint/no-throw-literal
             }
@@ -744,8 +745,15 @@ export class Util {
     /**
      * Does the string appear to be a uri (i.e. does it start with `file:`)
      */
-    private isUriLike(filePath: string) {
+    public isUriLike(filePath: string) {
         return filePath?.indexOf('file:') === 0;// eslint-disable-line @typescript-eslint/prefer-string-starts-ends-with
+    }
+
+    /**
+     * Gets a URI string for a file's srcPath
+     */
+    public getFileUri(file: BscFile) {
+        return this.pathToUri(file.srcPath);
     }
 
     /**
@@ -867,22 +875,6 @@ export class Util {
         }
     }
 
-    /**
-     * Determine whether this diagnostic should be supressed or not, based on brs comment-flags
-     */
-    public diagnosticIsSuppressed(diagnostic: BsDiagnostic) {
-        const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
-        for (let flag of diagnostic.file?.commentFlags ?? []) {
-            //this diagnostic is affected by this flag
-            if (diagnostic.range && this.rangeContains(flag.affectedRange, diagnostic.range.start)) {
-                //if the flag acts upon this diagnostic's code
-                if (flag.codes === null || (diagnosticCode !== undefined && flag.codes.includes(diagnosticCode))) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 
     /**
      * Walks up the chain to find the closest bsconfig.json file
@@ -1100,6 +1092,13 @@ export class Util {
             uri: util.pathToUri(uri),
             range: range
         };
+    }
+
+    /**
+     * Helper for creating `Location` objects from a file and range
+     */
+    public createLocationFromFileRange(file: BscFile, range: Range): Location {
+        return this.createLocationFromRange(util.getFileUri(file), range);
     }
 
     /**
@@ -1784,9 +1783,13 @@ export class Util {
                 location: util.createLocationFromRange('   ', util.createRange(0, 0, 0, 0))
             });
         }
+
+        const range = (diagnostic as BsDiagnostic).location?.range ??
+            (diagnostic as Diagnostic).range;
+
         let result = {
             severity: diagnostic.severity,
-            range: diagnostic.range,
+            range: range,
             message: diagnostic.message,
             relatedInformation: relatedInformation.map(x => {
 
@@ -1795,7 +1798,7 @@ export class Util {
                 if (!clone.location) {
                     // use the fallback location if available
                     if (relatedInformationFallbackLocation) {
-                        clone.location = util.createLocationFromRange(relatedInformationFallbackLocation, diagnostic.range);
+                        clone.location = util.createLocationFromRange(relatedInformationFallbackLocation, range);
                     } else {
                         //remove this related information so it doesn't bring crash the language server
                         return undefined;
@@ -2074,8 +2077,7 @@ export class Util {
         if (fileDepth >= 8) {
             file.program?.diagnostics.register({
                 ...DiagnosticMessages.detectedTooDeepFileSource(fileDepth),
-                file: file,
-                range: this.createRange(0, 0, 0, Number.MAX_VALUE)
+                location: util.createLocationFromFileRange(file, this.createRange(0, 0, 0, Number.MAX_VALUE))
             });
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -753,7 +753,7 @@ export class Util {
      * Gets a URI string for a file's srcPath
      */
     public getFileUri(file: BscFile) {
-        return this.pathToUri(file.srcPath);
+        return this.pathToUri(file?.srcPath);
     }
 
     /**

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -56,8 +56,7 @@ export class BsClassValidator {
                         if (expressionNameLower === 'm') {
                             this.diagnostics.push({
                                 ...DiagnosticMessages.classConstructorIllegalUseOfMBeforeSuperCall(),
-                                file: classStatement.file,
-                                range: expression.location?.range
+                                location: expression.location
                             });
                         }
                         if (isCallExpression(parent) && expressionNameLower === 'super') {
@@ -75,8 +74,7 @@ export class BsClassValidator {
                 if (!superCall && !(classStatement.file as BrsFile).isTypedef) {
                     this.diagnostics.push({
                         ...DiagnosticMessages.classConstructorMissingSuperCall(),
-                        file: classStatement.file,
-                        range: newMethod.location?.range
+                        location: newMethod.location
                     });
                 }
             }
@@ -97,8 +95,7 @@ export class BsClassValidator {
                     this.diagnostics.push({
                         ...DiagnosticMessages.circularReferenceDetected(
                             Array.from(names.values()).concat(className), this.scope.name),
-                        file: cls.file,
-                        range: cls.tokens.name.location?.range
+                        location: cls.tokens.name.location
                     });
                     break;
                 }
@@ -133,8 +130,7 @@ export class BsClassValidator {
                     if (methods[lowerMemberName] || fields[lowerMemberName]) {
                         this.diagnostics.push({
                             ...DiagnosticMessages.duplicateIdentifier(memberName.text),
-                            file: classStatement.file,
-                            range: memberName.location?.range
+                            location: memberName.location
                         });
                     }
 
@@ -151,8 +147,7 @@ export class BsClassValidator {
                                     ancestorMemberKind,
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
-                                file: classStatement.file,
-                                range: member.location?.range
+                                location: member.location
                             });
                         }
 
@@ -175,8 +170,7 @@ export class BsClassValidator {
                                         childFieldType.toString(),
                                         ancestorMemberType.toString()
                                     ),
-                                    file: classStatement.file,
-                                    range: member.location?.range
+                                    location: member.location
                                 });
                             }
                         }
@@ -194,8 +188,7 @@ export class BsClassValidator {
                                 ...DiagnosticMessages.missingOverrideKeyword(
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
-                                file: classStatement.file,
-                                range: member.location?.range
+                                location: member.location
                             });
                         }
 
@@ -213,8 +206,7 @@ export class BsClassValidator {
                                     ancestorAndMember.member.accessModifier?.text || 'public',
                                     ancestorAndMember.classStatement.getName(ParseMode.BrighterScript)
                                 ),
-                                file: classStatement.file,
-                                range: member.location?.range
+                                location: member.location
                             });
                         }
                     }


### PR DESCRIPTION
All diagnostics internal to Brighterscript now use a `location: Location` prop instead of `file: BscFile`

This has a few good points:
 - Diagnostics no longer have a reference to a file, so no circular references to remove
 - Aligns better with the change to use `Location` for Tokens and AstNodes

One thing to note is that sometimes we need to back-convert a URI to a path for finding the files that a diagnostic applies to. 
There might be some inconsistencies between Operating Systems (Mac vs. Windows, etc) that *should* be dealt with the `URI` namespace from `vscode-uri`, but I'm not entirely sure.


Addresses: #1155
