### PR TITLE
Ensure methods leading comments are transpiled above instance function definition

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1191,6 +1191,63 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
             `, 'trim', 'source/main.bs');
         });
+
+
+        it('puts leading comments from methods in correct place', async () => {
+            await testTranspile(`
+                    class Duck
+                        ' hatch from egg
+                        sub new()
+                        end sub
+                        ' it must be a duck
+                        sub quack()
+                            ' what does a duck say?
+                            print "quack"
+                        end sub
+                    end class
+                `, `
+                    function __Duck_builder()
+                        instance = {}
+                        ' hatch from egg
+                        instance.new = sub()
+                        end sub
+                        ' it must be a duck
+                        instance.quack = sub()
+                            ' what does a duck say?
+                            print "quack"
+                        end sub
+                        return instance
+                    end function
+                    function Duck()
+                        instance = __Duck_builder()
+                        instance.new()
+                        return instance
+                    end function
+                `, undefined, 'source/main.bs');
+        });
+
+        it('puts leading comments from fields in correct place', async () => {
+            await testTranspile(`
+                    class Duck
+                        ' what kind of duck?
+                        type as string = "mallard"
+                    end class
+                `, `
+                    function __Duck_builder()
+                        instance = {}
+                        instance.new = sub()
+                            ' what kind of duck?
+                            m.type = "mallard"
+                        end sub
+                        return instance
+                    end function
+                    function Duck()
+                        instance = __Duck_builder()
+                        instance.new()
+                        return instance
+                    end function
+                `, undefined, 'source/main.bs');
+        });
     });
 
     it('detects using `new` keyword on non-classes', () => {

--- a/src/parser/BrsTranspileState.ts
+++ b/src/parser/BrsTranspileState.ts
@@ -40,4 +40,9 @@ export class BrsTranspileState extends TranspileState {
      * Used by ConditionalCompileStatement to determine if there's already an conditional compile going on
      */
     public conditionalCompileStatement?: ConditionalCompileStatement;
+
+    /**
+     * Do not transpile leading comments
+     */
+    public skipLeadingComments = false;
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -284,7 +284,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         let results = [] as TranspileResult;
         //'function'|'sub'
         results.push(
-            state.transpileToken(this.tokens.functionType, 'function')
+            state.transpileToken(this.tokens.functionType, 'function', false, state.skipLeadingComments)
         );
         //functionName?
         if (name) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2584,6 +2584,14 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 }
 
                 state.classStatement = this;
+                state.skipLeadingComments = true;
+                //add leading comments
+                if (statement.leadingTrivia.filter(token => token.kind === TokenKind.Comment).length > 0) {
+                    result.push(
+                        ...state.transpileComments(statement.leadingTrivia),
+                        state.indent()
+                    );
+                }
                 result.push(
                     'instance.',
                     state.transpileToken(statement.tokens.name),
@@ -2592,6 +2600,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                     state.newline,
                     state.indent()
                 );
+                state.skipLeadingComments = false;
                 delete state.classStatement;
             } else {
                 //other random statements (probably just comments)


### PR DESCRIPTION
Due to the change to remove `CommentStatement`, leading trivia transpilation is done automatically for each statement.
Since we need to rely on function transpilation, a new state flag was added to remove transpiling function leading comments.
those comments are now added *before* the function is added to the instance  



Fixes #1256

Thanks for the find, @iBicha 
 