### PR TITLE
Add templatestring support for annotation.getArguments()

### DIFF
--- a/src/parser/Expression.spec.ts
+++ b/src/parser/Expression.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { Parser } from './Parser';
+import { isFunctionStatement } from '../astUtils/reflection';
+import type { FunctionStatement } from './Statement';
+
+describe('AnnotationExpression', () => {
+    describe('getArguments', () => {
+        function getArguments(text: string) {
+            return Parser.parse(`
+                @annotation(${text})
+                function test()
+                end function
+            `).ast.findChild<FunctionStatement>(isFunctionStatement).annotations[0].getArguments();
+        }
+
+        it('should return the value of a number', () => {
+            expect(getArguments('1')).to.eql([1]);
+        });
+
+        it('should return the value of a string', () => {
+            expect(getArguments('"hello"')).to.eql(['hello']);
+        });
+
+        it('should return the value of a boolean', () => {
+            expect(getArguments('true')).to.eql([true]);
+        });
+
+        it('should return the value of an object', () => {
+            expect(getArguments('{ a: 1 }')).to.eql([{ a: 1 }]);
+        });
+
+        it('should return the value of an array', () => {
+            expect(getArguments('[1, 2, 3]')).to.eql([
+                [1, 2, 3]
+            ]);
+        });
+
+        it('should return the value of a template string', () => {
+            expect(getArguments('`hello`')).to.eql(['hello']);
+        });
+
+        it.only('work with complex template string', () => {
+            expect(getArguments('`createObject("roSGNode", "BrsComponent")`')).to.eql([`createObject("roSGNode", "BrsComponent")`]);
+        });
+    });
+});

--- a/src/parser/Expression.spec.ts
+++ b/src/parser/Expression.spec.ts
@@ -39,7 +39,7 @@ describe('AnnotationExpression', () => {
             expect(getArguments('`hello`')).to.eql(['hello']);
         });
 
-        it.only('work with complex template string', () => {
+        it('work with complex template string', () => {
             expect(getArguments('`createObject("roSGNode", "BrsComponent")`')).to.eql([`createObject("roSGNode", "BrsComponent")`]);
         });
     });

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isTypeCastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isArrayLiteralExpression, isCallExpression, isCallfuncExpression, isCommentStatement, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isStringType, isTemplateStringExpression, isTypeCastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { TranspileResult, TypedefProvider } from '../interfaces';
 import { VoidType } from '../types/VoidType';
 import { DynamicType } from '../types/DynamicType';
@@ -1652,6 +1652,12 @@ function expressionToValue(expr: Expression, strict: boolean): ExpressionValue {
             }
             return acc;
         }, {});
+    }
+    //for annotations, we only support serializing pure string values
+    if (isTemplateStringExpression(expr)) {
+        if (expr.quasis?.length === 1 && expr.expressions.length === 0) {
+            return expr.quasis[0].expressions.map(x => x.token.text).join('');
+        }
     }
     return strict ? null : expr;
 }


### PR DESCRIPTION
Adds support for simple templatestrings as arguments for annotations when calling .getArguments()