### PR TITLE
Make absolute import completions use original extension

### DIFF
--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1291,6 +1291,35 @@ describe('CompletionsProcessor', () => {
             expect(completions).to.exist;
             expect(completions.map(comp => comp.label)).to.include('common2.bs');
             expect(completions.map(comp => comp.label)).to.include('../components/widget.bs');
+            expect(completions.map(comp => comp.label)).to.include('pkg:/components/widget.bs');
+            expect(completions.map(comp => comp.label)).to.include('pkg:/source/common2.bs');
+        });
+
+        it('should show import completions with original extensions', () => {
+            program.setFile('source/common.bs', `
+                import "
+            `);
+            program.setFile('source/common2.brs', `
+                sub SayHello()
+                end sub
+            `);
+            program.setFile('components/widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="widget.bs"/>
+                </component>
+            `);
+            program.setFile('components/widget.bs', `
+                import "pkg:/source/common.bs"
+            `);
+            program.validate();
+            // import "|
+            const completions = program.getCompletions('source/common.bs', util.createPosition(1, 25));
+            expect(completions).to.exist;
+            expect(completions.map(comp => comp.label)).to.include('common2.brs');
+            expect(completions.map(comp => comp.label)).to.include('../components/widget.bs');
+            expect(completions.map(comp => comp.label)).to.include('pkg:/components/widget.bs');
+            expect(completions.map(comp => comp.label)).to.include('pkg:/source/common2.brs');
         });
     });
 

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -141,6 +141,7 @@ export class CompletionsProcessor {
                 let relativePath = util.getRelativePath(sourcePkgPath, file.destPath).replace(/\\/g, '/');
                 let pkgPathStandardized = file.pkgPath.replace(/\\/g, '/');
                 let filePkgPath = `pkg:/${pkgPathStandardized}`;
+                let importPkgPath = util.getImportPackagePath(file.srcPath, filePkgPath);
                 let lowerFilePkgPath = filePkgPath.toLowerCase();
                 if (!resultPkgPaths[lowerFilePkgPath]) {
                     resultPkgPaths[lowerFilePkgPath] = true;
@@ -157,11 +158,11 @@ export class CompletionsProcessor {
 
                     //add the absolute path
                     result.push({
-                        label: filePkgPath,
+                        label: importPkgPath,
                         detail: file.srcPath,
                         kind: CompletionItemKind.File,
                         textEdit: {
-                            newText: filePkgPath,
+                            newText: importPkgPath,
                             range: scriptImport.filePathRange
                         }
                     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -520,6 +520,17 @@ export class Util {
         return path.join(...resultParts);
     }
 
+    public getImportPackagePath(srcPath: string, pkgTargetPath: string) {
+        const srcExt = this.getExtension(srcPath);
+        const lowerSrcExt = srcExt.toLowerCase();
+        const lowerTargetExt = this.getExtension(pkgTargetPath).toLowerCase();
+        if (lowerSrcExt === '.bs' && lowerTargetExt === '.brs') {
+            // if source is .bs, use that as the import extenstion
+            return pkgTargetPath.substring(0, pkgTargetPath.length - lowerTargetExt.length) + srcExt;
+        }
+        return pkgTargetPath;
+    }
+
     /**
      * Walks left in a DottedGetExpression and returns a VariableExpression if found, or undefined if not found
      */


### PR DESCRIPTION
If the original file ends in `.bs` , use that instead of `.brs` in absolute imports

![image](https://github.com/user-attachments/assets/1c871e24-c1bc-4ddf-b8bc-805cc7be4a12)


addresses: #1258 