### PR TITLE
Ensures conditional compilation blocks have proper validation segments

### DIFF
--- a/src/AstValidationSegmenter.ts
+++ b/src/AstValidationSegmenter.ts
@@ -1,5 +1,5 @@
 import type { DottedGetExpression, TypeExpression, VariableExpression } from './parser/Expression';
-import { isAliasStatement, isBinaryExpression, isBody, isClassStatement, isDottedGetExpression, isInterfaceStatement, isNamespaceStatement, isTypeExpression, isVariableExpression } from './astUtils/reflection';
+import { isAliasStatement, isBinaryExpression, isBlock, isBody, isClassStatement, isConditionalCompileStatement, isDottedGetExpression, isInterfaceStatement, isNamespaceStatement, isTypeExpression, isVariableExpression } from './astUtils/reflection';
 import { ChildrenSkipper, WalkMode, createVisitor } from './astUtils/visitors';
 import type { ExtraSymbolData, GetTypeOptions, TypeChainEntry } from './interfaces';
 import type { AstNode, Expression } from './parser/AstNode';
@@ -129,6 +129,11 @@ export class AstValidationSegmenter {
 
     checkSegmentWalk(segment: AstNode) {
         if (isNamespaceStatement(segment) || isBody(segment)) {
+            // skip namespaces and namespace bodies - no symbols to verify in those
+            return;
+        }
+        if (isConditionalCompileStatement(segment) || isBlock(segment)) {
+            // skip conditional compile statements and blocks - no symbols to verify in those
             return;
         }
         this.currentNamespaceStatement = segment.findAncestor(isNamespaceStatement);

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -10,13 +10,16 @@ import type { BrsFile } from '../../files/BrsFile';
 import { FloatType, InterfaceType } from '../../types';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import { AssociativeArrayType } from '../../types/AssociativeArrayType';
+import undent from 'undent';
+import * as fsExtra from 'fs-extra';
+import { tempDir, rootDir } from '../../testHelpers.spec';
 
 describe('ScopeValidator', () => {
 
     let sinon = sinonImport.createSandbox();
-    let rootDir = process.cwd();
     let program: Program;
     beforeEach(() => {
+        fsExtra.emptyDirSync(tempDir);
         program = new Program({
             rootDir: rootDir
         });
@@ -3190,4 +3193,74 @@ describe('ScopeValidator', () => {
             ]);
         });
     });
+
+
+    describe('preprocessor', () => {
+        it('should process class inheritance correctly', () => {
+            fsExtra.outputFileSync(`${rootDir}/manifest`, undent`
+                bs_const=DEBUG=true
+            `);
+            program.setFile('source/myClass.bs', `
+                namespace MyNamespace
+                    class MyClass1
+                        function new()
+                        end function
+                    end class
+                end namespace
+            `);
+
+            program.setFile('source/myClass2.bs', `
+                #if DEBUG
+                    namespace MyNamespace
+                        class MyClass2 extends MyClass1
+                            function new()
+                                super()
+                            end function
+                        end class
+                    end namespace
+                #end if
+            `);
+
+            program.setFile('source/main.bs', `
+                sub main()
+                    #if DEBUG
+                        m.test = new MyNamespace.MyClass2()
+                    #end if
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('should find types defined in condition compile blocks', () => {
+            fsExtra.outputFileSync(`${rootDir}/manifest`, undent`
+                bs_const=DEBUG=true
+            `);
+            program.setFile('source/debugInterfaces.bs', `
+                #if DEBUG
+                    interface DebugInfo
+                        name as string
+                    end interface
+                #end if
+            `);
+
+            program.setFile('source/main.bs', `
+                sub main()
+                     #if DEBUG
+                        info as DebugInfo = {name: "main.bs"}
+                        printDebugInfo(info)
+                     #end if
+                end sub
+
+                #if DEBUG
+                    sub printDebugInfo(info as DebugInfo)
+                        print info.name
+                    end sub
+                #end if
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+    });
+
 });


### PR DESCRIPTION
Fixes #1265 

Conditional compilation blocks (like namespaces) have no symbols in and of themselves that require validation, so they are skipped.

