### PR TITLE
`m` should be typed as roAssociativeArray for all inline functions

### DIFF
--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -711,6 +711,26 @@ describe('HoverProcessor', () => {
             let hover = program.getHover(file.srcPath, util.createPosition(6, 40))[0];
             expect(hover?.contents).eql([fence('MyIFace.member as invalid')]);
         });
+
+        it('has m as an AA in inline function', () => {
+            const file = program.setFile('source/main.bs', `
+                class Test
+                    sub method()
+                        stub = function()
+                            m.whatever = false
+                        end function
+                    end sub
+                end class
+            `);
+            program.validate();
+
+            // |m.whatever = false
+            let hover = program.getHover(file.srcPath, util.createPosition(4, 29))[0];
+            expect(hover?.contents).eql([fence('m as roAssociativeArray')]);
+            // m.what|ever = false
+            hover = program.getHover(file.srcPath, util.createPosition(4, 35))[0];
+            expect(hover?.contents).eql([fence('whatever as dynamic')]);
+        });
     });
 
     describe('callFunc', () => {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isAALiteralExpression, isAliasStatement, isArrayType, isBlock, isBody, isClassStatement, isConditionalCompileConstStatement, isConditionalCompileErrorStatement, isConditionalCompileStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isVariableExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isAliasStatement, isArrayType, isBlock, isBody, isClassStatement, isConditionalCompileConstStatement, isConditionalCompileErrorStatement, isConditionalCompileStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isMethodStatement, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isVariableExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -150,7 +150,8 @@ export class BrsFileValidator {
             },
             FunctionExpression: (node) => {
                 const funcSymbolTable = node.getSymbolTable();
-                if (!funcSymbolTable?.hasSymbol('m', SymbolTypeFlag.runtime) || node.findAncestor(isAALiteralExpression)) {
+                const isInlineFunc = !(isFunctionStatement(node.parent) || isMethodStatement(node.parent));
+                if (!funcSymbolTable?.hasSymbol('m', SymbolTypeFlag.runtime) || isInlineFunc) {
                     if (!isTypecastStatement(node.body?.statements?.[0])) {
                         funcSymbolTable?.addSymbol('m', { isInstance: true }, new AssociativeArrayType(), SymbolTypeFlag.runtime);
                     }

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1784,6 +1784,34 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('allows anything on m in an anonymous function', () => {
+            program.setFile('source/main.bs', `
+                function test()
+                    stub = function()
+                        m.something = true
+                    end function
+                    return stub
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows anything on m in an anonymous function in a class method', () => {
+            program.setFile('source/main.bs', `
+                class SomeKlass
+                    function test()
+                        stub = function()
+                            m.something = true
+                        end function
+                        return stub
+                    end function
+                end class
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('itemCannotBeUsedAsVariable', () => {


### PR DESCRIPTION
Example:

```
class Test
    sub method()
        stub = function()
            m.whatever = false ' m here is unknown - it is an AA
        end function
    end sub
end class
```


