### PR TITLE
Include missing transpiled comments

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2615,22 +2615,41 @@ describe('BrsFile', () => {
         it('includes comments above namespaced method call', async () => {
             await testTranspile(`
                 sub main()
-                    'delay for a bit
-                    utils.delay(sub()
-                    end sub)
+                    'do nothing
+                    utils.noop()
                 end sub
                 namespace utils
-                    function delay(callback as function)
-                    end function
+                    sub noop()
+                    end sub
                 end namespace
             `, `
                 sub main()
-                    'delay for a bit
-                    utils_delay(sub()
-                    end sub)
+                    'do nothing
+                    utils_noop()
                 end sub
-                function utils_delay(callback as function)
-                end function
+                sub utils_noop()
+                end sub
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes comments above inferred namespace function call', async () => {
+            await testTranspile(`
+                namespace utils
+                    sub test()
+                        'do nothing
+                        noop()
+                    end sub
+                    sub noop()
+                    end sub
+                end namespace
+            `, `
+                sub utils_test()
+                    'do nothing
+                    utils_noop()
+                end sub
+
+                sub utils_noop()
+                end sub
             `, undefined, 'source/main.bs');
         });
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2509,6 +2509,131 @@ describe('BrsFile', () => {
             `, 'trim', 'source/main.bs');
         });
 
+        it('includes annotation comments for class', async () => {
+            await testTranspile(`
+                'comment1
+                @annotation
+                'comment2
+                @annotation()
+                'comment3
+                class Beta
+                end class
+            `, `
+                function __Beta_builder()
+                    instance = {}
+                    instance.new = sub()
+                    end sub
+                    return instance
+                end function
+                'comment1
+                'comment2
+                'comment3
+                function Beta()
+                    instance = __Beta_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes annotation comments for function', async () => {
+            await testTranspile(`
+                'comment1
+                @annotation
+                'comment2
+                @annotation()
+                'comment3
+                function alpha()
+                end function
+            `, `
+                'comment1
+                'comment2
+                'comment3
+                function alpha()
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes annotation comments for enum', async () => {
+            await testTranspile(`
+                'comment1
+                @annotation
+                'comment2
+                @annotation()
+                'comment3
+                enum Direction
+                    up = "up"
+                end enum
+            `, `
+                'comment1
+                'comment2
+                'comment3
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes annotation comments for const', async () => {
+            await testTranspile(`
+                'comment1
+                @annotation
+                'comment2
+                @annotation()
+                'comment3
+                const direction = "up"
+            `, `
+                'comment1
+                'comment2
+                'comment3
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes annotation comments for empty namespaces', async () => {
+            await testTranspile(`
+                'comment1
+                @annotation
+                'comment2
+                @annotation()
+                'comment3
+                namespace alpha
+                    'comment4
+                    @annotation
+                    'comment5
+                    @annotation()
+                    'comment6
+                    namespace beta
+                    end namespace
+                end namespace
+            `, `
+                'comment1
+                'comment2
+                'comment3
+                'comment4
+                'comment5
+                'comment6
+            `, undefined, 'source/main.bs');
+        });
+
+        it('includes comments above namespaced method call', async () => {
+            await testTranspile(`
+                sub main()
+                    'delay for a bit
+                    utils.delay(sub()
+                    end sub)
+                end sub
+                namespace utils
+                    function delay(callback as function)
+                    end function
+                end namespace
+            `, `
+                sub main()
+                    'delay for a bit
+                    utils_delay(sub()
+                    end sub)
+                end sub
+                function utils_delay(callback as function)
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
         it('keeps end-of-line comments with their line', async () => {
             await testTranspile(`
                 function DoSomething() 'comment 1

--- a/src/parser/BrsTranspileState.ts
+++ b/src/parser/BrsTranspileState.ts
@@ -3,6 +3,7 @@ import { Editor } from '../astUtils/Editor';
 import type { BrsFile } from '../files/BrsFile';
 import type { ClassStatement, ConditionalCompileStatement } from './Statement';
 import { TranspileState } from './TranspileState';
+import type { Statement } from './AstNode';
 
 export class BrsTranspileState extends TranspileState {
     public constructor(
@@ -45,4 +46,13 @@ export class BrsTranspileState extends TranspileState {
      * Do not transpile leading comments
      */
     public skipLeadingComments = false;
+
+    /**
+     * Transpile all leading trivia for a given statement, including comments mixed between annotations
+     */
+    public transpileAnnotations(node: Statement) {
+        return (node?.annotations ?? []).map(x => {
+            return x.transpile(this);
+        });
+    }
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -143,6 +143,7 @@ export class CallExpression extends Expression {
 
     transpile(state: BrsTranspileState, nameOverride?: string) {
         let result: TranspileResult = [];
+        throw new Error('crash');
 
         //transpile the name
         if (nameOverride) {
@@ -1828,7 +1829,8 @@ export class AnnotationExpression extends Expression {
     }
 
     transpile(state: BrsTranspileState) {
-        return [];
+        //transpile only our leading comments
+        return state.transpileComments(this.leadingTrivia);
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -419,7 +419,10 @@ export class ExpressionStatement extends Statement {
     public readonly location: Location | undefined;
 
     transpile(state: BrsTranspileState) {
-        return this.expression.transpile(state);
+        return [
+            state.transpileAnnotations(this),
+            this.expression.transpile(state)
+        ];
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -2,7 +2,7 @@ import { SourceNode } from 'source-map';
 import type { Location } from 'vscode-languageserver';
 import type { BsConfig } from '../BsConfig';
 import { TokenKind } from '../lexer/TokenKind';
-import { isToken, type Token } from '../lexer/Token';
+import { type Token } from '../lexer/Token';
 import type { RangeLike } from '../util';
 import { util } from '../util';
 import type { TranspileResult } from '../interfaces';

--- a/src/parser/TranspileState.ts
+++ b/src/parser/TranspileState.ts
@@ -2,11 +2,10 @@ import { SourceNode } from 'source-map';
 import type { Location } from 'vscode-languageserver';
 import type { BsConfig } from '../BsConfig';
 import { TokenKind } from '../lexer/TokenKind';
-import type { Token } from '../lexer/Token';
+import { isToken, type Token } from '../lexer/Token';
 import type { RangeLike } from '../util';
 import { util } from '../util';
 import type { TranspileResult } from '../interfaces';
-
 
 interface TranspileToken {
     location?: Location;
@@ -113,6 +112,17 @@ export class TranspileState {
         );
     }
 
+    public transpileLeadingCommentsForAstNode(node: { leadingTrivia?: Token[] }) {
+        const leadingTrivia = node?.leadingTrivia ?? [];
+        const leadingCommentsSourceNodes = this.transpileComments(leadingTrivia);
+        if (leadingCommentsSourceNodes.length > 0) {
+            // indent in preparation for next text
+            leadingCommentsSourceNodes.push(this.indent());
+        }
+
+        return leadingCommentsSourceNodes;
+    }
+
     public transpileLeadingComments(token: TranspileToken) {
         const leadingTrivia = (token?.leadingTrivia ?? []);
         const leadingCommentsSourceNodes = this.transpileComments(leadingTrivia);
@@ -124,7 +134,7 @@ export class TranspileState {
         return leadingCommentsSourceNodes;
     }
 
-    public transpileComments(tokens: TranspileToken[]) {
+    public transpileComments(tokens: TranspileToken[], prepNextLine = false): Array<string | SourceNode> {
         const leadingCommentsSourceNodes = [];
         const justComments = tokens.filter(t => t.kind === TokenKind.Comment || t.kind === TokenKind.Newline);
         let newLinesSinceComment = 0;
@@ -149,6 +159,10 @@ export class TranspileState {
                 leadingCommentsSourceNodes.push(this.newline);
             }
             transpiledCommentAlready = true;
+        }
+        //if we should prepare for the next line, add an indent (only if applicable)
+        if (prepNextLine && transpiledCommentAlready) {
+            leadingCommentsSourceNodes.push(this.indent());
         }
         return leadingCommentsSourceNodes;
     }


### PR DESCRIPTION
Fixes several issues where comments were being missed when transpiling. Specifically around annotations above statements, and namespaced function calls.

Fixes #1274