### PR TITLE
Ast node clone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001599",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
-      "integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "dev": true,
       "funding": [
         {
@@ -10858,9 +10858,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001599",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
-      "integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "dev": true
     },
     "caseless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "rimraf": "^2.7.1",
         "semver-extra": "^3.0.0",
         "sinon": "^9.0.2",
-        "source-map-support": "^0.5.13",
+        "source-map-support": "^0.5.21",
         "sync-request": "^6.1.0",
         "testdouble": "^3.5.2",
         "thenby": "^1.3.4",
@@ -8098,9 +8098,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -15228,9 +15228,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "rimraf": "^2.7.1",
     "semver-extra": "^3.0.0",
     "sinon": "^9.0.2",
-    "source-map-support": "^0.5.13",
+    "source-map-support": "^0.5.21",
     "sync-request": "^6.1.0",
     "testdouble": "^3.5.2",
     "thenby": "^1.3.4",

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -105,6 +105,9 @@ export function isForEachStatement(element: AstNode | undefined): element is For
 }
 export function isWhileStatement(element: AstNode | undefined): element is WhileStatement {
     return element?.constructor?.name === 'WhileStatement';
+}
+export function isDimStatement(element: AstNode | undefined): element is DimStatement {
+    return element?.constructor?.name === 'DimStatement';
 }
 export function isDottedSetStatement(element: AstNode | undefined): element is DottedSetStatement {
     return element?.constructor?.name === 'DottedSetStatement';

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression } from '../parser/Expression';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -90,6 +90,12 @@ export function isLabelStatement(element: AstNode | undefined): element is Label
 }
 export function isReturnStatement(element: AstNode | undefined): element is ReturnStatement {
     return element?.constructor?.name === 'ReturnStatement';
+}
+export function isTernaryExpression(element: AstNode | undefined): element is TernaryExpression {
+    return element?.constructor?.name === 'TernaryExpression';
+}
+export function isNullCoalescingExpression(element: AstNode | undefined): element is NullCoalescingExpression {
+    return element?.constructor?.name === 'NullCoalescingExpression';
 }
 export function isEndStatement(element: AstNode | undefined): element is EndStatement {
     return element?.constructor?.name === 'EndStatement';

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -78,7 +78,7 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
  * @param filter a function used to filter items from the array. return true if that item should be walked
  */
 export function walkArray<T = AstNode>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode, filter?: <T>(element: T) => boolean) {
-    for (let i = 0; i < array.length; i++) {
+    for (let i = 0; i < array?.length; i++) {
         if (!filter || filter(array[i])) {
             const startLength = array.length;
             walk(array, i, visitor, options, parent);

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -3,10 +3,10 @@ import * as fsExtra from 'fs-extra';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
 import { expect } from '../chai-config.spec';
-import { AALiteralExpression, AAMemberExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, UnaryExpression, XmlAttributeGetExpression } from './Expression';
+import type { AALiteralExpression, AAMemberExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, GroupingExpression, IndexedGetExpression, NewExpression, NullCoalescingExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, UnaryExpression, XmlAttributeGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
-import { isAALiteralExpression, isAAMemberExpression, isAnnotationExpression, isArrayLiteralExpression, isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isCallfuncExpression, isCatchStatement, isClassStatement, isCommentStatement, isConstStatement, isDimStatement, isDottedGetExpression, isDottedSetStatement, isEnumMemberStatement, isEnumStatement, isExpressionStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionParameterExpression, isFunctionStatement, isGroupingExpression, isIfStatement, isIncrementStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isLibraryStatement, isMethodStatement, isNamespacedVariableNameExpression, isNamespaceStatement, isNewExpression, isNullCoalescingExpression, isPrintStatement, isReturnStatement, isTaggedTemplateStringExpression, isTemplateStringExpression, isTemplateStringQuasiExpression, isTernaryExpression, isThrowStatement, isTryCatchStatement, isTypeCastExpression, isUnaryExpression, isWhileStatement, isXmlAttributeGetExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isAnnotationExpression, isArrayLiteralExpression, isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isCallfuncExpression, isCatchStatement, isClassStatement, isCommentStatement, isConstStatement, isDimStatement, isDottedGetExpression, isDottedSetStatement, isEnumMemberStatement, isEnumStatement, isExpressionStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isGroupingExpression, isIfStatement, isIncrementStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isLibraryStatement, isMethodStatement, isNamespaceStatement, isNewExpression, isNullCoalescingExpression, isPrintStatement, isReturnStatement, isTaggedTemplateStringExpression, isTemplateStringExpression, isTemplateStringQuasiExpression, isTernaryExpression, isThrowStatement, isTryCatchStatement, isTypeCastExpression, isUnaryExpression, isWhileStatement, isXmlAttributeGetExpression } from '../astUtils/reflection';
 import type { ClassStatement, FunctionStatement, InterfaceFieldStatement, InterfaceMethodStatement, MethodStatement, InterfaceStatement, CatchStatement, ThrowStatement, EnumStatement, EnumMemberStatement, ConstStatement, Block, CommentStatement, PrintStatement, DimStatement, ForStatement, WhileStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, TryCatchStatement, DottedSetStatement } from './Statement';
 import { AssignmentStatement, EmptyStatement } from './Statement';
 import { ParseMode, Parser } from './Parser';
@@ -189,7 +189,7 @@ describe('AstNode', () => {
         });
     });
 
-    describe.only('clone', () => {
+    describe('clone', () => {
         function testClone(code: string | AstNode) {
             let originalOuter: AstNode;
             if (typeof code === 'string') {
@@ -1643,6 +1643,12 @@ describe('AstNode', () => {
             const original = Parser.parse(`
                 @annotation()
                 sub test()
+                    @annotation()
+                    statement = true
+                    @annotation()
+                    call()
+                    @annotation()
+                    'comment
                 end sub
 
                 @annotation()

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -6,9 +6,11 @@ import { expect } from '../chai-config.spec';
 import type { DottedGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
-import { isAssignmentStatement, isClassStatement, isDottedGetExpression, isPrintStatement } from '../astUtils/reflection';
-import type { FunctionStatement } from './Statement';
-import { AssignmentStatement } from './Statement';
+import { isAssignmentStatement, isBlock, isBody, isCatchStatement, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isEnumMemberStatement, isEnumStatement, isExpressionStatement, isFunctionExpression, isFunctionStatement, isIfStatement, isIncrementStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isMethodStatement, isPrintStatement, isThrowStatement } from '../astUtils/reflection';
+import type { ClassStatement, FunctionStatement, InterfaceFieldStatement, InterfaceMethodStatement, MethodStatement, InterfaceStatement, TryCatchStatement, CatchStatement, ThrowStatement, EnumStatement, EnumMemberStatement, ConstStatement, Body, Block, CommentStatement, ExpressionStatement, IfStatement, IncrementStatement, PrintStatement } from './Statement';
+import { AssignmentStatement, EmptyStatement } from './Statement';
+import { ParseMode, Parser } from './Parser';
+import type { AstNode } from './AstNode';
 
 describe('AstNode', () => {
     let program: Program;
@@ -183,5 +185,512 @@ describe('AstNode', () => {
             });
             expect(count).to.eql(1);
         });
+    });
+
+    describe.only('clone', () => {
+        function testClone(code: string | AstNode) {
+            let original: AstNode;
+            if (typeof code === 'string') {
+                const parser = Parser.parse(code, { mode: ParseMode.BrighterScript });
+                original = parser.ast;
+                expectZeroDiagnostics(parser);
+            } else {
+                original = code;
+            }
+
+            const clone = original.clone();
+            //ensure the clone is identical to the original
+
+            //compare them both ways to ensure no extra properties exist
+            ensureIdentical(original, clone);
+            ensureIdentical(clone, original);
+
+            function ensureIdentical(original: AstNode, clone: AstNode, ancestors = [], seenNodes = new Map<AstNode, number>()) {
+                for (let key in original) {
+                    let fullKey = [...ancestors, key].join('.');
+                    const originalValue = original?.[key];
+                    const cloneValue = clone?.[key];
+                    let typeOfValue = typeof originalValue;
+
+                    //skip these properties
+                    if (
+                        ['parent', 'symbolTable', 'range'].includes(key) ||
+                        //this is a circular reference property, skip it (it's redundant anyway)
+                        (isFunctionExpression(original) && key === 'functionStatement')
+                    ) {
+                        continue;
+                    }
+
+                    if (typeOfValue === 'object' && originalValue !== null) {
+                        //skip circular references (but give some tollerance)
+                        if (seenNodes.get(originalValue) > 2) {
+                            throw new Error(`${fullKey} is a circular reference`);
+                        }
+                        seenNodes.set(originalValue, (seenNodes.get(originalValue) ?? 0) + 1);
+
+                        //object references should not be the same
+                        if (originalValue === cloneValue) {
+                            throw new Error(`${fullKey} is the same object reference`);
+                        }
+                        //compare child object values
+                        ensureIdentical(originalValue, cloneValue, [...ancestors, key], seenNodes);
+                    } else if ([''].includes(typeOfValue)) {
+                        //primitive values should be identical
+                        expect(cloneValue).to.equal(originalValue, `${fullKey} should be equal`);
+                    }
+                }
+            }
+        }
+
+        it('clones EmptyStatement', () => {
+            testClone(new EmptyStatement(
+                util.createRange(1, 2, 3, 4)
+            ));
+        });
+
+        it('clones body with undefined statements array', () => {
+            const original = Parser.parse(`
+                sub main()
+                end sub
+            `).ast;
+            original.statements = undefined;
+            testClone(original);
+        });
+
+        it('clones body with undefined in the statements array', () => {
+            const original = Parser.parse(`
+                sub main()
+                end sub
+            `).ast;
+            original.statements.push(undefined);
+            testClone(original);
+        });
+
+        it('clones interfaces', () => {
+            testClone(`
+                interface Empty
+                end interface
+                interface Movie
+                    name as string
+                    previous as Movie
+                    sub play()
+                    function play2(a, b as string) as dynamic
+                end interface
+                interface Short extends Movie
+                    length as integer
+                end interface
+            `);
+        });
+
+        it('handles when interfaces are missing their body', () => {
+            const original = Parser.parse(`
+                interface Empty
+                end interface
+            `).ast;
+            original.findChild<InterfaceStatement>(isInterfaceStatement).body = undefined;
+            testClone(original);
+        });
+
+        it('handles when interfaces have undefined statements in the body', () => {
+            const original = Parser.parse(`
+                interface Empty
+                end interface
+            `).ast;
+            original.findChild<InterfaceStatement>(isInterfaceStatement).body.push(undefined);
+            testClone(original);
+        });
+
+        it('handles when interfaces have undefined field type', () => {
+            const original = Parser.parse(`
+                interface Empty
+                    name as string
+                end interface
+            `).ast;
+            original.findChild<InterfaceFieldStatement>(isInterfaceFieldStatement).type = undefined;
+            testClone(original);
+        });
+
+        it('handles when interface function has undefined param and return type', () => {
+            const original = Parser.parse(`
+                interface Empty
+                    function test() as dynamic
+                end interface
+            `).ast;
+            original.findChild<InterfaceMethodStatement>(isInterfaceMethodStatement).params.push(undefined);
+            original.findChild<InterfaceMethodStatement>(isInterfaceMethodStatement).returnType = undefined;
+            testClone(original);
+        });
+
+        it('handles when interface function has undefined params array', () => {
+            const original = Parser.parse(`
+                interface Empty
+                    function test(a) as dynamic
+                end interface
+            `).ast;
+            original.findChild<InterfaceMethodStatement>(isInterfaceMethodStatement).params = undefined;
+            testClone(original);
+        });
+
+        it('clones empty class', () => {
+            testClone(`
+                class Movie
+                end class
+            `);
+        });
+
+        it('clones class with undefined body', () => {
+            const original = Parser.parse(`
+                class Movie
+                end class
+            `).ast;
+            original.findChild<ClassStatement>(isClassStatement).body = undefined;
+            testClone(original);
+        });
+
+        it('clones class with undefined body statement', () => {
+            const original = Parser.parse(`
+                class Movie
+                end class
+            `).ast;
+            original.findChild<ClassStatement>(isClassStatement).body.push(undefined);
+            testClone(original);
+        });
+
+        it('clones class having parent class', () => {
+            testClone(`
+                class Video
+                end class
+                class Movie extends Video
+                end class
+            `);
+        });
+
+        it('clones class', () => {
+            testClone(`
+                class Movie
+                    name as string
+                    previous as Movie
+                    sub play()
+                    end sub
+                    function play2(a, b as string) as dynamic
+                    end function
+                end class
+            `);
+        });
+
+        it('clones access modifiers', () => {
+            testClone(`
+                class Movie
+                    public sub test()
+                    end sub
+                    protected name = "bob"
+                    private child = {}
+                end class
+            `);
+        });
+
+        it('clones AssignmentStatement', () => {
+            testClone(`
+                sub main()
+                    thing = true
+                end sub
+            `);
+        });
+
+        it('clones AssignmentStatement with missing value', () => {
+            const original = Parser.parse(`
+                sub main()
+                    thing = true
+                end sub
+            `).ast;
+            original.findChild<any>(isAssignmentStatement).value = undefined;
+            testClone(original);
+        });
+
+        it('clones Block with undefined statements array', () => {
+            const original = Parser.parse(`
+                sub main()
+                    thing = true
+                end sub
+            `).ast;
+            original.findChild<any>(isBlock).statements = undefined;
+            testClone(original);
+        });
+
+        it('clones Block with undefined statement in statements array', () => {
+            const original = Parser.parse(`
+                sub main()
+                    thing = true
+                end sub
+            `).ast;
+            original.findChild<Block>(isBlock).statements.push(undefined);
+            testClone(original);
+        });
+
+        it('clones comment statement with undefined comments array', () => {
+            const original = Parser.parse(`
+                'hello world
+            `).ast;
+            original.findChild<CommentStatement>(isCommentStatement).comments = undefined;
+            testClone(original);
+        });
+
+        it('clones class with undefined method modifiers array', () => {
+            const original = Parser.parse(`
+                class Movie
+                    sub test()
+                    end sub
+                end class
+            `).ast;
+            original.findChild<MethodStatement>(isMethodStatement).modifiers = undefined;
+            testClone(original);
+        });
+
+        it('clones class with undefined func', () => {
+            const original = Parser.parse(`
+                class Movie
+                    sub test()
+                    end sub
+                end class
+            `).ast;
+            original.findChild<MethodStatement>(isMethodStatement).func = undefined;
+            testClone(original);
+        });
+
+        it('clones ExpressionStatement', () => {
+            testClone(`
+                sub main()
+                    test()
+                end sub
+            `);
+        });
+
+        it('clones ExpressionStatement without an expression', () => {
+            const original = Parser.parse(`
+                sub main()
+                    test()
+                end sub
+            `).ast;
+            original.findChild<any>(isExpressionStatement).expression = undefined;
+            testClone(original);
+        });
+
+        it('clones IfStatement', () => {
+            testClone(`
+                sub main()
+                    if true
+                    end if
+                    if true then
+                    end if
+                    if true
+                        print 1
+                    else if true
+                        print 1
+                    else
+                        print 1
+                    end if
+                end sub
+            `);
+        });
+
+        it('clones IfStatement without condition or branches', () => {
+            const original = Parser.parse(`
+                sub main()
+                    if true
+                    end if
+                end sub
+            `).ast;
+            original.findChild<any>(isIfStatement).condition = undefined;
+            original.findChild<any>(isIfStatement).thenBranch = undefined;
+            original.findChild<any>(isIfStatement).elseBranch = undefined;
+            testClone(original);
+        });
+
+        it('clones IncrementStatement', () => {
+            testClone(`
+                sub main()
+                    i = 0
+                    i++
+                end sub
+            `);
+        });
+
+        it('clones IncrementStatement with missing `value`', () => {
+            const original = Parser.parse(`
+                sub main()
+                    i = 0
+                    i++
+                end sub
+            `).ast;
+            original.findChild<any>(isIncrementStatement).value = undefined;
+            testClone(original);
+        });
+
+        it('clones PrintStatement with undefined expressions array', () => {
+            const original = Parser.parse(`
+                sub main()
+                    print 1
+                end sub
+            `).ast;
+            original.findChild<any>(isPrintStatement).expressions = undefined;
+            testClone(original);
+        });
+
+        it('clones PrintStatement with undefined expression in the expressions array', () => {
+            const original = Parser.parse(`
+                sub main()
+                    print 1
+                end sub
+            `).ast;
+            original.findChild<PrintStatement>(isPrintStatement).expressions.push(undefined);
+            testClone(original);
+        });
+
+        it('clones ExitFor statement', () => {
+            testClone(`
+                sub main()
+                    for i = 0 to 10
+                        exit for
+                    end for
+                end sub
+            `);
+        });
+
+        it('clones ExitWhile statement', () => {
+            testClone(`
+                sub main()
+                    while true
+                        exit while
+                    end while
+                end sub
+            `);
+        });
+
+        it('clones tryCatch statement', () => {
+            testClone(`
+                sub main()
+                    try
+                    catch e
+                    end try
+                end sub
+            `);
+        });
+
+        it('clones tryCatch statement when missing catch branch', () => {
+            const original = Parser.parse(`
+               sub main()
+                    try
+                        print 1
+                    catch e
+                        print 2
+                    end try
+                end sub
+            `).ast;
+            original.findChild<CatchStatement>(isCatchStatement).catchBranch = undefined;
+            testClone(original);
+        });
+
+        it('clones throw statement', () => {
+            testClone(`
+                sub main()
+                    throw "Crash"
+                end sub
+            `);
+        });
+
+        it('clones throw statement with missing expression', () => {
+            const original = Parser.parse(`
+                sub main()
+                    throw "Crash"
+                end sub
+            `).ast;
+            original.findChild<ThrowStatement>(isThrowStatement).expression = undefined;
+            testClone(original);
+        });
+
+        it('clones FunctionStatement when missing .func', () => {
+            const original = Parser.parse(`
+               sub main()
+                end sub
+            `).ast;
+            original.findChild<FunctionStatement>(isFunctionStatement).func = undefined;
+            testClone(original);
+        });
+
+        it('clones empty enum statement', () => {
+            testClone(`
+               enum Direction
+               end enum
+            `);
+        });
+
+        it('clones enum statement with comments', () => {
+            testClone(`
+                enum Direction
+                    'the up direction
+                    up = "up"
+                end enum
+            `);
+        });
+
+        it('clones enum statement with missing body', () => {
+            const original = Parser.parse(`
+                enum Direction
+                    'the up direction
+                    up = "up"
+                end enum
+            `).ast;
+            original.findChild<EnumStatement>(isEnumStatement).body = undefined;
+            testClone(original);
+        });
+
+        it('clones enum statement with undefined in body', () => {
+            const original = Parser.parse(`
+                enum Direction
+                    'the up direction
+                    up = "up"
+                end enum
+            `).ast;
+            original.findChild<EnumStatement>(isEnumStatement).body.push(undefined);
+            testClone(original);
+        });
+
+        it('clones enum member with missing value', () => {
+            const original = Parser.parse(`
+                enum Direction
+                    up = "up"
+                end enum
+            `).ast;
+            original.findChild<EnumMemberStatement>(isEnumMemberStatement).value = undefined;
+            testClone(original);
+        });
+
+        it('clones const', () => {
+            const original = Parser.parse(`
+                const key = "KEY"
+            `).ast;
+            testClone(original);
+        });
+
+
+        it('clones const with missing value', () => {
+            const original = Parser.parse(`
+                const key = "KEY"
+            `).ast;
+            original.findChild<ConstStatement>(isConstStatement).value = undefined;
+
+            testClone(original);
+        });
+
+        it('clones continue statement', () => {
+            testClone(`
+                sub main()
+                    for i = 0 to 10
+                        continue for
+                    end for
+                end sub
+            `);
+        });
+
     });
 });

--- a/src/parser/AstNode.spec.ts
+++ b/src/parser/AstNode.spec.ts
@@ -3,10 +3,10 @@ import * as fsExtra from 'fs-extra';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
 import { expect } from '../chai-config.spec';
-import type { DottedGetExpression } from './Expression';
+import type { AALiteralExpression, AAMemberExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, TypeCastExpression, UnaryExpression, XmlAttributeGetExpression } from './Expression';
 import { expectZeroDiagnostics } from '../testHelpers.spec';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
-import { isAssignmentStatement, isBlock, isCatchStatement, isClassStatement, isCommentStatement, isConstStatement, isDimStatement, isDottedGetExpression, isDottedSetStatement, isEnumMemberStatement, isEnumStatement, isExpressionStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isIfStatement, isIncrementStatement, isIndexedSetStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isLibraryStatement, isMethodStatement, isNamespaceStatement, isPrintStatement, isReturnStatement, isThrowStatement, isTryCatchStatement, isWhileStatement } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isAssignmentStatement, isBinaryExpression, isBlock, isCallExpression, isCallfuncExpression, isCatchStatement, isClassStatement, isCommentStatement, isConstStatement, isDimStatement, isDottedGetExpression, isDottedSetStatement, isEnumMemberStatement, isEnumStatement, isExpressionStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionParameterExpression, isFunctionStatement, isGroupingExpression, isIfStatement, isIncrementStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceFieldStatement, isInterfaceMethodStatement, isInterfaceStatement, isLibraryStatement, isMethodStatement, isNamespacedVariableNameExpression, isNamespaceStatement, isNewExpression, isNullCoalescingExpression, isPrintStatement, isReturnStatement, isTaggedTemplateStringExpression, isTemplateStringExpression, isTemplateStringQuasiExpression, isTernaryExpression, isThrowStatement, isTryCatchStatement, isTypeCastExpression, isUnaryExpression, isWhileStatement, isXmlAttributeGetExpression } from '../astUtils/reflection';
 import type { ClassStatement, FunctionStatement, InterfaceFieldStatement, InterfaceMethodStatement, MethodStatement, InterfaceStatement, CatchStatement, ThrowStatement, EnumStatement, EnumMemberStatement, ConstStatement, Block, CommentStatement, PrintStatement, DimStatement, ForStatement, WhileStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, TryCatchStatement, DottedSetStatement } from './Statement';
 import { AssignmentStatement, EmptyStatement } from './Statement';
 import { ParseMode, Parser } from './Parser';
@@ -989,5 +989,642 @@ describe('AstNode', () => {
 
             testClone(original);
         });
+
+        it('clones BinaryExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print 1 + 2
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones BinaryExpression with missing props', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print 1 + 2
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<BinaryExpression>>(isBinaryExpression).left = undefined;
+            original.findChild<DeepWriteable<BinaryExpression>>(isBinaryExpression).right = undefined;
+
+            testClone(original);
+        });
+
+        it('clones CallExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    test()
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones CallExpression with args', () => {
+            const original = Parser.parse(`
+                sub test()
+                    test(1,2,3)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones CallExpression with missing props', () => {
+            const original = Parser.parse(`
+                sub test()
+                    test(1,2,3)
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<CallExpression>>(isCallExpression).callee = undefined;
+            original.findChild<DeepWriteable<CallExpression>>(isCallExpression).args = undefined;
+
+            testClone(original);
+        });
+
+        it('clones CallExpression with args containing undefined', () => {
+            const original = Parser.parse(`
+                sub test()
+                    test(1,2,3)
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<CallExpression>>(isCallExpression).args[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones FunctionExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones FunctionExpression with undefined props', () => {
+            const original = Parser.parse(`
+                sub test()
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<FunctionExpression>>(isFunctionExpression).parameters = undefined;
+            original.findChild<DeepWriteable<FunctionExpression>>(isFunctionExpression).body = undefined;
+
+            testClone(original);
+        });
+
+        it('clones FunctionExpression with a parameter that is undefined', () => {
+            const original = Parser.parse(`
+                sub test(p1)
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<FunctionExpression>>(isFunctionExpression).parameters[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones FunctionParameterExpression', () => {
+            const original = Parser.parse(`
+                sub test(p1)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones FunctionParameterExpression with default value', () => {
+            const original = Parser.parse(`
+                sub test(p1 = true)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+
+        it('clones FunctionParameterExpression with undefined default value', () => {
+            const original = Parser.parse(`
+                sub test(p1 = true)
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<FunctionExpression>>(isFunctionExpression).parameters[0].defaultValue = undefined;
+
+            testClone(original);
+        });
+
+        it('clones NamespacedVariableNameExpression', () => {
+            const original = Parser.parse(`
+                sub test(p1 as Alpha.Beta)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones NamespacedVariableNameExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                class Person extends Alpha.Humanoid
+                end class
+            `).ast;
+            original.findChild<DeepWriteable<ClassStatement>>(isClassStatement).parentClassName.expression = undefined;
+
+            testClone(original);
+        });
+
+        it('clones DottedGetExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print alpha.beta.charlie
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones DottedGetExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print alpha.beta.charlie
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<DottedGetExpression>>(isDottedGetExpression).obj = undefined;
+
+            testClone(original);
+        });
+
+        it('clones XmlAttributeGetExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print xml@name
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones XmlAttributeGetExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print xml@name
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<XmlAttributeGetExpression>>(isXmlAttributeGetExpression).obj = undefined;
+
+            testClone(original);
+        });
+
+        it('clones IndexedGetExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print m.stuff[0]
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones IndexedGetExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print m.stuff[0]
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<IndexedGetExpression>>(isIndexedGetExpression).obj = undefined;
+            original.findChild<DeepWriteable<IndexedGetExpression>>(isIndexedGetExpression).index = undefined;
+            original.findChild<DeepWriteable<IndexedGetExpression>>(isIndexedGetExpression).additionalIndexes = undefined;
+
+            testClone(original);
+        });
+
+        it('clones IndexedGetExpression with additionalIndexes', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print m.stuff[0, 1]
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones IndexedGetExpression with additionalIndexes having undefined', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print m.stuff[0, 1]
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<IndexedGetExpression>>(isIndexedGetExpression).additionalIndexes[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones GroupingExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print (1 + 2)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones GroupingExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print (1 + 2)
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<GroupingExpression>>(isGroupingExpression).expression = undefined;
+
+            testClone(original);
+        });
+
+        it('clones LiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print true
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones ExcapedCharCodeLiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`\n\`
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones ArrayLiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print []
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones ArrayLiteralExpression with undefined items', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print []
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<ArrayLiteralExpression>>(isArrayLiteralExpression).elements = undefined;
+
+            testClone(original);
+        });
+
+        it('clones ArrayLiteralExpression with with elements having an undefined', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print [1,2,3]
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<ArrayLiteralExpression>>(isArrayLiteralExpression).elements[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones AAMemberExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    movie = {
+                        duration: 20
+                    }
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones AAMemberExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    movie = {
+                        duration: 20
+                    }
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<AAMemberExpression>>(isAAMemberExpression).value = undefined;
+
+            testClone(original);
+        });
+
+        it('clones AALiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    movie = {
+                        duration: 20
+                    }
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones AALiteralExpression with undefined items', () => {
+            const original = Parser.parse(`
+                sub test()
+                    movie = {
+                        duration: 20
+                    }
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<AALiteralExpression>>(isAALiteralExpression).elements = undefined;
+
+            testClone(original);
+        });
+
+        it('clones AALiteralExpression with undefined items', () => {
+            const original = Parser.parse(`
+                sub test()
+                    movie = {
+                        duration: 20
+                    }
+                end sub
+            `).ast;
+            original.findChild<AALiteralExpression>(isAALiteralExpression).elements.push(undefined);
+
+            testClone(original);
+        });
+
+        it('clones UnaryExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print not true
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones UnaryExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print not true
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<UnaryExpression>>(isUnaryExpression).right = undefined;
+
+            testClone(original);
+        });
+
+        it('clones SourceLiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print LINE_NUM
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones NewExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print new Person()
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones NewExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print new Person()
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<NewExpression>>(isNewExpression).call = undefined;
+
+            testClone(original);
+        });
+
+        it('clones CallfuncExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print node@.run(1)
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones CallfuncExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print node@.run()
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<CallfuncExpression>>(isCallfuncExpression).callee = undefined;
+            original.findChild<DeepWriteable<CallfuncExpression>>(isCallfuncExpression).args = undefined;
+
+            testClone(original);
+        });
+
+        it('clones CallfuncExpression with undefined args', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print node@.run()
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<CallfuncExpression>>(isCallfuncExpression).args[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringQuasiExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name}\`
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringQuasiExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TemplateStringQuasiExpression>>(isTemplateStringQuasiExpression).expressions = undefined;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringQuasiExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TemplateStringQuasiExpression>>(isTemplateStringQuasiExpression).expressions[0] = undefined;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name} \\n\`
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TemplateStringExpression>>(isTemplateStringExpression).quasis = undefined;
+            original.findChild<DeepWriteable<TemplateStringExpression>>(isTemplateStringExpression).expressions = undefined;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print \`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TemplateStringExpression>>(isTemplateStringExpression).quasis.push(undefined);
+            original.findChild<DeepWriteable<TemplateStringExpression>>(isTemplateStringExpression).expressions.push(undefined);
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print tag\`hello \${name} \\n\`
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print tag\`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TaggedTemplateStringExpression>>(isTaggedTemplateStringExpression).quasis = undefined;
+            original.findChild<DeepWriteable<TaggedTemplateStringExpression>>(isTaggedTemplateStringExpression).expressions = undefined;
+
+            testClone(original);
+        });
+
+        it('clones TemplateStringExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print tag\`hello \${name}\`
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TaggedTemplateStringExpression>>(isTaggedTemplateStringExpression).quasis.push(undefined);
+            original.findChild<DeepWriteable<TaggedTemplateStringExpression>>(isTaggedTemplateStringExpression).expressions.push(undefined);
+
+            testClone(original);
+        });
+
+        it('clones AnnotationExpression', () => {
+            const original = Parser.parse(`
+                @test
+                sub main()
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TernaryExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print true ? 1 : 2
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TernaryExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print true ? 1 : 2
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TernaryExpression>>(isTernaryExpression).test = undefined;
+            original.findChild<DeepWriteable<TernaryExpression>>(isTernaryExpression).consequent = undefined;
+            original.findChild<DeepWriteable<TernaryExpression>>(isTernaryExpression).alternate = undefined;
+
+            testClone(original);
+        });
+
+        it('clones NullCoalescingExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print a ?? b
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones NullCoalescingExpression with undefined expressions', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print a ?? b
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<NullCoalescingExpression>>(isNullCoalescingExpression).consequent = undefined;
+            original.findChild<DeepWriteable<NullCoalescingExpression>>(isNullCoalescingExpression).alternate = undefined;
+
+            testClone(original);
+        });
+
+        it('clones RegexLiteralExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print /test/gi
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TypeCastExpression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print name as string
+                end sub
+            `).ast;
+
+            testClone(original);
+        });
+
+        it('clones TypeCastExpression with undefined expression', () => {
+            const original = Parser.parse(`
+                sub test()
+                    print name as string
+                end sub
+            `).ast;
+            original.findChild<DeepWriteable<TypeCastExpression>>(isTypeCastExpression).obj = undefined;
+
+            testClone(original);
+        });
+
     });
 });

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -127,6 +127,7 @@ export abstract class AstNode {
      * All tokens, statements, expressions, range, and location are cloned.
      */
     public abstract clone();
+
 }
 
 export abstract class Statement extends AstNode {
@@ -138,6 +139,16 @@ export abstract class Statement extends AstNode {
      * Annotations for this statement
      */
     public annotations: AnnotationExpression[] | undefined;
+
+    /**
+     * Helper function that clones the current annotations and places them onto the incoming statement
+     * @param node the already cloned node that needs the annotations attached
+     * @returns the already cloned node with the newly cloned annotations attached
+     */
+    protected cloneAnnotations<T extends Statement>(node: T) {
+        node.annotations = this.annotations?.map(x => x.clone());
+        return node;
+    }
 }
 
 

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -83,7 +83,7 @@ export abstract class AstNode {
      * Find the first child where the matcher evaluates to true.
      * @param matcher a function called for each node. If you return true, this function returns the specified node. If you return a node, that node is returned. all other return values continue the loop
      */
-    public findChild<TNode extends AstNode = AstNode>(matcher: (node: AstNode, cancellationSource) => boolean | AstNode | undefined | void, options?: WalkOptions): TNode | undefined {
+    public findChild<TNode = AstNode>(matcher: (node: AstNode, cancellationSource) => boolean | AstNode | undefined | void, options?: WalkOptions): TNode | undefined {
         const cancel = new CancellationTokenSource();
         let result: AstNode | undefined;
         this.walk((node) => {

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -121,6 +121,12 @@ export abstract class AstNode {
             walkMode: WalkMode.visitAllRecursive
         });
     }
+
+    /**
+     * Clone this node and all of its children. This creates a completely detached and identical copy of the AST.
+     * All tokens, statements, expressions, range, and location are cloned.
+     */
+    public abstract clone();
 }
 
 export abstract class Statement extends AstNode {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -81,7 +81,7 @@ export class CallExpression extends Expression {
         unused?: any
     ) {
         super();
-        this.range = util.createBoundingRange(this.callee, this.openingParen, ...args, this.closingParen);
+        this.range = util.createBoundingRange(this.callee, this.openingParen, ...args ?? [], this.closingParen);
     }
 
     public readonly range: Range | undefined;
@@ -222,7 +222,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     public get range() {
         return util.createBoundingRange(
             this.functionType, this.leftParen,
-            ...this.parameters,
+            ...this.parameters ?? [],
             this.rightParen,
             this.asToken,
             this.returnTypeToken,
@@ -444,7 +444,7 @@ export class NamespacedVariableNameExpression extends Expression {
         readonly expression: DottedGetExpression | VariableExpression
     ) {
         super();
-        this.range = expression.range;
+        this.range = expression?.range;
     }
     range: Range | undefined;
 
@@ -771,7 +771,7 @@ export class ArrayLiteralExpression extends Expression {
         readonly hasSpread = false
     ) {
         super();
-        this.range = util.createBoundingRange(this.open, ...this.elements, this.close);
+        this.range = util.createBoundingRange(this.open, ...this.elements ?? [], this.close);
     }
 
     public readonly range: Range | undefined;
@@ -880,7 +880,7 @@ export class AALiteralExpression extends Expression {
         readonly close: Token
     ) {
         super();
-        this.range = util.createBoundingRange(this.open, ...this.elements, this.close);
+        this.range = util.createBoundingRange(this.open, ...this.elements ?? [], this.close);
     }
 
     public readonly range: Range | undefined;
@@ -1220,7 +1220,7 @@ export class CallfuncExpression extends Expression {
             operator,
             methodName,
             openingParen,
-            ...args,
+            ...args ?? [],
             closingParen
         );
     }
@@ -1294,7 +1294,7 @@ export class TemplateStringQuasiExpression extends Expression {
     ) {
         super();
         this.range = util.createBoundingRange(
-            ...expressions
+            ...expressions ?? []
         );
     }
     readonly range: Range | undefined;
@@ -1340,8 +1340,8 @@ export class TemplateStringExpression extends Expression {
         super();
         this.range = util.createBoundingRange(
             openingBacktick,
-            quasis[0],
-            quasis[quasis.length - 1],
+            quasis?.[0],
+            quasis?.[quasis?.length - 1],
             closingBacktick
         );
     }
@@ -1437,8 +1437,8 @@ export class TaggedTemplateStringExpression extends Expression {
         this.range = util.createBoundingRange(
             tagName,
             openingBacktick,
-            quasis[0],
-            quasis[quasis.length - 1],
+            quasis?.[0],
+            quasis?.[quasis?.length - 1],
             closingBacktick
         );
     }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -51,6 +51,14 @@ export class BinaryExpression extends Expression {
             walk(this, 'right', visitor, options);
         }
     }
+
+    public clone() {
+        return new BinaryExpression(
+            this.left?.clone(),
+            util.cloneToken(this.operator),
+            this.right?.clone()
+        );
+    }
 }
 
 export class CallExpression extends Expression {
@@ -120,6 +128,15 @@ export class CallExpression extends Expression {
             walk(this, 'callee', visitor, options);
             walkArray(this.args, visitor, options, this);
         }
+    }
+
+    public clone() {
+        return new CallExpression(
+            this.callee?.clone(),
+            util.cloneToken(this.openingParen),
+            util.cloneToken(this.closingParen),
+            this.args?.map(e => e?.clone())
+        );
     }
 }
 
@@ -322,6 +339,19 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         return functionType;
     }
+
+    public clone() {
+        return new FunctionExpression(
+            this.parameters?.map(e => e?.clone()),
+            this.body?.clone(),
+            util.cloneToken(this.functionType),
+            util.cloneToken(this.end),
+            util.cloneToken(this.leftParen),
+            util.cloneToken(this.rightParen),
+            util.cloneToken(this.asToken),
+            util.cloneToken(this.returnTypeToken)
+        );
+    }
 }
 
 export class FunctionParameterExpression extends Expression {
@@ -397,6 +427,15 @@ export class FunctionParameterExpression extends Expression {
             walk(this, 'defaultValue', visitor, options);
         }
     }
+
+    public clone() {
+        return new FunctionParameterExpression(
+            util.cloneToken(this.name),
+            util.cloneToken(this.typeToken),
+            this.defaultValue?.clone(),
+            util.cloneToken(this.asToken)
+        );
+    }
 }
 
 export class NamespacedVariableNameExpression extends Expression {
@@ -446,6 +485,12 @@ export class NamespacedVariableNameExpression extends Expression {
             walk(this, 'expression', visitor, options);
         }
     }
+
+    public clone() {
+        return new NamespacedVariableNameExpression(
+            this.expression?.clone()
+        );
+    }
 }
 
 export class DottedGetExpression extends Expression {
@@ -482,6 +527,14 @@ export class DottedGetExpression extends Expression {
         }
     }
 
+    public clone() {
+        return new DottedGetExpression(
+            this.obj?.clone(),
+            util.cloneToken(this.name),
+            util.cloneToken(this.dot)
+        );
+    }
+
 }
 
 export class XmlAttributeGetExpression extends Expression {
@@ -511,6 +564,14 @@ export class XmlAttributeGetExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
         }
+    }
+
+    public clone() {
+        return new XmlAttributeGetExpression(
+            this.obj?.clone(),
+            util.cloneToken(this.name),
+            util.cloneToken(this.at)
+        );
     }
 }
 
@@ -567,6 +628,18 @@ export class IndexedGetExpression extends Expression {
             walkArray(this.additionalIndexes, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new IndexedGetExpression(
+            this.obj?.clone(),
+            this.index?.clone(),
+            util.cloneToken(this.openingSquare),
+            util.cloneToken(this.closingSquare),
+            util.cloneToken(this.questionDotToken),
+            this.additionalIndexes?.map(e => e?.clone())
+        );
+    }
+
 }
 
 export class GroupingExpression extends Expression {
@@ -598,6 +671,16 @@ export class GroupingExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'expression', visitor, options);
         }
+    }
+
+    public clone() {
+        return new GroupingExpression(
+            {
+                left: util.cloneToken(this.tokens.left),
+                right: util.cloneToken(this.tokens.right)
+            },
+            this.expression?.clone()
+        );
     }
 }
 
@@ -642,6 +725,12 @@ export class LiteralExpression extends Expression {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new LiteralExpression(
+            util.cloneToken(this.token)
+        );
+    }
 }
 
 /**
@@ -665,6 +754,12 @@ export class EscapedCharCodeLiteralExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new EscapedCharCodeLiteralExpression(
+            util.cloneToken(this.token)
+        );
     }
 }
 
@@ -734,6 +829,15 @@ export class ArrayLiteralExpression extends Expression {
             walkArray(this.elements, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new ArrayLiteralExpression(
+            this.elements?.map(e => e?.clone()),
+            util.cloneToken(this.open),
+            util.cloneToken(this.close),
+            this.hasSpread
+        );
+    }
 }
 
 export class AAMemberExpression extends Expression {
@@ -757,6 +861,14 @@ export class AAMemberExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         walk(this, 'value', visitor, options);
+    }
+
+    public clone() {
+        return new AAMemberExpression(
+            util.cloneToken(this.keyToken),
+            util.cloneToken(this.colonToken),
+            this.value?.clone()
+        );
     }
 
 }
@@ -848,6 +960,14 @@ export class AALiteralExpression extends Expression {
             walkArray(this.elements, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new AALiteralExpression(
+            this.elements?.map(e => e?.clone()),
+            util.cloneToken(this.open),
+            util.cloneToken(this.close)
+        );
+    }
 }
 
 export class UnaryExpression extends Expression {
@@ -880,6 +1000,13 @@ export class UnaryExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'right', visitor, options);
         }
+    }
+
+    public clone() {
+        return new UnaryExpression(
+            util.cloneToken(this.operator),
+            this.right?.clone()
+        );
     }
 }
 
@@ -921,6 +1048,12 @@ export class VariableExpression extends Expression {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new VariableExpression(
+            util.cloneToken(this.name)
+        );
     }
 }
 
@@ -1014,6 +1147,12 @@ export class SourceLiteralExpression extends Expression {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new SourceLiteralExpression(
+            util.cloneToken(this.token)
+        );
+    }
 }
 
 /**
@@ -1056,6 +1195,13 @@ export class NewExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'call', visitor, options);
         }
+    }
+
+    public clone() {
+        return new NewExpression(
+            util.cloneToken(this.newKeyword),
+            this.call?.clone()
+        );
     }
 }
 
@@ -1125,6 +1271,17 @@ export class CallfuncExpression extends Expression {
             walkArray(this.args, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new CallfuncExpression(
+            this.callee?.clone(),
+            util.cloneToken(this.operator),
+            util.cloneToken(this.methodName),
+            util.cloneToken(this.openingParen),
+            this.args?.map(e => e?.clone()),
+            util.cloneToken(this.closingParen)
+        );
+    }
 }
 
 /**
@@ -1164,6 +1321,12 @@ export class TemplateStringQuasiExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walkArray(this.expressions, visitor, options, this);
         }
+    }
+
+    public clone() {
+        return new TemplateStringQuasiExpression(
+            this.expressions?.map(e => e?.clone())
+        );
     }
 }
 
@@ -1251,6 +1414,15 @@ export class TemplateStringExpression extends Expression {
             }
         }
     }
+
+    public clone() {
+        return new TemplateStringExpression(
+            util.cloneToken(this.openingBacktick),
+            this.quasis?.map(e => e?.clone()),
+            this.expressions?.map(e => e?.clone()),
+            util.cloneToken(this.closingBacktick)
+        );
+    }
 }
 
 export class TaggedTemplateStringExpression extends Expression {
@@ -1328,6 +1500,16 @@ export class TaggedTemplateStringExpression extends Expression {
             }
         }
     }
+
+    public clone() {
+        return new TaggedTemplateStringExpression(
+            util.cloneToken(this.tagName),
+            util.cloneToken(this.openingBacktick),
+            this.quasis?.map(e => e?.clone()),
+            this.expressions?.map(e => e?.clone()),
+            util.cloneToken(this.closingBacktick)
+        );
+    }
 }
 
 export class AnnotationExpression extends Expression {
@@ -1374,6 +1556,13 @@ export class AnnotationExpression extends Expression {
             this.name,
             ...(this.call?.transpile(state) ?? [])
         ];
+    }
+
+    public clone() {
+        return new AnnotationExpression(
+            util.cloneToken(this.atToken),
+            util.cloneToken(this.nameToken)
+        );
     }
 }
 
@@ -1464,6 +1653,16 @@ export class TernaryExpression extends Expression {
             walk(this, 'alternate', visitor, options);
         }
     }
+
+    public clone() {
+        return new TernaryExpression(
+            this.test?.clone(),
+            util.cloneToken(this.questionMarkToken),
+            this.consequent?.clone(),
+            util.cloneToken(this.colonToken),
+            this.alternate?.clone()
+        );
+    }
 }
 
 export class NullCoalescingExpression extends Expression {
@@ -1547,6 +1746,14 @@ export class NullCoalescingExpression extends Expression {
             walk(this, 'alternate', visitor, options);
         }
     }
+
+    public clone() {
+        return new NullCoalescingExpression(
+            this.consequent?.clone(),
+            util.cloneToken(this.questionQuestionToken),
+            this.alternate?.clone()
+        );
+    }
 }
 
 export class RegexLiteralExpression extends Expression {
@@ -1590,6 +1797,12 @@ export class RegexLiteralExpression extends Expression {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new RegexLiteralExpression({
+            regexLiteral: util.cloneToken(this.tokens.regexLiteral)
+        });
+    }
 }
 
 
@@ -1616,6 +1829,14 @@ export class TypeCastExpression extends Expression {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'obj', visitor, options);
         }
+    }
+
+    public clone() {
+        return new TypeCastExpression(
+            this.obj?.clone(),
+            util.cloneToken(this.asToken),
+            util.cloneToken(this.typeToken)
+        );
     }
 }
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -20,7 +20,6 @@ import type { AstNode } from './AstNode';
 import { Expression } from './AstNode';
 import { SymbolTable } from '../SymbolTable';
 import { SourceNode } from 'source-map';
-import { createStackedVisitor } from '../astUtils/stackedVisitor';
 
 export type ExpressionVisitor = (expression: Expression, parent: Expression) => void;
 
@@ -54,10 +53,13 @@ export class BinaryExpression extends Expression {
     }
 
     public clone() {
-        return new BinaryExpression(
-            this.left?.clone(),
-            util.cloneToken(this.operator),
-            this.right?.clone()
+        return this.finalizeClone(
+            new BinaryExpression(
+                this.left?.clone(),
+                util.cloneToken(this.operator),
+                this.right?.clone()
+            ),
+            ['left', 'right']
         );
     }
 }
@@ -132,11 +134,14 @@ export class CallExpression extends Expression {
     }
 
     public clone() {
-        return new CallExpression(
-            this.callee?.clone(),
-            util.cloneToken(this.openingParen),
-            util.cloneToken(this.closingParen),
-            this.args?.map(e => e?.clone())
+        return this.finalizeClone(
+            new CallExpression(
+                this.callee?.clone(),
+                util.cloneToken(this.openingParen),
+                util.cloneToken(this.closingParen),
+                this.args?.map(e => e?.clone())
+            ),
+            ['callee', 'args']
         );
     }
 }
@@ -342,15 +347,18 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     }
 
     public clone() {
-        const clone = new FunctionExpression(
-            this.parameters?.map(e => e?.clone()),
-            this.body?.clone(),
-            util.cloneToken(this.functionType),
-            util.cloneToken(this.end),
-            util.cloneToken(this.leftParen),
-            util.cloneToken(this.rightParen),
-            util.cloneToken(this.asToken),
-            util.cloneToken(this.returnTypeToken)
+        const clone = this.finalizeClone(
+            new FunctionExpression(
+                this.parameters?.map(e => e?.clone()),
+                this.body?.clone(),
+                util.cloneToken(this.functionType),
+                util.cloneToken(this.end),
+                util.cloneToken(this.leftParen),
+                util.cloneToken(this.rightParen),
+                util.cloneToken(this.asToken),
+                util.cloneToken(this.returnTypeToken)
+            ),
+            ['body']
         );
 
         //rebuild the .callExpressions list in the clone
@@ -438,11 +446,14 @@ export class FunctionParameterExpression extends Expression {
     }
 
     public clone() {
-        return new FunctionParameterExpression(
-            util.cloneToken(this.name),
-            util.cloneToken(this.typeToken),
-            this.defaultValue?.clone(),
-            util.cloneToken(this.asToken)
+        return this.finalizeClone(
+            new FunctionParameterExpression(
+                util.cloneToken(this.name),
+                util.cloneToken(this.typeToken),
+                this.defaultValue?.clone(),
+                util.cloneToken(this.asToken)
+            ),
+            ['defaultValue']
         );
     }
 }
@@ -496,8 +507,10 @@ export class NamespacedVariableNameExpression extends Expression {
     }
 
     public clone() {
-        return new NamespacedVariableNameExpression(
-            this.expression?.clone()
+        return this.finalizeClone(
+            new NamespacedVariableNameExpression(
+                this.expression?.clone()
+            )
         );
     }
 }
@@ -537,13 +550,15 @@ export class DottedGetExpression extends Expression {
     }
 
     public clone() {
-        return new DottedGetExpression(
-            this.obj?.clone(),
-            util.cloneToken(this.name),
-            util.cloneToken(this.dot)
+        return this.finalizeClone(
+            new DottedGetExpression(
+                this.obj?.clone(),
+                util.cloneToken(this.name),
+                util.cloneToken(this.dot)
+            ),
+            ['obj']
         );
     }
-
 }
 
 export class XmlAttributeGetExpression extends Expression {
@@ -576,10 +591,13 @@ export class XmlAttributeGetExpression extends Expression {
     }
 
     public clone() {
-        return new XmlAttributeGetExpression(
-            this.obj?.clone(),
-            util.cloneToken(this.name),
-            util.cloneToken(this.at)
+        return this.finalizeClone(
+            new XmlAttributeGetExpression(
+                this.obj?.clone(),
+                util.cloneToken(this.name),
+                util.cloneToken(this.at)
+            ),
+            ['obj']
         );
     }
 }
@@ -639,16 +657,18 @@ export class IndexedGetExpression extends Expression {
     }
 
     public clone() {
-        return new IndexedGetExpression(
-            this.obj?.clone(),
-            this.index?.clone(),
-            util.cloneToken(this.openingSquare),
-            util.cloneToken(this.closingSquare),
-            util.cloneToken(this.questionDotToken),
-            this.additionalIndexes?.map(e => e?.clone())
+        return this.finalizeClone(
+            new IndexedGetExpression(
+                this.obj?.clone(),
+                this.index?.clone(),
+                util.cloneToken(this.openingSquare),
+                util.cloneToken(this.closingSquare),
+                util.cloneToken(this.questionDotToken),
+                this.additionalIndexes?.map(e => e?.clone())
+            ),
+            ['obj', 'index', 'additionalIndexes']
         );
     }
-
 }
 
 export class GroupingExpression extends Expression {
@@ -683,12 +703,15 @@ export class GroupingExpression extends Expression {
     }
 
     public clone() {
-        return new GroupingExpression(
-            {
-                left: util.cloneToken(this.tokens.left),
-                right: util.cloneToken(this.tokens.right)
-            },
-            this.expression?.clone()
+        return this.finalizeClone(
+            new GroupingExpression(
+                {
+                    left: util.cloneToken(this.tokens.left),
+                    right: util.cloneToken(this.tokens.right)
+                },
+                this.expression?.clone()
+            ),
+            ['expression']
         );
     }
 }
@@ -736,8 +759,10 @@ export class LiteralExpression extends Expression {
     }
 
     public clone() {
-        return new LiteralExpression(
-            util.cloneToken(this.token)
+        return this.finalizeClone(
+            new LiteralExpression(
+                util.cloneToken(this.token)
+            )
         );
     }
 }
@@ -766,8 +791,10 @@ export class EscapedCharCodeLiteralExpression extends Expression {
     }
 
     public clone() {
-        return new EscapedCharCodeLiteralExpression(
-            util.cloneToken(this.token)
+        return this.finalizeClone(
+            new EscapedCharCodeLiteralExpression(
+                util.cloneToken(this.token)
+            )
         );
     }
 }
@@ -840,11 +867,14 @@ export class ArrayLiteralExpression extends Expression {
     }
 
     public clone() {
-        return new ArrayLiteralExpression(
-            this.elements?.map(e => e?.clone()),
-            util.cloneToken(this.open),
-            util.cloneToken(this.close),
-            this.hasSpread
+        return this.finalizeClone(
+            new ArrayLiteralExpression(
+                this.elements?.map(e => e?.clone()),
+                util.cloneToken(this.open),
+                util.cloneToken(this.close),
+                this.hasSpread
+            ),
+            ['elements']
         );
     }
 }
@@ -873,10 +903,13 @@ export class AAMemberExpression extends Expression {
     }
 
     public clone() {
-        return new AAMemberExpression(
-            util.cloneToken(this.keyToken),
-            util.cloneToken(this.colonToken),
-            this.value?.clone()
+        return this.finalizeClone(
+            new AAMemberExpression(
+                util.cloneToken(this.keyToken),
+                util.cloneToken(this.colonToken),
+                this.value?.clone()
+            ),
+            ['value']
         );
     }
 
@@ -971,10 +1004,13 @@ export class AALiteralExpression extends Expression {
     }
 
     public clone() {
-        return new AALiteralExpression(
-            this.elements?.map(e => e?.clone()),
-            util.cloneToken(this.open),
-            util.cloneToken(this.close)
+        return this.finalizeClone(
+            new AALiteralExpression(
+                this.elements?.map(e => e?.clone()),
+                util.cloneToken(this.open),
+                util.cloneToken(this.close)
+            ),
+            ['elements']
         );
     }
 }
@@ -1012,9 +1048,12 @@ export class UnaryExpression extends Expression {
     }
 
     public clone() {
-        return new UnaryExpression(
-            util.cloneToken(this.operator),
-            this.right?.clone()
+        return this.finalizeClone(
+            new UnaryExpression(
+                util.cloneToken(this.operator),
+                this.right?.clone()
+            ),
+            ['right']
         );
     }
 }
@@ -1060,8 +1099,10 @@ export class VariableExpression extends Expression {
     }
 
     public clone() {
-        return new VariableExpression(
-            util.cloneToken(this.name)
+        return this.finalizeClone(
+            new VariableExpression(
+                util.cloneToken(this.name)
+            )
         );
     }
 }
@@ -1158,8 +1199,10 @@ export class SourceLiteralExpression extends Expression {
     }
 
     public clone() {
-        return new SourceLiteralExpression(
-            util.cloneToken(this.token)
+        return this.finalizeClone(
+            new SourceLiteralExpression(
+                util.cloneToken(this.token)
+            )
         );
     }
 }
@@ -1207,9 +1250,12 @@ export class NewExpression extends Expression {
     }
 
     public clone() {
-        return new NewExpression(
-            util.cloneToken(this.newKeyword),
-            this.call?.clone()
+        return this.finalizeClone(
+            new NewExpression(
+                util.cloneToken(this.newKeyword),
+                this.call?.clone()
+            ),
+            ['call']
         );
     }
 }
@@ -1282,13 +1328,16 @@ export class CallfuncExpression extends Expression {
     }
 
     public clone() {
-        return new CallfuncExpression(
-            this.callee?.clone(),
-            util.cloneToken(this.operator),
-            util.cloneToken(this.methodName),
-            util.cloneToken(this.openingParen),
-            this.args?.map(e => e?.clone()),
-            util.cloneToken(this.closingParen)
+        return this.finalizeClone(
+            new CallfuncExpression(
+                this.callee?.clone(),
+                util.cloneToken(this.operator),
+                util.cloneToken(this.methodName),
+                util.cloneToken(this.openingParen),
+                this.args?.map(e => e?.clone()),
+                util.cloneToken(this.closingParen)
+            ),
+            ['callee', 'args']
         );
     }
 }
@@ -1333,8 +1382,11 @@ export class TemplateStringQuasiExpression extends Expression {
     }
 
     public clone() {
-        return new TemplateStringQuasiExpression(
-            this.expressions?.map(e => e?.clone())
+        return this.finalizeClone(
+            new TemplateStringQuasiExpression(
+                this.expressions?.map(e => e?.clone())
+            ),
+            ['expressions']
         );
     }
 }
@@ -1425,11 +1477,14 @@ export class TemplateStringExpression extends Expression {
     }
 
     public clone() {
-        return new TemplateStringExpression(
-            util.cloneToken(this.openingBacktick),
-            this.quasis?.map(e => e?.clone()),
-            this.expressions?.map(e => e?.clone()),
-            util.cloneToken(this.closingBacktick)
+        return this.finalizeClone(
+            new TemplateStringExpression(
+                util.cloneToken(this.openingBacktick),
+                this.quasis?.map(e => e?.clone()),
+                this.expressions?.map(e => e?.clone()),
+                util.cloneToken(this.closingBacktick)
+            ),
+            ['quasis', 'expressions']
         );
     }
 }
@@ -1511,12 +1566,15 @@ export class TaggedTemplateStringExpression extends Expression {
     }
 
     public clone() {
-        return new TaggedTemplateStringExpression(
-            util.cloneToken(this.tagName),
-            util.cloneToken(this.openingBacktick),
-            this.quasis?.map(e => e?.clone()),
-            this.expressions?.map(e => e?.clone()),
-            util.cloneToken(this.closingBacktick)
+        return this.finalizeClone(
+            new TaggedTemplateStringExpression(
+                util.cloneToken(this.tagName),
+                util.cloneToken(this.openingBacktick),
+                this.quasis?.map(e => e?.clone()),
+                this.expressions?.map(e => e?.clone()),
+                util.cloneToken(this.closingBacktick)
+            ),
+            ['quasis', 'expressions']
         );
     }
 }
@@ -1568,10 +1626,13 @@ export class AnnotationExpression extends Expression {
     }
 
     public clone() {
-        return new AnnotationExpression(
-            util.cloneToken(this.atToken),
-            util.cloneToken(this.nameToken)
+        const clone = this.finalizeClone(
+            new AnnotationExpression(
+                util.cloneToken(this.atToken),
+                util.cloneToken(this.nameToken)
+            )
         );
+        return clone;
     }
 }
 
@@ -1664,12 +1725,15 @@ export class TernaryExpression extends Expression {
     }
 
     public clone() {
-        return new TernaryExpression(
-            this.test?.clone(),
-            util.cloneToken(this.questionMarkToken),
-            this.consequent?.clone(),
-            util.cloneToken(this.colonToken),
-            this.alternate?.clone()
+        return this.finalizeClone(
+            new TernaryExpression(
+                this.test?.clone(),
+                util.cloneToken(this.questionMarkToken),
+                this.consequent?.clone(),
+                util.cloneToken(this.colonToken),
+                this.alternate?.clone()
+            ),
+            ['test', 'consequent', 'alternate']
         );
     }
 }
@@ -1757,10 +1821,13 @@ export class NullCoalescingExpression extends Expression {
     }
 
     public clone() {
-        return new NullCoalescingExpression(
-            this.consequent?.clone(),
-            util.cloneToken(this.questionQuestionToken),
-            this.alternate?.clone()
+        return this.finalizeClone(
+            new NullCoalescingExpression(
+                this.consequent?.clone(),
+                util.cloneToken(this.questionQuestionToken),
+                this.alternate?.clone()
+            ),
+            ['consequent', 'alternate']
         );
     }
 }
@@ -1808,9 +1875,11 @@ export class RegexLiteralExpression extends Expression {
     }
 
     public clone() {
-        return new RegexLiteralExpression({
-            regexLiteral: util.cloneToken(this.tokens.regexLiteral)
-        });
+        return this.finalizeClone(
+            new RegexLiteralExpression({
+                regexLiteral: util.cloneToken(this.tokens.regexLiteral)
+            })
+        );
     }
 }
 
@@ -1841,10 +1910,13 @@ export class TypeCastExpression extends Expression {
     }
 
     public clone() {
-        return new TypeCastExpression(
-            this.obj?.clone(),
-            util.cloneToken(this.asToken),
-            util.cloneToken(this.typeToken)
+        return this.finalizeClone(
+            new TypeCastExpression(
+                this.obj?.clone(),
+                util.cloneToken(this.asToken),
+                util.cloneToken(this.typeToken)
+            ),
+            ['obj']
         );
     }
 }

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -124,9 +124,4 @@ describe('Statement', () => {
             });
         });
     });
-
-    describe('clone', () => {
-
-    });
-
 });

--- a/src/parser/Statement.spec.ts
+++ b/src/parser/Statement.spec.ts
@@ -125,4 +125,8 @@ describe('Statement', () => {
         });
     });
 
+    describe('clone', () => {
+
+    });
+
 });

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -37,8 +37,10 @@ export class EmptyStatement extends Statement {
     }
 
     public clone() {
-        return new EmptyStatement(
-            util.cloneRange(this.range)
+        return this.cloneAnnotations(
+            new EmptyStatement(
+                util.cloneRange(this.range)
+            )
         );
     }
 }
@@ -117,8 +119,10 @@ export class Body extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new Body(
-            this.statements?.map(s => s?.clone())
+        return this.cloneAnnotations(
+            new Body(
+                this.statements?.map(s => s?.clone())
+            )
         );
     }
 }
@@ -165,10 +169,12 @@ export class AssignmentStatement extends Statement {
     }
 
     public clone() {
-        return new AssignmentStatement(
-            util.cloneToken(this.equals),
-            util.cloneToken(this.name),
-            this.value?.clone()
+        return this.cloneAnnotations(
+            new AssignmentStatement(
+                util.cloneToken(this.equals),
+                util.cloneToken(this.name),
+                this.value?.clone()
+            )
         );
     }
 }
@@ -227,9 +233,11 @@ export class Block extends Statement {
     }
 
     public clone() {
-        return new Block(
-            this.statements?.map(s => s?.clone()),
-            util.cloneRange(this.startingRange)
+        return this.cloneAnnotations(
+            new Block(
+                this.statements?.map(s => s?.clone()),
+                util.cloneRange(this.startingRange)
+            )
         );
     }
 }
@@ -255,8 +263,10 @@ export class ExpressionStatement extends Statement {
     }
 
     public clone() {
-        return new ExpressionStatement(
-            this.expression?.clone()
+        return this.cloneAnnotations(
+            new ExpressionStatement(
+                this.expression?.clone()
+            )
         );
     }
 }
@@ -307,8 +317,10 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
     }
 
     public clone() {
-        return new CommentStatement(
-            this.comments?.map(x => util.cloneToken(x))
+        return this.cloneAnnotations(
+            new CommentStatement(
+                this.comments?.map(x => util.cloneToken(x))
+            )
         );
     }
 }
@@ -336,9 +348,11 @@ export class ExitForStatement extends Statement {
     }
 
     public clone() {
-        return new ExitForStatement({
-            exitFor: util.cloneToken(this.tokens.exitFor)
-        });
+        return this.cloneAnnotations(
+            new ExitForStatement({
+                exitFor: util.cloneToken(this.tokens.exitFor)
+            })
+        );
     }
 }
 
@@ -365,9 +379,11 @@ export class ExitWhileStatement extends Statement {
     }
 
     public clone() {
-        return new ExitWhileStatement({
-            exitWhile: util.cloneToken(this.tokens.exitWhile)
-        });
+        return this.cloneAnnotations(
+            new ExitWhileStatement({
+                exitWhile: util.cloneToken(this.tokens.exitWhile)
+            })
+        );
     }
 }
 
@@ -437,9 +453,11 @@ export class FunctionStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new FunctionStatement(
-            util.cloneToken(this.name),
-            this.func?.clone()
+        return this.cloneAnnotations(
+            new FunctionStatement(
+                util.cloneToken(this.name),
+                this.func?.clone()
+            )
         );
     }
 }
@@ -559,17 +577,19 @@ export class IfStatement extends Statement {
     }
 
     public clone() {
-        return new IfStatement(
-            {
-                if: util.cloneToken(this.tokens.if),
-                else: util.cloneToken(this.tokens.else),
-                endIf: util.cloneToken(this.tokens.endIf),
-                then: util.cloneToken(this.tokens.then)
-            },
-            this.condition?.clone(),
-            this.thenBranch?.clone(),
-            this.elseBranch?.clone(),
-            this.isInline
+        return this.cloneAnnotations(
+            new IfStatement(
+                {
+                    if: util.cloneToken(this.tokens.if),
+                    else: util.cloneToken(this.tokens.else),
+                    endIf: util.cloneToken(this.tokens.endIf),
+                    then: util.cloneToken(this.tokens.then)
+                },
+                this.condition?.clone(),
+                this.thenBranch?.clone(),
+                this.elseBranch?.clone(),
+                this.isInline
+            )
         );
     }
 }
@@ -602,9 +622,11 @@ export class IncrementStatement extends Statement {
     }
 
     public clone() {
-        return new IncrementStatement(
-            this.value?.clone(),
-            util.cloneToken(this.operator)
+        return this.cloneAnnotations(
+            new IncrementStatement(
+                this.value?.clone(),
+                util.cloneToken(this.operator)
+            )
         );
     }
 }
@@ -674,17 +696,19 @@ export class PrintStatement extends Statement {
     }
 
     public clone() {
-        return new PrintStatement(
-            {
-                print: util.cloneToken(this.tokens.print)
-            },
-            this.expressions?.map(e => {
-                if (isExpression(e as any)) {
-                    return (e as Expression).clone();
-                } else {
-                    return util.cloneToken(e as Token);
-                }
-            })
+        return this.cloneAnnotations(
+            new PrintStatement(
+                {
+                    print: util.cloneToken(this.tokens.print)
+                },
+                this.expressions?.map(e => {
+                    if (isExpression(e as any)) {
+                        return (e as Expression).clone();
+                    } else {
+                        return util.cloneToken(e as Token);
+                    }
+                })
+            )
         );
     }
 }
@@ -735,12 +759,14 @@ export class DimStatement extends Statement {
     }
 
     public clone() {
-        return new DimStatement(
-            util.cloneToken(this.dimToken),
-            util.cloneToken(this.identifier),
-            util.cloneToken(this.openingSquare),
-            this.dimensions?.map(e => e?.clone()),
-            util.cloneToken(this.closingSquare)
+        return this.cloneAnnotations(
+            new DimStatement(
+                util.cloneToken(this.dimToken),
+                util.cloneToken(this.identifier),
+                util.cloneToken(this.openingSquare),
+                this.dimensions?.map(e => e?.clone()),
+                util.cloneToken(this.closingSquare)
+            )
         );
     }
 }
@@ -774,10 +800,12 @@ export class GotoStatement extends Statement {
     }
 
     public clone() {
-        return new GotoStatement({
-            goto: util.cloneToken(this.tokens.goto),
-            label: util.cloneToken(this.tokens.label)
-        });
+        return this.cloneAnnotations(
+            new GotoStatement({
+                goto: util.cloneToken(this.tokens.goto),
+                label: util.cloneToken(this.tokens.label)
+            })
+        );
     }
 }
 
@@ -810,10 +838,12 @@ export class LabelStatement extends Statement {
     }
 
     public clone() {
-        return new LabelStatement({
-            identifier: util.cloneToken(this.tokens.identifier),
-            colon: util.cloneToken(this.tokens.colon)
-        });
+        return this.cloneAnnotations(
+            new LabelStatement({
+                identifier: util.cloneToken(this.tokens.identifier),
+                colon: util.cloneToken(this.tokens.colon)
+            })
+        );
     }
 }
 
@@ -852,11 +882,13 @@ export class ReturnStatement extends Statement {
     }
 
     public clone() {
-        return new ReturnStatement(
-            {
-                return: util.cloneToken(this.tokens.return)
-            },
-            this.value?.clone()
+        return this.cloneAnnotations(
+            new ReturnStatement(
+                {
+                    return: util.cloneToken(this.tokens.return)
+                },
+                this.value?.clone()
+            )
         );
     }
 }
@@ -884,9 +916,11 @@ export class EndStatement extends Statement {
     }
 
     public clone() {
-        return new EndStatement({
-            end: util.cloneToken(this.tokens.end)
-        });
+        return this.cloneAnnotations(
+            new EndStatement({
+                end: util.cloneToken(this.tokens.end)
+            })
+        );
     }
 }
 
@@ -913,9 +947,11 @@ export class StopStatement extends Statement {
     }
 
     public clone() {
-        return new StopStatement({
-            stop: util.cloneToken(this.tokens.stop)
-        });
+        return this.cloneAnnotations(
+            new StopStatement({
+                stop: util.cloneToken(this.tokens.stop)
+            })
+        );
     }
 }
 
@@ -1004,15 +1040,17 @@ export class ForStatement extends Statement {
     }
 
     public clone() {
-        return new ForStatement(
-            util.cloneToken(this.forToken),
-            this.counterDeclaration?.clone(),
-            util.cloneToken(this.toToken),
-            this.finalValue?.clone(),
-            this.body?.clone(),
-            util.cloneToken(this.endForToken),
-            util.cloneToken(this.stepToken),
-            this.increment?.clone()
+        return this.cloneAnnotations(
+            new ForStatement(
+                util.cloneToken(this.forToken),
+                this.counterDeclaration?.clone(),
+                util.cloneToken(this.toToken),
+                this.finalValue?.clone(),
+                this.body?.clone(),
+                util.cloneToken(this.endForToken),
+                util.cloneToken(this.stepToken),
+                this.increment?.clone()
+            )
         );
     }
 }
@@ -1086,15 +1124,17 @@ export class ForEachStatement extends Statement {
     }
 
     public clone() {
-        return new ForEachStatement(
-            {
-                forEach: util.cloneToken(this.tokens.forEach),
-                in: util.cloneToken(this.tokens.in),
-                endFor: util.cloneToken(this.tokens.endFor)
-            },
-            util.cloneToken(this.item),
-            this.target?.clone(),
-            this.body?.clone()
+        return this.cloneAnnotations(
+            new ForEachStatement(
+                {
+                    forEach: util.cloneToken(this.tokens.forEach),
+                    in: util.cloneToken(this.tokens.in),
+                    endFor: util.cloneToken(this.tokens.endFor)
+                },
+                util.cloneToken(this.item),
+                this.target?.clone(),
+                this.body?.clone()
+            )
         );
     }
 }
@@ -1157,13 +1197,15 @@ export class WhileStatement extends Statement {
     }
 
     public clone() {
-        return new WhileStatement(
-            {
-                while: util.cloneToken(this.tokens.while),
-                endWhile: util.cloneToken(this.tokens.endWhile)
-            },
-            this.condition?.clone(),
-            this.body?.clone()
+        return this.cloneAnnotations(
+            new WhileStatement(
+                {
+                    while: util.cloneToken(this.tokens.while),
+                    endWhile: util.cloneToken(this.tokens.endWhile)
+                },
+                this.condition?.clone(),
+                this.body?.clone()
+            )
         );
     }
 }
@@ -1212,11 +1254,13 @@ export class DottedSetStatement extends Statement {
     }
 
     public clone() {
-        return new DottedSetStatement(
-            this.obj?.clone(),
-            util.cloneToken(this.name),
-            this.value?.clone(),
-            util.cloneToken(this.dot)
+        return this.cloneAnnotations(
+            new DottedSetStatement(
+                this.obj?.clone(),
+                util.cloneToken(this.name),
+                this.value?.clone(),
+                util.cloneToken(this.dot)
+            )
         );
     }
 }
@@ -1285,13 +1329,15 @@ export class IndexedSetStatement extends Statement {
     }
 
     public clone() {
-        return new IndexedSetStatement(
-            this.obj?.clone(),
-            this.index?.clone(),
-            this.value?.clone(),
-            util.cloneToken(this.openingSquare),
-            util.cloneToken(this.closingSquare),
-            this.additionalIndexes?.map(e => e?.clone())
+        return this.cloneAnnotations(
+            new IndexedSetStatement(
+                this.obj?.clone(),
+                this.index?.clone(),
+                this.value?.clone(),
+                util.cloneToken(this.openingSquare),
+                util.cloneToken(this.closingSquare),
+                this.additionalIndexes?.map(e => e?.clone())
+            )
         );
     }
 }
@@ -1336,10 +1382,12 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new LibraryStatement({
-            library: util.cloneToken(this.tokens?.library),
-            filePath: util.cloneToken(this.tokens?.filePath)
-        });
+        return this.cloneAnnotations(
+            new LibraryStatement({
+                library: util.cloneToken(this.tokens?.library),
+                filePath: util.cloneToken(this.tokens?.filePath)
+            })
+        );
     }
 }
 
@@ -1428,11 +1476,13 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new NamespaceStatement(
-            util.cloneToken(this.keyword),
-            this.nameExpression?.clone(),
-            this.body?.clone(),
-            util.cloneToken(this.endKeyword)
+        return this.cloneAnnotations(
+            new NamespaceStatement(
+                util.cloneToken(this.keyword),
+                this.nameExpression?.clone(),
+                this.body?.clone(),
+                util.cloneToken(this.endKeyword)
+            )
         );
     }
 }
@@ -1492,9 +1542,11 @@ export class ImportStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new ImportStatement(
-            util.cloneToken(this.importToken),
-            util.cloneToken(this.filePathToken)
+        return this.cloneAnnotations(
+            new ImportStatement(
+                util.cloneToken(this.importToken),
+                util.cloneToken(this.filePathToken)
+            )
         );
     }
 }
@@ -1655,13 +1707,15 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new InterfaceStatement(
-            util.cloneToken(this.tokens.interface),
-            util.cloneToken(this.tokens.name),
-            util.cloneToken(this.tokens.extends),
-            this.parentInterfaceName?.clone(),
-            this.body?.map(x => x?.clone()),
-            util.cloneToken(this.tokens.endInterface)
+        return this.cloneAnnotations(
+            new InterfaceStatement(
+                util.cloneToken(this.tokens.interface),
+                util.cloneToken(this.tokens.name),
+                util.cloneToken(this.tokens.extends),
+                this.parentInterfaceName?.clone(),
+                this.body?.map(x => x?.clone()),
+                util.cloneToken(this.tokens.endInterface)
+            )
         );
     }
 }
@@ -1739,12 +1793,14 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     }
 
     public clone() {
-        return new InterfaceFieldStatement(
-            util.cloneToken(this.tokens.name),
-            util.cloneToken(this.tokens.as),
-            util.cloneToken(this.tokens.type),
-            this.type?.clone(),
-            util.cloneToken(this.tokens.optional)
+        return this.cloneAnnotations(
+            new InterfaceFieldStatement(
+                util.cloneToken(this.tokens.name),
+                util.cloneToken(this.tokens.as),
+                util.cloneToken(this.tokens.type),
+                this.type?.clone(),
+                util.cloneToken(this.tokens.optional)
+            )
         );
     }
 
@@ -1858,16 +1914,18 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
     }
 
     public clone() {
-        return new InterfaceMethodStatement(
-            util.cloneToken(this.tokens.functionType),
-            util.cloneToken(this.tokens.name),
-            util.cloneToken(this.tokens.leftParen),
-            this.params?.map(p => p?.clone()),
-            util.cloneToken(this.tokens.rightParen),
-            util.cloneToken(this.tokens.as),
-            util.cloneToken(this.tokens.returnType),
-            this.returnType?.clone(),
-            util.cloneToken(this.tokens.optional)
+        return this.cloneAnnotations(
+            new InterfaceMethodStatement(
+                util.cloneToken(this.tokens.functionType),
+                util.cloneToken(this.tokens.name),
+                util.cloneToken(this.tokens.leftParen),
+                this.params?.map(p => p?.clone()),
+                util.cloneToken(this.tokens.rightParen),
+                util.cloneToken(this.tokens.as),
+                util.cloneToken(this.tokens.returnType),
+                this.returnType?.clone(),
+                util.cloneToken(this.tokens.optional)
+            )
         );
     }
 }
@@ -2262,13 +2320,15 @@ export class ClassStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new ClassStatement(
-            util.cloneToken(this.classKeyword),
-            util.cloneToken(this.name),
-            this.body?.map(x => x?.clone()),
-            util.cloneToken(this.end),
-            util.cloneToken(this.extendsKeyword),
-            this.parentClassName?.clone()
+        return this.cloneAnnotations(
+            new ClassStatement(
+                util.cloneToken(this.classKeyword),
+                util.cloneToken(this.name),
+                this.body?.map(x => x?.clone()),
+                util.cloneToken(this.end),
+                util.cloneToken(this.extendsKeyword),
+                this.parentClassName?.clone()
+            )
         );
     }
 }
@@ -2463,11 +2523,13 @@ export class MethodStatement extends FunctionStatement {
     }
 
     public clone() {
-        return new MethodStatement(
-            this.modifiers?.map(m => util.cloneToken(m)),
-            util.cloneToken(this.name),
-            this.func?.clone(),
-            util.cloneToken(this.override)
+        return this.cloneAnnotations(
+            new MethodStatement(
+                this.modifiers?.map(m => util.cloneToken(m)),
+                util.cloneToken(this.name),
+                this.func?.clone(),
+                util.cloneToken(this.override)
+            )
         );
     }
 }
@@ -2560,14 +2622,16 @@ export class FieldStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new FieldStatement(
-            util.cloneToken(this.accessModifier),
-            util.cloneToken(this.name),
-            util.cloneToken(this.as),
-            util.cloneToken(this.type),
-            util.cloneToken(this.equal),
-            this.initialValue?.clone(),
-            util.cloneToken(this.optional)
+        return this.cloneAnnotations(
+            new FieldStatement(
+                util.cloneToken(this.accessModifier),
+                util.cloneToken(this.name),
+                util.cloneToken(this.as),
+                util.cloneToken(this.type),
+                util.cloneToken(this.equal),
+                this.initialValue?.clone(),
+                util.cloneToken(this.optional)
+            )
         );
     }
 }
@@ -2625,13 +2689,15 @@ export class TryCatchStatement extends Statement {
     }
 
     public clone() {
-        return new TryCatchStatement(
-            {
-                try: util.cloneToken(this.tokens.try),
-                endTry: util.cloneToken(this.tokens.endTry)
-            },
-            this.tryBranch?.clone(),
-            this.catchStatement?.clone()
+        return this.cloneAnnotations(
+            new TryCatchStatement(
+                {
+                    try: util.cloneToken(this.tokens.try),
+                    endTry: util.cloneToken(this.tokens.endTry)
+                },
+                this.tryBranch?.clone(),
+                this.catchStatement?.clone()
+            )
         );
     }
 }
@@ -2670,12 +2736,14 @@ export class CatchStatement extends Statement {
     }
 
     public clone() {
-        return new CatchStatement(
-            {
-                catch: util.cloneToken(this.tokens.catch)
-            },
-            util.cloneToken(this.exceptionVariable),
-            this.catchBranch?.clone()
+        return this.cloneAnnotations(
+            new CatchStatement(
+                {
+                    catch: util.cloneToken(this.tokens.catch)
+                },
+                util.cloneToken(this.exceptionVariable),
+                this.catchBranch?.clone()
+            )
         );
     }
 }
@@ -2719,9 +2787,11 @@ export class ThrowStatement extends Statement {
     }
 
     public clone() {
-        return new ThrowStatement(
-            util.cloneToken(this.throwToken),
-            this.expression?.clone()
+        return this.cloneAnnotations(
+            new ThrowStatement(
+                util.cloneToken(this.throwToken),
+                this.expression?.clone()
+            )
         );
     }
 }
@@ -2881,13 +2951,15 @@ export class EnumStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new EnumStatement(
-            {
-                enum: util.cloneToken(this.tokens.enum),
-                name: util.cloneToken(this.tokens.name),
-                endEnum: util.cloneToken(this.tokens.endEnum)
-            },
-            this.body?.map(x => x?.clone())
+        return this.cloneAnnotations(
+            new EnumStatement(
+                {
+                    enum: util.cloneToken(this.tokens.enum),
+                    name: util.cloneToken(this.tokens.name),
+                    endEnum: util.cloneToken(this.tokens.endEnum)
+                },
+                this.body?.map(x => x?.clone())
+            )
         );
     }
 }
@@ -2952,12 +3024,14 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new EnumMemberStatement(
-            {
-                name: util.cloneToken(this.tokens.name),
-                equal: util.cloneToken(this.tokens.equal)
-            },
-            this.value?.clone()
+        return this.cloneAnnotations(
+            new EnumMemberStatement(
+                {
+                    name: util.cloneToken(this.tokens.name),
+                    equal: util.cloneToken(this.tokens.equal)
+                },
+                this.value?.clone()
+            )
         );
     }
 }
@@ -3025,13 +3099,15 @@ export class ConstStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return new ConstStatement(
-            {
-                const: util.cloneToken(this.tokens.const),
-                name: util.cloneToken(this.tokens.name),
-                equals: util.cloneToken(this.tokens.equals)
-            },
-            this.value?.clone()
+        return this.cloneAnnotations(
+            new ConstStatement(
+                {
+                    const: util.cloneToken(this.tokens.const),
+                    name: util.cloneToken(this.tokens.name),
+                    equals: util.cloneToken(this.tokens.equals)
+                },
+                this.value?.clone()
+            )
         );
     }
 }
@@ -3065,9 +3141,11 @@ export class ContinueStatement extends Statement {
     }
 
     public clone() {
-        return new ContinueStatement({
-            continue: util.cloneToken(this.tokens.continue),
-            loopType: util.cloneToken(this.tokens.loopType)
-        });
+        return this.cloneAnnotations(
+            new ContinueStatement({
+                continue: util.cloneToken(this.tokens.continue),
+                loopType: util.cloneToken(this.tokens.loopType)
+            })
+        );
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -37,7 +37,7 @@ export class EmptyStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new EmptyStatement(
                 util.cloneRange(this.range)
             )
@@ -119,10 +119,11 @@ export class Body extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new Body(
                 this.statements?.map(s => s?.clone())
-            )
+            ),
+            ['statements']
         );
     }
 }
@@ -169,12 +170,13 @@ export class AssignmentStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new AssignmentStatement(
                 util.cloneToken(this.equals),
                 util.cloneToken(this.name),
                 this.value?.clone()
-            )
+            ),
+            ['value']
         );
     }
 }
@@ -233,11 +235,12 @@ export class Block extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new Block(
                 this.statements?.map(s => s?.clone()),
                 util.cloneRange(this.startingRange)
-            )
+            ),
+            ['statements']
         );
     }
 }
@@ -263,10 +266,11 @@ export class ExpressionStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ExpressionStatement(
                 this.expression?.clone()
-            )
+            ),
+            ['expression']
         );
     }
 }
@@ -317,10 +321,11 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new CommentStatement(
                 this.comments?.map(x => util.cloneToken(x))
-            )
+            ),
+            ['comments' as any]
         );
     }
 }
@@ -348,7 +353,7 @@ export class ExitForStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ExitForStatement({
                 exitFor: util.cloneToken(this.tokens.exitFor)
             })
@@ -379,7 +384,7 @@ export class ExitWhileStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ExitWhileStatement({
                 exitWhile: util.cloneToken(this.tokens.exitWhile)
             })
@@ -453,11 +458,12 @@ export class FunctionStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new FunctionStatement(
                 util.cloneToken(this.name),
                 this.func?.clone()
-            )
+            ),
+            ['func']
         );
     }
 }
@@ -577,7 +583,7 @@ export class IfStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new IfStatement(
                 {
                     if: util.cloneToken(this.tokens.if),
@@ -589,7 +595,8 @@ export class IfStatement extends Statement {
                 this.thenBranch?.clone(),
                 this.elseBranch?.clone(),
                 this.isInline
-            )
+            ),
+            ['condition', 'thenBranch', 'elseBranch']
         );
     }
 }
@@ -622,11 +629,12 @@ export class IncrementStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new IncrementStatement(
                 this.value?.clone(),
                 util.cloneToken(this.operator)
-            )
+            ),
+            ['value']
         );
     }
 }
@@ -696,7 +704,7 @@ export class PrintStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new PrintStatement(
                 {
                     print: util.cloneToken(this.tokens.print)
@@ -708,7 +716,8 @@ export class PrintStatement extends Statement {
                         return util.cloneToken(e as Token);
                     }
                 })
-            )
+            ),
+            ['expressions' as any]
         );
     }
 }
@@ -759,14 +768,15 @@ export class DimStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new DimStatement(
                 util.cloneToken(this.dimToken),
                 util.cloneToken(this.identifier),
                 util.cloneToken(this.openingSquare),
                 this.dimensions?.map(e => e?.clone()),
                 util.cloneToken(this.closingSquare)
-            )
+            ),
+            ['dimensions']
         );
     }
 }
@@ -800,7 +810,7 @@ export class GotoStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new GotoStatement({
                 goto: util.cloneToken(this.tokens.goto),
                 label: util.cloneToken(this.tokens.label)
@@ -838,7 +848,7 @@ export class LabelStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new LabelStatement({
                 identifier: util.cloneToken(this.tokens.identifier),
                 colon: util.cloneToken(this.tokens.colon)
@@ -882,13 +892,14 @@ export class ReturnStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ReturnStatement(
                 {
                     return: util.cloneToken(this.tokens.return)
                 },
                 this.value?.clone()
-            )
+            ),
+            ['value']
         );
     }
 }
@@ -916,7 +927,7 @@ export class EndStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new EndStatement({
                 end: util.cloneToken(this.tokens.end)
             })
@@ -947,7 +958,7 @@ export class StopStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new StopStatement({
                 stop: util.cloneToken(this.tokens.stop)
             })
@@ -1040,7 +1051,7 @@ export class ForStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ForStatement(
                 util.cloneToken(this.forToken),
                 this.counterDeclaration?.clone(),
@@ -1050,7 +1061,8 @@ export class ForStatement extends Statement {
                 util.cloneToken(this.endForToken),
                 util.cloneToken(this.stepToken),
                 this.increment?.clone()
-            )
+            ),
+            ['counterDeclaration', 'finalValue', 'body', 'increment']
         );
     }
 }
@@ -1124,7 +1136,7 @@ export class ForEachStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ForEachStatement(
                 {
                     forEach: util.cloneToken(this.tokens.forEach),
@@ -1134,7 +1146,8 @@ export class ForEachStatement extends Statement {
                 util.cloneToken(this.item),
                 this.target?.clone(),
                 this.body?.clone()
-            )
+            ),
+            ['target', 'body']
         );
     }
 }
@@ -1197,7 +1210,7 @@ export class WhileStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new WhileStatement(
                 {
                     while: util.cloneToken(this.tokens.while),
@@ -1205,7 +1218,8 @@ export class WhileStatement extends Statement {
                 },
                 this.condition?.clone(),
                 this.body?.clone()
-            )
+            ),
+            ['condition', 'body']
         );
     }
 }
@@ -1254,13 +1268,14 @@ export class DottedSetStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new DottedSetStatement(
                 this.obj?.clone(),
                 util.cloneToken(this.name),
                 this.value?.clone(),
                 util.cloneToken(this.dot)
-            )
+            ),
+            ['obj', 'value']
         );
     }
 }
@@ -1329,7 +1344,7 @@ export class IndexedSetStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new IndexedSetStatement(
                 this.obj?.clone(),
                 this.index?.clone(),
@@ -1337,7 +1352,8 @@ export class IndexedSetStatement extends Statement {
                 util.cloneToken(this.openingSquare),
                 util.cloneToken(this.closingSquare),
                 this.additionalIndexes?.map(e => e?.clone())
-            )
+            ),
+            ['obj', 'index', 'value', 'additionalIndexes']
         );
     }
 }
@@ -1351,8 +1367,8 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     ) {
         super();
         this.range = util.createBoundingRange(
-            this.tokens.library,
-            this.tokens.filePath
+            this.tokens?.library,
+            this.tokens?.filePath
         );
     }
 
@@ -1382,11 +1398,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
-            new LibraryStatement({
-                library: util.cloneToken(this.tokens?.library),
-                filePath: util.cloneToken(this.tokens?.filePath)
-            })
+        return this.finalizeClone(
+            new LibraryStatement(
+                this.tokens === undefined ? undefined : {
+                    library: util.cloneToken(this.tokens?.library),
+                    filePath: util.cloneToken(this.tokens?.filePath)
+                }
+            )
         );
     }
 }
@@ -1400,14 +1418,15 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
         public endKeyword: Token
     ) {
         super();
-        this.name = this.getName(ParseMode.BrighterScript);
         this.symbolTable = new SymbolTable(`NamespaceStatement: '${this.name}'`, () => this.parent?.getSymbolTable());
     }
 
     /**
      * The string name for this namespace
      */
-    public name: string;
+    public get name(): string {
+        return this.getName(ParseMode.BrighterScript);
+    }
 
     public get range() {
         return this.cacheRange();
@@ -1476,14 +1495,17 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        const clone = this.finalizeClone(
             new NamespaceStatement(
                 util.cloneToken(this.keyword),
                 this.nameExpression?.clone(),
                 this.body?.clone(),
                 util.cloneToken(this.endKeyword)
-            )
+            ),
+            ['nameExpression', 'body']
         );
+        clone.cacheRange();
+        return clone;
     }
 }
 
@@ -1542,7 +1564,7 @@ export class ImportStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ImportStatement(
                 util.cloneToken(this.importToken),
                 util.cloneToken(this.filePathToken)
@@ -1707,7 +1729,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new InterfaceStatement(
                 util.cloneToken(this.tokens.interface),
                 util.cloneToken(this.tokens.name),
@@ -1715,7 +1737,8 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
                 this.parentInterfaceName?.clone(),
                 this.body?.map(x => x?.clone()),
                 util.cloneToken(this.tokens.endInterface)
-            )
+            ),
+            ['parentInterfaceName', 'body']
         );
     }
 }
@@ -1793,7 +1816,7 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new InterfaceFieldStatement(
                 util.cloneToken(this.tokens.name),
                 util.cloneToken(this.tokens.as),
@@ -1914,7 +1937,7 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new InterfaceMethodStatement(
                 util.cloneToken(this.tokens.functionType),
                 util.cloneToken(this.tokens.name),
@@ -1925,7 +1948,8 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
                 util.cloneToken(this.tokens.returnType),
                 this.returnType?.clone(),
                 util.cloneToken(this.tokens.optional)
-            )
+            ),
+            ['params']
         );
     }
 }
@@ -2320,7 +2344,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ClassStatement(
                 util.cloneToken(this.classKeyword),
                 util.cloneToken(this.name),
@@ -2328,7 +2352,8 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 util.cloneToken(this.end),
                 util.cloneToken(this.extendsKeyword),
                 this.parentClassName?.clone()
-            )
+            ),
+            ['body', 'parentClassName']
         );
     }
 }
@@ -2523,13 +2548,14 @@ export class MethodStatement extends FunctionStatement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new MethodStatement(
                 this.modifiers?.map(m => util.cloneToken(m)),
                 util.cloneToken(this.name),
                 this.func?.clone(),
                 util.cloneToken(this.override)
-            )
+            ),
+            ['func']
         );
     }
 }
@@ -2622,7 +2648,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new FieldStatement(
                 util.cloneToken(this.accessModifier),
                 util.cloneToken(this.name),
@@ -2631,7 +2657,8 @@ export class FieldStatement extends Statement implements TypedefProvider {
                 util.cloneToken(this.equal),
                 this.initialValue?.clone(),
                 util.cloneToken(this.optional)
-            )
+            ),
+            ['initialValue']
         );
     }
 }
@@ -2689,7 +2716,7 @@ export class TryCatchStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new TryCatchStatement(
                 {
                     try: util.cloneToken(this.tokens.try),
@@ -2697,7 +2724,8 @@ export class TryCatchStatement extends Statement {
                 },
                 this.tryBranch?.clone(),
                 this.catchStatement?.clone()
-            )
+            ),
+            ['tryBranch', 'catchStatement']
         );
     }
 }
@@ -2736,14 +2764,15 @@ export class CatchStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new CatchStatement(
                 {
                     catch: util.cloneToken(this.tokens.catch)
                 },
                 util.cloneToken(this.exceptionVariable),
                 this.catchBranch?.clone()
-            )
+            ),
+            ['catchBranch']
         );
     }
 }
@@ -2787,11 +2816,12 @@ export class ThrowStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ThrowStatement(
                 util.cloneToken(this.throwToken),
                 this.expression?.clone()
-            )
+            ),
+            ['expression']
         );
     }
 }
@@ -2951,7 +2981,7 @@ export class EnumStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new EnumStatement(
                 {
                     enum: util.cloneToken(this.tokens.enum),
@@ -2959,7 +2989,8 @@ export class EnumStatement extends Statement implements TypedefProvider {
                     endEnum: util.cloneToken(this.tokens.endEnum)
                 },
                 this.body?.map(x => x?.clone())
-            )
+            ),
+            ['body']
         );
     }
 }
@@ -3024,14 +3055,15 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new EnumMemberStatement(
                 {
                     name: util.cloneToken(this.tokens.name),
                     equal: util.cloneToken(this.tokens.equal)
                 },
                 this.value?.clone()
-            )
+            ),
+            ['value']
         );
     }
 }
@@ -3099,7 +3131,7 @@ export class ConstStatement extends Statement implements TypedefProvider {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ConstStatement(
                 {
                     const: util.cloneToken(this.tokens.const),
@@ -3107,7 +3139,8 @@ export class ConstStatement extends Statement implements TypedefProvider {
                     equals: util.cloneToken(this.tokens.equals)
                 },
                 this.value?.clone()
-            )
+            ),
+            ['value']
         );
     }
 }
@@ -3141,7 +3174,7 @@ export class ContinueStatement extends Statement {
     }
 
     public clone() {
-        return this.cloneAnnotations(
+        return this.finalizeClone(
             new ContinueStatement({
                 continue: util.cloneToken(this.tokens.continue),
                 loopType: util.cloneToken(this.tokens.loopType)

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -35,6 +35,12 @@ export class EmptyStatement extends Statement {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new EmptyStatement(
+            util.cloneRange(this.range)
+        );
+    }
 }
 
 /**
@@ -109,6 +115,12 @@ export class Body extends Statement implements TypedefProvider {
             walkArray(this.statements, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new Body(
+            this.statements?.map(s => s?.clone())
+        );
+    }
 }
 
 export class AssignmentStatement extends Statement {
@@ -150,6 +162,14 @@ export class AssignmentStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
         }
+    }
+
+    public clone() {
+        return new AssignmentStatement(
+            util.cloneToken(this.equals),
+            util.cloneToken(this.name),
+            this.value?.clone()
+        );
     }
 }
 
@@ -205,6 +225,13 @@ export class Block extends Statement {
             walkArray(this.statements, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new Block(
+            this.statements?.map(s => s?.clone()),
+            util.cloneRange(this.startingRange)
+        );
+    }
 }
 
 export class ExpressionStatement extends Statement {
@@ -225,6 +252,12 @@ export class ExpressionStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'expression', visitor, options);
         }
+    }
+
+    public clone() {
+        return new ExpressionStatement(
+            this.expression?.clone()
+        );
     }
 }
 
@@ -272,6 +305,12 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new CommentStatement(
+            this.comments?.map(x => util.cloneToken(x))
+        );
+    }
 }
 
 export class ExitForStatement extends Statement {
@@ -296,6 +335,11 @@ export class ExitForStatement extends Statement {
         //nothing to walk
     }
 
+    public clone() {
+        return new ExitForStatement({
+            exitFor: util.cloneToken(this.tokens.exitFor)
+        });
+    }
 }
 
 export class ExitWhileStatement extends Statement {
@@ -318,6 +362,12 @@ export class ExitWhileStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new ExitWhileStatement({
+            exitWhile: util.cloneToken(this.tokens.exitWhile)
+        });
     }
 }
 
@@ -384,6 +434,13 @@ export class FunctionStatement extends Statement implements TypedefProvider {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'func', visitor, options);
         }
+    }
+
+    public clone() {
+        return new FunctionStatement(
+            util.cloneToken(this.name),
+            this.func?.clone()
+        );
     }
 }
 
@@ -500,6 +557,21 @@ export class IfStatement extends Statement {
             walk(this, 'elseBranch', visitor, options);
         }
     }
+
+    public clone() {
+        return new IfStatement(
+            {
+                if: util.cloneToken(this.tokens.if),
+                else: util.cloneToken(this.tokens.else),
+                endIf: util.cloneToken(this.tokens.endIf),
+                then: util.cloneToken(this.tokens.then)
+            },
+            this.condition?.clone(),
+            this.thenBranch?.clone(),
+            this.elseBranch?.clone(),
+            this.isInline
+        );
+    }
 }
 
 export class IncrementStatement extends Statement {
@@ -527,6 +599,13 @@ export class IncrementStatement extends Statement {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
         }
+    }
+
+    public clone() {
+        return new IncrementStatement(
+            this.value?.clone(),
+            util.cloneToken(this.operator)
+        );
     }
 }
 
@@ -593,6 +672,21 @@ export class PrintStatement extends Statement {
             walkArray(this.expressions, visitor, options, this, (item) => isExpression(item as any));
         }
     }
+
+    public clone() {
+        return new PrintStatement(
+            {
+                print: util.cloneToken(this.tokens.print)
+            },
+            this.expressions?.map(e => {
+                if (isExpression(e as any)) {
+                    return (e as Expression)?.clone();
+                } else {
+                    return util.cloneToken(e as Token);
+                }
+            })
+        );
+    }
 }
 
 export class DimStatement extends Statement {
@@ -639,6 +733,16 @@ export class DimStatement extends Statement {
 
         }
     }
+
+    public clone() {
+        return new DimStatement(
+            util.cloneToken(this.dimToken),
+            util.cloneToken(this.identifier),
+            util.cloneToken(this.openingSquare),
+            this.dimensions?.map(e => e?.clone()),
+            util.cloneToken(this.closingSquare)
+        );
+    }
 }
 
 export class GotoStatement extends Statement {
@@ -668,6 +772,13 @@ export class GotoStatement extends Statement {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new GotoStatement({
+            goto: util.cloneToken(this.tokens.goto),
+            label: util.cloneToken(this.tokens.label)
+        });
+    }
 }
 
 export class LabelStatement extends Statement {
@@ -696,6 +807,13 @@ export class LabelStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new LabelStatement({
+            identifier: util.cloneToken(this.tokens.identifier),
+            colon: util.cloneToken(this.tokens.colon)
+        });
     }
 }
 
@@ -732,6 +850,15 @@ export class ReturnStatement extends Statement {
             walk(this, 'value', visitor, options);
         }
     }
+
+    public clone() {
+        return new ReturnStatement(
+            {
+                return: util.cloneToken(this.tokens.return)
+            },
+            this.value?.clone()
+        );
+    }
 }
 
 export class EndStatement extends Statement {
@@ -755,6 +882,12 @@ export class EndStatement extends Statement {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
     }
+
+    public clone() {
+        return new EndStatement({
+            end: util.cloneToken(this.tokens.end)
+        });
+    }
 }
 
 export class StopStatement extends Statement {
@@ -777,6 +910,12 @@ export class StopStatement extends Statement {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new StopStatement({
+            stop: util.cloneToken(this.tokens.stop)
+        });
     }
 }
 
@@ -863,6 +1002,19 @@ export class ForStatement extends Statement {
             walk(this, 'body', visitor, options);
         }
     }
+
+    public clone() {
+        return new ForStatement(
+            util.cloneToken(this.forToken),
+            this.counterDeclaration?.clone(),
+            util.cloneToken(this.toToken),
+            this.finalValue?.clone(),
+            this.body?.clone(),
+            util.cloneToken(this.endForToken),
+            util.cloneToken(this.stepToken),
+            this.increment?.clone()
+        );
+    }
 }
 
 export class ForEachStatement extends Statement {
@@ -932,6 +1084,19 @@ export class ForEachStatement extends Statement {
             walk(this, 'body', visitor, options);
         }
     }
+
+    public clone() {
+        return new ForEachStatement(
+            {
+                forEach: util.cloneToken(this.tokens.forEach),
+                in: util.cloneToken(this.tokens.in),
+                endFor: util.cloneToken(this.tokens.endFor)
+            },
+            util.cloneToken(this.item),
+            this.target?.clone(),
+            this.body?.clone()
+        );
+    }
 }
 
 export class WhileStatement extends Statement {
@@ -990,6 +1155,17 @@ export class WhileStatement extends Statement {
             walk(this, 'body', visitor, options);
         }
     }
+
+    public clone() {
+        return new WhileStatement(
+            {
+                while: util.cloneToken(this.tokens.while),
+                endWhile: util.cloneToken(this.tokens.endWhile)
+            },
+            this.condition?.clone(),
+            this.body?.clone()
+        );
+    }
 }
 
 export class DottedSetStatement extends Statement {
@@ -1033,6 +1209,15 @@ export class DottedSetStatement extends Statement {
             walk(this, 'obj', visitor, options);
             walk(this, 'value', visitor, options);
         }
+    }
+
+    public clone() {
+        return new DottedSetStatement(
+            this.obj?.clone(),
+            util.cloneToken(this.name),
+            this.value?.clone(),
+            util.cloneToken(this.dot)
+        );
     }
 }
 
@@ -1098,6 +1283,17 @@ export class IndexedSetStatement extends Statement {
             walk(this, 'value', visitor, options);
         }
     }
+
+    public clone() {
+        return new IndexedSetStatement(
+            this.obj?.clone(),
+            this.index?.clone(),
+            this.value?.clone(),
+            util.cloneToken(this.openingSquare),
+            util.cloneToken(this.closingSquare),
+            this.additionalIndexes?.map(e => e?.clone())
+        );
+    }
 }
 
 export class LibraryStatement extends Statement implements TypedefProvider {
@@ -1137,6 +1333,13 @@ export class LibraryStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new LibraryStatement({
+            library: util.cloneToken(this.tokens?.library),
+            filePath: util.cloneToken(this.tokens?.filePath)
+        });
     }
 }
 
@@ -1220,6 +1423,15 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
             walk(this, 'body', visitor, options);
         }
     }
+
+    public clone() {
+        return new NamespaceStatement(
+            util.cloneToken(this.keyword),
+            this.nameExpression?.clone(),
+            this.body?.clone(),
+            util.cloneToken(this.endKeyword)
+        );
+    }
 }
 
 export class ImportStatement extends Statement implements TypedefProvider {
@@ -1274,6 +1486,13 @@ export class ImportStatement extends Statement implements TypedefProvider {
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new ImportStatement(
+            util.cloneToken(this.importToken),
+            util.cloneToken(this.filePathToken)
+        );
     }
 }
 
@@ -1431,6 +1650,17 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
             walkArray(this.body, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new InterfaceStatement(
+            util.cloneToken(this.tokens.interface),
+            util.cloneToken(this.tokens.name),
+            util.cloneToken(this.tokens.extends),
+            this.parentInterfaceName?.clone(),
+            this.body?.map(x => x?.clone()),
+            util.cloneToken(this.tokens.endInterface)
+        );
+    }
 }
 
 export class InterfaceFieldStatement extends Statement implements TypedefProvider {
@@ -1503,6 +1733,16 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
             );
         }
         return result;
+    }
+
+    public clone() {
+        return new InterfaceFieldStatement(
+            util.cloneToken(this.tokens.name),
+            util.cloneToken(this.tokens.as),
+            util.cloneToken(this.tokens.type),
+            this.type.clone(),
+            util.cloneToken(this.tokens.optional)
+        );
     }
 
 }
@@ -1612,6 +1852,20 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
             );
         }
         return result;
+    }
+
+    public clone() {
+        return new InterfaceMethodStatement(
+            util.cloneToken(this.tokens.functionType),
+            util.cloneToken(this.tokens.name),
+            util.cloneToken(this.tokens.leftParen),
+            this.params?.map(p => p?.clone()),
+            util.cloneToken(this.tokens.rightParen),
+            util.cloneToken(this.tokens.as),
+            util.cloneToken(this.tokens.returnType),
+            this.returnType?.clone(),
+            util.cloneToken(this.tokens.optional)
+        );
     }
 }
 
@@ -2003,6 +2257,17 @@ export class ClassStatement extends Statement implements TypedefProvider {
             walkArray(this.body, visitor, options, this);
         }
     }
+
+    public clone() {
+        return new ClassStatement(
+            util.cloneToken(this.classKeyword),
+            util.cloneToken(this.name),
+            this.body?.map(x => x?.clone()),
+            util.cloneToken(this.end),
+            util.cloneToken(this.extendsKeyword),
+            this.parentClassName?.clone()
+        );
+    }
 }
 
 const accessModifiers = [
@@ -2193,6 +2458,15 @@ export class MethodStatement extends FunctionStatement {
             walk(this, 'func', visitor, options);
         }
     }
+
+    public clone() {
+        return new MethodStatement(
+            this.modifiers?.map(m => util.cloneToken(m)),
+            util.cloneToken(this.name),
+            this.func?.clone(),
+            util.cloneToken(this.override)
+        );
+    }
 }
 /**
  * @deprecated use `MethodStatement`
@@ -2281,7 +2555,20 @@ export class FieldStatement extends Statement implements TypedefProvider {
             walk(this, 'initialValue', visitor, options);
         }
     }
+
+    public clone() {
+        return new FieldStatement(
+            util.cloneToken(this.accessModifier),
+            util.cloneToken(this.name),
+            util.cloneToken(this.as),
+            util.cloneToken(this.type),
+            util.cloneToken(this.equal),
+            this.initialValue?.clone(),
+            util.cloneToken(this.optional)
+        );
+    }
 }
+
 /**
  * @deprecated use `FieldStatement`
  */
@@ -2333,6 +2620,17 @@ export class TryCatchStatement extends Statement {
             walk(this, 'catchStatement', visitor, options);
         }
     }
+
+    public clone() {
+        return new TryCatchStatement(
+            {
+                try: util.cloneToken(this.tokens.try),
+                endTry: util.cloneToken(this.tokens.endTry)
+            },
+            this.tryBranch?.clone(),
+            this.catchStatement?.clone()
+        );
+    }
 }
 
 export class CatchStatement extends Statement {
@@ -2366,6 +2664,16 @@ export class CatchStatement extends Statement {
         if (this.catchBranch && options.walkMode & InternalWalkMode.walkStatements) {
             walk(this, 'catchBranch', visitor, options);
         }
+    }
+
+    public clone() {
+        return new CatchStatement(
+            {
+                catch: util.cloneToken(this.tokens.catch)
+            },
+            util.cloneToken(this.exceptionVariable),
+            this.catchBranch?.clone()
+        );
     }
 }
 
@@ -2405,6 +2713,13 @@ export class ThrowStatement extends Statement {
         if (this.expression && options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'expression', visitor, options);
         }
+    }
+
+    public clone() {
+        return new ThrowStatement(
+            util.cloneToken(this.throwToken),
+            this.expression?.clone()
+        );
     }
 }
 
@@ -2561,6 +2876,17 @@ export class EnumStatement extends Statement implements TypedefProvider {
 
         }
     }
+
+    public clone() {
+        return new EnumStatement(
+            {
+                enum: util.cloneToken(this.tokens.enum),
+                name: util.cloneToken(this.tokens.name),
+                endEnum: util.cloneToken(this.tokens.endEnum)
+            },
+            this.body?.map(x => x?.clone())
+        );
+    }
 }
 
 export class EnumMemberStatement extends Statement implements TypedefProvider {
@@ -2620,6 +2946,16 @@ export class EnumMemberStatement extends Statement implements TypedefProvider {
         if (this.value && options.walkMode & InternalWalkMode.walkExpressions) {
             walk(this, 'value', visitor, options);
         }
+    }
+
+    public clone() {
+        return new EnumMemberStatement(
+            {
+                name: util.cloneToken(this.tokens.name),
+                equal: util.cloneToken(this.tokens.equal)
+            },
+            this.value?.clone()
+        );
     }
 }
 
@@ -2684,6 +3020,17 @@ export class ConstStatement extends Statement implements TypedefProvider {
             walk(this, 'value', visitor, options);
         }
     }
+
+    public clone() {
+        return new ConstStatement(
+            {
+                const: util.cloneToken(this.tokens.const),
+                name: util.cloneToken(this.tokens.name),
+                equals: util.cloneToken(this.tokens.equals)
+            },
+            this.value?.clone()
+        );
+    }
 }
 
 export class ContinueStatement extends Statement {
@@ -2709,7 +3056,15 @@ export class ContinueStatement extends Statement {
             state.sourceNode(this.tokens.continue, this.tokens.loopType?.text)
         ];
     }
+
     walk(visitor: WalkVisitor, options: WalkOptions) {
         //nothing to walk
+    }
+
+    public clone() {
+        return new ContinueStatement({
+            continue: util.cloneToken(this.tokens.continue),
+            loopType: util.cloneToken(this.tokens.loopType)
+        });
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1380,7 +1380,10 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
 
     public getName(parseMode: ParseMode) {
         const parentNamespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
-        let name = this.nameExpression.getName(parseMode);
+        let name = this.nameExpression?.getName?.(parseMode);
+        if (!name) {
+            return name;
+        }
 
         if (parentNamespace) {
             const sep = parseMode === ParseMode.BrighterScript ? '.' : '_';

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -239,7 +239,7 @@ export class ExpressionStatement extends Statement {
         readonly expression: Expression
     ) {
         super();
-        this.range = this.expression.range;
+        this.range = this.expression?.range;
     }
 
     public readonly range: Range | undefined;
@@ -377,7 +377,7 @@ export class FunctionStatement extends Statement implements TypedefProvider {
         public func: FunctionExpression
     ) {
         super();
-        this.range = this.func.range;
+        this.range = this.func?.range;
     }
 
     public readonly range: Range | undefined;
@@ -680,7 +680,7 @@ export class PrintStatement extends Statement {
             },
             this.expressions?.map(e => {
                 if (isExpression(e as any)) {
-                    return (e as Expression)?.clone();
+                    return (e as Expression).clone();
                 } else {
                     return util.cloneToken(e as Token);
                 }
@@ -1515,7 +1515,7 @@ export class InterfaceStatement extends Statement implements TypedefProvider {
             this.tokens.name,
             this.tokens.extends,
             this.parentInterfaceName,
-            ...this.body,
+            ...this.body ?? [],
             this.tokens.endInterface
         );
     }
@@ -1740,7 +1740,7 @@ export class InterfaceFieldStatement extends Statement implements TypedefProvide
             util.cloneToken(this.tokens.name),
             util.cloneToken(this.tokens.as),
             util.cloneToken(this.tokens.type),
-            this.type.clone(),
+            this.type?.clone(),
             util.cloneToken(this.tokens.optional)
         );
     }

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -44,4 +44,8 @@ export class ArrayType implements BscType {
     public toTypeString(): string {
         return 'object';
     }
+
+    public clone() {
+        return new ArrayType(...this.innerTypes?.map(x => x?.clone()) ?? []);
+    }
 }

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -24,4 +24,8 @@ export class BooleanType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new BooleanType(this.typeText);
+    }
 }

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -3,4 +3,5 @@ export interface BscType {
     isConvertibleTo(targetType: BscType): boolean;
     toString(): string;
     toTypeString(): string;
+    clone(): BscType;
 }

--- a/src/types/CustomType.ts
+++ b/src/types/CustomType.ts
@@ -28,4 +28,8 @@ export class CustomType implements BscType {
     public isConvertibleTo(targetType: BscType) {
         return this.isAssignableTo(targetType);
     }
+
+    public clone() {
+        return new CustomType(this.name);
+    }
 }

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -36,4 +36,8 @@ export class DoubleType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new DoubleType(this.typeText);
+    }
 }

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -27,4 +27,8 @@ export class DynamicType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new DynamicType(this.typeText);
+    }
 }

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -37,4 +37,8 @@ export class FloatType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new FloatType(this.typeText);
+    }
 }

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -76,4 +76,14 @@ export class FunctionType implements BscType {
     public toTypeString(): string {
         return 'Function';
     }
+
+    public clone() {
+        const result = new FunctionType(this.returnType);
+        for (let param of this.params) {
+            result.addParameter(param.name, param.type, param.isOptional);
+        }
+        result.isSub = this.isSub;
+        result.returnType = this.returnType?.clone();
+        return result;
+    }
 }

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -37,4 +37,8 @@ export class IntegerType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new IntegerType(this.typeText);
+    }
 }

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -68,4 +68,14 @@ export class InterfaceType implements BscType {
         }
         return false;
     }
+
+    public clone() {
+        let members = new Map<string, BscType>();
+        for (const [key, member] of this.members) {
+            members.set(key, member?.clone());
+        }
+        const result = new InterfaceType(members);
+        result.name = this.name;
+        return result;
+    }
 }

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -24,4 +24,8 @@ export class InvalidType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new InvalidType(this.typeText);
+    }
 }

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -37,4 +37,8 @@ export class LongIntegerType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new LongIntegerType(this.typeText);
+    }
 }

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -24,4 +24,8 @@ export class ObjectType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new ObjectType(this.typeText);
+    }
 }

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -24,4 +24,8 @@ export class StringType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new StringType(this.typeText);
+    }
 }

--- a/src/types/UninitializedType.ts
+++ b/src/types/UninitializedType.ts
@@ -20,4 +20,8 @@ export class UninitializedType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new UninitializedType();
+    }
 }

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -24,4 +24,8 @@ export class VoidType implements BscType {
     public toTypeString(): string {
         return this.toString();
     }
+
+    public clone() {
+        return new VoidType(this.typeText);
+    }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,7 +36,6 @@ import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
 import type { AstNode, Expression, Statement } from './parser/AstNode';
 import { components, events, interfaces } from './roku-types';
-import { createToken } from './astUtils/creators';
 
 export class Util {
     public clearConsole() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,6 +36,7 @@ import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
 import type { AstNode, Expression, Statement } from './parser/AstNode';
 import { components, events, interfaces } from './roku-types';
+import { createToken } from './astUtils/creators';
 
 export class Util {
     public clearConsole() {
@@ -992,6 +993,34 @@ export class Util {
                 character: endPosition.character
             }
         };
+    }
+
+    /**
+     * Clone a range
+     */
+    public cloneRange(range: Range) {
+        if (range) {
+            return this.createRange(range.start.line, range.start.character, range.end.line, range.end.character);
+        } else {
+            return range;
+        }
+    }
+
+    /**
+     * Clone every token
+     */
+    public cloneToken<T extends Token>(token: T) {
+        if (token) {
+            return {
+                kind: token.kind,
+                range: this.cloneRange(token.range),
+                text: token.text,
+                isReserved: token.isReserved,
+                leadingWhitespace: token.leadingWhitespace
+            } as T;
+        } else {
+            return token;
+        }
     }
 
     /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -1019,7 +1019,7 @@ export class Util {
             } as T;
             //handle those tokens that have charCode
             if ('charCode' in token) {
-                (result as any).charCode = token.charCode;
+                (result as any).charCode = (token as any).charCode;
             }
             return result;
         } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1010,13 +1010,18 @@ export class Util {
      */
     public cloneToken<T extends Token>(token: T) {
         if (token) {
-            return {
+            const result = {
                 kind: token.kind,
                 range: this.cloneRange(token.range),
                 text: token.text,
                 isReserved: token.isReserved,
                 leadingWhitespace: token.leadingWhitespace
             } as T;
+            //handle those tokens that have charCode
+            if ('charCode' in token) {
+                (result as any).charCode = token.charCode;
+            }
+            return result;
         } else {
             return token;
         }


### PR DESCRIPTION
Add `.clone()` method to AstNode and BscType objects. This will make for much easier duplication of template code for plugins. 

- [x] add `.clone()` method to `Statement`s
- [x] add `.clone()` method to `Expression`s
- [x] add `.clone()` method to `BscType`s
- [x] add unit tests