### PR TITLE
Added tests and fixes around transpiling variables that shadow stuff

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -4264,6 +4264,115 @@ describe('Scope', () => {
             program.validate();
             expectDiagnosticsIncludes(program, DiagnosticMessages.localVarSameNameAsClass('Person').message);
         });
+
+        it('allows reusing a namespaced class name as "for each" variable in a method', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    class Person
+                        name as string
+                        children as Person[]
+
+                        sub test()
+                            for each person in m.children
+                                print person.name
+                            end for
+                        end sub
+                    end class
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows reusing a namespaced function name as "for each" variable in a method', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    sub bar()
+                    end sub
+
+                    sub test()
+                        for each bar in m.bars
+                            print bar.whatever
+                        end for
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows reusing a namespaced class name as variable in a method', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    class Person
+                        name as string
+                        children as Person[]
+                    end class
+
+                    sub test()
+                        person = {name: 123}
+                        print person
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows using a namespace name as a parameter inside a function in the namespace', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    sub foo(alpha as string)
+                        print alpha
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows using a namespace name as a variable inside a function in the namespace', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    sub foo()
+                        alpha = "hello"
+                        print alpha
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows using a namespace name as a variable, and claling methods on it', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    sub foo()
+                        alpha = "hello"
+                        print alpha.len()
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows shadowing namespaced function in same namespace', () => {
+            program.setFile<BrsFile>('source/file.bs', `
+                namespace alpha
+                    sub foo()
+                    end sub
+
+                    sub test()
+                        foo = 1
+                        m.data = []
+                        m.data.push(foo)
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
 

--- a/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
@@ -123,8 +123,8 @@ export class BrsFilePreTranspileProcessor {
             // skip any changes in an Alias Statement
             return;
         }
-
-        let containingNamespace = this.event.file.getNamespaceStatementForPosition(expression.location?.range.start)?.getName(ParseMode.BrighterScript);
+        let containingNamespaceStmt = this.event.file.getNamespaceStatementForPosition(expression.location?.range.start);
+        let containingNamespace = containingNamespaceStmt?.getName(ParseMode.BrighterScript);
 
         const parts = util.splitExpression(expression);
         const processedNames: string[] = [];
@@ -149,8 +149,12 @@ export class BrsFilePreTranspileProcessor {
                 return;
             }
 
-            let value: Expression;
+            if (!currentPartIsAlias && firstPart && util.isVariableShadowingSomething(entityName, part)) {
+                // this expression starts with a variable that has been redefined, so skip it
+                return;
+            }
 
+            let value: Expression;
             let constStatement = scope?.getConstFileLink(entityName, containingNamespace)?.item;
             let enumInfo = this.getEnumInfo(entityName, containingNamespace, scope);
             let namespaceInfo = isAlias && this.getNamespaceInfo(entityName, scope);

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -1178,7 +1178,7 @@ describe('BrsFile BrighterScript classes', () => {
                         button = Alpha_Button()
                         items = [
                             m.button
-                            Alpha_button
+                            button
                             Alpha_Button
                         ]
                     end sub

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -767,55 +767,6 @@ export class BrsFile implements BscFile {
     }
 
     /**
-     * Determine if the callee (i.e. function name) is a known function declared on the given namespace.
-     */
-    public calleeIsKnownNamespaceFunction(callee: Expression, namespaceName: string | undefined) {
-        //if we have a variable and a namespace
-        if (isVariableExpression(callee) && namespaceName) {
-            let lowerCalleeName = callee?.tokens.name?.text?.toLowerCase();
-            if (lowerCalleeName) {
-                let scopes = this.program.getScopesForFile(this);
-                for (let scope of scopes) {
-                    let namespace = scope.namespaceLookup.get(namespaceName.toLowerCase());
-                    if (!namespace) {
-                        continue;
-                    }
-                    if (namespace.functionStatements.has(lowerCalleeName)) {
-                        return true;
-                    }
-                    if (namespace.classStatements.has(lowerCalleeName)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Determine if the callee (i.e. function name) is a known function
-     */
-    public calleeIsKnownFunction(callee: Expression, namespaceName?: string) {
-        //if we have a variable and a namespace
-        if (isVariableExpression(callee)) {
-            if (namespaceName) {
-                return this.calleeIsKnownNamespaceFunction(callee, namespaceName);
-            }
-            let scopes = this.program.getScopesForFile(this);
-            let lowerCalleeName = callee?.tokens.name?.text?.toLowerCase();
-            for (let scope of scopes) {
-                if (scope.getCallableByName(lowerCalleeName)) {
-                    return true;
-                }
-                if (scope.getClass(lowerCalleeName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
      * Get the token closest to the position. if no token is found, the previous token is returned
      */
     public getClosestToken(position: Position) {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1187,7 +1187,7 @@ export class VariableExpression extends Expression {
         let result: TranspileResult = [];
         const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
         //if the callee is the name of a known namespace function
-        if (namespace && state.file.calleeIsKnownNamespaceFunction(this, namespace.getName(ParseMode.BrighterScript))) {
+        if (namespace && util.isCalleeMemberOfNamespace(this.tokens.name.text, this, namespace)) {
             result.push(
                 //transpile leading comments since the token isn't being transpiled directly
                 ...state.transpileLeadingCommentsForAstNode(this),
@@ -1197,7 +1197,6 @@ export class VariableExpression extends Expression {
                     this.getName(ParseMode.BrightScript)
                 ])
             );
-
             //transpile  normally
         } else {
             result.push(


### PR DESCRIPTION
Addresses #1277 

Fixes transpilation issues with variables that shadow things in namespaces.

Basically, "closest thing wins"

If a variable or function param shadows a const, enum, etc. then it does not do any special transpilation, but instead uses it as-is.

However, there are still diagnostics for when a variable shadows a non-namespaced function or class, because using those still lead to un-defined behaviour.

eg:

```
sub foo()
end sub

sub bar()
  foo = 1 ' this shadows the function above
  print foo ' this could lead to un-defined behaviour
end sub
```


however, if the function or class IS in a namespace, then it’s okay, because the transpilation will change the name:
```
namespace alpha
  sub foo()
  end sub

  sub bar()
    foo = 1 
    print foo
  end sub
end namespace
```
transpiles to:

```
sub alpha_foo()
end sub

sub alpha_bar()
  foo = 1  
  print foo
end sub
```

because of transpilation of the namespace, `foo` no longer shadows the function, so it is OK