### PR TITLE
Handles diagnostic with invalid location, and semantic tokens for unscoped file

### DIFF
--- a/src/DiagnosticCollection.ts
+++ b/src/DiagnosticCollection.ts
@@ -30,7 +30,11 @@ export class DiagnosticCollection {
         const keys = {};
         //build the full current set of diagnostics by file
         for (let diagnostic of diagnostics) {
-            const fileUri = diagnostic.location.uri;
+            const fileUri = diagnostic?.location?.uri;
+            if (!fileUri) {
+                continue;
+            }
+
             //ensure the file entry exists
             if (!result[fileUri]) {
                 result[fileUri] = [];

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -166,7 +166,7 @@ export class DiagnosticManager {
     public clearForFile(fileSrcPath: string) {
         const fileSrcPathUri = util.pathToUri(fileSrcPath).toLowerCase();
         for (const [key, cachedData] of this.diagnosticsCache.entries()) {
-            if (cachedData.diagnostic.location.uri.toLowerCase() === fileSrcPathUri) {
+            if (cachedData.diagnostic.location?.uri.toLowerCase() === fileSrcPathUri) {
                 this.diagnosticsCache.delete(key);
             }
         }

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -20,7 +20,9 @@ export class BrsFileSemanticTokensProcessor {
     public process() {
         const scope = this.event.scopes[0];
         this.result.clear();
-        scope.linkSymbolTable();
+        if (scope) {
+            scope.linkSymbolTable();
+        }
 
         this.event.file.ast.walk(createVisitor({
             VariableExpression: (node) => {
@@ -57,7 +59,9 @@ export class BrsFileSemanticTokensProcessor {
             walkMode: WalkMode.visitAllRecursive
         });
 
-        scope.unlinkSymbolTable();
+        if (scope) {
+            scope.unlinkSymbolTable();
+        }
 
         //add all tokens to the event
         this.event.semanticTokens.push(


### PR DESCRIPTION
Fixes #1275

Also, if there was a BrsFile that was unscoped, like in `/components` but not included in a component, the Language server would crash in the semantic tokens parser when trying to link a scope

