### PR TITLE
Add support for resolving sourceRoot at time of config load

### DIFF
--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -30,7 +30,10 @@
                     "type": "object",
                     "patternProperties": {
                         "^.+$": {
-                            "type": ["boolean", "null"]
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
                         }
                     }
                 }
@@ -161,8 +164,16 @@
             "type": "object",
             "patternProperties": {
                 ".{1,}": {
-                    "type": ["number", "string"],
-                    "enum": ["error", "warn", "info", "hint"]
+                    "type": [
+                        "number",
+                        "string"
+                    ],
+                    "enum": [
+                        "error",
+                        "warn",
+                        "info",
+                        "hint"
+                    ]
                 }
             }
         },
@@ -267,6 +278,11 @@
         "sourceRoot": {
             "description": "Override the root directory path where debugger should locate the source files. The location will be embedded in the source map to help debuggers locate the original source files. This only applies to files found within rootDir. This is useful when you want to preprocess files before passing them to BrighterScript, and want a debugger to open the original files. This option also affects the `SOURCE_FILE_PATH` and `SOURCE_LOCATION` source literals.",
             "type": "string"
+        },
+        "resolveSourceRoot": {
+            "description": "Should the `sourceRoot` property be resolve to an absolute path (relative to the bsconfig it's defined in)",
+            "type": "boolean",
+            "default": false
         },
         "diagnosticLevel": {
             "description": "Specify what diagnostic levels are printed to the console. This has no effect on what diagnostics are reported in the LanguageServer. Defaults to 'warn'",

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -182,6 +182,11 @@ export interface BsConfig {
      */
     sourceRoot?: string;
     /**
+     * Should the `sourceRoot` property be resolve to an absolute path (relative to the bsconfig it's defined in)
+     * @default false
+     */
+    resolveSourceRoot?: boolean;
+    /**
      * Enables generating sourcemap files, which allow debugging tools to show the original source code while running the emitted files.
      * @default true
      */

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -95,6 +95,26 @@ describe('util', () => {
             ]);
         });
 
+        it('resolves sourceRoot relative to the bsconfig file', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/folder1/parent.json`, { sourceRoot: './alpha/beta', resolveSourceRoot: true });
+            fsExtra.outputJsonSync(s`${rootDir}/child.json`, { extends: 'folder1/parent.json' });
+            expect(
+                util.loadConfigFile(s`${rootDir}/child.json`).sourceRoot
+            ).to.eql(
+                s`${rootDir}/folder1/alpha/beta`
+            );
+        });
+
+        it('leaves sourceRoot relative when defaulted to', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/folder1/parent.json`, { sourceRoot: './alpha/beta' });
+            fsExtra.outputJsonSync(s`${rootDir}/child.json`, { extends: 'folder1/parent.json' });
+            expect(
+                util.loadConfigFile(s`${rootDir}/child.json`).sourceRoot
+            ).to.eql(
+                `./alpha/beta`
+            );
+        });
+
         it('returns empty ancestors list for non-extends files', () => {
             fsExtra.outputFileSync(s`${rootDir}/child.json`, `{}`);
             let config = util.loadConfigFile(s`${rootDir}/child.json`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -237,6 +237,9 @@ export class Util {
             if (result.stagingDir) {
                 result.stagingDir = path.resolve(projectFileCwd, result.stagingDir);
             }
+            if (result.sourceRoot && result.resolveSourceRoot) {
+                result.sourceRoot = path.resolve(projectFileCwd, result.sourceRoot);
+            }
             return result;
         }
     }
@@ -367,6 +370,7 @@ export class Util {
             autoImportComponentScript: config.autoImportComponentScript === true ? true : false,
             showDiagnosticsInConsole: config.showDiagnosticsInConsole === false ? false : true,
             sourceRoot: config.sourceRoot ? standardizePath(config.sourceRoot) : undefined,
+            resolveSourceRoot: config.resolveSourceRoot === true ? true: false,
             allowBrighterScriptInBrightScript: config.allowBrighterScriptInBrightScript === true ? true : false,
             emitDefinitions: config.emitDefinitions === true ? true : false,
             removeParameterTypes: config.removeParameterTypes === true ? true : false,


### PR DESCRIPTION
Add bsconfig value for resolving the `sourceRoot` at time of loading the config. 