### PR TITLE
Refactors PrintStatement so that `.values` array is all expressions

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, TypecastStatement, AliasStatement, ConditionalCompileStatement, ConditionalCompileConstStatement, ConditionalCompileErrorStatement, AugmentedAssignmentStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypecastExpression, TypeExpression, TypedArrayExpression } from '../parser/Expression';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypecastExpression, TypeExpression, TypedArrayExpression, PrintSeparatorExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BsDiagnostic, TypedefProvider } from '../interfaces';
@@ -294,6 +294,9 @@ export function isTypecastExpression(element: any): element is TypecastExpressio
 }
 export function isTypedArrayExpression(element: any): element is TypedArrayExpression {
     return element?.kind === AstNodeKind.TypedArrayExpression;
+}
+export function isPrintSeparatorExpression(element: any): element is PrintSeparatorExpression {
+    return element?.kind === AstNodeKind.PrintSeparatorExpression;
 }
 
 // BscType reflection

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -339,7 +339,7 @@ describe('astUtils visitors', () => {
             program.setFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 'PrintStatement:1:LiteralExpression',             // print <"msg">; 3
-                'PrintStatement:1:LiteralExpression',             // print "msg"<;> 3
+                'PrintStatement:1:PrintSeparatorExpression',             // print "msg"<;> 3
                 'PrintStatement:1:LiteralExpression',             // print "msg"; <3>
                 'PrintStatement:1:TemplateStringExpression',      // print <`expand ${var}`>
                 'PrintStatement:1:TemplateStringQuasiExpression', // print `<expand >${var}`

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -339,7 +339,7 @@ describe('astUtils visitors', () => {
             program.setFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 'PrintStatement:1:LiteralExpression',             // print <"msg">; 3
-                'PrintStatement:1:PrintSeparatorExpression',             // print "msg"<;> 3
+                'PrintStatement:1:PrintSeparatorExpression',      // print "msg"<;> 3
                 'PrintStatement:1:LiteralExpression',             // print "msg"; <3>
                 'PrintStatement:1:TemplateStringExpression',      // print <`expand ${var}`>
                 'PrintStatement:1:TemplateStringQuasiExpression', // print `<expand >${var}`

--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -339,6 +339,7 @@ describe('astUtils visitors', () => {
             program.setFile('source/main.brs', EXPRESSIONS_SRC);
             expect(actual).to.deep.equal([
                 'PrintStatement:1:LiteralExpression',             // print <"msg">; 3
+                'PrintStatement:1:LiteralExpression',             // print "msg"<;> 3
                 'PrintStatement:1:LiteralExpression',             // print "msg"; <3>
                 'PrintStatement:1:TemplateStringExpression',      // print <`expand ${var}`>
                 'PrintStatement:1:TemplateStringQuasiExpression', // print `<expand >${var}`

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -699,3 +699,12 @@ export const AllowedTriviaTokens: ReadonlyArray<TokenKind> = [
     TokenKind.Comment,
     TokenKind.Colon
 ];
+
+
+/**
+ * The tokens that are used as print separators
+ */
+export const PrintSeparatorTokens: ReadonlyArray<TokenKind> = [
+    TokenKind.Comma,
+    TokenKind.Semicolon
+];

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -1,3 +1,5 @@
+import type { Token } from './Token';
+
 export enum TokenKind {
     // parens (and friends)
     LeftParen = 'LeftParen', // (
@@ -708,3 +710,9 @@ export const PrintSeparatorTokens: ReadonlyArray<TokenKind> = [
     TokenKind.Comma,
     TokenKind.Semicolon
 ];
+/**
+ * Tokens that can be used between expressions in a print statement
+ */
+export type PrintSeparatorToken = Token & {
+    kind: TokenKind.Comma | TokenKind.Semicolon;
+};

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -704,14 +704,6 @@ export const AllowedTriviaTokens: ReadonlyArray<TokenKind> = [
 
 
 /**
- * The tokens that are used as print separators
- */
-export const PrintSeparatorTokens: ReadonlyArray<TokenKind> = [
-    TokenKind.Comma,
-    TokenKind.Semicolon
-];
-
-/**
  * Tokens that can be used between expressions in a print statement
  */
 export type PrintSeparatorToken = Token & {

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -290,5 +290,6 @@ export enum AstNodeKind {
     ConditionalCompileStatement = 'ConditionalCompileStatement',
     ConditionalCompileConstStatement = 'ConditionalCompileConstStatement',
     ConditionalCompileErrorStatement = 'ConditionalCompileErrorStatement',
-    AugmentedAssignmentStatement = 'AugmentedAssignmentStatement'
+    AugmentedAssignmentStatement = 'AugmentedAssignmentStatement',
+    PrintSeparatorExpression = 'PrintSeparatorExpression'
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
+import type { PrintSeparatorToken } from '../lexer/TokenKind';
 import { TokenKind } from '../lexer/TokenKind';
 import type { Block, NamespaceStatement } from './Statement';
 import type { Location } from 'vscode-languageserver';
@@ -971,7 +972,7 @@ export class LiteralExpression extends Expression {
  */
 export class PrintSeparatorExpression extends Expression {
     constructor(options: {
-        separator: Token;
+        separator: PrintSeparatorToken;
     }) {
         super();
         this.tokens = {
@@ -981,7 +982,7 @@ export class PrintSeparatorExpression extends Expression {
     }
 
     public readonly tokens: {
-        readonly separator: Token;
+        readonly separator: PrintSeparatorToken;
     };
 
     public readonly kind = AstNodeKind.PrintSeparatorExpression;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -839,6 +839,46 @@ export class LiteralExpression extends Expression {
 }
 
 /**
+ * The print statement can have a mix of expressions and separators. These separators represent actual output to the screen,
+ * so this AstNode represents those separators (comma, semicolon, and whitespace)
+ */
+export class PrintSeparatorExpression extends Expression {
+    constructor(options: {
+        separator: Token;
+    }) {
+        super();
+        this.tokens = {
+            separator: options.separator
+        };
+        this.location = this.tokens.separator.location;
+    }
+
+    public readonly tokens: {
+        readonly separator: Token;
+    };
+
+    public readonly kind = AstNodeKind.PrintSeparatorExpression;
+
+    public location: Location;
+
+    transpile(state: BrsTranspileState) {
+        return [
+            ...this.tokens.separator.leadingWhitespace ?? [],
+            ...state.transpileToken(this.tokens.separator)
+        ];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+
+    get leadingTrivia(): Token[] {
+        return this.tokens.separator.leadingTrivia;
+    }
+}
+
+
+/**
  * This is a special expression only used within template strings. It exists so we can prevent producing lots of empty strings
  * during template string transpile by identifying these expressions explicitly and skipping the bslib_toString around them
  */

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2428,16 +2428,13 @@ export class Parser {
     private printStatement(): PrintStatement {
         let printKeyword = this.advance();
 
-        let values: (
-            | Expression
-            | PrintSeparatorTab
-            | PrintSeparatorSpace)[] = [];
+        let values: Expression[] = [];
 
         while (!this.checkEndOfStatement()) {
             if (this.check(TokenKind.Semicolon)) {
-                values.push(this.advance() as PrintSeparatorSpace);
+                values.push(new LiteralExpression({ value: this.advance() as PrintSeparatorSpace }));
             } else if (this.check(TokenKind.Comma)) {
-                values.push(this.advance() as PrintSeparatorTab);
+                values.push(new LiteralExpression({ value: this.advance() as PrintSeparatorTab }));
             } else if (this.check(TokenKind.Else)) {
                 break; // inline branch
             } else {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1,6 +1,6 @@
 import type { Token, Identifier } from '../lexer/Token';
 import { isToken } from '../lexer/Token';
-import type { BlockTerminator } from '../lexer/TokenKind';
+import type { BlockTerminator, PrintSeparatorToken } from '../lexer/TokenKind';
 import { Lexer } from '../lexer/Lexer';
 import {
     AllowedLocalIdentifiers,
@@ -16,10 +16,6 @@ import {
     ReservedWords,
     CompoundAssignmentOperators
 } from '../lexer/TokenKind';
-import type {
-    PrintSeparatorSpace,
-    PrintSeparatorTab
-} from './Statement';
 import {
     AliasStatement,
     AssignmentStatement,
@@ -95,7 +91,8 @@ import {
     TypedArrayExpression,
     UnaryExpression,
     VariableExpression,
-    XmlAttributeGetExpression
+    XmlAttributeGetExpression,
+    PrintSeparatorExpression
 } from './Expression';
 import type { Range } from 'vscode-languageserver';
 import type { Logger } from '../logging';
@@ -2431,10 +2428,8 @@ export class Parser {
         let values: Expression[] = [];
 
         while (!this.checkEndOfStatement()) {
-            if (this.check(TokenKind.Semicolon)) {
-                values.push(new LiteralExpression({ value: this.advance() as PrintSeparatorSpace }));
-            } else if (this.check(TokenKind.Comma)) {
-                values.push(new LiteralExpression({ value: this.advance() as PrintSeparatorTab }));
+            if (this.checkAny(TokenKind.Semicolon, TokenKind.Comma)) {
+                values.push(new PrintSeparatorExpression({ separator: this.advance() as PrintSeparatorToken }));
             } else if (this.check(TokenKind.Else)) {
                 break; // inline branch
             } else {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -15,7 +15,7 @@ import { createInvalidLiteral, createMethodStatement, createToken } from '../ast
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { SymbolTable } from '../SymbolTable';
-import type { AstNode, Expression } from './AstNode';
+import type { Expression } from './AstNode';
 import { AstNodeKind, Statement } from './AstNode';
 import { ClassType } from '../types/ClassType';
 import { EnumMemberType, EnumType } from '../types/EnumType';
@@ -915,7 +915,7 @@ export class PrintStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         let result = [
-            state.transpileToken(this.tokens.print, 'print'),
+            state.transpileToken(this.tokens.print, 'print')
         ] as TranspileResult;
 
         //if the first expression has no leading whitespace, add a single space between the `print` and the expression

--- a/src/parser/tests/statement/PrintStatement.spec.ts
+++ b/src/parser/tests/statement/PrintStatement.spec.ts
@@ -189,8 +189,8 @@ describe('parser print statements', () => {
                     x = 5
                     print 25; " is equal to"; x ^ 2
                     a$ = "string"
-                    print a$; a$, a$; " "; a$
-                    print "zone 1", "zone 2", "zone 3", "zone 4"
+                    print a$;a$,a$;" ";a$
+                    print "zone 1","zone 2","zone 3","zone 4"
                     print "print statement #1 "
                     print "print statement #2"
                     print "this is a five " 5 "!!"
@@ -202,7 +202,7 @@ describe('parser print statements', () => {
                     print [
                         5
                     ]
-                    print tab(5) "tabbed 5"; tab(25) "tabbed 25"
+                    print tab(5) "tabbed 5";tab(25) "tabbed 25"
                     print tab(40) pos(0) 'prints 40 at position 40
                     print "these" tab(pos(0) + 5) "words" tab(pos(0) + 5) "are"
                     print tab(pos(0) + 5) "evenly" tab(pos(0) + 5) "spaced"


### PR DESCRIPTION
`;` and `,` are converted to `PrintSeparatorExpression`

Addresses #1280 