### PR TITLE
Adds diagnostic if no return statement found in function

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -809,6 +809,11 @@ export let DiagnosticMessages = {
         message: `Unsafe unmatched terminator '${terminator}' in conditional compilation block`,
         code: 1153,
         severity: DiagnosticSeverity.Error
+    }),
+    expectedReturnStatement: () => ({
+        message: `Expected return statement in function`,
+        code: 1154,
+        severity: DiagnosticSeverity.Error
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1301,6 +1301,7 @@ describe('Scope', () => {
                             return a + b
                         end function
                     }
+                    return aa
                 end function
             `);
             program.setFile('components/comp.xml', trim`
@@ -1535,10 +1536,9 @@ describe('Scope', () => {
                         end interface
 
                         function bar(param as MyNamespace.MyInterface) as MyNamespace.MyInterface
+                            return param
                         end function
-
                     end namespace
-
                 `);
                 program.validate();
 
@@ -1553,10 +1553,9 @@ describe('Scope', () => {
 
                     namespace MyNamespace
                         function bar(param as MyInterface) as MyInterface
+                            return param
                         end function
-
                     end namespace
-
                 `);
                 program.validate();
 
@@ -1571,10 +1570,9 @@ describe('Scope', () => {
                         end enum
 
                         function bar(param as MyNamespace.MyEnum) as MyNamespace.MyEnum
+                            return param
                         end function
-
                     end namespace
-
                 `);
                 program.validate();
 
@@ -1589,10 +1587,9 @@ describe('Scope', () => {
 
                     namespace MyNamespace
                         function bar(param as MyEnum) as MyEnum
+                            return param
                         end function
-
                     end namespace
-
                 `);
                 program.validate();
 
@@ -1606,13 +1603,13 @@ describe('Scope', () => {
                         end class
 
                         function foo(param as MyClass) as MyClass
+                            return param
                         end function
 
                         function bar(param as MyNamespace.MyClass) as MyNamespace.MyClass
+                            return param
                         end function
-
                     end namespace
-
                 `);
                 program.validate();
 
@@ -1627,6 +1624,7 @@ describe('Scope', () => {
                     end namespace
 
                     function foo(param as MyNamespace.MyClass) as MyNamespace.MyClass
+                        return param
                     end function
                 `);
                 program.validate();
@@ -1668,6 +1666,7 @@ describe('Scope', () => {
                     namespace MyNamespace
                         class OtherKlass
                             function beClassy() as MyNamespace.Klass
+                                return new Klass()
                             end function
                         end class
                     end namespace
@@ -1698,6 +1697,7 @@ describe('Scope', () => {
             it('finds custom types from other other files', () => {
                 program.setFile(`source/main.bs`, `
                     function foo(param as MyClass) as MyClass
+                        return param
                     end function
                 `);
                 program.setFile(`source/MyClass.bs`, `
@@ -1712,6 +1712,7 @@ describe('Scope', () => {
             it('finds custom types from other other files', () => {
                 program.setFile(`source/main.bs`, `
                     function foo(param as MyNameSpace.MyClass) as MyNameSpace.MyClass
+                        return param
                     end function
                 `);
                 program.setFile(`source/MyNameSpace.bs`, `
@@ -1798,6 +1799,7 @@ describe('Scope', () => {
                 `);
                 program.setFile(s`components/child.bs`, `
                     function getFoo() as MyClass
+                        return invalid
                     end function
                 `);
 

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -2264,6 +2264,51 @@ describe('ScopeValidator', () => {
                 }).message
             ]);
         });
+
+        it('allows function with no return types with void return value', () => {
+            program.setFile('source/util.bs', `
+                function doSomething()
+                    return
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows function with dynamic return types with void return value ', () => {
+            program.setFile('source/util.bs', `
+                function doSomething() as dynamic
+                    return
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+
+        it('validates for sub with return types with no return value', () => {
+            program.setFile('source/util.bs', `
+                sub doSomething() as integer
+                    return
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.returnTypeMismatch('void', 'integer').message
+            ]);
+        });
+
+        it('validates for function with void return types with non-void return value', () => {
+            program.setFile('source/util.bs', `
+                function doSomething() as void
+                    return 123
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.returnTypeMismatch('integer', 'void').message
+            ]);
+        });
     });
 
     describe('expectedReturnStatement', () => {
@@ -2349,6 +2394,28 @@ describe('ScopeValidator', () => {
                         return 2
                     end if
                 end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('works for sub with return types with missing return', () => {
+            program.setFile('source/util.bs', `
+                sub doSomething() as integer
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.expectedReturnStatement().message
+            ]);
+        });
+
+
+        it('works for sub with return types', () => {
+            program.setFile('source/util.bs', `
+                sub doSomething() as integer
+                    return 1
+                end sub
             `);
             program.validate();
             expectZeroDiagnostics(program);

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2099,27 +2099,30 @@ describe('BrsFile', () => {
         });
 
         it('retains casing of return types', async () => {
-            async function test(type: string) {
+            async function test(type: string, result: string) {
                 await testTranspile(`
                     sub one() as ${type}
+                        return ${result}
                     end sub
 
                     sub two() as ${type.toLowerCase()}
+                        return ${result}
                     end sub
 
                     sub three() as ${type.toUpperCase()}
+                        return ${result}
                     end sub
                 `);
             }
-            await test('Boolean');
-            await test('Double');
-            await test('Dynamic');
-            await test('Float');
-            await test('Integer');
-            await test('LongInteger');
-            await test('Object');
-            await test('String');
-            await test('Void');
+            await test('Boolean', 'true');
+            await test('Double', '1.23');
+            await test('Dynamic', 'invalid');
+            await test('Float', '1.23');
+            await test('Integer', '123');
+            await test('LongInteger', '123');
+            await test('Object', '{}');
+            await test('String', '"test"');
+            await test('Void', '');
         });
 
         it('retains casing of literal types', async () => {
@@ -2508,6 +2511,7 @@ describe('BrsFile', () => {
         it('keeps function parameter types in proper order', async () => {
             await testTranspile(`
                 function CreateTestStatistic(name as string, result = "Success" as string, time = 0 as integer, errorCode = 0 as integer, errorMessage = "" as string) as object
+                    return {}
                 end function
             `);
         });

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -82,7 +82,7 @@ function cloneDiagnostic(actualDiagnosticInput: BsDiagnostic, expectedDiagnostic
         ['message', 'code', 'severity', 'relatedInformation']
     );
     //clone Location if available
-    if (expectedDiagnostic.location) {
+    if (expectedDiagnostic?.location) {
         actualDiagnostic.location = cloneObject(actualDiagnosticInput.location, expectedDiagnostic.location, ['uri', 'range']) as any;
     }
     //deep clone relatedInformation if available


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8f2c95ff-d395-4cef-8c6a-b35fe29216dc)

If a function explicitly says it will return something, ensure there is a return statement.

This could be improved by checking all branches.

I know there's a BSLint option that basically checks the same thing, but if you don't have a return statement when you say you're going to return a string or an integer, it will crash.

