### PR TITLE
Prevent crash for missing classtype name

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1256,4 +1256,10 @@ describe('util', () => {
             );
         });
     });
+
+    describe('isClassUsedAsFunction', () => {
+        it('does not crash when class type has no name', () => {
+            util.isClassUsedAsFunction(new ClassType(undefined), undefined, { flags: SymbolTypeFlag.runtime });
+        });
+    });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -2378,8 +2378,8 @@ export class Util {
         if ((options?.flags ?? 0) & SymbolTypeFlag.runtime &&
             isClassType(potentialClassType) &&
             !options.isExistenceTest &&
-            potentialClassType.name.toLowerCase() === this.getAllDottedGetPartsAsString(expression).toLowerCase() &&
-            !expression.findAncestor(isNewExpression)) {
+            potentialClassType.name?.toLowerCase() === this.getAllDottedGetPartsAsString(expression)?.toLowerCase() &&
+            !expression?.findAncestor(isNewExpression)) {
             return true;
         }
         return false;


### PR DESCRIPTION
Prevent a runtime exception in the validator whenever `ClassType.name` is missing. I'm not sure how to reproduce this, but it's good enough to harden this code so it doesn't happen.