### PR TITLE
Fix semantic tokens for components and interfaces, and m

### DIFF
--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -503,6 +503,36 @@ describe('BrsFileSemanticTokensProcessor', () => {
         ], false);
     });
 
+    it('does not color variable of type roSGNode as a type', () => {
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            sub main()
+                node = CreateObject("roSGNode", "ContentNode")
+                node.id = "content"
+            end sub
+        `);
+        program.validate();
+        expectSemanticTokensIncludes(file, [
+            // |node|.id = "content"
+            [SemanticTokenTypes.variable, 3, 16, 3, 20]
+        ], false);
+    });
+
+    it('does not color variable when it is an instance of an interface', () => {
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            sub main(video as Movie)
+                video.url = "http://example.com"
+            end sub
+            interface Movie
+                url as string
+            end interface
+        `);
+        program.validate();
+        expectSemanticTokensIncludes(file, [
+            // |video|.url = "http://example.com"
+            [SemanticTokenTypes.variable, 2, 16, 2, 21]
+        ], false);
+    });
+
     it('works for `new` statement', () => {
         const file = program.setFile<BrsFile>('source/main.bs', `
             class Person

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.spec.ts
@@ -452,8 +452,6 @@ describe('BrsFileSemanticTokensProcessor', () => {
         expectSemanticTokens(file, [
             // sub |init|()
             [SemanticTokenTypes.function, 1, 16, 1, 20],
-            // |m|.alien = new Humanoids.Aliens.Alien.NOT_A_CLASS() 'bs:disable-line
-            [SemanticTokenTypes.variable, 2, 16, 2, 17],
             // m.alien = new |Humanoids|.Aliens.Alien.NOT_A_CLASS() 'bs:disable-line
             [SemanticTokenTypes.namespace, 2, 30, 2, 39],
             // m.alien = new Humanoids.|Aliens|.Alien.NOT_A_CLASS() 'bs:disable-line

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -1,6 +1,6 @@
 import { SemanticTokenModifiers } from 'vscode-languageserver-protocol';
 import { SemanticTokenTypes } from 'vscode-languageserver-protocol';
-import { isCallableType, isClassType, isComponentType, isConstStatement, isDottedGetExpression, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionStatement, isInterfaceType, isNamespaceType, isVariableExpression } from '../../astUtils/reflection';
+import { isCallableType, isClassType, isComponentType, isConstStatement, isDottedGetExpression, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionStatement, isInterfaceType, isNamespaceType, isTypeExpression, isVariableExpression } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { ExtraSymbolData, OnGetSemanticTokensEvent, SemanticToken, TypeChainEntry } from '../../interfaces';
 import type { Locatable, Token } from '../../lexer/Token';
@@ -132,9 +132,9 @@ export class BrsFileSemanticTokensProcessor {
             } else {
                 return { type: SemanticTokenTypes.method };
             }
-        } else if (isInterfaceType(type)) {
+        } else if (isInterfaceType(type) && extraData.isInstance !== true) {
             return { type: SemanticTokenTypes.interface };
-        } else if (isComponentType(type)) {
+        } else if (isComponentType(type) && extraData.isInstance !== true) {
             return { type: SemanticTokenTypes.class };
         } else if (isEnumType(type)) {
             return { type: SemanticTokenTypes.enum };
@@ -146,7 +146,11 @@ export class BrsFileSemanticTokensProcessor {
         } else if (isConstStatement(node)) {
             return { type: SemanticTokenTypes.variable, modifiers: [SemanticTokenModifiers.readonly, SemanticTokenModifiers.static] };
         } else if (isVariableExpression(node)) {
-            return { type: SemanticTokenTypes.variable };
+            if (/m/i.test(node.tokens?.name?.text)) {
+                //don't color `m` variables
+            } else {
+                return { type: SemanticTokenTypes.variable };
+            }
         } else {
             //we don't know what it is...return undefined to prevent creating a semantic token
         }

--- a/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
+++ b/src/bscPlugin/semanticTokens/BrsFileSemanticTokensProcessor.ts
@@ -1,6 +1,6 @@
 import { SemanticTokenModifiers } from 'vscode-languageserver-protocol';
 import { SemanticTokenTypes } from 'vscode-languageserver-protocol';
-import { isCallableType, isClassType, isComponentType, isConstStatement, isDottedGetExpression, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionStatement, isInterfaceType, isNamespaceType, isTypeExpression, isVariableExpression } from '../../astUtils/reflection';
+import { isCallableType, isClassType, isComponentType, isConstStatement, isDottedGetExpression, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionStatement, isInterfaceType, isNamespaceType, isVariableExpression } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
 import type { ExtraSymbolData, OnGetSemanticTokensEvent, SemanticToken, TypeChainEntry } from '../../interfaces';
 import type { Locatable, Token } from '../../lexer/Token';


### PR DESCRIPTION
Fix incorrect semantic token colorization for instances of components and interfaces. Since they're _instances_, they should be normal variable colors. 

Also fixes incorrect `m` colorization

**Before:**
![image](https://github.com/user-attachments/assets/dcbd80e2-290c-4288-abc4-7f6497397c58)


**After (fixed):**
![image](https://github.com/user-attachments/assets/86a51e22-c07c-43ca-b3d7-1bf9a8f2ee28)


Fixes #1308 