### PR TITLE
Fixes transpile issue with global functions

### DIFF
--- a/src/bscPlugin/serialize/FileSerializer.ts
+++ b/src/bscPlugin/serialize/FileSerializer.ts
@@ -16,6 +16,7 @@ export class FileSerializer {
         if (this.event.result.has(this.event.file)) {
             return;
         }
+        this.event.scope?.linkSymbolTable();
         if (isBrsFile(this.event.file)) {
             this.serializeBrsFile(this.event.file);
         } else if (isXmlFile(this.event.file)) {
@@ -23,6 +24,7 @@ export class FileSerializer {
         } else if (isAssetFile(this.event.file)) {
             this.serializeAssetFile(this.event.file);
         }
+        this.event.scope?.unlinkSymbolTable();
     }
 
     private serializeBrsFile(file: BrsFile) {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2282,6 +2282,68 @@ describe('BrsFile', () => {
                 `);
             });
 
+            it('does not prefix global function names', async () => {
+                await testTranspile(`
+                    namespace is
+                        function valid(thing) as boolean
+                            return invalid <> thing
+                        end function
+
+                        function node(thing) as boolean
+                            return valid(thing) and valid(getInterface(thing, "ifSgNodeChildren"))
+                        end function
+                    end namespace`, `
+                    function is_valid(thing) as boolean
+                        return invalid <> thing
+                    end function
+
+                    function is_node(thing) as boolean
+                        return is_valid(thing) and is_valid(getInterface(thing, "ifSgNodeChildren"))
+                    end function`
+                );
+            });
+
+            it('does not prefix unnamespaced function names', async () => {
+                await testTranspile(`
+                    function valid(thing) as boolean
+                        return invalid <> thing
+                    end function
+
+                    namespace is
+                          function node(thing) as boolean
+                            return valid(thing) and valid(getInterface(thing, "ifSgNodeChildren"))
+                        end function
+                    end namespace`, `
+                    function valid(thing) as boolean
+                        return invalid <> thing
+                    end function
+                    function is_node(thing) as boolean
+                        return valid(thing) and valid(getInterface(thing, "ifSgNodeChildren"))
+                    end function`
+                );
+            });
+
+            it('does not prefix unnamespaced function names in deep namespace', async () => {
+                await testTranspile(`
+                     namespace is.a.deep.namespace
+                        function valid(thing) as boolean
+                            return invalid <> thing
+                        end function
+
+                        function node(thing) as boolean
+                            return valid(thing) and valid(getInterface(thing, "ifSgNodeChildren"))
+                        end function
+                    end namespace`, `
+                    function is_a_deep_namespace_valid(thing) as boolean
+                        return invalid <> thing
+                    end function
+
+                    function is_a_deep_namespace_node(thing) as boolean
+                        return is_a_deep_namespace_valid(thing) and is_a_deep_namespace_valid(getInterface(thing, "ifSgNodeChildren"))
+                    end function`
+                );
+            });
+
         });
 
         describe('shadowing', () => {


### PR DESCRIPTION
Fixes issue where use of global functions in a namespace would cause tranpilier to prefix the functions
fixes #1307 

Given:

```
                  namespace is
                        function node(thing) as boolean
                            return invalid <> getInterface(thing, "ifSgNodeChildren")
                        end function
                    end namespace
```


before would transpile to:
```
                        function is_node(thing) as boolean
                            return invalid <> is_getInterface(thing, "ifSgNodeChildren")
                        end function
```

now transpiles to:

```
                        function is_node(thing) as boolean
                            return invalid <> getInterface(thing, "ifSgNodeChildren")
                        end function
```