### PR TITLE
Prevent crash when ProgramBuilder.run called with no options

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -131,6 +131,11 @@ describe('ProgramBuilder', () => {
     });
 
     describe('run', () => {
+        it('does not crash when options is undefined', async () => {
+            sinon.stub(builder as any, 'runOnce').callsFake(() => { });
+            await builder.run(undefined as any);
+        });
+
         it('uses default options when the config file fails to parse', async () => {
             //supress the console log statements for the bsconfig parse errors
             sinon.stub(console, 'log').returns(undefined);

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -95,7 +95,9 @@ export class ProgramBuilder {
     }
 
     public async run(options: BsConfig) {
-        this.logger.logLevel = options.logLevel;
+        if (options?.logLevel) {
+            this.logger.logLevel = options.logLevel;
+        }
 
         if (this.isRunning) {
             throw new Error('Server is already running');


### PR DESCRIPTION
Fixes a crash when calling ProgramBuilder.run with undefined options.