### PR TITLE
Fix bslib prefix transpile

### DIFF
--- a/src/bscPlugin/serialize/BslibInjector.spec.ts
+++ b/src/bscPlugin/serialize/BslibInjector.spec.ts
@@ -2,18 +2,48 @@ import { createSandbox } from 'sinon';
 import * as fsExtra from 'fs-extra';
 import { Program } from '../../Program';
 import { tempDir, rootDir } from '../../testHelpers.spec';
+import { BslibManager } from './BslibManager';
+import { expect } from 'chai';
 const sinon = createSandbox();
 
 describe('BslibInjector', () => {
 
     let program: Program;
+    let manager: BslibManager;
 
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
         program = new Program({ rootDir: rootDir, sourceMap: true });
+        manager = new BslibManager();
     });
     afterEach(() => {
         sinon.restore();
         program.dispose();
+    });
+
+    describe('isBslibPkgPath', () => {
+        it('works for valid paths', () => {
+            expect(
+                BslibManager.isBslibPkgPath('source/bslib.brs')
+            ).to.be.true;
+            expect(
+                BslibManager.isBslibPkgPath('source/roku_modules/bslib/bslib.brs')
+            ).to.be.true;
+            expect(
+                BslibManager.isBslibPkgPath('source/roku_modules/rokucommunity_bslib/bslib.brs')
+            ).to.be.true;
+        });
+
+        it('works for invalid paths', () => {
+            expect(
+                BslibManager.isBslibPkgPath('source/bslib2.brs')
+            ).to.be.false;
+            expect(
+                BslibManager.isBslibPkgPath('source/roku_modules/1bslib/bslib.brs')
+            ).to.be.false;
+            expect(
+                BslibManager.isBslibPkgPath('source/roku_modules/rokucommunity_bslib/3bslib.brs')
+            ).to.be.false;
+        });
     });
 });

--- a/src/bscPlugin/serialize/BslibManager.ts
+++ b/src/bscPlugin/serialize/BslibManager.ts
@@ -3,6 +3,8 @@ import { standardizePath as s } from '../../util';
 import { source as bslibSource } from '@rokucommunity/bslib';
 import { Cache } from '../../Cache';
 import { BrsFile } from '../../files/BrsFile';
+import type { FunctionStatement } from '../../parser/Statement';
+import type { Editor } from '../../astUtils/Editor';
 const bslibSrcPath = s`${require.resolve('@rokucommunity/bslib')}/dist/source/bslib.brs`;
 export class BslibManager {
 
@@ -28,10 +30,17 @@ export class BslibManager {
         }
     }
 
+    public static applyPrefixIfMissing(statement: FunctionStatement, editor: Editor, prefix: string) {
+        //add the bslib prefix if the function does not start with bslib_ or rokucommunity_bslib_
+        if (!/^(rokucommunity_)?bslib_/i.test(statement.tokens.name.text)) {
+            editor.setProperty(statement.tokens.name, 'text', `${prefix}_${statement.tokens.name.text}`);
+        }
+    }
+
     /**
      * Is the pkgPath a support path to bslib?
      */
     public static isBslibPkgPath(pkgPath: string) {
-        return /(source[\\\/]bslib.brs)|(source[\\\/]roku_modules[\\\/]bslib[\\\/]bslib.brs)$/i.test(pkgPath);
+        return /(source[\\\/]bslib.brs)|(source[\\\/]roku_modules[\\\/](rokucommunity_)?bslib)[\\\/]bslib.brs$/i.test(pkgPath);
     }
 }

--- a/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFileTranspileProcessor.ts
@@ -24,17 +24,14 @@ export class BrsFilePreTranspileProcessor {
         this.iterateExpressions();
         //apply prefixes to bslib
         if (BslibManager.isBslibPkgPath(this.event.file.pkgPath)) {
-            this.applyPrefixesIfMissing(this.event.file, this.event.editor);
+            this.applyBslibPrefixesIfMissing(this.event.file, this.event.editor);
         }
     }
 
-    public applyPrefixesIfMissing(file: BrsFile, editor: Editor) {
+    public applyBslibPrefixesIfMissing(file: BrsFile, editor: Editor) {
         file.ast.walk(createVisitor({
             FunctionStatement: (statement) => {
-                //add the bslib prefix
-                if (!statement.tokens.name.text.startsWith('bslib_')) {
-                    editor.setProperty(statement.tokens.name, 'text', `bslib_${statement.tokens.name.text}`);
-                }
+                BslibManager.applyPrefixIfMissing(statement, editor, this.event.program.bslibPrefix);
             }
         }), {
             walkMode: WalkMode.visitAllRecursive


### PR DESCRIPTION
Fixes a bug with transpiling the bslib prefix in certain situations (specifically when using rokucommunity_bslib). This somehow broke in v1.0.0-alpha.37 and remained broken in v1.0.0-alpha.38.