### PR TITLE
Fixes using upper namespaced function indirectly

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -110,14 +110,18 @@ end sub
 ```
 </details>
 
-## Sharing name of namespaced item and non-namespaced item is prohibited
-The compiler will throw an error whenever it encounters a namespaced function with the same name as a global function. The same rule applies to classes.
+## Sharing name of namespaced item and non-namespaced items
+The compiler allows a namespaced function with the same name as a global function. As per the [name-shadowing](./variable-shadowing.md) rules, the function inside the namespace will be used in the transpiled code. The same rule applies to classes.
 
 ```BrighterScript
 sub Quack()
 end sub
 namespace Vertibrates.Birds
-    sub Quack() ' this will result in a compile error.
+    sub Quack()
+    end sub
+
+    sub Speak()
+        Quack() ' calls the function Vertibrates.Birds.Quack()
     end sub
 end namespace
 ```
@@ -128,7 +132,10 @@ end namespace
 ```BrightScript
 sub Quack()
 end sub
-sub Vertibrates_Birds_Quack() ' this will result in a compile error.
+sub Vertibrates_Birds_Quack()
+end sub
+sub Vertibrates_Birds_Speak()
+    Vertibrates_Birds_Quack() ' calls the function Vertibrates.Birds.Quack()
 end sub
 ```
 </details>
@@ -158,6 +165,37 @@ end namespace
 sub Vertibrates_Birds_Quack()
 end sub
 sub Vertibrates_Reptiles_Hiss()
+end sub
+```
+</details>
+
+## Calling parent namespace functions
+
+Brighterscript does not support accessing a function (or other entity) of a parent namespace without fully qualifying the name of the function.
+
+```BrighterScript
+namespace Vertibrates
+    sub Move()
+    end sub
+
+    namespace Birds
+        sub Fly()
+            Move() ' this is an error - no global Move() function
+            Vertibrates.Move() ' this is allowed
+        end sub
+    end namespace
+end namespace
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```BrightScript
+sub Vertibrates_Move()
+end sub
+sub Vertibrates_Birds_Fly()
+     Move() ' this is an error - no global Move() function
+     Vertibrates_Move() ' this is allowed
 end sub
 ```
 </details>

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1839,6 +1839,44 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('has error when referencing something in outer namespace directly', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    sub foo()
+                    end sub
+
+                    namespace beta
+                        sub bar()
+                            foo()
+                        end sub
+                    end namespace
+                end namespace
+            `);
+
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindFunction('foo').message
+            ]);
+        });
+
+        it('allows referencing something in outer namespace with namespace in front', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    sub foo()
+                    end sub
+
+                    namespace beta
+                        sub bar()
+                            alpha.foo()
+                        end sub
+                    end namespace
+                end namespace
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('itemCannotBeUsedAsVariable', () => {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -227,6 +227,30 @@ describe('ScopeValidator', () => {
             //should have an error
             expectZeroDiagnostics(program);
         });
+
+        it('validates against scope-defined func in inner namespace, when outer namespace has same named func', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    sub foo()
+                    end sub
+
+                    namespace beta
+                        sub bar()
+                            foo()
+                        end sub
+                    end namespace
+                end namespace
+
+                function foo(x as integer) as integer
+                    return x
+                end function
+            `);
+
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount(1, 0).message
+            ]);
+        });
     });
 
     describe('argumentTypeMismatch', () => {
@@ -1872,6 +1896,28 @@ describe('ScopeValidator', () => {
                         end sub
                     end namespace
                 end namespace
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows referencing scope-defined func in inner namespace, when outer namespace has same named func', () => {
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    sub foo()
+                    end sub
+
+                    namespace beta
+                        sub bar()
+                            foo(1)
+                        end sub
+                    end namespace
+                end namespace
+
+                function foo(x as integer) as integer
+                    return x
+                end function
             `);
 
             program.validate();

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2344,6 +2344,47 @@ describe('BrsFile', () => {
                 );
             });
 
+            it('transpiles namespaced functions when used as variables', async () => {
+                await testTranspile(`
+                    namespace Vertibrates.Birds
+                        function GetAllBirds()
+                            return [
+                                GetDuck(),
+                                GetGoose()
+                            ]
+                        end function
+
+                        function GetDuck()
+                        end function
+
+                        function GetGoose()
+                        end function
+
+                        function Test()
+                            duckGetter = Vertibrates.Birds.GetDuck
+                            gooseGetter = GetGoose
+                        end function
+                    end namespace`, `
+                    function Vertibrates_Birds_GetAllBirds()
+                        return [
+                            Vertibrates_Birds_GetDuck()
+                            Vertibrates_Birds_GetGoose()
+                        ]
+                    end function
+
+                    function Vertibrates_Birds_GetDuck()
+                    end function
+
+                    function Vertibrates_Birds_GetGoose()
+                    end function
+
+                    function Vertibrates_Birds_Test()
+                        duckGetter = Vertibrates_Birds_GetDuck
+                        gooseGetter = Vertibrates_Birds_GetGoose
+                    end function
+               `);
+            });
+
         });
 
         describe('shadowing', () => {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1879,7 +1879,7 @@ export class NamespaceStatement extends Statement implements TypedefProvider {
         };
         this.nameExpression = options.nameExpression;
         this.body = options.body;
-        this.symbolTable = new SymbolTable(`NamespaceStatement: '${this.name}'`, () => this.parent?.getSymbolTable());
+        this.symbolTable = new SymbolTable(`NamespaceStatement: '${this.name}'`, () => this.getRoot()?.getSymbolTable());
     }
 
     public readonly tokens: {


### PR DESCRIPTION
Fixes:

```brighterscript
namespace alpha
    sub foo()
    end sub

    namespace beta
        sub bar()
            foo()  ' this SHOULD be a an error -- no function foo() at file scope.
        end sub
    end namespace
end namespace
```

From this slack conversation: https://rokudevelopers.slack.com/archives/CKF1QQGTY/p1728307032364379

