### PR TITLE
Fix namespace-relative transpile bug for standalone file

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2641,6 +2641,38 @@ describe('BrsFile', () => {
                 `);
             });
 
+            it('transpiles namespace calls from within an array', () => {
+                testTranspile(`
+                    namespace Vertibrates.Birds
+                        function GetAllBirds()
+                            return [
+                                GetDuck(),
+                                GetGoose()
+                            ]
+                        end function
+
+                        function GetDuck()
+                        end function
+
+                        function GetGoose()
+                        end function
+                    end namespace
+                    `, `
+                        function Vertibrates_Birds_GetAllBirds()
+                            return [
+                                Vertibrates_Birds_GetDuck()
+                                Vertibrates_Birds_GetGoose()
+                            ]
+                        end function
+
+                        function Vertibrates_Birds_GetDuck()
+                        end function
+
+                        function Vertibrates_Birds_GetGoose()
+                        end function
+                `, undefined, 'components/NobodyImportsMe.bs', false);
+            });
+
             it('properly transpiles inferred namespace function for assignment', () => {
                 testTranspile(`
                     namespace NameA.NameB

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -5,7 +5,7 @@ import { CancellationTokenSource } from 'vscode-languageserver';
 import { CompletionItemKind, TextEdit } from 'vscode-languageserver';
 import chalk from 'chalk';
 import * as path from 'path';
-import type { Scope } from '../Scope';
+import { Scope } from '../Scope';
 import { DiagnosticCodeMap, diagnosticCodes, DiagnosticMessages } from '../DiagnosticMessages';
 import { FunctionScope } from '../FunctionScope';
 import type { Callable, CallableArg, CallableParam, CommentFlag, FunctionCall, BsDiagnostic, FileReference, FileLink, BscFile } from '../interfaces';
@@ -1243,6 +1243,15 @@ export class BrsFile {
             let lowerCalleeName = callee?.name?.text?.toLowerCase();
             if (lowerCalleeName) {
                 let scopes = this.program.getScopesForFile(this);
+
+                //if this file does not belong to any scopes, make a temporary one to answer the question
+                if (scopes.length === 0) {
+                    const scope = new Scope(`temporary-for-${this.pkgPath}`, this.program);
+                    scope.getAllFiles = () => [this];
+                    scope.getOwnFiles = scope.getAllFiles;
+                    scopes.push(scope);
+                }
+
                 for (let scope of scopes) {
                     let namespace = scope.namespaceLookup.get(namespaceName.toLowerCase());
                     if (namespace?.functionStatements[lowerCalleeName]) {


### PR DESCRIPTION
Fixes a bug with namespace-relative function calls when the file is a member of no scopes.