### PR TITLE
Fix issues with the .gitignore loading for pathFilterer

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -22,6 +22,7 @@ import type { Project } from './lsp/Project';
 import { LogLevel, Logger, createLogger } from './logging';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { standardizePath } from 'roku-deploy';
+import undent from 'undent';
 
 const sinon = createSandbox();
 
@@ -575,6 +576,133 @@ describe('LanguageServer', () => {
             await server['syncLogLevel']();
 
             expect(server.logger.logLevel).to.eql(LogLevel.info);
+        });
+    });
+
+    describe.only('rebuildPathFilterer', () => {
+        let workspaceConfigs: WorkspaceConfigWithExtras[] = [];
+        beforeEach(() => {
+            workspaceConfigs = [
+                {
+                    bsconfigPath: undefined,
+                    languageServer: {
+                        enableThreading: true,
+                        logLevel: 'info'
+                    },
+                    workspaceFolder: workspacePath,
+                    excludePatterns: []
+                } as WorkspaceConfigWithExtras
+            ];
+            server['connection'] = connection as any;
+            sinon.stub(server as any, 'getWorkspaceConfigs').callsFake(() => Promise.resolve(workspaceConfigs));
+        });
+
+        it('allows files from dist by default', async () => {
+            const filterer = await server['rebuildPathFilterer']();
+            //certain files are allowed through by default
+            expect(
+                filterer.filter([
+                    s`${rootDir}/manifest`,
+                    s`${rootDir}/dist/file.brs`,
+                    s`${rootDir}/source/file.brs`
+                ])
+            ).to.eql([
+                s`${rootDir}/manifest`,
+                s`${rootDir}/dist/file.brs`,
+                s`${rootDir}/source/file.brs`
+            ]);
+        });
+
+        it('filters out some standard locations by default', async () => {
+            const filterer = await server['rebuildPathFilterer']();
+
+            expect(
+                filterer.filter([
+                    s`${workspacePath}/node_modules/file.brs`,
+                    s`${workspacePath}/.git/file.brs`,
+                    s`${workspacePath}/out/file.brs`,
+                    s`${workspacePath}/.roku-deploy-staging/file.brs`
+                ])
+            ).to.eql([]);
+        });
+
+        it('properly handles a .gitignore list', async () => {
+            fsExtra.outputFileSync(s`${workspacePath}/.gitignore`, undent`
+                dist/
+            `);
+
+            const filterer = await server['rebuildPathFilterer']();
+
+            //filters files that appear in a .gitignore list
+            expect(
+                filterer.filter([
+                    s`${workspacePath}/src/source/file.brs`,
+                    s`${workspacePath}/dist/source/file.brs`
+                ])
+            ).to.eql([
+                s`${workspacePath}/src/source/file.brs`
+            ]);
+        });
+
+        it('does not crash for path outside of workspaceFolder', async () => {
+            fsExtra.outputFileSync(s`${workspacePath}/.gitignore`, undent`
+                dist/
+            `);
+
+            const filterer = await server['rebuildPathFilterer']();
+
+            //filters files that appear in a .gitignore list
+            expect(
+                filterer.filter([
+                    s`${workspacePath}/../flavor1/src/source/file.brs`
+                ])
+            ).to.eql([
+                //since the path is outside the workspace, it does not match the .gitignore patter, and thus is not excluded
+                s`${workspacePath}/../flavor1/src/source/file.brs`
+            ]);
+        });
+
+        it('a gitignore file from any workspace will apply to all workspaces', async () => {
+            workspaceConfigs = [{
+                bsconfigPath: undefined,
+                languageServer: {
+                    enableThreading: true,
+                    logLevel: 'info'
+                },
+                workspaceFolder: s`${tempDir}/flavor1`,
+                excludePatterns: []
+            }, {
+                bsconfigPath: undefined,
+                languageServer: {
+                    enableThreading: true,
+                    logLevel: 'info'
+                },
+                workspaceFolder: s`${tempDir}/flavor2`,
+                excludePatterns: []
+            }] as WorkspaceConfigWithExtras[];
+            fsExtra.outputFileSync(s`${workspaceConfigs[0].workspaceFolder}/.gitignore`, undent`
+                dist/
+            `);
+            fsExtra.outputFileSync(s`${workspaceConfigs[1].workspaceFolder}/.gitignore`, undent`
+                out/
+            `);
+
+            const filterer = await server['rebuildPathFilterer']();
+
+            //filters files that appear in a .gitignore list
+            expect(
+                filterer.filter([
+                    //included files
+                    s`${workspaceConfigs[0].workspaceFolder}/src/source/file.brs`,
+                    s`${workspaceConfigs[1].workspaceFolder}/src/source/file.brs`,
+                    //excluded files
+                    s`${workspaceConfigs[0].workspaceFolder}/dist/source/file.brs`,
+                    s`${workspaceConfigs[1].workspaceFolder}/out/source/file.brs`
+                ])
+            ).to.eql([
+                s`${workspaceConfigs[0].workspaceFolder}/src/source/file.brs`,
+                s`${workspaceConfigs[1].workspaceFolder}/src/source/file.brs`
+            ]);
         });
     });
 

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -579,7 +579,7 @@ describe('LanguageServer', () => {
         });
     });
 
-    describe.only('rebuildPathFilterer', () => {
+    describe('rebuildPathFilterer', () => {
         let workspaceConfigs: WorkspaceConfigWithExtras[] = [];
         beforeEach(() => {
             workspaceConfigs = [

--- a/src/lsp/PathFilterer.spec.ts
+++ b/src/lsp/PathFilterer.spec.ts
@@ -2,12 +2,18 @@ import { PathCollection, PathFilterer } from './PathFilterer';
 import { cwd, rootDir } from '../testHelpers.spec';
 import { expect } from 'chai';
 import { standardizePath as s } from '../util';
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
 
 describe('PathFilterer', () => {
     let filterer: PathFilterer;
 
     beforeEach(() => {
         filterer = new PathFilterer();
+        sinon.restore();
+    });
+    afterEach(() => {
+        sinon.restore();
     });
 
     it('allows all files through when no filters exist', () => {
@@ -155,4 +161,20 @@ describe('PathFilterer', () => {
         ).to.eql([]);
     });
 
+    describe.only('registerExcludeMatcher', () => {
+        it('calls the callback function on every path', () => {
+            const spy = sinon.spy();
+            filterer.registerExcludeMatcher(spy);
+            filterer.filter([
+                s`${rootDir}/a.brs`,
+                s`${rootDir}/b.txt`,
+                s`${rootDir}/c.brs`
+            ]);
+            expect(spy.getCalls().map(x => s`${x.args[0]}`)).to.eql([
+                s`${rootDir}/a.brs`,
+                s`${rootDir}/b.txt`,
+                s`${rootDir}/c.brs`
+            ]);
+        });
+    });
 });

--- a/src/lsp/PathFilterer.spec.ts
+++ b/src/lsp/PathFilterer.spec.ts
@@ -161,7 +161,7 @@ describe('PathFilterer', () => {
         ).to.eql([]);
     });
 
-    describe.only('registerExcludeMatcher', () => {
+    describe('registerExcludeMatcher', () => {
         it('calls the callback function on every path', () => {
             const spy = sinon.spy();
             filterer.registerExcludeMatcher(spy);

--- a/src/lsp/PathFilterer.ts
+++ b/src/lsp/PathFilterer.ts
@@ -135,6 +135,7 @@ export class PathFilterer {
         const collection = new PathCollection({
             matcher: matcher
         });
+        this.excludeCollections.push(collection);
         return () => {
             this.removeCollection(collection);
         };


### PR DESCRIPTION
Fixes bugs with the .gitignore entries in PathFilterer for the language server. There were several bugs in there:
 - the `PathFilterer` wasn't registering the exclusion callbacks
 - the gitignore function (called `ignore`) requires relative paths with no `../` or absolute paths, so we need to call `path.relative()` and exclude any paths not matched
