### PR TITLE
Quiet down grouping expressions in cached lookups

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -14,7 +14,7 @@ import type { BsConfig } from './BsConfig';
 import type { BscFile } from './files/BscFile';
 import { tempDir, rootDir, stagingDir } from './testHelpers.spec';
 import { Deferred } from './deferred';
-import type { BsDiagnostic } from './interfaces';
+import type { AfterProgramCreateEvent, BsDiagnostic } from './interfaces';
 
 describe('ProgramBuilder', () => {
 
@@ -74,6 +74,26 @@ describe('ProgramBuilder', () => {
         expect(
             await deferred.promise
         ).to.exist;
+    });
+
+
+    it('can edit files array in afterProgramCreate event', async () => {
+        builder = new ProgramBuilder();
+        const deferred = new Deferred<Program>();
+        builder.plugins.add({
+            name: 'test',
+            afterProgramCreate: (event: AfterProgramCreateEvent) => {
+                event.program.options.files.push('other/**/*.*');
+                deferred.resolve(builder.program);
+
+            }
+        });
+        builder['createProgram']();
+        expect(
+            await deferred.promise
+        ).to.exist;
+
+        expect(builder.options.files.length).to.equal(5);
     });
 
     describe('loadFiles', () => {

--- a/src/astUtils/CachedLookups.spec.ts
+++ b/src/astUtils/CachedLookups.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from '../chai-config.spec';
+import type { BrsFile } from '../files/BrsFile';
+import * as sinon from 'sinon';
+import { Program } from '../Program';
+import { expectZeroDiagnostics } from '../testHelpers.spec';
+import { CachedLookups } from './CachedLookups';
+
+describe('CachedLookups', () => {
+    const rootDir = process.cwd();
+    let program: Program;
+
+    beforeEach(() => {
+        program = new Program({ rootDir: rootDir });
+    });
+    afterEach(() => {
+        program.dispose();
+    });
+
+    it('doesnt complain with nested grouping expressions in a call chain', () => {
+        const file = program.setFile<BrsFile>('source/main.brs', `
+            sub test(bookmark)
+                print ((bookmark.duration - bookmark.position) \\ 60).toStr()
+            end sub
+        `);
+        const loggerDebug = sinon.stub(program.logger, 'debug');
+        program.validate();
+        expectZeroDiagnostics(program);
+        const cache = new CachedLookups({ program: program, _parser: file.parser });
+
+        expect(file.ast).to.exist;
+        expect(cache.expressions.size).to.be.greaterThan(0);
+        const loggerCalls = loggerDebug.getCalls();
+        const unknownExpressionCall = loggerCalls.find((call) => {
+            if (call.args.length > 0 && typeof call.args[0] === 'string') {
+                return !!call.args[0].includes('Encountered unknown expression');
+            }
+            return false;
+        });
+        expect(unknownExpressionCall).to.be.undefined;
+    });
+});


### PR DESCRIPTION
Code like this would cause a lot of logging:

```
  (1 + 2).toStr()
```

Because the grouping expression was not handled in the call handler in CachedLookups


Also added a test for a specific use case (editing file list through plugin) that was in the docs.