### PR TITLE
Allows more missing tokens in Transpile

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -178,11 +178,9 @@ export class CallExpression extends Expression {
             let arg = this.args[i];
             result.push(...arg.transpile(state));
         }
-        if (this.tokens.closingParen) {
-            result.push(
-                state.transpileToken(this.tokens.closingParen)
-            );
-        }
+        result.push(
+            state.transpileToken(this.tokens.closingParen, ')')
+        );
         return result;
     }
 
@@ -318,7 +316,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         //leftParen
         results.push(
-            state.transpileToken(this.tokens.leftParen)
+            state.transpileToken(this.tokens.leftParen, '(')
         );
         //parameters
         for (let i = 0; i < this.parameters.length; i++) {
@@ -332,7 +330,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         //right paren
         results.push(
-            state.transpileToken(this.tokens.rightParen)
+            state.transpileToken(this.tokens.rightParen, ')')
         );
         //as [Type]
         if (!state.options.removeParameterTypes && this.returnTypeExpression) {
@@ -871,9 +869,9 @@ export class GroupingExpression extends Expression {
             return this.expression.transpile(state);
         }
         return [
-            state.transpileToken(this.tokens.leftParen),
+            state.transpileToken(this.tokens.leftParen, '('),
             ...this.expression.transpile(state),
-            state.transpileToken(this.tokens.rightParen)
+            state.transpileToken(this.tokens.rightParen, ')')
         ];
     }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -187,7 +187,7 @@ export class AssignmentStatement extends Statement {
         return [
             state.transpileToken(this.tokens.name),
             ' ',
-            state.transpileToken(this.tokens.equals ?? createToken(TokenKind.Equal)),
+            state.transpileToken(this.tokens.equals ?? createToken(TokenKind.Equal), '='),
             ' ',
             ...this.value.transpile(state)
         ];
@@ -739,7 +739,7 @@ export class IfStatement extends Statement {
         if (this.tokens.then) {
             results.push(' ');
             results.push(
-                state.transpileToken(this.tokens.then)
+                state.transpileToken(this.tokens.then, 'then')
             );
         }
         state.lineage.unshift(this);
@@ -900,7 +900,7 @@ export class PrintStatement extends Statement {
      * @param options.expressions an array of expressions or `PrintSeparator`s to be evaluated and printed.
      */
     constructor(options: {
-        print: Token;
+        print?: Token;
         expressions: Array<Expression | PrintSeparatorTab | PrintSeparatorSpace>;
     }) {
         super();
@@ -914,7 +914,7 @@ export class PrintStatement extends Statement {
         );
     }
     public readonly tokens: {
-        readonly print: Token;
+        readonly print?: Token;
     };
     public readonly expressions: Array<Expression | PrintSeparatorTab | PrintSeparatorSpace>;
     public readonly kind = AstNodeKind.PrintStatement;
@@ -923,7 +923,7 @@ export class PrintStatement extends Statement {
 
     transpile(state: BrsTranspileState) {
         let result = [
-            state.transpileToken(this.tokens.print),
+            state.transpileToken(this.tokens.print, 'print'),
             ' '
         ] as TranspileResult;
         for (let i = 0; i < this.expressions.length; i++) {


### PR DESCRIPTION
For some expressions and statements, we can do a better job of assuming what some missing tokens will be.

This is useful for constructing AST nodes via code, so we don't need to specify tokens for open and close parens in a function call, for example.

Includes fixes for `CallExpression`, `PrintStatement` and `FunctionExpression`

Basically, anywhere there is a token where it HAS to be a certain character or string, we might as well put in a default for transpile time, so you don't need to include EVERY token in a constructor.

