### PR TITLE
Fix infinite loop issue with standalone projects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -223,7 +223,8 @@ module.exports = {
             '@typescript-eslint/no-unsafe-argument': 'off',
             'new-cap': 'off',
             'no-shadow': 'off',
-            'no-void': 'off'
+            'no-void': 'off',
+            'func-names': 'off'
         }
     }, {
         files: ['benchmarks/**/*'],

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -11,7 +11,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Program } from './Program';
 import * as assert from 'assert';
 import type { PartialDiagnostic } from './testHelpers.spec';
-import { expectZeroDiagnostics, normalizeDiagnostics, trim } from './testHelpers.spec';
+import { createInactivityStub, expectZeroDiagnostics, normalizeDiagnostics, trim } from './testHelpers.spec';
 import { isBrsFile, isLiteralString } from './astUtils/reflection';
 import { createVisitor, WalkMode } from './astUtils/visitors';
 import { tempDir, rootDir } from './testHelpers.spec';
@@ -23,6 +23,7 @@ import { LogLevel, Logger, createLogger } from './logging';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { standardizePath } from 'roku-deploy';
 import undent from 'undent';
+import { ProjectManager } from './lsp/ProjectManager';
 
 const sinon = createSandbox();
 
@@ -84,6 +85,8 @@ describe('LanguageServer', () => {
 
     beforeEach(() => {
         sinon.restore();
+        fsExtra.emptyDirSync(tempDir);
+
         server = new LanguageServer();
         server['busyStatusTracker'] = new BusyStatusTracker();
         workspaceFolders = [workspacePath];
@@ -95,9 +98,11 @@ describe('LanguageServer', () => {
         });
         server['hasConfigurationCapability'] = true;
     });
+
     afterEach(() => {
         sinon.restore();
         fsExtra.emptyDirSync(tempDir);
+
         server['dispose']();
         LanguageServer.enableThreadingDefault = enableThreadingDefault;
     });
@@ -122,6 +127,44 @@ describe('LanguageServer', () => {
             return document;
         }
     }
+
+    it('does not cause infinite loop of project creation', async () => {
+        //add a project with a files array that includes (and then excludes) a file
+        fsExtra.outputFileSync(s`${rootDir}/bsconfig.json`, JSON.stringify({
+            files: ['source/**/*', '!source/**/*.spec.bs']
+        }));
+
+        server['run']();
+
+        function setSyncedDocument(srcPath: string, text: string, version = 1) {
+            //force an open text document
+            const document = TextDocument.create(util.pathToUri(
+                util.standardizePath(srcPath
+                )
+            ), 'brightscript', 1, `sub main()\nend sub`);
+            (server['documents']['_syncedDocuments'] as Map<string, TextDocument>).set(document.uri, document);
+        }
+
+        //wait for the projects to finish loading up
+        await server['syncProjects']();
+
+        //this bug was causing an infinite async loop of new project creations. So monitor the creation of new projects for evaluation later
+        const { stub, promise: createProjectsSettled } = createInactivityStub(ProjectManager.prototype as any, 'constructProject', 400, sinon);
+
+        setSyncedDocument(s`${rootDir}/source/lib1.spec.bs`, 'sub lib1()\nend sub');
+        setSyncedDocument(s`${rootDir}/source/lib2.spec.bs`, 'sub lib2()\nend sub');
+
+        // open a file that is excluded by the project, so it should trigger a standalone project.
+        await server['onTextDocumentDidChangeContent']({
+            document: TextDocument.create(util.pathToUri(s`${rootDir}/source/lib1.spec.bs`), 'brightscript', 1, `sub main()\nend sub`)
+        });
+
+        //wait for the "create projects" deferred debounce to settle
+        await createProjectsSettled;
+
+        //test passes if we've only made 2 new projects (one for each of the standalone projects)
+        expect(stub.callCount).to.eql(2);
+    });
 
     describe('onDidChangeConfiguration', () => {
         async function doTest(startingConfigs: WorkspaceConfigWithExtras[], endingConfigs: WorkspaceConfigWithExtras[]) {

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -135,7 +135,6 @@ export class LanguageServer {
         });
 
         this.projectManager.busyStatusTracker.on('active-runs-change', (event) => {
-            console.log(event);
             this.sendBusyStatus();
         });
     }

--- a/src/lsp/PathFilterer.spec.ts
+++ b/src/lsp/PathFilterer.spec.ts
@@ -178,3 +178,47 @@ describe('PathFilterer', () => {
         });
     });
 });
+
+describe('PathCollection', () => {
+    function doTest(globs: string[], filePath: string, expected: boolean) {
+        const collection = new PathCollection({
+            rootDir: rootDir,
+            globs: globs
+        });
+        expect(collection.isMatch(filePath)).to.equal(expected);
+    }
+
+    it('includes a file that matches a single pattern', () => {
+        doTest([
+            '**/*.brs'
+        ], s`${rootDir}/alpha.brs`, true);
+    });
+
+    it('includes a file that matches the 2nd pattern', () => {
+        doTest([
+            '**/*beta*.brs',
+            '**/*alpha*.brs'
+        ], s`${rootDir}/alpha.brs`, true);
+    });
+
+    it('includes a file that is included then excluded then included again', () => {
+        doTest([
+            '**/*.brs',
+            '!**/a*.brs',
+            '**/alpha.brs'
+        ], s`${rootDir}/alpha.brs`, true);
+    });
+
+    it('excludes a file that does not match the pattern', () => {
+        doTest([
+            '**/beta.brs'
+        ], s`${rootDir}/alpha.brs`, false);
+    });
+
+    it('excludes a file that matches first pattern but is excluded from the second pattern', () => {
+        doTest([
+            '**/*.brs',
+            '!**/alpha.brs'
+        ], s`${rootDir}/alpha.brs`, false);
+    });
+});

--- a/src/lsp/PathFilterer.ts
+++ b/src/lsp/PathFilterer.ts
@@ -133,7 +133,8 @@ export class PathFilterer {
         this.logger.debug('registerExcludeMatcher', matcher);
 
         const collection = new PathCollection({
-            matcher: matcher
+            matcher: matcher,
+            isExcludePattern: true
         });
         this.excludeCollections.push(collection);
         return () => {
@@ -168,33 +169,53 @@ export class PathCollection {
             globs: string[];
         } | {
             matcher: (path: string) => boolean;
+            isExcludePattern: boolean;
         }
     ) {
         if ('globs' in options) {
             //build matcher patterns from the globs
-            for (const glob of options.globs ?? []) {
+            for (let glob of options.globs ?? []) {
+                let isExcludePattern = glob.startsWith('!');
+                if (isExcludePattern) {
+                    glob = glob.substring(1);
+                }
                 const pattern = path.resolve(
                     options.rootDir,
                     glob
                 ).replace(/\\+/g, '/');
-                this.matchers.push(
-                    micromatch.matcher(pattern)
-                );
+                this.matchers.push({
+                    isMatch: micromatch.matcher(pattern),
+                    isExcludePattern: isExcludePattern
+                });
             }
         } else {
-            this.matchers.push(options.matcher);
+            this.matchers.push({
+                isMatch: options.matcher,
+                isExcludePattern: options.isExcludePattern
+            });
         }
     }
 
-    private matchers: Array<(string) => boolean> = [];
+    private matchers: Array<{
+        isMatch: (string) => boolean;
+        isExcludePattern: boolean;
+    }> = [];
+
     public isMatch(path: string) {
+        let keep = false;
         //coerce the path into a normalized form and unix slashes
         path = util.standardizePath(path).replace(/\\+/g, '/');
         for (let matcher of this.matchers) {
-            if (matcher(path)) {
-                return true;
+            //exclusion pattern: do not keep the path if it matches
+            if (matcher.isExcludePattern) {
+                if (matcher.isMatch(path)) {
+                    keep = false;
+                }
+                //inclusion pattern: keep the path if it matches
+            } else {
+                keep = keep || matcher.isMatch(path);
             }
         }
-        return false;
+        return keep;
     }
 }


### PR DESCRIPTION
Fixes a critical bug where the language server gets suck in an infinite loop creating and deleting projects. You can look at the unit test for how to reproduce, but it basically is caused by opening and editing two non-project files at the same time. Here's what it looked like when it happened:

https://github.com/user-attachments/assets/1a8b91c4-ac55-41bb-b2f6-d6d4dccd5a5c

