### PR TITLE
Adds Callfunc Completion and Validation

### DIFF
--- a/src/AstValidationSegmenter.ts
+++ b/src/AstValidationSegmenter.ts
@@ -268,7 +268,9 @@ export class AstValidationSegmenter {
                 }
                 let addedSymbol = false;
                 for (const unresolvedMember of unresolvedMembers) {
-                    addedSymbol = this.addUnresolvedSymbol(segment, unresolvedMember?.data?.definingNode) || addedSymbol;
+                    if (unresolvedMember?.data?.definingNode) {
+                        addedSymbol = this.addUnresolvedSymbol(segment, unresolvedMember.data.definingNode) || addedSymbol;
+                    }
 
                 }
                 return addedSymbol;

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -277,7 +277,7 @@ export class CrossScopeValidator {
         if (this.providedTreeMap.has(scope)) {
             return this.providedTreeMap.get(scope);
         }
-        const providedTree = new ProvidedNode('', this.componentsMap);
+        const providedTree = new ProvidedNode('');//, this.componentsMap);
         const duplicatesMap = new Map<string, Set<FileSymbolPair>>();
 
         const referenceTypesMap = new Map<{ symbolName: string; file: BscFile; symbolObj: ProvidedSymbol }, Array<{ name: string; namespacedName?: string }>>();
@@ -499,7 +499,7 @@ export class CrossScopeValidator {
             const typeName = 'rosgnode' + componentName;
             const component = this.program.getComponent(componentName);
             const componentSymbol = this.program.globalScope.symbolTable.getSymbol(typeName, SymbolTypeFlag.typetime)?.[0];
-            if (componentSymbol && component) {
+            if (componentSymbol && component && componentSymbol.type.isBuiltIn) {
                 this.componentsMap.set(typeName, { file: component.file, symbol: componentSymbol });
             }
         }

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -499,7 +499,7 @@ export class CrossScopeValidator {
             const typeName = 'rosgnode' + componentName;
             const component = this.program.getComponent(componentName);
             const componentSymbol = this.program.globalScope.symbolTable.getSymbol(typeName, SymbolTypeFlag.typetime)?.[0];
-            if (componentSymbol && component && componentSymbol.data?.isBuiltIn) {
+            if (componentSymbol && component && componentSymbol.type?.isBuiltIn) {
                 this.componentsMap.set(typeName, { file: component.file, symbol: componentSymbol });
             }
         }

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -234,7 +234,7 @@ export class DiagnosticManager {
                     isMatch = !!context.tags?.includes(filter.tag);
                 }
                 if (isMatch && needToMatch.scope) {
-                    isMatch = context.scope === filter.scope;
+                    isMatch = context.scope?.name === filter.scope.name;
                 }
                 if (isMatch && needToMatch.fileUri) {
                     isMatch = cachedData.diagnostic.location?.uri === filter.fileUri;

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -822,6 +822,17 @@ export let DiagnosticMessages = {
         message: `Expected return statement in function`,
         code: 1155,
         severity: DiagnosticSeverity.Error
+    }),
+    cannotFindCallFuncFunction: (name: string, fullName: string, typeName: string) => ({
+        message: `Cannot find callfunc function '${name}' for type '${typeName}'`,
+        code: 1156,
+        data: {
+            name: name,
+            fullName: fullName,
+            typeName: typeName,
+            isCallfunc: true
+        },
+        severity: DiagnosticSeverity.Error
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -54,6 +54,7 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
      * Call `event` on plugins
      */
     public emit<K extends keyof PluginEventArgs<T> & string>(event: K, ...args: PluginEventArgs<T>[K]) {
+        this.logger.debug(`Emitting plugin event: ${event}`);
         for (let plugin of this.plugins) {
             if ((plugin as any)[event]) {
                 try {
@@ -75,6 +76,7 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
      * Call `event` on plugins, but allow the plugins to return promises that will be awaited before the next plugin is notified
      */
     public async emitAsync<K extends keyof PluginEventArgs<T> & string>(event: K, ...args: PluginEventArgs<T>[K]): Promise< PluginEventArgs<T>[K][0]> {
+        this.logger.debug(`Emitting async plugin event: ${event}`);
         for (let plugin of this.plugins) {
             if ((plugin as any)[event]) {
                 try {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -419,13 +419,12 @@ export class Program {
         // There is a component that can be added - use it.
         if (components.length > 0) {
             const componentScope = components[0].scope;
-            // TODO: May need to link symbol tables to get correct types for callfuncs
+
             componentScope.linkSymbolTable();
             const componentType = componentScope.getComponentType();
             if (componentType) {
                 this.componentsTable.addSymbol(symbolName, {}, componentType, SymbolTypeFlag.typetime);
             }
-            // TODO: Remember to unlink!
             componentScope.unlinkSymbolTable();
         }
     }
@@ -661,7 +660,7 @@ export class Program {
                     let scope = new XmlScope(file, this);
                     this.addScope(scope);
 
-                    //register this compoent now that we have parsed it and know its component name
+                    //register this componet now that we have parsed it and know its component name
                     this.registerComponent(file, scope);
 
                     //notify plugins that the scope is created and the component is registered

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1035,6 +1035,12 @@ export class Program {
                 changedSymbols.set(SymbolTypeFlag.typetime, new Set([...changedTypeSymbols, ...dependentTypesChanged]));
             }).durationText;
 
+            if (this.options.logLevel === LogLevel.debug) {
+                const changedRuntime = Array.from(changedSymbols.get(SymbolTypeFlag.runtime)).sort();
+                this.logger.debug('Changed Symbols (runTime):', changedRuntime.join(', '));
+                const changedTypetime = Array.from(changedSymbols.get(SymbolTypeFlag.typetime)).sort();
+                this.logger.debug('Changed Symbols (typeTime):', changedTypetime.join(', '));
+            }
             const filesToBeValidatedInScopeContext = new Set<BscFile>(afterValidateFiles);
 
             metrics.crossScopeValidationTime = validationStopwatch.getDurationTextFor(() => {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -901,8 +901,8 @@ export class Program {
 
             const afterValidateFiles: BscFile[] = [];
             const sortedFiles = Object.values(this.files).sort(firstBy(x => x.srcPath));
-            // Create reference component types for any component that changes
             this.logger.time(LogLevel.info, ['Prebuild component types'], () => {
+                // cast a wide net for potential changes in components
                 for (const file of sortedFiles) {
                     if (isXmlFile(file)) {
                         this.addDeferredComponentTypeSymbolCreation(file);
@@ -915,6 +915,7 @@ export class Program {
                     }
                 }
 
+                // Create reference component types for any component that changes
                 for (let [componentKey, componentName] of this.componentSymbolsToUpdate.entries()) {
                     this.addComponentReferenceType(componentKey, componentName);
                 }
@@ -976,7 +977,6 @@ export class Program {
                     }
                     return null;
                 }).filter(x => x);
-
 
                 // update the map of typetime dependencies
                 for (const file of brsFilesValidated) {

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -243,6 +243,12 @@ export class Program {
     private symbolDependencies = new Map<string, Set<string>>();
 
 
+    /**
+     * Symbol Table for storing custom component types
+     * This is a sibling to the global table (as Components can be used/referenced anywhere)
+     * Keeping custom components out of the global table and in a specific symbol table
+     * compartmentalizes their use
+     */
     private componentsTable = new SymbolTable('Custom Components');
 
     public addFileSymbolInfo(file: BrsFile) {
@@ -452,6 +458,8 @@ export class Program {
 
     /**
      * Adds a reference type to the global symbol table with the first component in this.components to have the same name as the component in the file
+     * This is so on a first validation, these types can be resolved in teh future (eg. when the actual component is created)
+     * If we don't add reference types at this top level, they will be created at the file level, and will never get resolved
      * @param componentKey key getting a component from `this.components`
      * @param componentName the unprefixed name of the component that will be added (e.g. 'MyLabel' NOT 'roSgNodeMyLabel')
      */

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -912,6 +912,7 @@ export class Program {
                 fileValidationTime: '',
                 crossScopeValidationTime: '',
                 scopesValidated: 0,
+                changedSymbols: 0,
                 totalLinkTime: '',
                 totalScopeValidationTime: '',
                 componentValidationTime: '',
@@ -1069,6 +1070,7 @@ export class Program {
                 const changedTypetime = Array.from(changedSymbols.get(SymbolTypeFlag.typetime)).sort();
                 this.logger.debug('Changed Symbols (typeTime):', changedTypetime.join(', '));
             }
+            metrics.changedSymbols = changedSymbols.get(SymbolTypeFlag.runtime).size + changedSymbols.get(SymbolTypeFlag.typetime).size;
             const filesToBeValidatedInScopeContext = new Set<BscFile>(afterValidateFiles);
 
             metrics.crossScopeValidationTime = validationStopwatch.getDurationTextFor(() => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -3387,7 +3387,7 @@ describe('Scope', () => {
         });
 
         describe('callFunc invocations', () => {
-            it('TODO: should set correct return type', () => {
+            it('should set correct return type', () => {
 
                 program.setFile('components/Widget.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
@@ -3418,8 +3418,48 @@ describe('Scope', () => {
                 const opts = { flags: SymbolTypeFlag.runtime };
                 const sourceScope = program.getScopeByName('source');
                 sourceScope.linkSymbolTable();
-                //TODO: This *SHOULD* be float, but callfunc returns aren't inferred yet
-                expectTypeToBe(symbolTable.getSymbolType('pi', opts), DynamicType);
+                expectTypeToBe(symbolTable.getSymbolType('pi', opts), FloatType);
+                sourceScope.unlinkSymbolTable();
+            });
+
+            it('should set correct return type with a custom type', () => {
+                program.setFile('components/Widget.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="Widget" extends="Group">
+                        <script uri="Widget.bs"/>
+                        <interface>
+                            <function name="getWidgetType" />
+                        </interface>
+                    </component>
+                `);
+
+                program.setFile('components/Widget.bs', `
+                    interface WidgetInternal
+                       name as string
+                    end interface
+
+                    function getWidgetType(input as string) as WidgetInternal
+                        return {name: input}
+                    end function
+                `);
+
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    sub someFunc(widget as roSGNodeWidget)
+                        thing = widget@.getWidgetType("hello")
+                        print thing
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const processFnScope = utilFile.getFunctionScopeAtPosition(util.createPosition(3, 31));
+                const symbolTable = processFnScope.symbolTable;
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const sourceScope = program.getScopeByName('source');
+                sourceScope.linkSymbolTable();
+                const thingType = symbolTable.getSymbolType('thing', opts) as InterfaceType;
+
+                expectTypeToBe(thingType, InterfaceType);
+                expect(thingType.name).to.eq('WidgetInternal');
                 sourceScope.unlinkSymbolTable();
             });
         });

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -233,6 +233,7 @@ export class SymbolTable implements SymbolTypeGetter {
             options.data.isAlias = data?.isAlias;
             options.data.isInstance = data?.isInstance;
             options.data.isFromDocComment = data?.isFromDocComment;
+            options.data.isFromCallFunc = data?.isFromCallFunc;
         }
         return resolvedType;
     }

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -411,6 +411,7 @@ export interface SymbolTypeGetter {
     name: string;
     getSymbolType(name: string, options: GetSymbolTypeOptions): BscType;
     setCachedType(name: string, cacheEntry: TypeCacheEntry, options: GetSymbolTypeOptions);
+    addSibling(symbolTable: SymbolTable);
 }
 
 /**

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -49,6 +49,7 @@ export class SymbolTable implements SymbolTypeGetter {
      * Push a function that will provide a parent SymbolTable when requested
      */
     public pushParentProvider(provider: SymbolTableProvider) {
+        this.cachedCircularReferenceCheck = null;
         this.parentProviders.push(provider);
         return () => {
             this.popParentProvider();
@@ -59,6 +60,7 @@ export class SymbolTable implements SymbolTypeGetter {
      * Pop the current parentProvider
      */
     public popParentProvider() {
+        this.cachedCircularReferenceCheck = null;
         this.parentProviders.pop();
     }
 
@@ -304,6 +306,23 @@ export class SymbolTable implements SymbolTypeGetter {
         return symbols;
     }
 
+
+    private cachedCircularReferenceCheck: null | boolean = null;
+
+    private hasCircularReferenceWithAncestor() {
+        if (this.cachedCircularReferenceCheck === false || this.cachedCircularReferenceCheck === true) {
+            return this.cachedCircularReferenceCheck;
+        }
+        let foundCircReference = false;
+        let p = this.parent;
+        while (!foundCircReference && p) {
+            foundCircReference = p === this;
+            p = p.parent;
+        }
+        this.cachedCircularReferenceCheck = foundCircReference;
+        return foundCircReference;
+    }
+
     /**
      * Get list of all symbols declared in this SymbolTable (includes parent SymbolTable).
      */
@@ -313,7 +332,8 @@ export class SymbolTable implements SymbolTypeGetter {
         for (let sibling of this.siblings) {
             symbols = symbols.concat(sibling.getAllSymbols(bitFlags));
         }
-        if (this.parent) {
+
+        if (this.parent && !this.hasCircularReferenceWithAncestor()) {
             symbols = symbols.concat(this.parent.getAllSymbols(bitFlags));
         }
         // eslint-disable-next-line no-bitwise

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -7,6 +7,7 @@ import type { BscFile } from './files/BscFile';
 import { DynamicType } from './types/DynamicType';
 import type { BaseFunctionType } from './types/BaseFunctionType';
 import { ComponentType } from './types/ComponentType';
+import { ExtraSymbolData } from './interfaces';
 
 export class XmlScope extends Scope {
     constructor(
@@ -56,13 +57,14 @@ export class XmlScope extends Scope {
         //add functions
         for (const func of iface.functions ?? []) {
             if (func.name) {
-                const componentFuncType = this.symbolTable.getSymbolType(func.name, { flags: SymbolTypeFlag.runtime, fullName: func.name, tableProvider: () => this.symbolTable });
+                const extraData: ExtraSymbolData = {};
+                const componentFuncType = this.symbolTable.getSymbolType(func.name, { flags: SymbolTypeFlag.runtime, data: extraData, fullName: func.name, tableProvider: () => this.symbolTable });
                 // TODO: Get correct function type, and fully resolve all param and return types of function
                 // eg.:
                 // callFuncType = new CallFuncType(componentFuncType) // does something to fully resolve & store all associated types
 
                 //TODO: add documentation - need to get previous comment from XML
-                result.addCallFuncMember(func.name, {}, componentFuncType as BaseFunctionType, SymbolTypeFlag.runtime);
+                result.addCallFuncMember(func.name, extraData, componentFuncType as BaseFunctionType, SymbolTypeFlag.runtime);
             }
         }
         //add fields

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -7,7 +7,7 @@ import type { BscFile } from './files/BscFile';
 import { DynamicType } from './types/DynamicType';
 import type { BaseFunctionType } from './types/BaseFunctionType';
 import { ComponentType } from './types/ComponentType';
-import { ExtraSymbolData } from './interfaces';
+import type { ExtraSymbolData } from './interfaces';
 
 export class XmlScope extends Scope {
     constructor(

--- a/src/XmlScope.ts
+++ b/src/XmlScope.ts
@@ -59,12 +59,7 @@ export class XmlScope extends Scope {
             if (func.name) {
                 const extraData: ExtraSymbolData = {};
                 const componentFuncType = this.symbolTable.getSymbolType(func.name, { flags: SymbolTypeFlag.runtime, data: extraData, fullName: func.name, tableProvider: () => this.symbolTable });
-                // TODO: Get correct function type, and fully resolve all param and return types of function
-                // eg.:
-                // callFuncType = new CallFuncType(componentFuncType) // does something to fully resolve & store all associated types
-
-                //TODO: add documentation - need to get previous comment from XML
-                result.addCallFuncMember(func.name, extraData, componentFuncType as BaseFunctionType, SymbolTypeFlag.runtime);
+                result.addCallFuncMember(func.name, extraData, componentFuncType as BaseFunctionType, SymbolTypeFlag.runtime, () => this.symbolTable);
             }
         }
         //add fields

--- a/src/bscPlugin/completions/CompletionsProcessor.spec.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.spec.ts
@@ -1824,7 +1824,7 @@ describe('CompletionsProcessor', () => {
             expect(completions.length).to.eql(1);
             expectCompletionsIncludes(completions, [{
                 label: 'someFunc',
-                kind: CompletionItemKind.Function
+                kind: CompletionItemKind.Method
             }]);
         });
 
@@ -1855,8 +1855,57 @@ describe('CompletionsProcessor', () => {
             expect(completions.length).to.eql(1);
             expectCompletionsIncludes(completions, [{
                 label: 'someFunc',
-                kind: CompletionItemKind.Function,
+                kind: CompletionItemKind.Method,
                 documentation: 'This is documentation'
+            }]);
+        });
+
+        it('does not include callfunc members for other components', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                     <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="someFunc" />
+                    </interface>
+                </component>
+            `);
+            program.setFile('components/Widget.bs', `
+                function someFunc(input as string) as float
+                    return input.toFloat()
+                end function
+            `);
+            program.setFile('components/Thing.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Thing" extends="Group">
+                     <script uri="Thing.bs"/>
+                    <interface>
+                        <function name="otherFunc" />
+                    </interface>
+                </component>
+            `);
+            program.setFile('components/Thing.bs', `
+                function otherFunc(input as string) as float
+                    return input.toFloat()
+                end function
+            `);
+
+            program.setFile('source/util.bs', `
+                sub callWidgetSomeFunc(widget as roSGNodeWidget)
+                    print widget@.
+                end sub
+            `);
+            program.validate();
+            // print widget@.|
+            let completions = program.getCompletions('source/util.bs', util.createPosition(2, 34));
+            expect(completions.length).to.eql(1);
+            expectCompletionsIncludes(completions, [{
+                label: 'someFunc',
+                kind: CompletionItemKind.Method
+            }]);
+            expectCompletionsExcludes(completions, [{
+                label: 'otherFunc',
+                kind: CompletionItemKind.Method
             }]);
         });
     });

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -516,11 +516,11 @@ export class CompletionsProcessor {
         }));
     }
 
-    public createCompletionFromFunctionStatement(statement: FunctionStatement): CompletionItem {
+    public createCompletionFromFunctionStatement(statement: FunctionStatement, completionKind: CompletionItemKind = CompletionItemKind.Function): CompletionItem {
         const funcType = statement.getType({ flags: SymbolTypeFlag.runtime });
         return {
             label: statement.getName(ParseMode.BrighterScript),
-            kind: CompletionItemKind.Function,
+            kind: completionKind,
             detail: funcType.toString(),
             documentation: util.getNodeDocumentation(statement)
         };
@@ -601,12 +601,10 @@ export class CompletionsProcessor {
         const xmlScopes = this.event.program.getScopes().filter((s) => isXmlScope(s)) as XmlScope[];
         // is next to a @. callfunc invocation - must be an component interface method.
 
-
-        //TODO refactor this to utilize the actual variable's component type (when available)
         for (const scope of xmlScopes) {
             let fileLinks = this.event.program.getStatementsForXmlFile(scope);
             for (let fileLink of fileLinks) {
-                let pushItem = this.createCompletionFromFunctionStatement(fileLink.item);
+                let pushItem = this.createCompletionFromFunctionStatement(fileLink.item, CompletionItemKind.Method);
                 if (!completetionsLabels.includes(pushItem.label)) {
                     completetionsLabels.push(pushItem.label);
                     completionsArray.push(pushItem);

--- a/src/bscPlugin/completions/CompletionsProcessor.ts
+++ b/src/bscPlugin/completions/CompletionsProcessor.ts
@@ -433,7 +433,7 @@ export class CompletionsProcessor {
             const symbolNameLower = symbol?.name.toLowerCase();
             let nameMatchesType = symbolNameLower === finalTypeNameLower;
             if (isTypedFunctionType(type) && !nameMatchesType) {
-                if (symbolNameLower === type.name.replace(/\./gi, '_').toLowerCase()) {
+                if (symbolNameLower === type.name?.replace(/\./gi, '_').toLowerCase()) {
                     nameMatchesType = true;
                 }
             }

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -762,7 +762,7 @@ describe('HoverProcessor', () => {
             expect(hover?.contents).eql([fence('function roSGNodeWidget@.someFunc(input as string) as float')]);
         });
 
-        it('should documentation on @callfunc hovers', () => {
+        it('should include documentation on @callfunc hovers', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Widget" extends="Group">

--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -762,6 +762,34 @@ describe('HoverProcessor', () => {
             expect(hover?.contents).eql([fence('function roSGNodeWidget@.someFunc(input as string) as float')]);
         });
 
+        it('should documentation on @callfunc hovers', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                     <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="someFunc" />
+                    </interface>
+                </component>
+            `);
+            const file = program.setFile('components/Widget.bs', `
+                sub foo()
+                    top = m.top as roSgNodeWidget
+                    print top@.someFunc("3.14")
+                end sub
+
+                ' Some Cool function
+                function someFunc(input as string) as float
+                    return input.toFloat()
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            // print top@.some|Func("3.14")
+            let hover = program.getHover(file.srcPath, util.createPosition(3, 35))[0];
+            expect(hover?.contents[0]).include('Some Cool function');
+        });
+
     });
 
     describe('multiple definition locations', () => {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -109,7 +109,7 @@ export class BrsFileValidator {
                 const data: ExtraSymbolData = {};
                 //register this variable
                 const nodeType = node.getType({ flags: SymbolTypeFlag.runtime, data: data });
-                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, { definingNode: node, isInstance: true, isFromDocComment: data.isFromDocComment }, nodeType, SymbolTypeFlag.runtime);
+                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, { definingNode: node, isInstance: true, isFromDocComment: data.isFromDocComment, isFromCallFunc: data.isFromCallFunc }, nodeType, SymbolTypeFlag.runtime);
             },
             DottedSetStatement: (node) => {
                 this.validateNoOptionalChainingInVarSet(node, [node.obj]);

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4349,6 +4349,35 @@ describe('ScopeValidator', () => {
                 DiagnosticMessages.cannotFindCallFuncFunction('someFunc', 'roSGNodeRectangle@.someFunc', 'roSGNodeRectangle')
             ]);
         });
+
+        it('allows callfunc on flexible types', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc(obj as object, dyn as dynamic, node as roSGNode)
+                    obj.callfunc("testFunc")
+                    obj@.testFunc()
+
+                    dyn.callfunc("testFunc")
+                    dyn@.testFunc()
+
+                    node.callfunc("testFunc")
+                    node@.testFunc()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows callfunc on components from component library', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc()
+                    fromComponentLibrary = CreateObject("roSGNode", "library:SomeComponent")
+                    fromComponentLibrary@.someFunc()
+                    fromComponentLibrary.callfunc("someFunc")
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 });
 

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3638,7 +3638,7 @@ describe('ScopeValidator', () => {
         });
     });
 
-    describe.only('callFunc', () => {
+    describe('callFunc', () => {
         it('allows access to member of return type when return type is custom node', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -3826,7 +3826,7 @@ describe('ScopeValidator', () => {
             ]);
         });
 
-        it.only('allows to types that reference themselves', () => {
+        it('allows to types that reference themselves', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Widget" extends="Group">

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3638,4 +3638,54 @@ describe('ScopeValidator', () => {
         });
     });
 
+    describe('callFunc', () => {
+        it('allows access to member of return type when return type is custom node', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="getOther" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                function getOther(name as string) as roSgNodeOther
+                    other =  createObject("roSgNode", "Other")
+                    other.myValue = name
+                    return other
+                end function
+            `);
+
+            program.setFile('components/Other.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Other" extends="Group">
+                    <interface>
+                        <field id="myValue" type="string" />
+                    </interface>
+                </component>
+            `);
+
+
+            program.setFile('components/MainScene.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MainScene" extends="Scene">
+                    <script uri="MainScene.bs"/>
+                </component>
+            `);
+
+            program.setFile('components/MainScene.bs', `
+                sub someFunc(widget as roSGNodeWidget)
+                    otherNode = widget@.getOther("3.14")
+                    print otherNode.myValue
+                end sub
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+    });
+
 });

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3990,33 +3990,29 @@ describe('ScopeValidator', () => {
             ]);
         });
 
-        it('validates arg count of callfunc()', () => {
-            program.setFile('components/Widget.xml', trim`
-                <?xml version="1.0" encoding="utf-8" ?>
-                <component name="Widget" extends="Group">
-                    <script uri="Widget.bs"/>
-                    <interface>
-                        <function name="getName" />
-                    </interface>
-                </component>
-            `);
-
-            program.setFile('components/Widget.bs', `
-                function getName() as string
-                    return "John Doe"
-                end function
-            `);
-
+        it('has no error on plain roSGNode', () => {
             program.setFile('source/test.bs', `
-                sub printName(widget as roSGNodeWidget)
-                    print widget.callFunc("getName", "extra", "args", "here")
+                sub doCallfunc(nodeName as string)
+                    node = createObject("roSgNode", nodeName)
+                    node.callfunc("someFunc", 1, 2, 3)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('has error on regular builtIn types', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc()
+                    node = createObject("roSgNode", "Rectangle")
+                    node.callfunc("someFunc", 1, 2, 3)
                 end sub
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.mismatchArgumentCount(1, 4).message
+                DiagnosticMessages.cannotFindFunction('someFunc', 'roSGNodeRectangle@.someFunc', 'roSGNodeRectangle')
             ]);
         });
     });
-
 });
+

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4026,6 +4026,18 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        it('catches when a non-component type has callfunc invocation', () => {
+            program.setFile('source/test.bs', `
+                sub printName(widget as integer)
+                    print widget@.toStr()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('toStr', 'integer@.toStr', 'integer').message
+            ]);
+        });
+
         it('allows to types that reference themselves', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -4103,7 +4115,35 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindFunction('whatever', 'roSGNodeWidget@.whatever', 'roSGNodeWidget').message
+                DiagnosticMessages.cannotFindCallFuncFunction('whatever', 'roSGNodeWidget@.whatever', 'roSGNodeWidget').message
+            ]);
+        });
+
+        it('finds invalid func name of @ callfunc invocation', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="getName" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                function getName() as string
+                    return "John Doe"
+                end function
+            `);
+
+            program.setFile('source/test.bs', `
+                sub printName(widget as roSGNodeWidget)
+                    print widget@.whatever()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('whatever', 'roSGNodeWidget@.whatever', 'roSGNodeWidget').message
             ]);
         });
 
@@ -4131,7 +4171,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindFunction('whatever the name is', 'roSGNodeWidget@.whatever the name is', 'roSGNodeWidget').message
+                DiagnosticMessages.cannotFindCallFuncFunction('whatever the name is', 'roSGNodeWidget@.whatever the name is', 'roSGNodeWidget').message
             ]);
         });
 
@@ -4184,7 +4224,7 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.cannotFindFunction('someFunc', 'roSGNodeRectangle@.someFunc', 'roSGNodeRectangle')
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', 'roSGNodeRectangle@.someFunc', 'roSGNodeRectangle')
             ]);
         });
     });

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3727,7 +3727,7 @@ describe('ScopeValidator', () => {
             expectZeroDiagnostics(program);
         });
 
-        it.only('rechecks file using callfunc when exported function type of xml changes', () => {
+        it('rechecks file using callfunc when exported function type of xml changes', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Widget" extends="Group">
@@ -3746,8 +3746,7 @@ describe('ScopeValidator', () => {
 
 
             program.setFile('source/callFoo.bs', `
-                sub callFoo()
-                    widget = createObject("roSGNode", "Widget")
+                sub callFoo(widget as roSGNodeWidget)
                     widget@.foo(123) ' foo expects string
                 end sub
             `);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -696,7 +696,7 @@ export class ScopeValidator {
                     }
                 } else {
                     const typeChainScan = util.processTypeChain(typeChain);
-                    //if this is a function call, provide a different diganostic code
+                    //if this is a function call, provide a different diagnostic code
                     if (isCallExpression(typeChainScan.astNode.parent) && typeChainScan.astNode.parent.callee === expression) {
                         this.addMultiScopeDiagnostic({
                             ...DiagnosticMessages.cannotFindFunction(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
@@ -710,7 +710,7 @@ export class ScopeValidator {
                     }
                 }
 
-            } else if (!typeData?.isFromDocComment) {
+            } else if (!(typeData?.isFromDocComment || typeData?.isFromCallFunc)) {
                 // only show "cannot find... " errors if the type is not defined from a doc comment
                 const typeChainScan = util.processTypeChain(typeChain);
                 if (isCallExpression(typeChainScan.astNode.parent) && typeChainScan.astNode.parent.callee === expression) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { DiagnosticTag, type Range } from 'vscode-languageserver';
-import { isAliasStatement, isAssignmentStatement, isAssociativeArrayType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isCallfuncExpression, isClassStatement, isClassType, isComponentType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isReturnStatement, isStringType, isTypedFunctionType, isUnionType, isVariableExpression, isVoidType, isXmlScope } from '../../astUtils/reflection';
+import { isAliasStatement, isAssignmentStatement, isAssociativeArrayType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isComponentType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isReturnStatement, isStringType, isTypedFunctionType, isUnionType, isVariableExpression, isVoidType, isXmlScope } from '../../astUtils/reflection';
 import type { DiagnosticInfo } from '../../DiagnosticMessages';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -134,11 +134,12 @@ export class ScopeValidator {
                         this.validateVariableAndDottedGetExpressions(file, dottedGet);
                     },
                     CallExpression: (functionCall) => {
-                        this.validateFunctionCall(file, functionCall);
+                        this.validateCallExpression(file, functionCall);
                         this.validateCreateObjectCall(file, functionCall);
+                        this.validateComponentMethods(file, functionCall);
                     },
                     CallfuncExpression: (functionCall) => {
-                        this.validateFunctionCall(file, functionCall);
+                        this.validateCallFuncExpression(file, functionCall);
                     },
                     ReturnStatement: (returnStatement) => {
                         this.validateReturnStatement(file, returnStatement);
@@ -292,18 +293,8 @@ export class ScopeValidator {
         //if this is a `createObject('roSGNode'` call, only support known sg node types
         if (firstParamStringValueLower === 'rosgnode' && isLiteralExpression(call?.args[1])) {
             const componentName: Token = call?.args[1]?.tokens.value;
-            //don't validate any components with a colon in their name (probably component libraries, but regular components can have them too).
-            if (!componentName || componentName?.text?.includes(':')) {
-                return;
-            }
-            //add diagnostic for unknown components
-            const unquotedComponentName = componentName?.text?.replace(/"/g, '');
-            if (unquotedComponentName && !platformNodeNames.has(unquotedComponentName.toLowerCase()) && !this.event.program.getComponent(unquotedComponentName)) {
-                this.addDiagnostic({
-                    ...DiagnosticMessages.unknownRoSGNode(unquotedComponentName),
-                    location: componentName.location
-                });
-            } else if (call?.args.length !== 2) {
+            this.checkComponentName(componentName);
+            if (call?.args.length !== 2) {
                 // roSgNode should only ever have 2 args in `createObject`
                 this.addDiagnostic({
                     ...DiagnosticMessages.mismatchCreateObjectArgumentCount(firstParamStringValue, [2], call?.args.length),
@@ -344,77 +335,134 @@ export class ScopeValidator {
 
     }
 
+    private checkComponentName(componentName: Token) {
+        //don't validate any components with a colon in their name (probably component libraries, but regular components can have them too).
+        if (!componentName || componentName?.text?.includes(':')) {
+            return;
+        }
+        //add diagnostic for unknown components
+        const unquotedComponentName = componentName?.text?.replace(/"/g, '');
+        if (unquotedComponentName && !platformNodeNames.has(unquotedComponentName.toLowerCase()) && !this.event.program.getComponent(unquotedComponentName)) {
+            this.addDiagnostic({
+                ...DiagnosticMessages.unknownRoSGNode(unquotedComponentName),
+                location: componentName.location
+            });
+        }
+    }
+
     /**
-     * Detect calls to functions with the incorrect number of parameters, or wrong types of arguments
+     * Validate every method call to `component.callfunc()`, `component.createChild()`, etc.
      */
-    private validateFunctionCall(file: BrsFile, expression: CallExpression | CallfuncExpression) {
-        const getTypeOptions = { flags: SymbolTypeFlag.runtime, data: {} };
-        let funcType: BscType;
-        let callErrorLocation: Location;
-        if (isCallExpression(expression)) {
-            funcType = this.getNodeTypeWrapper(file, expression?.callee, getTypeOptions);
-            callErrorLocation = expression?.callee?.location;
-        } else if (isCallfuncExpression(expression)) {
-            funcType = this.getNodeTypeWrapper(file, expression, { ...getTypeOptions, ignoreCall: true });
-            callErrorLocation = expression.location;
+    protected validateComponentMethods(file: BrsFile, call: CallExpression) {
+        const lowerMethodNamesChecked = ['callfunc', 'createchild'];
+        if (!isDottedGetExpression(call.callee)) {
+            return;
         }
 
+        const callName = call.callee.tokens?.name?.text?.toLowerCase();
+        if (!callName || !lowerMethodNamesChecked.includes(callName) || !isLiteralExpression(call?.args[0])) {
+            return;
+        }
+
+        const callerType = call.callee.obj?.getType({ flags: SymbolTypeFlag.runtime });
+        if (!isComponentType(callerType)) {
+            return;
+        }
+        const firstArgToken = call?.args[0]?.tokens.value;
+        if (callName === 'createchild') {
+            this.checkComponentName(firstArgToken);
+        } else if (callName === 'callfunc') {
+            const funcType = util.getCallFuncType(call, firstArgToken, { flags: SymbolTypeFlag.runtime, ignoreCall: true });
+            if (!funcType?.isResolvable()) {
+                const functionName = firstArgToken.text.replace(/"/g, '');
+                const functionFullname = `${callerType.toString()}@.${functionName}`;
+                this.addMultiScopeDiagnostic({
+                    ...DiagnosticMessages.cannotFindFunction(functionName, functionFullname, callerType.toString()),
+                    location: firstArgToken?.location
+                });
+            } else {
+                this.validateFunctionCall(file, funcType, firstArgToken.location, call.args, 1);
+            }
+        }
+    }
+
+
+    private validateCallExpression(file: BrsFile, expression: CallExpression) {
+        const getTypeOptions = { flags: SymbolTypeFlag.runtime, data: {} };
+        let funcType = this.getNodeTypeWrapper(file, expression?.callee, getTypeOptions);
         if (funcType?.isResolvable() && isClassType(funcType)) {
             // We're calling a class - get the constructor
             funcType = funcType.getMemberType('new', getTypeOptions);
         }
-        if (funcType?.isResolvable() && isTypedFunctionType(funcType)) {
-            //funcType.setName(expression.callee. .name);
+        const callErrorLocation = expression?.callee?.location;
+        return this.validateFunctionCall(file, funcType, callErrorLocation, expression.args);
 
-            //get min/max parameter count for callable
-            let minParams = 0;
-            let maxParams = 0;
-            for (let param of funcType.params) {
-                maxParams++;
-                //optional parameters must come last, so we can assume that minParams won't increase once we hit
-                //the first isOptional
-                if (param.isOptional !== true) {
-                    minParams++;
-                }
+    }
+
+    private validateCallFuncExpression(file: BrsFile, expression: CallfuncExpression) {
+        const getTypeOptions = { flags: SymbolTypeFlag.runtime, data: {} };
+        const funcType = this.getNodeTypeWrapper(file, expression, { ...getTypeOptions, ignoreCall: true });
+        const callErrorLocation = expression.location;
+        return this.validateFunctionCall(file, funcType, callErrorLocation, expression.args);
+    }
+
+    /**
+     * Detect calls to functions with the incorrect number of parameters, or wrong types of arguments
+     */
+    private validateFunctionCall(file: BrsFile, funcType: BscType, callErrorLocation: Location, args: Expression[], argOffset = 0) {
+        if (!funcType?.isResolvable() || !isTypedFunctionType(funcType)) {
+            return;
+        }
+
+        //get min/max parameter count for callable
+        let minParams = 0;
+        let maxParams = 0;
+        for (let param of funcType.params) {
+            maxParams++;
+            //optional parameters must come last, so we can assume that minParams won't increase once we hit
+            //the first isOptional
+            if (param.isOptional !== true) {
+                minParams++;
             }
-            if (funcType.isVariadic) {
-                // function accepts variable number of arguments
-                maxParams = CallExpression.MaximumArguments;
+        }
+        if (funcType.isVariadic) {
+            // function accepts variable number of arguments
+            maxParams = CallExpression.MaximumArguments;
+        }
+        const argsForCall = argOffset < 1 ? args : args.slice(argOffset);
+
+        let expCallArgCount = argsForCall.length;
+        if (expCallArgCount > maxParams || expCallArgCount < minParams) {
+            let minMaxParamsText = minParams === maxParams ? maxParams + argOffset : `${minParams + argOffset}-${maxParams + argOffset}`;
+            this.addMultiScopeDiagnostic({
+                ...DiagnosticMessages.mismatchArgumentCount(minMaxParamsText, expCallArgCount + argOffset),
+                location: callErrorLocation
+            });
+        }
+        let paramIndex = 0;
+        for (let arg of argsForCall) {
+            const data = {} as ExtraSymbolData;
+            let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
+
+            const paramType = funcType.params[paramIndex]?.type;
+            if (!paramType) {
+                // unable to find a paramType -- maybe there are more args than params
+                break;
             }
-            let expCallArgCount = expression.args.length;
-            if (expCallArgCount > maxParams || expCallArgCount < minParams) {
-                let minMaxParamsText = minParams === maxParams ? maxParams : `${minParams}-${maxParams}`;
+
+            if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
+                argType = data.definingNode.getConstructorType();
+            }
+
+            const compatibilityData: TypeCompatibilityData = {};
+            const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
+            if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
                 this.addMultiScopeDiagnostic({
-                    ...DiagnosticMessages.mismatchArgumentCount(minMaxParamsText, expCallArgCount),
-                    location: callErrorLocation
+                    ...DiagnosticMessages.argumentTypeMismatch(argType.toString(), paramType.toString(), compatibilityData),
+                    location: arg.location
                 });
             }
-            let paramIndex = 0;
-            for (let arg of expression.args) {
-                const data = {} as ExtraSymbolData;
-                let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
-
-                const paramType = funcType.params[paramIndex]?.type;
-                if (!paramType) {
-                    // unable to find a paramType -- maybe there are more args than params
-                    break;
-                }
-
-                if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
-                    argType = data.definingNode.getConstructorType();
-                }
-
-                const compatibilityData: TypeCompatibilityData = {};
-                const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
-                if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
-                    this.addMultiScopeDiagnostic({
-                        ...DiagnosticMessages.argumentTypeMismatch(argType.toString(), paramType.toString(), compatibilityData),
-                        location: arg.location
-                    });
-                }
-                paramIndex++;
-            }
-
+            paramIndex++;
         }
     }
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -773,7 +773,7 @@ export class ScopeValidator {
                     }
                 }
 
-            } else if (!(typeData?.isFromDocComment)) { //|| typeData?.isFromCallFunc)) {
+            } else if (!(typeData?.isFromDocComment)) {
                 // only show "cannot find... " errors if the type is not defined from a doc comment
                 const typeChainScan = util.processTypeChain(typeChain);
                 if (isCallExpression(typeChainScan.astNode.parent) && typeChainScan.astNode.parent.callee === expression) {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -368,10 +368,12 @@ export class ScopeValidator {
         if (!isComponentType(callerType)) {
             return;
         }
+        const componentNameLower = callerType.toString().toLowerCase();
+
         const firstArgToken = call?.args[0]?.tokens.value;
         if (callName === 'createchild') {
             this.checkComponentName(firstArgToken);
-        } else if (callName === 'callfunc') {
+        } else if (callName === 'callfunc' && !['rosgnode', 'rosgnodenode'].includes(componentNameLower)) {
             const funcType = util.getCallFuncType(call, firstArgToken, { flags: SymbolTypeFlag.runtime, ignoreCall: true });
             if (!funcType?.isResolvable()) {
                 const functionName = firstArgToken.text.replace(/"/g, '');

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -408,6 +408,10 @@ export class ScopeValidator {
         const methodName = methodToken?.text ?? '';
         const functionFullname = `${callerType.toString()}@.${methodName}`;
         const callErrorLocation = expression.location;
+        if (util.isGenericNodeType(callerType) || isObjectType(callerType) || isDynamicType(callerType)) {
+            // ignore "general" node
+            return;
+        }
 
         if (!isComponentType(callerType)) {
             this.addMultiScopeDiagnostic({
@@ -416,10 +420,7 @@ export class ScopeValidator {
             });
             return;
         }
-        if (util.isGenericNodeType(callerType)) {
-            // ignore "general" node
-            return;
-        }
+
         const funcType = util.getCallFuncType(expression, methodToken, { flags: SymbolTypeFlag.runtime, ignoreCall: true });
         if (!funcType?.isResolvable()) {
             this.addMultiScopeDiagnostic({

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1833,8 +1833,8 @@ describe('BrsFile', () => {
                         print PKG_PATH
                         print LINE_NUM
                         print new Person()
-                        m@.someCallfunc()
-                        m@.someCallfunc(1, 2)
+                        m.node@.someCallfunc()
+                        m.node@.someCallfunc(1, 2)
                         print tag\`stuff\${LINE_NUM}\${LINE_NUM}\`
                         print 1 = 1 ? 1 : 2
                         print 1 = 1 ? m.one : m.two
@@ -1887,8 +1887,8 @@ describe('BrsFile', () => {
                         print "pkg:/source/main.brs"
                         print LINE_NUM
                         print Person()
-                        m.callfunc("someCallfunc")
-                        m.callfunc("someCallfunc", 1, 2)
+                        m.node.callfunc("someCallfunc")
+                        m.node.callfunc("someCallfunc", 1, 2)
                         print tag(["stuff", "", ""], [LINE_NUM, LINE_NUM])
                         print bslib_ternary(1 = 1, 1, 2)
                         print (function(__bsCondition, m)
@@ -4090,10 +4090,10 @@ describe('BrsFile', () => {
 
     describe('callfunc operator', () => {
         describe('transpile', () => {
-            it('does not produce diagnostics', () => {
+            it('does not produce diagnostics on plain roSGNode', () => {
                 program.setFile('source/main.bs', `
                     sub test()
-                        someNode = createObject("roSGNode", "Rectangle")
+                        someNode = createObject("roSGNode", "Node")
                         someNode@.someFunction({test: "value"})
                     end sub
                 `);

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -5066,15 +5066,22 @@ describe('BrsFile', () => {
                 end class
             `);
             validateFile(mainFile);
-
-            expect(mainFile.requiredSymbols.length).to.eq(5);
+            // 'DataKind' is there twice:
+            // - when used as a type
+            // - when DataObject.kind is used
+            expect(mainFile.requiredSymbols.length).to.eq(6);
             const requiredTypeChains = mainFile.requiredSymbols.map(x => x.typeChain.map(tc => tc.name).join('.'));
-            expect(requiredTypeChains).to.have.same.members([
-                'DataKind', 'SubData', 'BaseData', 'DataProcessor', 'ProcessedData'
+            expect(Array.from(requiredTypeChains)).to.have.same.members([
+                'DataKind', 'DataKind', 'SubData', 'BaseData', 'DataProcessor', 'ProcessedData'
             ]);
             const requiredSymbolsFlags = mainFile.requiredSymbols.map(x => x.flags);
             expect(requiredSymbolsFlags).to.have.same.members([
-                SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime
+                SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime
+            ]);
+
+            const requiredSymbolsEndFlags = mainFile.requiredSymbols.map(x => x.endChainFlags);
+            expect(requiredSymbolsEndFlags).to.have.same.members([
+                SymbolTypeFlag.typetime, SymbolTypeFlag.runtime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime, SymbolTypeFlag.typetime
             ]);
         });
 

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1199,6 +1199,7 @@ export class BrsFile implements BscFile {
         const previousSymbolsChecked = new Map<SymbolTypeFlag, Set<string>>();
         previousSymbolsChecked.set(SymbolTypeFlag.runtime, new Set<string>());
         previousSymbolsChecked.set(SymbolTypeFlag.typetime, new Set<string>());
+
         for (const flag of [SymbolTypeFlag.runtime, SymbolTypeFlag.typetime]) {
             const newSymbolMapForFlag = symbolMap.get(flag);
             const oldSymbolMapForFlag = previouslyProvidedSymbols?.get(flag);

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -986,9 +986,10 @@ export class BrsFile implements BscFile {
 
     public processSymbolInformation() {
         // Get namespaces across imported files
+        this.program.logger.debug('Processing symbol information', this.srcPath);
+
         const nsTable = this.getNamespaceSymbolTable(false);
         this.linkSymbolTableDisposables.push(this.ast.symbolTable.addSibling(nsTable));
-
         this.validationSegmenter.processTree(this.ast);
         this.program.addFileSymbolInfo(this);
         this.unlinkNamespaceSymbolTables();
@@ -1052,6 +1053,8 @@ export class BrsFile implements BscFile {
 
     public get requiredSymbols() {
         return this.cache.getOrAdd(`requiredSymbols`, () => {
+            this.program.logger.debug('Getting required symbols', this.srcPath);
+
             const allNeededSymbolSets = this.validationSegmenter.unresolvedSegmentsSymbols.values();
 
             const requiredSymbols: UnresolvedSymbol[] = [];
@@ -1103,6 +1106,8 @@ export class BrsFile implements BscFile {
     }
 
     private getProvidedSymbols() {
+        this.program.logger.debug('Getting provided symbols', this.srcPath);
+
         const symbolMap = new Map<SymbolTypeFlag, Map<string, ProvidedSymbol>>();
         const runTimeSymbolMap = new Map<string, ProvidedSymbol>();
         const typeTimeSymbolMap = new Map<string, ProvidedSymbol>();

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -299,7 +299,7 @@ export class XmlFile implements BscFile {
     private dependencyGraph: DependencyGraph;
 
     public onDependenciesChanged(event: DependencyChangedEvent) {
-        this.logDebug('clear cache because dependency graph changed');
+        this.logDebug('clear cache because dependency graph changed', event?.sourceKey);
         this.cache.clear();
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1076,6 +1076,8 @@ export interface TypeCompatibilityData {
     // override for diagnostic message - useful for Arrays with different default types
     actualType?: BscType;
     expectedType?: BscType;
+    allowNameEquality?: boolean;
+    unresolveableTarget?: string;
 }
 
 export interface NamespaceContainer {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1063,6 +1063,10 @@ export interface TypeChainProcessResult {
      * The AstNode of the item
      */
     astNode: AstNode;
+    /**
+     * Does the chain contain a type that crossed a callFunc boundary?
+     */
+    crossedCallFunc: boolean;
 }
 
 export interface TypeCompatibilityData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -977,6 +977,10 @@ export interface ExtraSymbolData {
      * Is this type as defined in a doc comment?
      */
     isFromDocComment?: boolean;
+    /**
+     * was this a result of a callfunc?
+     */
+    isFromCallFunc?: boolean;
 }
 
 export interface GetTypeOptions {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1713,18 +1713,14 @@ export class CallfuncExpression extends Expression {
                 }));
                 if (options.ignoreCall) {
                     result = funcType;
+                } else if (isCallableType(funcType) && (!isReferenceType(funcType.returnType) || funcType.returnType.isResolvable())) {
+                    result = funcType.returnType;
+                } else if (!isReferenceType(funcType) && (funcType as any)?.returnType?.isResolvable()) {
+                    result = (funcType as any).returnType;
+                } else {
+                    return new TypePropertyReferenceType(funcType, 'returnType');
                 }
             }
-            /* TODO:
-                make callfunc return types work
-            else if (isCallableType(funcType) && (!isReferenceType(funcType.returnType) || funcType.returnType.isResolvable())) {
-                result = funcType.returnType;
-            } else if (!isReferenceType(funcType) && (funcType as any)?.returnType?.isResolvable()) {
-                result = (funcType as any).returnType;
-            } else {
-                return new TypePropertyReferenceType(funcType, 'returnType');
-            }
-            */
         }
 
         return result;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -28,8 +28,6 @@ import { UnionType } from '../types/UnionType';
 import { ArrayType } from '../types/ArrayType';
 import { AssociativeArrayType } from '../types/AssociativeArrayType';
 import { TypedFunctionType } from '../types/TypedFunctionType';
-import type { ComponentType } from '../types/ComponentType';
-import { createToken } from '../astUtils/creators';
 import { InvalidType } from '../types/InvalidType';
 import { UninitializedType } from '../types/UninitializedType';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -8,7 +8,7 @@ import type { AliasStatement, AssignmentStatement, Block, ClassStatement, Condit
 import { PrintStatement, FunctionStatement, NamespaceStatement, ImportStatement } from './Statement';
 import { Range } from 'vscode-languageserver';
 import { DiagnosticMessages } from '../DiagnosticMessages';
-import { isAliasStatement, isAssignmentStatement, isBinaryExpression, isBlock, isBody, isCallExpression, isClassStatement, isConditionalCompileConstStatement, isConditionalCompileErrorStatement, isConditionalCompileStatement, isDottedGetExpression, isExitStatement, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAliasStatement, isAssignmentStatement, isBinaryExpression, isBlock, isBody, isCallExpression, isCallfuncExpression, isClassStatement, isConditionalCompileConstStatement, isConditionalCompileErrorStatement, isConditionalCompileStatement, isDottedGetExpression, isExitStatement, isExpression, isExpressionStatement, isFunctionStatement, isGroupingExpression, isIfStatement, isIndexedGetExpression, isInterfaceStatement, isLiteralExpression, isNamespaceStatement, isPrintStatement, isTypecastExpression, isTypecastStatement, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import { expectDiagnostics, expectDiagnosticsIncludes, expectTypeToBe, expectZeroDiagnostics, rootDir } from '../testHelpers.spec';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { Expression, Statement } from './AstNode';
@@ -595,6 +595,19 @@ describe('parser', () => {
                     expect(isExpressionStatement(stmt)).to.be.true;
                     expect(isBinaryExpression((stmt).expression)).to.be.true;
                 }
+            });
+
+            it('adds callfunc expressions', () => {
+                let parser = parse(`
+                    sub foo(thing)
+                        thing@.
+                    end sub
+                `, ParseMode.BrighterScript);
+                expect(parser.diagnostics[0]?.message).to.exist;
+                let body = (parser.ast.statements[0] as FunctionStatement).func.body;
+
+                let callFunc = body.findChild<CallExpression>(isCallfuncExpression);
+                expect(callFunc).to.exist;
             });
         });
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2861,19 +2861,24 @@ export class Parser {
     private callfunc(callee: Expression): Expression {
         this.warnIfNotBrighterScriptMode('callfunc operator');
         let operator = this.previous();
-        let methodName = this.consume(DiagnosticMessages.expectedIdentifier(), TokenKind.Identifier, ...AllowedProperties);
-        // force it into an identifier so the AST makes some sense
-        methodName.kind = TokenKind.Identifier;
-        let openParen = this.consume(DiagnosticMessages.expectedOpenParenToFollowCallfuncIdentifier(), TokenKind.LeftParen);
-        let call = this.finishCall(openParen, callee, false);
-
+        let methodName = this.tryConsume(DiagnosticMessages.expectedIdentifier(), TokenKind.Identifier, ...AllowedProperties);
+        let openParen: Token;
+        let call: CallExpression;
+        if (methodName) {
+            // force it into an identifier so the AST makes some sense
+            methodName.kind = TokenKind.Identifier;
+            openParen = this.tryConsume(DiagnosticMessages.expectedOpenParenToFollowCallfuncIdentifier(), TokenKind.LeftParen);
+            if (openParen) {
+                call = this.finishCall(openParen, callee, false);
+            }
+        }
         return new CallfuncExpression({
             callee: callee,
             operator: operator,
             methodName: methodName as Identifier,
             openingParen: openParen,
-            args: call.args,
-            closingParen: call.tokens.closingParen
+            args: call?.args,
+            closingParen: call?.tokens?.closingParen
         });
     }
 

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -248,7 +248,7 @@ export default class SGParser {
             startTagName: this.mapToken(children.Name[0]),
             attributes: this.mapAttributes(children.attribute),
             // > or />
-            startTagClose: this.mapToken((children.SLASH_CLOSE ?? children.START_CLOSE)[0]),
+            startTagClose: this.mapToken((children.SLASH_CLOSE ?? children.START_CLOSE)?.[0]),
             elements: this.mapNodes(children.content?.[0]),
             // </
             endTagOpen: this.mapToken(children.SLASH_OPEN?.[0]),

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -187,7 +187,7 @@ export function expectZeroDiagnostics(arg: DiagnosticCollection) {
         for (const diagnostic of diagnostics) {
             //escape any newlines
             diagnostic.message = diagnostic.message.replace(/\r/g, '\\r').replace(/\n/g, '\\n');
-            message += `\n        • bs${diagnostic.code} "${diagnostic.message}" at ${diagnostic.location?.uri ?? ''}#(${diagnostic.location?.range?.start.line}:${diagnostic.location?.range?.start.character})-(${diagnostic.location?.range?.end.line}:${diagnostic.location?.range?.end.character})`;
+            message += `\n        • bs:${diagnostic.code} "${diagnostic.message}" at ${diagnostic.location?.uri ?? ''}#(${diagnostic.location?.range?.start.line}:${diagnostic.location?.range?.start.character})-(${diagnostic.location?.range?.end.line}:${diagnostic.location?.range?.end.character})`;
             //print the line containing the error (if we can find it)srcPath
             if (arg instanceof Program) {
                 const file = arg.getFile(diagnostic.location.uri);

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -18,6 +18,7 @@ export class ArrayType extends BscType {
     }
 
     public readonly kind = BscTypeKind.ArrayType;
+    public isBuiltIn = true;
 
     public innerTypes: BscType[] = [];
 

--- a/src/types/AssociativeArrayType.ts
+++ b/src/types/AssociativeArrayType.ts
@@ -12,6 +12,8 @@ export class AssociativeArrayType extends BscType {
 
     public readonly kind = BscTypeKind.AssociativeArrayType;
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         if (isDynamicType(targetType)) {
             return true;

--- a/src/types/BaseFunctionType.ts
+++ b/src/types/BaseFunctionType.ts
@@ -5,6 +5,7 @@ import { DynamicType } from './DynamicType';
 export abstract class BaseFunctionType extends BscType {
 
     public returnType: BscType = DynamicType.instance;
+    public isBuiltIn = true;
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData): boolean {
         throw new Error('Method not implemented.');

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -13,6 +13,7 @@ export class BooleanType extends BscType {
     }
 
     public readonly kind = BscTypeKind.BooleanType;
+    public isBuiltIn = true;
 
     public static instance = new BooleanType('boolean');
 

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -74,7 +74,7 @@ export abstract class BscType {
         throw new Error('Method not implemented.');
     }
 
-    checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}) {
+    checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}, memberTable?: SymbolTable) {
         if (!targetType) {
             return false;
         }
@@ -99,7 +99,7 @@ export abstract class BscType {
             // some sort of circular reference
             return false;
         }
-        const mySymbols = this.getMemberTable()?.getAllSymbols(flags);
+        const mySymbols = (memberTable ?? this.getMemberTable())?.getAllSymbols(flags);
         for (const memberSymbol of mySymbols) {
             const targetTypesOfSymbol = targetType.getMemberTable()
                 .getSymbolTypes(memberSymbol.name, { flags: flags })

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -74,7 +74,7 @@ export abstract class BscType {
         throw new Error('Method not implemented.');
     }
 
-    checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}, memberTable?: SymbolTable) {
+    checkCompatibilityBasedOnMembers(targetType: BscType, flags: SymbolTypeFlag, data: TypeCompatibilityData = {}, memberTable?: SymbolTable, targetMemberTable?: SymbolTable) {
         if (!targetType) {
             return false;
         }
@@ -91,6 +91,7 @@ export abstract class BscType {
         }
 
         if (isReferenceType(targetType) && !targetType.isResolvable()) {
+            data.unresolveableTarget = targetType.fullName;
             // we can't resolve the other type. Assume it does not fail on member checks
             return true;
         }
@@ -100,8 +101,9 @@ export abstract class BscType {
             return false;
         }
         const mySymbols = (memberTable ?? this.getMemberTable())?.getAllSymbols(flags);
+        const targetTable = (targetMemberTable ?? targetType.getMemberTable());
         for (const memberSymbol of mySymbols) {
-            const targetTypesOfSymbol = targetType.getMemberTable()
+            const targetTypesOfSymbol = targetTable
                 .getSymbolTypes(memberSymbol.name, { flags: flags })
                 ?.map(symbol => symbol.type);
             if (!targetTypesOfSymbol || targetTypesOfSymbol.length === 0) {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -10,6 +10,7 @@ export abstract class BscType {
     public readonly memberTable: SymbolTable;
     protected __identifier: string;
     protected hasAddedBuiltInInterfaces = false;
+    public isBuiltIn = false;
 
     constructor(name = '') {
         this.__identifier = `${this.constructor.name}${name ? ': ' + name : ''}`;

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -50,8 +50,11 @@ export class ClassType extends InheritableType {
         }
     }
 
+    private hasStartedAddingBuiltInInterfaces = false;
+
     addBuiltInInterfaces() {
-        if (!this.hasAddedBuiltInInterfaces) {
+        if (!this.hasAddedBuiltInInterfaces && !this.hasStartedAddingBuiltInInterfaces) {
+            this.hasStartedAddingBuiltInInterfaces = true;
             if (this.parentType) {
                 this.parentType.addBuiltInInterfaces();
             }

--- a/src/types/ComponentType.ts
+++ b/src/types/ComponentType.ts
@@ -47,9 +47,20 @@ export class ComponentType extends InheritableType {
         if (this === targetType) {
             return true;
         }
+        if (!isComponentType(targetType)) {
+            return false;
+        }
 
-        return isComponentType(targetType) && this.name.toLowerCase() === targetType.name.toLowerCase() &&
-            this.isParentTypeEqual(targetType, data) &&
+        const thisNameLower = this.name.toLowerCase();
+        const targetNameLower = targetType.name.toLowerCase();
+        if (thisNameLower !== targetNameLower) {
+            return false;
+        }
+        if (this.isBuiltIn && targetType.isBuiltIn) {
+            return true;
+        }
+
+        return this.isParentTypeEqual(targetType, data) &&
             this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data) &&
             targetType.checkCompatibilityBasedOnMembers(this, SymbolTypeFlag.runtime, data) &&
             this.checkCompatibilityBasedOnMembers(targetType, SymbolTypeFlag.runtime, data, this.callFuncMemberTable) &&

--- a/src/types/ComponentType.ts
+++ b/src/types/ComponentType.ts
@@ -121,27 +121,12 @@ export class ComponentType extends InheritableType {
             originalTypesToCheck.add(funcType.returnType);
         }
         const additionalTypesToCheck = new Set<BscType>();
-        /*function addSubTypes(type: BscType) {
-            const subSymbols = type.getMemberTable().getAllSymbols(SymbolTypeFlag.runtime);
-            for (const subSymbol of subSymbols) {
-                if (!subSymbol.type.isBuiltIn && !(additionalTypesToCheck.has(subSymbol.type) || originalTypesToCheck.has(subSymbol.type))) {
-                    // if this is a custom type, and we haven't added it to the types to check to see if can add it to the additional types
-                    // add the type, and investigate any members
-                    additionalTypesToCheck.add(subSymbol.type);
-                    addSubTypes(subSymbol.type);
-                }
-
-            }
-        }*/
 
         for (const type of originalTypesToCheck) {
             if (!type.isBuiltIn) {
                 util.getCustomTypesInSymbolTree(additionalTypesToCheck, type, (subSymbol: BscSymbol) => {
                     return !originalTypesToCheck.has(subSymbol.type);
                 });
-
-
-                //addSubTypes(type);
             }
         }
 
@@ -183,7 +168,6 @@ export class ComponentType extends InheritableType {
                         addAssociatedTypesTableAsSiblingToMemberTable(memberSymbol?.type);
                     }
                 }
-
             }
         };
 

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -17,6 +17,8 @@ export class DoubleType extends BscType {
 
     public static instance = new DoubleType('double');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isDynamicType(targetType) ||

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -15,6 +15,8 @@ export class DynamicType extends BscType {
 
     public static readonly instance = new DynamicType();
 
+    public isBuiltIn = true;
+
     get returnType() {
         return DynamicType.instance;
     }

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -16,6 +16,8 @@ export class FloatType extends BscType {
 
     public static instance = new FloatType('float');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isDynamicType(targetType) ||

--- a/src/types/InheritableType.ts
+++ b/src/types/InheritableType.ts
@@ -125,6 +125,15 @@ export abstract class InheritableType extends BscType {
         if (this === targetType) {
             return true;
         }
+        if (data?.allowNameEquality) {
+            const thisKind = (this as any).kind;
+            if (thisKind && thisKind === (targetType as any).kind) {
+                if (this.toString().toLowerCase() === targetType.toString().toLowerCase()) {
+                    return true;
+                }
+            }
+        }
+
         if (this.isAncestorUnresolvedReferenceType() || targetType.isAncestorUnresolvedReferenceType()) {
             return this.name.toLowerCase() === targetType.name?.toLowerCase() &&
                 this.isParentTypeEqual(targetType, data);

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -16,6 +16,8 @@ export class IntegerType extends BscType {
 
     public static instance = new IntegerType('integer');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isDynamicType(targetType) ||

--- a/src/types/InvalidType.ts
+++ b/src/types/InvalidType.ts
@@ -15,6 +15,8 @@ export class InvalidType extends BscType {
 
     public static instance = new InvalidType('invalid');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType) {
         return (
             isInvalidType(targetType) ||

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -16,6 +16,8 @@ export class LongIntegerType extends BscType {
 
     public static instance = new LongIntegerType('longinteger');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isDynamicType(targetType) ||

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -15,6 +15,8 @@ export class ObjectType extends BscType {
 
     public readonly kind = BscTypeKind.ObjectType;
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         //Brightscript allows anything passed "as object", so as long as a type is provided, this is true
         return !!targetType;

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -14,6 +14,7 @@ export class StringType extends BscType {
 
     public readonly kind = BscTypeKind.StringType;
 
+    public isBuiltIn = true;
     /**
      * A static instance that can be used to reduce memory and constructor costs, since there's nothing unique about this
      */

--- a/src/types/TypedFunctionType.ts
+++ b/src/types/TypedFunctionType.ts
@@ -79,9 +79,15 @@ export class TypedFunctionType extends BaseFunctionType {
         return 'Function';
     }
 
-    isEqual(targetType: BscType) {
+    isEqual(targetType: BscType, data: TypeCompatibilityData = {}) {
         if (isTypedFunctionType(targetType)) {
-            return this.checkParamsAndReturnValue(targetType, false, (t1, t2) => t1.isEqual(t2));
+            if (this.toString().toLowerCase() === targetType.toString().toLowerCase()) {
+                // this function has the same param names and types and return type as the target
+                return true;
+            }
+            return this.checkParamsAndReturnValue(targetType, false, (t1, t2, predData = {}) => {
+                return t1.isEqual(t2, { ...predData, allowNameEquality: true });
+            }, data);
         }
         return false;
     }

--- a/src/types/UninitializedType.ts
+++ b/src/types/UninitializedType.ts
@@ -14,6 +14,8 @@ export class UninitializedType extends BscType {
 
     public readonly kind = BscTypeKind.UninitializedType;
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isUninitializedType(targetType) ||

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -56,6 +56,9 @@ export class UnionType extends BscType {
                     },
                     setCachedType: (innerName: string, innerCacheEntry: TypeCacheEntry, innerOptions: GetTypeOptions) => {
                         // TODO: is this even cachable? This is a NO-OP for now, and it shouldn't hurt anything
+                    },
+                    addSibling: (symbolTable: SymbolTable) => {
+                        // TODO: I don't know what this means in this context?
                     }
                 };
             });

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -16,6 +16,8 @@ export class VoidType extends BscType {
 
     public static instance = new VoidType('void');
 
+    public isBuiltIn = true;
+
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
             isVoidType(targetType) ||

--- a/src/util.ts
+++ b/src/util.ts
@@ -2271,6 +2271,17 @@ export class Util {
         return false;
     }
 
+    public isGenericNodeType(type: BscType) {
+        if (isComponentType(type)) {
+            const lowerName = type.toString().toLowerCase();
+            if (lowerName === 'rosgnode' || lowerName === 'rosgnodenode') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
     public hasAnyRequiredSymbolChanged(requiredSymbols: UnresolvedSymbol[], changedSymbols: Map<SymbolTypeFlag, Set<string>>) {
         if (!requiredSymbols || !changedSymbols) {
             return false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -2556,6 +2556,10 @@ export class Util {
                 }
             }
         }
+        if (isVoidType(result)) {
+            // CallFunc will always return invalid, even if function called is `as void`
+            result = DynamicType.instance;
+        }
         if (options.data && !options.ignoreCall) {
             options.data.isFromCallFunc = true;
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2256,12 +2256,12 @@ export class Util {
     public isInTypeExpression(expression: AstNode): boolean {
         //TODO: this is much faster than node.findAncestor(), but may need to be updated for "complicated" type expressions
         if (isTypeExpression(expression) ||
-            isTypeExpression(expression.parent) ||
+            isTypeExpression(expression?.parent) ||
             isTypedArrayExpression(expression) ||
-            isTypedArrayExpression(expression.parent)) {
+            isTypedArrayExpression(expression?.parent)) {
             return true;
         }
-        if (isBinaryExpression(expression.parent)) {
+        if (isBinaryExpression(expression?.parent)) {
             let currentExpr: AstNode = expression.parent;
             while (isBinaryExpression(currentExpr) && currentExpr.tokens.operator.kind === TokenKind.Or) {
                 currentExpr = currentExpr.parent;

--- a/src/util.ts
+++ b/src/util.ts
@@ -2470,9 +2470,9 @@ export class Util {
         // It's nicer for CallExpression, because it's a call on any expression.
         let calleeType: BscType;
         if (isCallfuncExpression(callExpr)) {
-            calleeType = callExpr.callee.getType({ ...options, flags: SymbolTypeFlag.runtime });
+            calleeType = callExpr.callee.getType({ ...options, flags: SymbolTypeFlag.runtime, ignoreCall: false });
         } else if (isCallExpression(callExpr) && isDottedGetExpression(callExpr.callee)) {
-            calleeType = callExpr.callee.obj.getType({ ...options, flags: SymbolTypeFlag.runtime });
+            calleeType = callExpr.callee.obj.getType({ ...options, flags: SymbolTypeFlag.runtime, ignoreCall: false });
         }
         if (isComponentType(calleeType) || isReferenceType(calleeType)) {
             const funcType = (calleeType as ComponentType).getCallFuncType?.(methodName, options);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2409,15 +2409,28 @@ export class Util {
                 }
             }
         } else if (isDottedGetExpression(callExpr.callee) &&
-            callExpr.callee.tokens.name.text.toLowerCase() === 'callfunc' &&
+            callExpr.callee.tokens?.name?.text?.toLowerCase() === 'callfunc' &&
             isLiteralString(callExpr.args?.[0])) {
             return this.getCallFuncType(callExpr, callExpr.args?.[0]?.tokens.value, options);
+        } else if (isDottedGetExpression(callExpr.callee) &&
+            callExpr.callee.tokens?.name?.text?.toLowerCase() === 'createchild' &&
+            isComponentType(callExpr.callee.obj?.getType({ flags: SymbolTypeFlag.runtime })) &&
+            isLiteralString(callExpr.args?.[0])) {
+            const fullName = `roSGNode${callExpr.args?.[0].tokens?.value?.text?.replace(/"/g, '')}`;
+            const data = {};
+            const symbolTable = callExpr.getSymbolTable();
+            return symbolTable.getSymbolType(fullName, {
+                flags: SymbolTypeFlag.typetime,
+                data: data,
+                tableProvider: () => callExpr?.getSymbolTable(),
+                fullName: fullName
+            });
         }
     }
 
     public getCallFuncType(callExpr: CallExpression | CallfuncExpression, methodNameToken: Token | Identifier, options: GetSymbolTypeOptions) {
         let result: BscType;
-        let methodName = methodNameToken.text.replaceAll('"', '');
+        let methodName = methodNameToken?.text?.replace(/"/g, ''); // remove quotes if it was the first arg of .callFunc()
 
         // a little hacky here with checking options.ignoreCall because callFuncExpression has the method name
         // It's nicer for CallExpression, because it's a call on any expression.

--- a/src/util.ts
+++ b/src/util.ts
@@ -2374,7 +2374,7 @@ export class Util {
     public getCustomTypesInSymbolTree(setToFill: Set<BscType>, type: BscType, filter?: (t: BscSymbol) => boolean) {
         const subSymbols = type.getMemberTable()?.getAllSymbols(SymbolTypeFlag.runtime) ?? [];
         for (const subSymbol of subSymbols) {
-            if (!subSymbol.data?.isBuiltIn && !setToFill.has(subSymbol.type)) {
+            if (!subSymbol.type?.isBuiltIn && !setToFill.has(subSymbol.type)) {
                 if (filter && !filter(subSymbol)) {
                     continue;
                 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2185,6 +2185,7 @@ export class Util {
         let errorLocation: Location;
         let containsDynamic = false;
         let continueResolvingAllItems = true;
+        let crossedCallFunc = false;
         for (let i = 0; i < typeChain.length; i++) {
             const chainItem = typeChain[i];
             const dotSep = chainItem.separatorToken?.text ?? '.';
@@ -2230,6 +2231,7 @@ export class Util {
                 itemName = chainItem.name;
                 astNode = chainItem.astNode;
                 containsDynamic = containsDynamic || (isDynamicType(chainItem.type) && !isAnyReferenceType(chainItem.type));
+                crossedCallFunc = crossedCallFunc || chainItem.data?.isFromCallFunc;
                 if (!chainItem.isResolved) {
                     errorLocation = chainItem.location;
                     continueResolvingAllItems = false;
@@ -2245,7 +2247,8 @@ export class Util {
             fullChainName: fullChainName,
             location: errorLocation,
             containsDynamic: containsDynamic,
-            astNode: astNode
+            astNode: astNode,
+            crossedCallFunc: crossedCallFunc
         };
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2422,7 +2422,14 @@ export class Util {
             const componentName = isLiteralString(callExpr.args[0]) ? callExpr.args[0].tokens.value?.text?.replace(/"/g, '') : '';
             const nodeType = componentName.toLowerCase() === 'rosgnode' && isLiteralString(callExpr.args[1]) ? callExpr.args[1].tokens.value?.text?.replace(/"/g, '') : '';
             if (componentName?.toLowerCase().startsWith('ro')) {
-                const fullName = componentName + nodeType;
+                let fullName = componentName + nodeType;
+
+                if (nodeType.includes(':')) {
+                    // This node has a colon in its name, most likely from a component Library
+                    // This componentType is most likely unknown, so return `roSGNode`
+                    fullName = 'roSGNode';
+                }
+
                 const data = {};
                 const symbolTable = callExpr.getSymbolTable();
                 const foundType = symbolTable.getSymbolType(fullName, {


### PR DESCRIPTION
Gives `callFunc` a whole lotta love!


- Fixes an issue with completions on `@.` where ALL possible callfuncs would appear. This was a result of the parser having an exception on incomplete `@.` invocations
- Adds function documentation to hovers on `@.` callfunc invocations
- Stores all resolved types associated with callfuncs for a component in a symbolTable that is used a sibiling table when the callfunc is used in another scope
- Return type of `Callfunc` and `@.` invocations are used to set types in assignments 
- Validates arg counts and type mismatches for `callfunc` and `@.`

While I was it, I also added validation and return typing for `<component>.createChild()`

Additional validation enhancements:
- if a type depends on another type (eg, has a member of another type), and that member type changes, then all segments/ASTNodes that reference the wider type are also re-validated. This means that the type-safety flows down and things get appropriately re-validated when there are changes.
- Better handling of `typecast` statements when setting up file segments for revalidation
- Better handling of when component types change, and re-validation because of that.

TODO:
- [x] Make validation updates work better. Currently, you need to edit an XML file of the component for things to revalidate if the exported function type changes
- [x] Deal with how adding sibling tables messes up other validations. Like if the resolved version stay around when they actually should be unresolved
- [x] Do not have validation errors if the component type is the generic `roSGNode` 

To be honest, I think that if we properly re-build the Component type when a member file changes, that would fix both problems.


![image](https://github.com/user-attachments/assets/8c7ef6fe-aec5-4707-99a0-403ba8d9b1b1)

![image](https://github.com/user-attachments/assets/48efa484-ead6-4105-a53f-a2719f592c6e)


Also fixes #1309
