### PR TITLE
Fix bug with ternary transpile for indexed set

### DIFF
--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -131,7 +131,8 @@ export class BrsFilePreTranspileProcessor {
                 }),
                 endIf: createToken(TokenKind.EndIf, 'end if', ternaryExpression.questionMarkToken.range)
             });
-        } else if (isIndexedSetStatement(parent)) {
+            //if this is an indexedSetStatement, and the ternary expression is NOT an index
+        } else if (isIndexedSetStatement(parent) && parent.index !== ternaryExpression && !parent.additionalIndexes?.includes(ternaryExpression)) {
             ifStatement = createIfStatement({
                 if: createToken(TokenKind.If, 'if', ternaryExpression.questionMarkToken.range),
                 condition: ternaryExpression.test,

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -831,11 +831,13 @@ describe('ternary expressions', () => {
             testTranspile(
                 `
                     sub main()
+                        m[m.isShiftPressed ? "a" : "b"] = 0
                         m[m.useAltKey ? m.altKey : m.key] = 1
                     end sub
                 `,
                 `
                     sub main()
+                        m[bslib_ternary(m.isShiftPressed, "a", "b")] = 0
                         m[(function(__bsCondition, m)
                                 if __bsCondition then
                                     return m.altKey

--- a/src/parser/tests/expression/TernaryExpression.spec.ts
+++ b/src/parser/tests/expression/TernaryExpression.spec.ts
@@ -827,6 +827,27 @@ describe('ternary expressions', () => {
             );
         });
 
+        it('supports ternary in indexedSet key', () => {
+            testTranspile(
+                `
+                    sub main()
+                        m[m.useAltKey ? m.altKey : m.key] = 1
+                    end sub
+                `,
+                `
+                    sub main()
+                        m[(function(__bsCondition, m)
+                                if __bsCondition then
+                                    return m.altKey
+                                else
+                                    return m.key
+                                end if
+                            end function)(m.useAltKey, m)] = 1
+                    end sub
+                `
+            );
+        });
+
         it('supports scope-captured outer, and simple inner', () => {
             testTranspile(
                 `


### PR DESCRIPTION
Fixes #1356 . 

The issue was that we were only checking if the parent of the ternaryExpression was an IndexedSet, but we currently only support lifting the VALUE of those expressions, not their indexes. So this now guards against matching on the indexes.