### PR TITLE
Add more convenience exports from vscode-languageserver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export * from './parser/Statement';
 export * from './BsConfig';
 export * from './deferred';
 // convenience re-export from vscode
-export { Range, Position, CancellationToken, CancellationTokenSource, DiagnosticSeverity, DiagnosticTag, SemanticTokenTypes, CodeAction } from 'vscode-languageserver';
+export { Diagnostic, Range, Location, Position, CancellationToken, CancellationTokenSource, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, SemanticTokenTypes, CodeAction, CodeDescription, URI } from 'vscode-languageserver';
 export * from './astUtils/visitors';
 export * from './astUtils/stackedVisitor';
 export * from './astUtils/reflection';


### PR DESCRIPTION
Adds a few additional exports from the vscode-languageserver package to eliminate the need for external projects to directly require that package.