### PR TITLE
Emit `active-runs-change` event _after_ removing it from the array.

### DIFF
--- a/src/BusyStatusTracker.spec.ts
+++ b/src/BusyStatusTracker.spec.ts
@@ -213,7 +213,7 @@ describe('BusyStatusTracker', () => {
             expect(count).to.eql(10);
         });
 
-        it.only('emits active-runs-change with the correct list of remaining active runs', () => {
+        it('emits active-runs-change with the correct list of remaining active runs', () => {
             const spy = sinon.spy();
             tracker.on('active-runs-change', spy);
             tracker.run(() => {

--- a/src/BusyStatusTracker.spec.ts
+++ b/src/BusyStatusTracker.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { Deferred } from './deferred';
 import { BusyStatus, BusyStatusTracker } from './BusyStatusTracker';
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
 
 describe('BusyStatusTracker', () => {
     let tracker: BusyStatusTracker;
@@ -8,6 +10,7 @@ describe('BusyStatusTracker', () => {
     let latestStatus: BusyStatus;
 
     beforeEach(() => {
+        sinon.restore();
         latestStatus = BusyStatus.idle;
         tracker = new BusyStatusTracker();
         tracker.on('change', (value) => {
@@ -16,6 +19,7 @@ describe('BusyStatusTracker', () => {
     });
 
     afterEach(() => {
+        sinon.restore();
         tracker?.destroy();
     });
 
@@ -207,6 +211,24 @@ describe('BusyStatusTracker', () => {
 
             //we should have 10 total events (5 starts, 5 ends)
             expect(count).to.eql(10);
+        });
+
+        it.only('emits active-runs-change with the correct list of remaining active runs', () => {
+            const spy = sinon.spy();
+            tracker.on('active-runs-change', spy);
+            tracker.run(() => {
+                expect(tracker.status).to.eql(BusyStatus.busy);
+            }, 'test');
+            //small timeout to allow all the events to show up
+            expect(spy.callCount).to.eql(2);
+            expect(
+                spy.getCall(0).args[0].activeRuns.map(x => ({ label: x.label }))
+            ).to.eql([
+                { label: 'test' }
+            ]);
+            expect(
+                spy.getCall(1).args[0].activeRuns
+            ).to.eql([]);
         });
 
         it('removes the entry for the scope when the last run is cleared', async () => {

--- a/src/BusyStatusTracker.ts
+++ b/src/BusyStatusTracker.ts
@@ -95,12 +95,13 @@ export class BusyStatusTracker<T = any> {
             if (isFinalized === false) {
                 isFinalized = true;
 
-                this.emit('active-runs-change', { activeRuns: [...this.activeRuns] });
-
                 let idx = this.activeRuns.indexOf(runInfo);
                 if (idx > -1) {
                     this.activeRuns.splice(idx, 1);
                 }
+
+                this.emit('active-runs-change', { activeRuns: [...this.activeRuns] });
+
                 if (this.activeRuns.length <= 0) {
                     this.emit('change', BusyStatus.idle);
                 }


### PR DESCRIPTION
Fix bug with the lsp busy spinner never stopping.