### PR TITLE
Fixes default type for ArrayLIteral with enum member inner types

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -3387,6 +3387,31 @@ describe('Scope', () => {
                 expectTypeToBe((dataType as ArrayType).defaultType, ComponentType);
                 expect((dataType as ArrayType).defaultType.toString()).to.equal('roSGNodeLabel');
             });
+
+            it('should allow a typed array of an enum', () => {
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    enum Direction
+                        North = 1
+                        East = 2
+                        South = 3
+                        West = 4
+                    end enum
+
+                    sub EnumTest()
+                        arr = [Direction.North]
+                        arr.push(Direction.South)
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const processFnScope = utilFile.getFunctionScopeAtPosition(util.createPosition(9, 24));
+                const symbolTable = processFnScope.symbolTable;
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const dataType = symbolTable.getSymbolType('arr', opts) as ArrayType;
+                expectTypeToBe(dataType, ArrayType);
+                expectTypeToBe(dataType.defaultType, EnumType);
+                expect(dataType.defaultType.toString()).to.equal('Direction');
+            });
         });
 
         describe('callFunc invocations', () => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -20,13 +20,13 @@ import { FloatType } from './types/FloatType';
 import { NamespaceType } from './types/NamespaceType';
 import { DoubleType } from './types/DoubleType';
 import { UnionType } from './types/UnionType';
-import { isBlock, isForEachStatement, isFunctionExpression, isFunctionStatement, isNamespaceStatement } from './astUtils/reflection';
+import { isBlock, isCallExpression, isForEachStatement, isFunctionExpression, isFunctionStatement, isNamespaceStatement } from './astUtils/reflection';
 import { ArrayType } from './types/ArrayType';
 import { AssociativeArrayType } from './types/AssociativeArrayType';
 import { InterfaceType } from './types/InterfaceType';
 import { ComponentType } from './types/ComponentType';
 import { WalkMode, createVisitor } from './astUtils/visitors';
-import type { FunctionExpression } from './parser/Expression';
+import type { CallExpression, FunctionExpression } from './parser/Expression';
 import { ObjectType } from './types';
 
 describe('Scope', () => {
@@ -2518,9 +2518,10 @@ describe('Scope', () => {
 
         it('finds correct parameter type with default value enums are used', () => {
             const mainFile = program.setFile<BrsFile>('source/main.bs', `
-                sub paint(colorChoice = Color.red)
+                sub paint(x as Color, colorChoice = Color.red)
                     paintColor = colorChoice
                     print paintColor
+                    print x.toStr()
                 end sub
 
                 enum Color
@@ -2535,7 +2536,7 @@ describe('Scope', () => {
             expect(sourceScope).to.exist;
             expect(mainFnScope).to.exist;
             sourceScope.linkSymbolTable();
-            expectTypeToBe(mainFnScope.symbolTable.getSymbol('paintColor', SymbolTypeFlag.runtime)[0].type, EnumMemberType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('paintColor', SymbolTypeFlag.runtime)[0].type, EnumType);
         });
 
         it('finds correct class field type with default value enums are used', () => {
@@ -2561,10 +2562,10 @@ describe('Scope', () => {
             const sourceScope = program.getScopeByName('source');
             expect(sourceScope).to.exist;
             expect(mainFnScope).to.exist;
-            //sourceScope.linkSymbolTable();
+            sourceScope.linkSymbolTable();
             let mainScopeSymbolTable = mainFnScope.symbolTable;
             let paintType = mainScopeSymbolTable.getSymbolType('paintColor', { flags: SymbolTypeFlag.runtime });
-            expectTypeToBe(paintType, EnumMemberType);
+            expectTypeToBe(paintType, EnumType);
         });
 
 
@@ -2583,7 +2584,7 @@ describe('Scope', () => {
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoy', SymbolTypeFlag.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('flyBoy', SymbolTypeFlag.runtime)[0].type.toString()).to.eq('Animals.Bird');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoysWings', SymbolTypeFlag.runtime)[0].type, BooleanType);
-            expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoysSkin', SymbolTypeFlag.runtime)[0].type, EnumMemberType);
+            expectTypeToBe(mainFnScope.symbolTable.getSymbol('flyBoysSkin', SymbolTypeFlag.runtime)[0].type, EnumType);
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlag.runtime)[0].type, ClassType);
             expect(mainFnScope.symbolTable.getSymbol('fido', SymbolTypeFlag.runtime)[0].type.toString()).to.eq('Animals.Dog');
             expectTypeToBe(mainFnScope.symbolTable.getSymbol('fidoBark', SymbolTypeFlag.runtime)[0].type, StringType);
@@ -3411,6 +3412,112 @@ describe('Scope', () => {
                 expectTypeToBe(dataType, ArrayType);
                 expectTypeToBe(dataType.defaultType, EnumType);
                 expect(dataType.defaultType.toString()).to.equal('Direction');
+            });
+
+            it('should allow a typed array of an enum defined in a different namespace', () => {
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    namespace nsOne
+                        sub EnumTest()
+                            arr = [nsTwo.Direction.North]
+                            arr.push(nsTwo.Direction.South)
+                        end sub
+                    end namespace
+
+                    namespace nsTwo
+                        enum Direction
+                            North = 1
+                            East = 2
+                            South = 3
+                            West = 4
+                        end enum
+                    end namespace
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const symbolTable = utilFile.ast.findChild<CallExpression>(isCallExpression).getSymbolTable();
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const dataType = symbolTable.getSymbolType('arr', opts) as ArrayType;
+                expectTypeToBe(dataType, ArrayType);
+                expectTypeToBe(dataType.defaultType, EnumType);
+                expect(dataType.defaultType.toString()).to.equal('nsTwo.Direction');
+            });
+
+            it('should allow a typed array of an enum defined with multiple enum members', () => {
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    namespace nsOne
+                        sub EnumTest()
+                            arr = [nsTwo.Direction.North, nsTwo.Direction.South]
+                            arr.push(nsTwo.Direction.South)
+                        end sub
+                    end namespace
+
+                    namespace nsTwo
+                        enum Direction
+                            North = 1
+                            East = 2
+                            South = 3
+                            West = 4
+                        end enum
+                    end namespace
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const symbolTable = utilFile.ast.findChild<CallExpression>(isCallExpression).getSymbolTable();
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const dataType = symbolTable.getSymbolType('arr', opts) as ArrayType;
+                expectTypeToBe(dataType, ArrayType);
+                expectTypeToBe(dataType.defaultType, EnumType);
+                expect(dataType.defaultType.toString()).to.equal('nsTwo.Direction');
+            });
+
+            it('should allow a typed array of an enum defined with multiple consts', () => {
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    namespace nsOne
+                        sub ArrayTest()
+                            arr = [nsTwo.Letters.abc, nsTwo.Letters.def]
+                            arr.push(nsTwo.Letters.abc)
+                        end sub
+                    end namespace
+
+                    namespace nsTwo
+                        namespace Letters
+                            const abc = "ABC"
+                            const def = "DEF"
+                        end namespace
+                    end namespace
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const symbolTable = utilFile.ast.findChild<CallExpression>(isCallExpression).getSymbolTable();
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const dataType = symbolTable.getSymbolType('arr', opts) as ArrayType;
+                expectTypeToBe(dataType, ArrayType);
+                expectTypeToBe(dataType.defaultType, StringType);
+                expect(dataType.defaultType.toString()).to.equal('string');
+            });
+
+            it('should correctly set an array as initial value', () => {
+                let utilFile = program.setFile<BrsFile>('source/util.bs', `
+                    function alsoGoEast(path = [Direction.North, Direction.South])
+                        path.Push(Direction.East) ' "path" should be typed as Array<Direction>
+                        return path
+                    end function
+
+                    enum Direction
+                        North = "North"
+                        South = "South"
+                        East = "East"
+                        West = "West"
+                    end  enum
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                let symbolTable = utilFile.ast.findChild<CallExpression>(isFunctionExpression).getSymbolTable();
+                const opts = { flags: SymbolTypeFlag.runtime };
+                const pathType = symbolTable.getSymbolType('Path', opts) as ArrayType;
+                expectTypeToBe(pathType, ArrayType);
+                expectTypeToBe(pathType.defaultType, EnumType);
+                expect(pathType.defaultType.toString()).to.eql('Direction');
             });
         });
 

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -23,7 +23,7 @@ import type { ObjectType } from '../types/ObjectType';
 import type { AstNode, Expression, Statement } from '../parser/AstNode';
 import type { AssetFile } from '../files/AssetFile';
 import { AstNodeKind } from '../parser/AstNode';
-import type { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType, ArrayDefaultTypeReferenceType, AnyReferenceType } from '../types/ReferenceType';
+import type { TypePropertyReferenceType, ReferenceType, BinaryOperatorReferenceType, ArrayDefaultTypeReferenceType, AnyReferenceType, ParamTypeFromValueReferenceType } from '../types/ReferenceType';
 import type { EnumMemberType, EnumType } from '../types/EnumType';
 import type { UnionType } from '../types/UnionType';
 import type { UninitializedType } from '../types/UninitializedType';
@@ -369,6 +369,9 @@ export function isBinaryOperatorReferenceType(value: any): value is BinaryOperat
 export function isArrayDefaultTypeReferenceType(value: any): value is ArrayDefaultTypeReferenceType {
     return value?.__reflection?.name === 'ArrayDefaultTypeReferenceType';
 }
+export function isParamTypeFromValueReferenceType(value: any): value is ParamTypeFromValueReferenceType {
+    return value?.__reflection?.name === 'ParamTypeFromValueReferenceType';
+}
 export function isNamespaceType(value: any): value is NamespaceType {
     return value?.kind === BscTypeKind.NamespaceType;
 }
@@ -394,7 +397,7 @@ export function isCallableType(target): target is BaseFunctionType {
 
 export function isAnyReferenceType(target): target is AnyReferenceType {
     const name = target?.__reflection?.name;
-    return name === 'ReferenceType' || name === 'TypePropertyReferenceType' || name === 'BinaryOperatorReferenceType' || name === 'ArrayDefaultTypeReferenceType';
+    return name === 'ReferenceType' || name === 'TypePropertyReferenceType' || name === 'BinaryOperatorReferenceType' || name === 'ArrayDefaultTypeReferenceType' || name === 'ParamTypeFromValueReferenceType';
 }
 
 const numberTypeKinds = [

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -381,7 +381,7 @@ export class ScopeValidator {
                 const data = {} as ExtraSymbolData;
                 let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
 
-                const paramType = funcType.params[paramIndex]?.type;
+                let paramType = funcType.params[paramIndex]?.type;
                 if (!paramType) {
                     // unable to find a paramType -- maybe there are more args than params
                     break;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEnumMemberType, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -1068,7 +1068,14 @@ export class ArrayLiteralExpression extends Expression {
     }
 
     getType(options: GetTypeOptions): BscType {
-        const innerTypes = this.elements.map(expr => expr.getType(options));
+        const innerTypes = this.elements.map(expr => {
+            const innerType = expr.getType(options);
+            if (isEnumMemberType(innerType)) {
+                return this.getSymbolTable().getSymbolType(innerType.enumName, { flags: SymbolTypeFlag.typetime, tableProvider: () => this.getSymbolTable() });
+            }
+            return innerType;
+        });
+
         return new ArrayType(...innerTypes);
     }
     get leadingTrivia(): Token[] {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEnumMemberType, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -497,7 +497,7 @@ export class FunctionParameterExpression extends Expression {
         const paramName = this.tokens.name.text;
 
         const paramTypeFromCode = this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime, typeChain: undefined }) ??
-            this.defaultValue?.getType({ ...options, flags: SymbolTypeFlag.runtime, typeChain: undefined });
+            util.getDefaultTypeFromValueType(this.defaultValue?.getType({ ...options, flags: SymbolTypeFlag.runtime, typeChain: undefined }));
         const paramTypeFromDoc = docs.getParamBscType(paramName, { ...options, fullName: paramName, typeChain: undefined, tableProvider: () => this.getSymbolTable() });
 
         let paramType = util.chooseTypeFromCodeOrDocComment(paramTypeFromCode, paramTypeFromDoc, options) ?? DynamicType.instance;
@@ -1068,14 +1068,7 @@ export class ArrayLiteralExpression extends Expression {
     }
 
     getType(options: GetTypeOptions): BscType {
-        const innerTypes = this.elements.map(expr => {
-            const innerType = expr.getType(options);
-            if (isEnumMemberType(innerType)) {
-                return this.getSymbolTable().getSymbolType(innerType.enumName, { flags: SymbolTypeFlag.typetime, tableProvider: () => this.getSymbolTable() });
-            }
-            return innerType;
-        });
-
+        const innerTypes = this.elements.map(expr => expr.getType(options));
         return new ArrayType(...innerTypes);
     }
     get leadingTrivia(): Token[] {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1242,8 +1242,8 @@ export class Parser {
 
             const exitText = exitToken.text.substring(0, 4);
             const whileText = exitToken.text.substring(4);
-            const originalRange = exitToken.location.range;
-            const originalStart = originalRange.start;
+            const originalRange = exitToken.location?.range;
+            const originalStart = originalRange?.start;
 
             const exitRange = util.createRange(
                 originalStart.line,

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3341,7 +3341,8 @@ export class FieldStatement extends Statement implements TypedefProvider {
      */
     getType(options: GetTypeOptions) {
         return this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime }) ??
-            this.initialValue?.getType({ ...options, flags: SymbolTypeFlag.runtime }) ?? DynamicType.instance;
+            util.getDefaultTypeFromValueType(this.initialValue?.getType({ ...options, flags: SymbolTypeFlag.runtime })) ??
+            DynamicType.instance;
     }
 
     public readonly location: Location | undefined;
@@ -3813,7 +3814,9 @@ export class EnumStatement extends Statement implements TypedefProvider {
         );
         resultType.pushMemberProvider(() => this.getSymbolTable());
         for (const statement of members) {
-            resultType.addMember(statement?.tokens?.name?.text, { definingNode: statement }, statement.getType(options), SymbolTypeFlag.runtime);
+            const memberType = statement.getType({ ...options, typeChain: undefined });
+            memberType.parentEnumType = resultType;
+            resultType.addMember(statement?.tokens?.name?.text, { definingNode: statement }, memberType, SymbolTypeFlag.runtime);
         }
         return resultType;
     }

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,6 +1,6 @@
 
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { isArrayType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isArrayType, isDynamicType, isEnumMemberType, isObjectType } from '../astUtils/reflection';
 import type { TypeCompatibilityData } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
@@ -10,6 +10,7 @@ import { DynamicType } from './DynamicType';
 import { IntegerType } from './IntegerType';
 import { unionTypeFactory } from './UnionType';
 import { getUniqueType, isUnionTypeCompatible } from './helpers';
+import { util } from '../util';
 
 export class ArrayType extends BscType {
     constructor(...innerTypes: BscType[]) {
@@ -21,13 +22,24 @@ export class ArrayType extends BscType {
 
     public innerTypes: BscType[] = [];
 
+    public _defaultType: BscType;
+
     public get defaultType(): BscType {
+        if (this._defaultType) {
+            return this._defaultType;
+        }
         if (this.innerTypes?.length === 0) {
             return DynamicType.instance;
-        } else if (this.innerTypes?.length === 1) {
-            return this.innerTypes[0];
         }
-        return getUniqueType(this.innerTypes, unionTypeFactory);
+        let resultType = this.innerTypes[0];
+        if (this.innerTypes?.length > 1) {
+            resultType = getUniqueType(this.innerTypes, unionTypeFactory);
+        }
+        if (isEnumMemberType(resultType)) {
+            resultType = resultType.parentEnumType ?? resultType;
+        }
+        this._defaultType = util.getDefaultTypeFromValueType(this.innerTypes);
+        return resultType;
     }
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -1,11 +1,12 @@
 import type { GetTypeOptions, TypeChainEntry, TypeCompatibilityData } from '../interfaces';
 import type { GetSymbolTypeOptions, SymbolTypeGetterProvider } from '../SymbolTable';
 import type { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { isAnyReferenceType, isArrayDefaultTypeReferenceType, isArrayType, isBinaryOperatorReferenceType, isComponentType, isDynamicType, isReferenceType, isTypePropertyReferenceType } from '../astUtils/reflection';
+import { isAnyReferenceType, isArrayDefaultTypeReferenceType, isArrayType, isBinaryOperatorReferenceType, isComponentType, isDynamicType, isParamTypeFromValueReferenceType, isReferenceType, isTypePropertyReferenceType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { DynamicType } from './DynamicType';
 import { BscTypeKind } from './BscTypeKind';
 import type { Token } from '../lexer/Token';
+import { util } from '../util';
 
 export type AnyReferenceType = ReferenceType | TypePropertyReferenceType | BinaryOperatorReferenceType | ArrayDefaultTypeReferenceType;
 
@@ -244,7 +245,7 @@ export class ReferenceType extends BscType {
                     return;
                 }
                 this.referenceChain.add(resolvedType);
-                resolvedType = (resolvedType as any).getTarget?.();
+                resolvedType = (resolvedType as any)?.getTarget?.();
             }
             this.tableProvider().setCachedType(this.memberKey, { type: resolvedType }, { flags: this.flags });
         }
@@ -461,6 +462,18 @@ export class ArrayDefaultTypeReferenceType extends BscType {
                     return objType;
                 }
 
+                if (propName === 'getTarget') {
+                    return () => {
+                        if (this.cachedType) {
+                            return this.cachedType;
+                        }
+                        if (isReferenceType(this.objType)) {
+                            (this.objType as any).getTarget();
+                        }
+                        return this.objType;
+                    };
+                }
+
                 let resultType: BscType = this.cachedType ?? DynamicType.instance;
                 if (!this.cachedType) {
                     if ((isAnyReferenceType(this.objType) && !this.objType.isResolvable())
@@ -477,6 +490,66 @@ export class ArrayDefaultTypeReferenceType extends BscType {
                         } else {
                             resultType = DynamicType.instance;
                         }
+                        this.cachedType = resultType;
+                    }
+
+                }
+                if (resultType) {
+                    const result = Reflect.get(resultType, propName, resultType);
+                    return result;
+                }
+            }
+        });
+    }
+}
+
+/**
+ * Used for when a Param's initial value is unresolved
+ * Generally, this will be resolved later *except* for Enum
+ * Enum Types will have an initial value of an EnumMemberType, but the param
+ * should be an EnumType
+ */
+export class ParamTypeFromValueReferenceType extends BscType {
+    cachedType: BscType;
+
+    constructor(public objType: BscType) {
+        super('ParamInitialValueType');
+        // eslint-disable-next-line no-constructor-return
+        return new Proxy(this, {
+            get: (target, propName, receiver) => {
+                if (propName === '__reflection') {
+                    // Cheeky way to get reflection to work
+                    return { name: 'ParamTypeFromValueReferenceType' };
+                }
+
+                if (propName === 'objType') {
+                    return objType;
+                }
+
+                if (propName === 'getTarget') {
+                    return () => {
+                        if (this.cachedType) {
+                            return this.cachedType;
+                        }
+                        if (isReferenceType(this.objType)) {
+                            (this.objType as any).getTarget();
+                        }
+                        return this.objType;
+                    };
+                }
+
+                let resultType: BscType = this.cachedType ?? DynamicType.instance;
+                if (!this.cachedType) {
+                    if ((isAnyReferenceType(this.objType) && !this.objType.isResolvable())
+                    ) {
+                        if (propName === 'isResolvable') {
+                            return () => false;
+                        }
+                        if (propName === 'getTarget') {
+                            return () => undefined;
+                        }
+                    } else {
+                        resultType = util.getDefaultTypeFromValueType(this.objType);
                         this.cachedType = resultType;
                     }
 
@@ -529,6 +602,14 @@ export function getAllRequiredSymbolNames(refType: BscType, namespaceLower?: str
 
         }
         return result;
+    }
+    if (isParamTypeFromValueReferenceType(refType)) {
+        const objType = refType.objType;
+        if (isAnyReferenceType(objType)) {
+            return getAllRequiredSymbolNames(objType);
+        } else {
+            return [];
+        }
     }
     return [];
 }

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -134,7 +134,7 @@ export class UnionType extends BscType {
 
 
 function joinTypesString(types: BscType[]) {
-    return types.map(t => t.toString()).join(' or ');
+    return [...new Set(types.map(t => t.toString()))].join(' or ');
 }
 
 BuiltInInterfaceAdder.unionTypeFactory = (types: BscType[]) => {

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,5 @@
 import type { TypeCompatibilityData } from '../interfaces';
-import { isAnyReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isInterfaceType, isUnionType } from '../astUtils/reflection';
+import { isAnyReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isInterfaceType, isReferenceType, isUnionType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import type { UnionType } from './UnionType';
 
@@ -55,6 +55,13 @@ export function reduceTypesToMostGeneric(types: BscType[]): BscType[] {
         // only one type
         return [types[0]];
     }
+
+    types = types.map(t => {
+        if (isReferenceType(t) && t.isResolvable()) {
+            return (t as any).getTarget() ?? t;
+        }
+        return t;
+    });
 
     // Get a list of unique types, based on the `isEqual()` method
     const uniqueTypes = getUniqueTypesFromArray(types).map(t => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,13 +42,15 @@ import { MAX_RELATED_INFOS_COUNT } from './diagnosticUtils';
 import type { BscType } from './types/BscType';
 import { unionTypeFactory } from './types/UnionType';
 import { ArrayType } from './types/ArrayType';
-import { BinaryOperatorReferenceType } from './types/ReferenceType';
+import { BinaryOperatorReferenceType, ParamTypeFromValueReferenceType } from './types/ReferenceType';
 import { AssociativeArrayType } from './types/AssociativeArrayType';
 import { ComponentType } from './types/ComponentType';
 import { FunctionType } from './types/FunctionType';
 import type { AssignmentStatement, NamespaceStatement } from './parser/Statement';
 import type { BscFile } from './files/BscFile';
 import type { NamespaceType } from './types/NamespaceType';
+import { getUniqueType } from './types/helpers';
+
 
 export class Util {
     public clearConsole() {
@@ -2494,6 +2496,46 @@ export class Util {
             }
         }
         return returnType;
+    }
+
+    /**
+     * Gets the type for a default value (eg. as a function param, class member or typed array)
+     */
+    public getDefaultTypeFromValueType(valueType: (BscType | BscType[])) {
+        if (!valueType) {
+            return undefined;
+        }
+        let resultType: BscType = DynamicType.instance;
+        if (Array.isArray(valueType)) {
+            // passed an array opf types, potential from ArrayType.innerTypes
+            if (valueType.length > 0) {
+                //at least one, use it
+                resultType = valueType[0];
+                if (valueType?.length > 1) {
+                    // more than 1, find union
+                    resultType = getUniqueType(valueType, unionTypeFactory);
+                }
+            }
+        } else {
+            resultType = valueType;
+        }
+        if (!resultType.isResolvable()) {
+            resultType = new ParamTypeFromValueReferenceType(resultType);
+        } else if (isEnumMemberType(resultType)) {
+            // the type was an enum member... Try to get the parent enum type
+            resultType = resultType.parentEnumType ?? resultType;
+        } else if (isUnionType(resultType)) {
+            // it was a union -- I wonder if they're resolvable now?
+            const moddedTypes = resultType.types.map(t => {
+                if (isEnumMemberType(t)) {
+                    // the type was an enum member... Try to get the parent enum type
+                    return t.parentEnumType ?? resultType;
+                }
+                return t;
+            });
+            resultType = getUniqueType(moddedTypes, unionTypeFactory);
+        }
+        return resultType;
     }
 }
 


### PR DESCRIPTION
Fixes #1323 

- [x] Make it work for Namespaced Enums



Default values/initial values are much more stable, and support things like arrays of enum values:

  
![image](https://github.com/user-attachments/assets/21b91b69-1abe-4e28-b374-70ebaacf6ebf)
