### PR TITLE
Properly types 'invalid' as InvalidType

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3088,6 +3088,20 @@ describe('ScopeValidator', () => {
                 DiagnosticMessages.operatorTypeMismatch('++', 'string').message
             ]);
         });
+
+        it('deals with adding int, bool and invalid', () => {
+            program.setFile('source/util.bs', `
+                sub doStuff()
+                    print 1 + (true + invalid)
+                end sub
+
+            `);
+            program.validate();
+            //should have errors
+            expectDiagnostics(program, [
+                DiagnosticMessages.operatorTypeMismatch('+', 'boolean', 'invalid').message
+            ]);
+        });
     });
 
     describe('memberAccessibilityMismatch', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -539,6 +539,7 @@ export class ScopeValidator {
             // Because you need to verify each combination of types
             return;
         }
+
         const leftIsPrimitive = isPrimitiveType(leftTypeToTest);
         const rightIsPrimitive = isPrimitiveType(rightTypeToTest);
         const leftIsAny = isDynamicType(leftTypeToTest) || isObjectType(leftTypeToTest);

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -642,7 +642,7 @@ export const DeclarableTypes = [
 
 /** List of TokenKind that will not break parsing a TypeExpression in Brighterscript*/
 export const AllowedTypeIdentifiers = [
-    ...AllowedProperties
+    ...(AllowedProperties.filter(tokenKind => tokenKind !== TokenKind.Invalid))
 ];
 
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isComponentType, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isInvalidType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression, isVoidType } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -496,8 +496,11 @@ export class FunctionParameterExpression extends Expression {
         const docs = brsDocParser.parseNode(this.findAncestor(isFunctionStatement));
         const paramName = this.tokens.name.text;
 
-        const paramTypeFromCode = this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime, typeChain: undefined }) ??
+        let paramTypeFromCode = this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime, typeChain: undefined }) ??
             this.defaultValue?.getType({ ...options, flags: SymbolTypeFlag.runtime, typeChain: undefined });
+        if (isInvalidType(paramTypeFromCode) || isVoidType(paramTypeFromCode)) {
+            paramTypeFromCode = undefined;
+        }
         const paramTypeFromDoc = docs.getParamBscType(paramName, { ...options, fullName: paramName, typeChain: undefined, tableProvider: () => this.getSymbolTable() });
 
         let paramType = util.chooseTypeFromCodeOrDocComment(paramTypeFromCode, paramTypeFromDoc, options) ?? DynamicType.instance;

--- a/src/parser/Parser.spec.ts
+++ b/src/parser/Parser.spec.ts
@@ -291,6 +291,28 @@ describe('parser', () => {
             expectZeroDiagnostics(parser);
         });
 
+        it('does not allow return type as invalid', () => {
+            let parser = parse(`
+                function test(x) as invalid
+                    return invalid
+                 end function
+            `, ParseMode.BrighterScript);
+            expectDiagnosticsIncludes(parser, [
+                DiagnosticMessages.expectedIdentifier('as').message
+            ]);
+        });
+
+        it('does not allow param type as invalid', () => {
+            let parser = parse(`
+                function test(x as invalid)
+                    return invalid
+                 end function
+            `, ParseMode.BrighterScript);
+            expectDiagnosticsIncludes(parser, [
+                DiagnosticMessages.expectedIdentifier('as').message
+            ]);
+        });
+
         describe('namespace', () => {
             it('allows namespaces declared inside other namespaces', () => {
                 const parser = parse(`

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3340,8 +3340,14 @@ export class FieldStatement extends Statement implements TypedefProvider {
      * Defaults to `DynamicType`
      */
     getType(options: GetTypeOptions) {
+        let initialValueType = this.initialValue?.getType({ ...options, flags: SymbolTypeFlag.runtime });
+
+        if (isInvalidType(initialValueType) || isVoidType(initialValueType)) {
+            initialValueType = undefined;
+        }
+
         return this.typeExpression?.getType({ ...options, flags: SymbolTypeFlag.typetime }) ??
-            this.initialValue?.getType({ ...options, flags: SymbolTypeFlag.runtime }) ?? DynamicType.instance;
+            initialValueType ?? DynamicType.instance;
     }
 
     public readonly location: Location | undefined;

--- a/src/types/ClassType.ts
+++ b/src/types/ClassType.ts
@@ -1,5 +1,5 @@
 import { SymbolTable } from '../SymbolTable';
-import { isClassType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isClassType, isDynamicType, isInvalidType, isObjectType } from '../astUtils/reflection';
 import type { TypeCompatibilityData } from '../interfaces';
 import type { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
@@ -19,7 +19,9 @@ export class ClassType extends InheritableType {
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         if (this.isEqual(targetType, data)) {
             return true;
-        } else if (isDynamicType(targetType) ||
+        } else if (
+            isInvalidType(targetType) ||
+            isDynamicType(targetType) ||
             isObjectType(targetType) ||
             isUnionTypeCompatible(this, targetType, data)) {
             return true;

--- a/src/types/ComponentType.ts
+++ b/src/types/ComponentType.ts
@@ -1,7 +1,7 @@
 import type { GetSymbolTypeOptions } from '../SymbolTable';
 import type { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { SymbolTable } from '../SymbolTable';
-import { isComponentType, isDynamicType, isObjectType } from '../astUtils/reflection';
+import { isComponentType, isDynamicType, isInvalidType, isObjectType } from '../astUtils/reflection';
 import type { ExtraSymbolData, TypeCompatibilityData } from '../interfaces';
 import type { BaseFunctionType } from './BaseFunctionType';
 import type { BscType } from './BscType';
@@ -27,7 +27,8 @@ export class ComponentType extends InheritableType {
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         if (this.isEqual(targetType)) {
             return true;
-        } else if (isDynamicType(targetType) ||
+        } else if (isInvalidType(targetType) ||
+            isDynamicType(targetType) ||
             isObjectType(targetType) ||
             isUnionTypeCompatible(this, targetType, data)) {
             return true;

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,6 +1,6 @@
 import type { TypeCompatibilityData } from '../interfaces';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { isDynamicType, isInterfaceType, isObjectType } from '../astUtils/reflection';
+import { isDynamicType, isInterfaceType, isInvalidType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import { InheritableType } from './InheritableType';
@@ -18,7 +18,10 @@ export class InterfaceType extends InheritableType {
     public readonly kind = BscTypeKind.InterfaceType;
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
-        if (isDynamicType(targetType) || isObjectType(targetType) || isUnionTypeCompatible(this, targetType, data)) {
+        if (isInvalidType(targetType) ||
+            isDynamicType(targetType) ||
+            isObjectType(targetType) ||
+            isUnionTypeCompatible(this, targetType, data)) {
             return true;
         }
         if (isInterfaceType(targetType)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,6 +49,7 @@ import { FunctionType } from './types/FunctionType';
 import type { AssignmentStatement, NamespaceStatement } from './parser/Statement';
 import type { BscFile } from './files/BscFile';
 import type { NamespaceType } from './types/NamespaceType';
+import { InvalidType } from './types/InvalidType';
 
 export class Util {
     public clearConsole() {
@@ -1359,7 +1360,7 @@ export class Util {
             case TokenKind.IntegerLiteral:
                 return IntegerType.instance;
             case TokenKind.Invalid:
-                return DynamicType.instance; // TODO: use InvalidType better new InvalidType(token.text);
+                return new InvalidType(token.text);
             case TokenKind.LongInteger:
                 return new LongIntegerType(token.text);
             case TokenKind.LongIntegerLiteral:
@@ -1390,7 +1391,7 @@ export class Util {
                     case 'integer':
                         return new IntegerType(token.text);
                     case 'invalid':
-                        return DynamicType.instance; // TODO: use InvalidType better new InvalidType(token.text);
+                        return new InvalidType(token.text);
                     case 'longinteger':
                         return new LongIntegerType(token.text);
                     case 'object':


### PR DESCRIPTION
Previously, `invalid` was typed as `DynamicType`

This PR changes it so it is `InvalidType`

This fixes the BinaryOperator validation and fixes #1367

In addition:
- when the default value for function params and fields is set to `invalid`, then the type of the param/field is set to Dynamic.
- Changes `AllowableTypes` to NOT include 'invalid' because that is a compile error:

![image](https://github.com/user-attachments/assets/f1b98653-5d89-4357-bc30-f04d0c2eab30)
