### PR TITLE
Prevent simultaneous validate() for same project

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -696,7 +696,7 @@ export class Program {
             });
 
             //we are not async but there's a pending promise, then we cannot run this validation
-        } else if (previousValidationPromise) {
+        } else if (previousValidationPromise !== undefined) {
             throw new Error('Cannot run synchronous validation while an async validation is in progress');
         }
 

--- a/src/common/Sequencer.spec.ts
+++ b/src/common/Sequencer.spec.ts
@@ -19,4 +19,35 @@ describe('Sequencer', () => {
 
         expect(values).to.eql([1, 2]);
     });
+
+    it('throws when returning a promise from runSync', () => {
+        let error;
+        try {
+            void new Sequencer({
+                name: 'test',
+                minSyncDuration: 100
+            }).once(() => {
+                return Promise.resolve();
+            }).run();
+        } catch (e) {
+            error = e;
+        }
+        expect(error.message).to.eql(`Action returned a promise which is unsupported when running 'runSync'`);
+    });
+
+    it('waits for async actions to complete', async () => {
+        const values = [];
+        await new Sequencer({
+            name: 'test',
+            async: true,
+            minSyncDuration: 100
+        }).forEach([1, 2, 3], async (i) => {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+            values.push(i);
+        }).run();
+
+        expect(values).to.eql([1, 2, 3]);
+    });
 });

--- a/src/common/Sequencer.ts
+++ b/src/common/Sequencer.ts
@@ -7,17 +7,20 @@ import { EventEmitter } from 'eventemitter3';
  */
 export class Sequencer {
     constructor(
-        private options: {
-            name: string;
-            async?: boolean;
+        private options?: {
+            name?: string;
             cancellationToken?: CancellationToken;
             /**
              * The number of operations to run before registering a nexttick
              */
-            minSyncDuration: number;
+            minSyncDuration?: number;
         }
     ) {
 
+    }
+
+    private get minSyncDuration() {
+        return this.options?.minSyncDuration ?? 150;
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
@@ -58,29 +61,18 @@ export class Sequencer {
         return this;
     }
 
-    /**
-     * Actually run the sequence
-     */
-    public run() {
-        if (this.options?.async) {
-            return this.runAsync();
-        } else {
-            return this.runSync();
-        }
-    }
-
-    private async runAsync() {
+    public async run() {
         try {
             let start = Date.now();
             for (const action of this.actions) {
                 //register a very short timeout between every action so we don't hog the CPU
-                if (Date.now() - start > this.options.minSyncDuration) {
+                if (Date.now() - start > this.minSyncDuration) {
                     await util.sleep(1);
                     start = Date.now();
                 }
 
                 //if the cancellation token has asked us to cancel, then stop processing now
-                if (this.options.cancellationToken?.isCancellationRequested) {
+                if (this.options?.cancellationToken?.isCancellationRequested) {
                     return this.handleCancel();
                 }
                 await Promise.resolve(
@@ -88,17 +80,20 @@ export class Sequencer {
                 );
             }
             this.emitter.emit('success');
+        } catch (e) {
+            this.handleCancel();
+            throw e;
         } finally {
             this.emitter.emit('complete');
             this.dispose();
         }
     }
 
-    private runSync() {
+    public runSync() {
         try {
             for (const action of this.actions) {
                 //if the cancellation token has asked us to cancel, then stop processing now
-                if (this.options.cancellationToken?.isCancellationRequested) {
+                if (this.options?.cancellationToken?.isCancellationRequested) {
                     return this.handleCancel();
                 }
                 const result = action.func(...action.args);
@@ -107,6 +102,9 @@ export class Sequencer {
                 }
             }
             this.emitter.emit('success');
+        } catch (e) {
+            this.handleCancel();
+            throw e;
         } finally {
             this.emitter.emit('complete');
             this.dispose();
@@ -114,7 +112,7 @@ export class Sequencer {
     }
 
     private handleCancel() {
-        console.log(`Cancelling sequence ${this.options.name}`);
+        console.log(`Cancelling sequence ${this.options?.name}`);
         this.emitter.emit('cancel');
     }
 

--- a/src/lsp/Project.spec.ts
+++ b/src/lsp/Project.spec.ts
@@ -43,7 +43,6 @@ describe('Project', () => {
 
     describe('validate', () => {
         it('prevents multiple valiations from running at the same time', async () => {
-            console.log("validate begin");
             //create 10 scopes, which should each take at least 1ms to validate
             for (let i = 0; i < 20; i++) {
                 fsExtra.outputFileSync(`${rootDir}/components/component${i}.xml`, `<component name="component${i}"></component>`);

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -471,3 +471,15 @@ export function createInactivityStub<T, K extends keyof T>(obj: T, methodName: k
         promise: inactivityPromise
     };
 }
+
+export async function once<T = any>(
+    obj: { on: (event, callback) => () => void },
+    event: string
+): Promise<T[]> {
+    return new Promise<T[]>((resolve) => {
+        const off = obj.on('diagnostics', (...args) => {
+            off();
+            resolve(args);
+        });
+    });
+}


### PR DESCRIPTION
Forces `validate()` to run one-at-a-time. This prevents race conditions with diagnostics not always being cleaned up correctly.