### PR TITLE
Plugins Must Declare Annotations

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -11,7 +11,7 @@ A statement can have multiple annotations.
 
 The name of the annotation should be a valid identifier and can not be a keyword (e.g. `for`, `while`, `else`...).
 
-Annotations can have parameters - these parameters should be a list of valid BrighterScript expressions separated by commas.
+Annotations can have parameters - these parameters should be a list of valid BrighterScript literal expressions separated by commas.
 
 ```
 @<annotation_name>[(parameters)]
@@ -20,6 +20,18 @@ Annotations can have parameters - these parameters should be a list of valid Bri
 
 @<annotation_name>[(parameters)] [more annotations] <statement>
 ```
+
+## Annotation Arguments
+
+Annotations can only take literal values as arguments. That includes literal strings, numbers, arrays with literal values and associative arrays with literal values.
+
+Examples:
+
+ - literal numbers: `123`, `3.14`, `0`, `&HFF`
+ - literal strings: `"hello"`, `""`, `"any string with quotes"`
+ - literal arrays: `[1, 2, 3]`, `["array", "of", "strings"]`, `[1, {letter: "A"}, "mixed"]`
+ - literal associative arrays: `{key: "value"}`, `{translation: [200, 300], fields: {title: "Star Wars", description: "A long time ago in a galaxy far, far away..."}}`
+
 
 ## Examples
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -1031,6 +1031,19 @@ export let DiagnosticMessages = {
         legacyCode: 1151,
         severity: DiagnosticSeverity.Error,
         code: 'return-type-coercion-mismatch'
+    }),
+    cannotFindAnnotation: (name: string) => ({
+        message: `Cannot find annotation '${name}' `,
+        data: {
+            name: name
+        },
+        severity: DiagnosticSeverity.Error,
+        code: 'cannot-find-annotation'
+    }),
+    expectedLiteralValue: (context: string, value: string) => ({
+        message: `Expected literal value ${context}, but found '${value}' `,
+        severity: DiagnosticSeverity.Error,
+        code: 'expected-literal-value'
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -254,6 +254,8 @@ export class Program {
     public addAnnotationSymbol(name: string, annoType: TypedFunctionType, extraData: ExtraSymbolData = {}) {
         if (name && annoType) {
             annoType.setName(name);
+            const pluginName = extraData?.pluginName ?? '';
+            this.logger.info(`Adding annotation '${name}' (${pluginName})`);
             this.pluginAnnotationTable.addSymbol(name, extraData, annoType, SymbolTypeFlag.annotation);
         }
     }

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -55,6 +55,7 @@ import { ProgramValidatorDiagnosticsTag } from './bscPlugin/validation/ProgramVa
 import type { ProvidedSymbolInfo, BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
 import { SymbolTable } from './SymbolTable';
+import type { TypedFunctionType } from './types/TypedFunctionType';
 
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
@@ -238,15 +239,22 @@ export class Program {
         for (const [pluginName, annotations] of this.plugins.getAnnotationMap().entries()) {
             for (const annotation of annotations) {
                 if (isTypedFunctionType(annotation) && annotation.name) {
-                    this.pluginAnnotationTable.addSymbol(annotation.name, { pluginName: pluginName }, annotation, SymbolTypeFlag.annotation);
+                    this.addAnnotationSymbol(annotation.name, annotation, { pluginName: pluginName });
                 } else if (isAnnotationDeclaration(annotation)) {
                     const annoType = annotation.type;
                     let description = (typeof annotation.description === 'string') ? annotation.description : undefined;
-                    this.pluginAnnotationTable.addSymbol(annoType.name, { pluginName: pluginName, description: description }, annoType, SymbolTypeFlag.annotation);
+                    this.addAnnotationSymbol(annoType.name, annoType, { pluginName: pluginName, description: description });
                 } else if (typeof annotation === 'string') {
                     // TODO: Do we need to parse this?
                 }
             }
+        }
+    }
+
+    public addAnnotationSymbol(name: string, annoType: TypedFunctionType, extraData: ExtraSymbolData = {}) {
+        if (name && annoType) {
+            annoType.setName(name);
+            this.pluginAnnotationTable.addSymbol(name, extraData, annoType, SymbolTypeFlag.annotation);
         }
     }
 

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -163,6 +163,9 @@ export class ProgramBuilder {
         for (let plugin of plugins) {
             this.plugins.add(plugin);
         }
+        this.plugins.emit('onPluginConfigure', {
+            builder: this
+        });
 
         this.plugins.emit('beforeProgramCreate', {
             builder: this

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -233,6 +233,7 @@ export class SymbolTable implements SymbolTypeGetter {
             options.data.isAlias = data?.isAlias;
             options.data.isInstance = data?.isInstance;
             options.data.isFromDocComment = data?.isFromDocComment;
+            options.data.pluginName = data?.pluginName;
         }
         return resolvedType;
     }

--- a/src/SymbolTypeFlag.ts
+++ b/src/SymbolTypeFlag.ts
@@ -6,5 +6,6 @@ export const enum SymbolTypeFlag {
     private = 8,
     protected = 16,
     postTranspile = 32,
-    deprecated = 64
+    deprecated = 64,
+    annotation = 128
 }

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -2,7 +2,7 @@ import type { Body, AssignmentStatement, Block, ExpressionStatement, ExitStateme
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypecastExpression, TypeExpression, TypedArrayExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
-import type { BsDiagnostic, TypedefProvider } from '../interfaces';
+import type { AnnotationDeclaration, BsDiagnostic, TypedefProvider } from '../interfaces';
 import type { InvalidType } from '../types/InvalidType';
 import type { VoidType } from '../types/VoidType';
 import { InternalWalkMode } from './visitors';
@@ -461,4 +461,11 @@ export function isLiteralDouble(value: any): value is LiteralExpression & { type
 // Diagnostics
 export function isBsDiagnostic(value: any): value is BsDiagnostic {
     return value.message;
+}
+
+
+// Plugins
+
+export function isAnnotationDeclaration(value: any): value is AnnotationDeclaration {
+    return isTypedFunctionType(value.type);
 }

--- a/src/bscPlugin/hover/HoverProcessor.ts
+++ b/src/bscPlugin/hover/HoverProcessor.ts
@@ -133,6 +133,9 @@ export class HoverProcessor {
             return null;
         }
         const expression = file.getClosestExpression(this.event.position);
+        if (!expression) {
+            return null;
+        }
         const hoverContents: string[] = [];
         for (let scope of this.event.scopes) {
             try {

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1349,7 +1349,7 @@ describe('BrsFileValidator', () => {
         });
 
         it('allows known annotations', () => {
-            program.pluginAnnotationTable.addSymbol('knownAnnotation', { pluginName: 'Test' }, new TypedFunctionType(VoidType.instance).setName('knownAnnotation'), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('knownAnnotation', new TypedFunctionType(VoidType.instance));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @knownAnnotation
@@ -1362,12 +1362,12 @@ describe('BrsFileValidator', () => {
         });
 
         it('checks annotation function arg count', () => {
-            program.pluginAnnotationTable.addSymbol('takesOneOrTwo', { pluginName: 'Test' },
+            program.addAnnotationSymbol('takesOneOrTwo',
                 new TypedFunctionType(VoidType.instance)
                     .setName('takesOneOrTwo')
                     .addParameter('x', DynamicType.instance)
                     .addParameter('y', DynamicType.instance, true),
-                SymbolTypeFlag.annotation);
+                { pluginName: 'Test' });
 
             program.setFile<BrsFile>('source/main.bs', `
                 @takesOneOrTwo
@@ -1382,12 +1382,11 @@ describe('BrsFileValidator', () => {
         });
 
         it('allows valid arg counts', () => {
-            program.pluginAnnotationTable.addSymbol('takesOneOrTwo', { pluginName: 'Test' },
+            program.addAnnotationSymbol('takesOneOrTwo',
                 new TypedFunctionType(VoidType.instance)
                     .setName('takesOneOrTwo')
                     .addParameter('x', DynamicType.instance)
-                    .addParameter('y', DynamicType.instance, true),
-                SymbolTypeFlag.annotation);
+                    .addParameter('y', DynamicType.instance, true));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @takesOneOrTwo(1)
@@ -1403,12 +1402,11 @@ describe('BrsFileValidator', () => {
         });
 
         it('allows valid arg counts for variadic functions', () => {
-            program.pluginAnnotationTable.addSymbol('takesOneOrMore', { pluginName: 'Test' },
+            program.addAnnotationSymbol('takesOneOrMore',
                 new TypedFunctionType(VoidType.instance)
                     .setName('takesOneOrMore')
                     .addParameter('x', DynamicType.instance)
-                    .seVariadic(true),
-                SymbolTypeFlag.annotation);
+                    .seVariadic(true));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @takesOneOrMore(1)
@@ -1424,16 +1422,14 @@ describe('BrsFileValidator', () => {
         });
 
         it('ignores when multiple annotations of same name are added', () => {
-            program.pluginAnnotationTable.addSymbol('usedTwice', { pluginName: 'Test' },
+            program.addAnnotationSymbol('usedTwice',
                 new TypedFunctionType(VoidType.instance)
                     .setName('usedTwice')
-                    .addParameter('x', IntegerType.instance),
-                SymbolTypeFlag.annotation);
+                    .addParameter('x', IntegerType.instance));
 
-            program.pluginAnnotationTable.addSymbol('usedTwice', { pluginName: 'Other' },
+            program.addAnnotationSymbol('usedTwice',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('usedTwice'),
-                SymbolTypeFlag.annotation);
+                    .setName('usedTwice'));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @usedTwice(1)
@@ -1453,12 +1449,10 @@ describe('BrsFileValidator', () => {
         });
 
         it('validates arg types', () => {
-            program.pluginAnnotationTable.addSymbol('annoStringInt', { pluginName: 'Test' },
+            program.addAnnotationSymbol('annoStringInt',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('annoStringInt')
                     .addParameter('str', StringType.instance)
-                    .addParameter('int', IntegerType.instance),
-                SymbolTypeFlag.annotation);
+                    .addParameter('int', IntegerType.instance));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @annoStringInt(3.14, "test")
@@ -1474,12 +1468,10 @@ describe('BrsFileValidator', () => {
 
 
         it('allows valid arg types', () => {
-            program.pluginAnnotationTable.addSymbol('annoStringInt', { pluginName: 'Test' },
+            program.addAnnotationSymbol('annoStringInt',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('annoStringInt')
                     .addParameter('str', StringType.instance)
-                    .addParameter('int', IntegerType.instance),
-                SymbolTypeFlag.annotation);
+                    .addParameter('int', IntegerType.instance));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @annoStringInt("test", 123)
@@ -1491,11 +1483,9 @@ describe('BrsFileValidator', () => {
         });
 
         it('validates uninitialized values', () => {
-            program.pluginAnnotationTable.addSymbol('annoString', { pluginName: 'Test' },
+            program.addAnnotationSymbol('annoString',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('annoString')
-                    .addParameter('str', StringType.instance),
-                SymbolTypeFlag.annotation);
+                    .addParameter('str', StringType.instance));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @annoString(someVar)
@@ -1509,11 +1499,9 @@ describe('BrsFileValidator', () => {
         });
 
         it('validates uninitialized values', () => {
-            program.pluginAnnotationTable.addSymbol('annoString', { pluginName: 'Test' },
+            program.addAnnotationSymbol('annoString',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('annoString')
-                    .addParameter('str', StringType.instance),
-                SymbolTypeFlag.annotation);
+                    .addParameter('str', StringType.instance));
 
             program.setFile<BrsFile>('source/main.bs', `
 
@@ -1529,11 +1517,9 @@ describe('BrsFileValidator', () => {
         });
 
         it('allows associative arrays', () => {
-            program.pluginAnnotationTable.addSymbol('annoAA', { pluginName: 'Test' },
+            program.addAnnotationSymbol('annoAA',
                 new TypedFunctionType(VoidType.instance)
-                    .setName('annoAA')
-                    .addParameter('aa', new AssociativeArrayType()),
-                SymbolTypeFlag.annotation);
+                    .addParameter('aa', new AssociativeArrayType()));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @annoAA({name: "John Doe", age: 25, ids: [1, 2, 3, 4]})

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1406,7 +1406,7 @@ describe('BrsFileValidator', () => {
                 new TypedFunctionType(VoidType.instance)
                     .setName('takesOneOrMore')
                     .addParameter('x', DynamicType.instance)
-                    .seVariadic(true));
+                    .setVariadic(true));
 
             program.setFile<BrsFile>('source/main.bs', `
                 @takesOneOrMore(1)

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -1334,7 +1334,7 @@ describe('BrsFileValidator', () => {
         });
     });
 
-    describe.only('annotations', () => {
+    describe('annotations', () => {
         it('validates when unknown annotation is used', () => {
             program.setFile<BrsFile>('source/main.bs', `
                 @unknownAnnotation

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -14,7 +14,7 @@ import { FloatType } from '../../types/FloatType';
 import { IntegerType } from '../../types/IntegerType';
 import { InterfaceType } from '../../types/InterfaceType';
 import { StringType } from '../../types/StringType';
-import { DynamicType, TypedFunctionType } from '../../types';
+import { DynamicType, TypedFunctionType, VoidType } from '../../types';
 import { ParseMode } from '../../parser/Parser';
 import type { ExtraSymbolData } from '../../interfaces';
 
@@ -1330,6 +1330,34 @@ describe('BrsFileValidator', () => {
                 end sub
             `);
             expectDiagnostics(program, []);
+        });
+    });
+
+    describe('annotations', () => {
+        it('validates when unknown annotation is used', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                @unknownAnnotation
+                sub someFunc()
+                    print "hello"
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindName('unknownAnnotation')
+            ]);
+        });
+
+        it('allows known annotations', () => {
+            program.pluginAnnotationTable.addSymbol('knownAnnotation', { pluginName: 'Test' }, new TypedFunctionType(VoidType.instance).setName('knownAnnotation'), SymbolTypeFlag.annotation);
+
+            program.setFile<BrsFile>('source/main.bs', `
+                @knownAnnotation
+                sub someFunc()
+                    print "hello"
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
         });
     });
 });

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -13,8 +13,7 @@ import type { Token } from '../../lexer/Token';
 import { AstNodeKind } from '../../parser/AstNode';
 import type { AstNode } from '../../parser/AstNode';
 import type { Expression } from '../../parser/AstNode';
-import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression, FunctionExpression } from '../../parser/Expression';
-import { CallExpression } from '../../parser/Expression';
+import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression, FunctionExpression, CallExpression } from '../../parser/Expression';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BscType } from '../../types/BscType';
 import type { BscFile } from '../../files/BscFile';
@@ -352,23 +351,8 @@ export class ScopeValidator {
             funcType = funcType.getMemberType('new', getTypeOptions);
         }
         if (funcType?.isResolvable() && isTypedFunctionType(funcType)) {
-            //funcType.setName(expression.callee. .name);
-
             //get min/max parameter count for callable
-            let minParams = 0;
-            let maxParams = 0;
-            for (let param of funcType.params) {
-                maxParams++;
-                //optional parameters must come last, so we can assume that minParams won't increase once we hit
-                //the first isOptional
-                if (param.isOptional !== true) {
-                    minParams++;
-                }
-            }
-            if (funcType.isVariadic) {
-                // function accepts variable number of arguments
-                maxParams = CallExpression.MaximumArguments;
-            }
+            const { minParams, maxParams } = funcType.getMinMaxParamCount();
             let expCallArgCount = expression.args.length;
             if (expCallArgCount > maxParams || expCallArgCount < minParams) {
                 let minMaxParamsText = minParams === maxParams ? maxParams : `${minParams}-${maxParams}`;

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -13,12 +13,7 @@ import type { Token } from '../../lexer/Token';
 import { AstNodeKind } from '../../parser/AstNode';
 import type { AstNode } from '../../parser/AstNode';
 import type { Expression } from '../../parser/AstNode';
-<<<<<<< HEAD
-import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression, FunctionExpression, CallExpression } from '../../parser/Expression';
-=======
-import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression, FunctionExpression, CallfuncExpression } from '../../parser/Expression';
-import { CallExpression } from '../../parser/Expression';
->>>>>>> release-1.0.0
+import type { VariableExpression, DottedGetExpression, BinaryExpression, UnaryExpression, NewExpression, LiteralExpression, FunctionExpression, CallExpression, CallfuncExpression } from '../../parser/Expression';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BscType } from '../../types/BscType';
 import type { BscFile } from '../../files/BscFile';
@@ -399,14 +394,6 @@ export class ScopeValidator {
             // We're calling a class - get the constructor
             funcType = funcType.getMemberType('new', getTypeOptions);
         }
-<<<<<<< HEAD
-        if (funcType?.isResolvable() && isTypedFunctionType(funcType)) {
-            //get min/max parameter count for callable
-            const { minParams, maxParams } = funcType.getMinMaxParamCount();
-            let expCallArgCount = expression.args.length;
-            if (expCallArgCount > maxParams || expCallArgCount < minParams) {
-                let minMaxParamsText = minParams === maxParams ? maxParams : `${minParams}-${maxParams}`;
-=======
         const callErrorLocation = expression?.callee?.location;
         return this.validateFunctionCall(file, funcType, callErrorLocation, expression.args);
 
@@ -453,20 +440,7 @@ export class ScopeValidator {
         }
 
         //get min/max parameter count for callable
-        let minParams = 0;
-        let maxParams = 0;
-        for (let param of funcType.params) {
-            maxParams++;
-            //optional parameters must come last, so we can assume that minParams won't increase once we hit
-            //the first isOptional
-            if (param.isOptional !== true) {
-                minParams++;
-            }
-        }
-        if (funcType.isVariadic) {
-            // function accepts variable number of arguments
-            maxParams = CallExpression.MaximumArguments;
-        }
+        const { minParams, maxParams } = funcType.getMinMaxParamCount();
         const argsForCall = argOffset < 1 ? args : args.slice(argOffset);
 
         let expCallArgCount = argsForCall.length;
@@ -489,48 +463,18 @@ export class ScopeValidator {
             }
 
             if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
-                argType = data.definingNode.getConstructorType();
+                argType = data.definingNode?.getConstructorType();
             }
 
             const compatibilityData: TypeCompatibilityData = {};
             const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
             if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
->>>>>>> release-1.0.0
                 this.addMultiScopeDiagnostic({
                     ...DiagnosticMessages.argumentTypeMismatch(argType.toString(), paramType.toString(), compatibilityData),
                     location: arg.location
                 });
             }
-<<<<<<< HEAD
-            let paramIndex = 0;
-            for (let arg of expression.args) {
-                const data = {} as ExtraSymbolData;
-                let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
-
-                let paramType = funcType.params[paramIndex]?.type;
-                if (!paramType) {
-                    // unable to find a paramType -- maybe there are more args than params
-                    break;
-                }
-
-                if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
-                    argType = data.definingNode?.getConstructorType();
-                }
-
-                const compatibilityData: TypeCompatibilityData = {};
-                const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
-                if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
-                    this.addMultiScopeDiagnostic({
-                        ...DiagnosticMessages.argumentTypeMismatch(argType.toString(), paramType.toString(), compatibilityData),
-                        location: arg.location
-                    });
-                }
-                paramIndex++;
-            }
-
-=======
             paramIndex++;
->>>>>>> release-1.0.0
         }
     }
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -373,7 +373,7 @@ export class ScopeValidator {
                 }
 
                 if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
-                    argType = data.definingNode.getConstructorType();
+                    argType = data.definingNode?.getConstructorType();
                 }
 
                 const compatibilityData: TypeCompatibilityData = {};

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -1830,7 +1830,7 @@ describe('BrsFile', () => {
             });
 
             it('works for bs content', () => {
-                program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+                program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
                 program.setFile('source/lib.bs', ``);
                 doTest(`
                     import "pkg:/source/lib.bs"
@@ -2986,7 +2986,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for class', async () => {
-            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3014,7 +3014,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for function', async () => {
-            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3033,7 +3033,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for enum', async () => {
-            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3051,7 +3051,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for const', async () => {
-            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3067,7 +3067,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for empty namespaces', async () => {
-            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('annotation', new TypedFunctionType(VoidType.instance));
             await testTranspile(`
                 'comment1
                 @annotation
@@ -4380,9 +4380,9 @@ describe('BrsFile', () => {
         });
 
         it('includes annotations', () => {
-            program.pluginAnnotationTable.addSymbol('an', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
-            program.pluginAnnotationTable.addSymbol('anfunc', {}, new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true), SymbolTypeFlag.annotation);
-            program.pluginAnnotationTable.addSymbol('anmember', {}, new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true), SymbolTypeFlag.annotation);
+            program.addAnnotationSymbol('an', new TypedFunctionType(VoidType.instance));
+            program.addAnnotationSymbol('anfunc', new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true));
+            program.addAnnotationSymbol('anmember', new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true));
 
             testTypedef(`
                 namespace test

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -21,7 +21,7 @@ import * as fsExtra from 'fs-extra';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { ClassType, EnumType, FloatType, InterfaceType } from '../types';
+import { ClassType, EnumType, FloatType, InterfaceType, VoidType } from '../types';
 import type { StandardizedFileEntry } from 'roku-deploy';
 import * as fileUrl from 'file-url';
 import { isAALiteralExpression, isBlock } from '../astUtils/reflection';
@@ -1830,6 +1830,7 @@ describe('BrsFile', () => {
             });
 
             it('works for bs content', () => {
+                program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
                 program.setFile('source/lib.bs', ``);
                 doTest(`
                     import "pkg:/source/lib.bs"
@@ -2985,6 +2986,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for class', async () => {
+            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3012,6 +3014,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for function', async () => {
+            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3030,6 +3033,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for enum', async () => {
+            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3047,6 +3051,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for const', async () => {
+            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
             await testTranspile(`
                 'comment1
                 @annotation
@@ -3062,6 +3067,7 @@ describe('BrsFile', () => {
         });
 
         it('includes annotation comments for empty namespaces', async () => {
+            program.pluginAnnotationTable.addSymbol('annotation', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
             await testTranspile(`
                 'comment1
                 @annotation
@@ -4374,6 +4380,10 @@ describe('BrsFile', () => {
         });
 
         it('includes annotations', () => {
+            program.pluginAnnotationTable.addSymbol('an', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+            program.pluginAnnotationTable.addSymbol('anfunc', {}, new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true), SymbolTypeFlag.annotation);
+            program.pluginAnnotationTable.addSymbol('anmember', {}, new TypedFunctionType(VoidType.instance).addParameter('name', StringType.instance, true), SymbolTypeFlag.annotation);
+
             testTypedef(`
                 namespace test
                     @an

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1024,6 +1024,7 @@ export interface GetTypeOptions {
     ignoreCacheForRetrieval?: boolean;
     isExistenceTest?: boolean;
     preferDocType?: boolean;
+    onlyAllowLiterals?: boolean;
 }
 
 export class TypeChainEntry {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -228,13 +228,9 @@ export interface CompilerPlugin {
     name: string;
 
     /**
-     * A list of brighterscript-style function declarations of allowed annotations
-     * Eg.: [
-     *   `inline()`,
-     *   `suite(suiteConfig as object)`
-     * ]
+     * A list of function declarations of allowed annotations
      */
-    annotations?: Array<string | TypedFunctionType | AnnotationDeclaration>;
+    annotations?: Array<TypedFunctionType | AnnotationDeclaration>;
 
     /**
      * Called when plugin is initially loaded

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -219,6 +219,11 @@ export interface CommentFlag {
 
 export type CompilerPluginFactory = () => CompilerPlugin;
 
+export interface AnnotationDeclaration {
+    description?: string;
+    type: TypedFunctionType;
+}
+
 export interface CompilerPlugin {
     name: string;
 
@@ -229,7 +234,7 @@ export interface CompilerPlugin {
      *   `suite(suiteConfig as object)`
      * ]
      */
-    annotations?: string[];
+    annotations?: Array<string | TypedFunctionType | AnnotationDeclaration>;
 
     /**
      * Called when plugin is initially loaded
@@ -1000,6 +1005,10 @@ export interface ExtraSymbolData {
      * Is this type as defined in a doc comment?
      */
     isFromDocComment?: boolean;
+    /**
+     * Name of plugin that defined this symbol
+     */
+    pluginName?: string;
 }
 
 export interface GetTypeOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -221,6 +221,21 @@ export type CompilerPluginFactory = () => CompilerPlugin;
 
 export interface CompilerPlugin {
     name: string;
+
+    /**
+     * A list of brighterscript-style function declarations of allowed annotations
+     * Eg.: [
+     *   `inline()`,
+     *   `suite(suiteConfig as object)`
+     * ]
+     */
+    annotations?: string[];
+
+    /**
+     * Called when plugin is initially loaded
+     */
+    onPluginConfigure?(event: onPluginConfigureEvent): any;
+
     /**
      * Called before a new program is created
      */
@@ -506,6 +521,9 @@ export interface OnGetCodeActionsEvent<TFile extends BscFile = BscFile> {
     codeActions: CodeAction[];
 }
 
+export interface onPluginConfigureEvent {
+    builder: ProgramBuilder;
+}
 export interface BeforeProgramCreateEvent {
     builder: ProgramBuilder;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -239,7 +239,7 @@ export interface CompilerPlugin {
     /**
      * Called when plugin is initially loaded
      */
-    onPluginConfigure?(event: onPluginConfigureEvent): any;
+    onPluginConfigure?(event: OnPluginConfigureEvent): any;
 
     /**
      * Called before a new program is created

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -526,7 +526,7 @@ export interface OnGetCodeActionsEvent<TFile extends BscFile = BscFile> {
     codeActions: CodeAction[];
 }
 
-export interface onPluginConfigureEvent {
+export interface OnPluginConfigureEvent {
     builder: ProgramBuilder;
 }
 export interface BeforeProgramCreateEvent {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1441,7 +1441,7 @@ export class VariableExpression extends Expression {
     getType(options: GetTypeOptions) {
         let resultType: BscType = util.tokenToBscType(this.tokens.name);
         const nameKey = this.getName();
-        if (!resultType) {
+        if (!resultType || !options?.onlyAllowLiterals) {
             const symbolTable = this.getSymbolTable();
             resultType = symbolTable?.getSymbolType(nameKey, { ...options, fullName: nameKey, tableProvider: () => this.getSymbolTable() });
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -1441,7 +1441,7 @@ export class VariableExpression extends Expression {
     getType(options: GetTypeOptions) {
         let resultType: BscType = util.tokenToBscType(this.tokens.name);
         const nameKey = this.getName();
-        if (!resultType || !options?.onlyAllowLiterals) {
+        if (!resultType && !options?.onlyAllowLiterals) {
             const symbolTable = this.getSymbolTable();
             resultType = symbolTable?.getSymbolType(nameKey, { ...options, fullName: nameKey, tableProvider: () => this.getSymbolTable() });
 

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -1,6 +1,9 @@
 import { expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
 import { rootDir } from '../../../testHelpers.spec';
 import { Program } from '../../../Program';
+import { TypedFunctionType } from '../../../types/TypedFunctionType';
+import { VoidType } from '../../../types/VoidType';
+import { SymbolTypeFlag } from '../../../SymbolTypeFlag';
 
 describe('InterfaceStatement', () => {
     let program: Program;
@@ -50,6 +53,9 @@ describe('InterfaceStatement', () => {
     });
 
     it('includes annotations', async () => {
+        program.pluginAnnotationTable.addSymbol('IFace', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+        program.pluginAnnotationTable.addSymbol('Method', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+        program.pluginAnnotationTable.addSymbol('Field', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
         await testGetTypedef(`
             @IFace
             interface Person

--- a/src/parser/tests/statement/InterfaceStatement.spec.ts
+++ b/src/parser/tests/statement/InterfaceStatement.spec.ts
@@ -3,7 +3,6 @@ import { rootDir } from '../../../testHelpers.spec';
 import { Program } from '../../../Program';
 import { TypedFunctionType } from '../../../types/TypedFunctionType';
 import { VoidType } from '../../../types/VoidType';
-import { SymbolTypeFlag } from '../../../SymbolTypeFlag';
 
 describe('InterfaceStatement', () => {
     let program: Program;
@@ -53,9 +52,9 @@ describe('InterfaceStatement', () => {
     });
 
     it('includes annotations', async () => {
-        program.pluginAnnotationTable.addSymbol('IFace', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
-        program.pluginAnnotationTable.addSymbol('Method', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
-        program.pluginAnnotationTable.addSymbol('Field', {}, new TypedFunctionType(VoidType.instance), SymbolTypeFlag.annotation);
+        program.addAnnotationSymbol('IFace', new TypedFunctionType(VoidType.instance));
+        program.addAnnotationSymbol('Method', new TypedFunctionType(VoidType.instance));
+        program.addAnnotationSymbol('Field', new TypedFunctionType(VoidType.instance));
         await testGetTypedef(`
             @IFace
             interface Person

--- a/src/types/TypedFunctionType.ts
+++ b/src/types/TypedFunctionType.ts
@@ -47,7 +47,7 @@ export class TypedFunctionType extends BaseFunctionType {
         return this;
     }
 
-    public seVariadic(variadic: boolean) {
+    public setVariadic(variadic: boolean) {
         this.isVariadic = variadic;
         return this;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2310,6 +2310,9 @@ export class Util {
 
 
     public isInTypeExpression(expression: AstNode): boolean {
+        if (!expression) {
+            return false;
+        }
         //TODO: this is much faster than node.findAncestor(), but may need to be updated for "complicated" type expressions
         if (isTypeExpression(expression) ||
             isTypeExpression(expression.parent) ||


### PR DESCRIPTION
Addresses #1348 

Plugins must declare their annotations, so that can be validated.

- [x] Add Documentation about Annotations
- [x] Fix Deprecated docs with references to old plugin events
- [x] Add validation on annotation names and args
- [x] Ensure Annotation args are literals 
- [ ] Agree on format of annotation declarations

Future PR:
- Enhance hovers/completions/Signature help for annotations



![image](https://github.com/user-attachments/assets/bcc17b61-86f7-4998-a129-4e08ba02a0a9)

![image](https://github.com/user-attachments/assets/2155df4a-ee74-414c-ab36-d28c36d890e0)

![image](https://github.com/user-attachments/assets/02dc2020-4eff-46e6-b2cd-02076ac9f1b0)

![image](https://github.com/user-attachments/assets/cf686144-a556-4c8e-97cb-77325b5be2f5)


Extra `info` logging:

```
[11:24:45:357 AM] [prj0] Adding annotation 'takesString' (testPlugin)
```

