### PR TITLE
Fix class transpile issue with child class constructor not inherriting parent params

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -451,7 +451,7 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it('works for simple  class', () => {
+        it('works for simple class', () => {
             testTranspile(`
                 class Duck
                 end class
@@ -470,13 +470,15 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
-        it.only('test;lkajdsf;lkasjdf;lksajdf', () => {
+        it('inherits the parameters of the last known constructor', () => {
             testTranspile(`
                 class Bird
                     sub new(p1)
                     end sub
                 end class
                 class Duck extends Bird
+                end class
+                class BabyDuck extends Duck
                 end class
             `, `
                 function __Bird_builder()
@@ -500,6 +502,19 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
                 function Duck(p1)
                     instance = __Duck_builder()
+                    instance.new(p1)
+                    return instance
+                end function
+                function __BabyDuck_builder()
+                    instance = __Duck_builder()
+                    instance.super1_new = instance.new
+                    instance.new = sub(p1)
+                        m.super1_new(p1)
+                    end sub
+                    return instance
+                end function
+                function BabyDuck(p1)
+                    instance = __BabyDuck_builder()
                     instance.new(p1)
                     return instance
                 end function

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -470,6 +470,42 @@ describe('BrsFile BrighterScript classes', () => {
             `, undefined, 'source/main.bs');
         });
 
+        it.only('test;lkajdsf;lkasjdf;lksajdf', () => {
+            testTranspile(`
+                class Bird
+                    sub new(p1)
+                    end sub
+                end class
+                class Duck extends Bird
+                end class
+            `, `
+                function __Bird_builder()
+                    instance = {}
+                    instance.new = sub(p1)
+                    end sub
+                    return instance
+                end function
+                function Bird(p1)
+                    instance = __Bird_builder()
+                    instance.new(p1)
+                    return instance
+                end function
+                function __Duck_builder()
+                    instance = __Bird_builder()
+                    instance.super0_new = instance.new
+                    instance.new = sub()
+                        m.super0_new()
+                    end sub
+                    return instance
+                end function
+                function Duck(p1)
+                    instance = __Duck_builder()
+                    instance.new(p1)
+                    return instance
+                end function
+            `);
+        });
+
         it('registers the constructor and properly handles its parameters', () => {
             testTranspile(`
                 class Duck

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -493,8 +493,8 @@ describe('BrsFile BrighterScript classes', () => {
                 function __Duck_builder()
                     instance = __Bird_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
+                    instance.new = sub(p1)
+                        m.super0_new(p1)
                     end sub
                     return instance
                 end function

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -605,8 +605,8 @@ describe('BrsFile BrighterScript classes', () => {
                 function __Duck_builder()
                     instance = __Creature_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
+                    instance.new = sub(name as string)
+                        m.super0_new(name)
                     end sub
                     instance.super0_sayHello = instance.sayHello
                     instance.sayHello = function(text)
@@ -617,9 +617,9 @@ describe('BrsFile BrighterScript classes', () => {
                     end function
                     return instance
                 end function
-                function Duck()
+                function Duck(name as string)
                     instance = __Duck_builder()
-                    instance.new()
+                    instance.new(name)
                     return instance
                 end function
             `, 'trim', 'source/main.bs'
@@ -810,8 +810,8 @@ describe('BrsFile BrighterScript classes', () => {
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
+                    instance.new = sub(name as string)
+                        m.super0_new(name)
                     end sub
                     instance.super0_move = instance.move
                     instance.move = sub(distanceInMeters as integer)
@@ -820,16 +820,16 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                     return instance
                 end function
-                function Duck()
+                function Duck(name as string)
                     instance = __Duck_builder()
-                    instance.new()
+                    instance.new(name)
                     return instance
                 end function
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
                     instance.super1_new = instance.new
-                    instance.new = sub()
-                        m.super1_new()
+                    instance.new = sub(name as string)
+                        m.super1_new(name)
                     end sub
                     instance.super1_move = instance.move
                     instance.move = sub(distanceInMeters as integer)
@@ -838,9 +838,9 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                     return instance
                 end function
-                function BabyDuck()
+                function BabyDuck(name as string)
                     instance = __BabyDuck_builder()
-                    instance.new()
+                    instance.new(name)
                     return instance
                 end function
 

--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -472,18 +472,37 @@ describe('BrsFile BrighterScript classes', () => {
 
         it('inherits the parameters of the last known constructor', () => {
             testTranspile(`
-                class Bird
+                class Animal
                     sub new(p1)
                     end sub
                 end class
+                class Bird extends Animal
+                end class
                 class Duck extends Bird
+                    sub new(p1, p2)
+                        super(p1)
+                        m.p2 = p2
+                    end sub
                 end class
                 class BabyDuck extends Duck
                 end class
             `, `
-                function __Bird_builder()
+                function __Animal_builder()
                     instance = {}
                     instance.new = sub(p1)
+                    end sub
+                    return instance
+                end function
+                function Animal(p1)
+                    instance = __Animal_builder()
+                    instance.new(p1)
+                    return instance
+                end function
+                function __Bird_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = sub(p1)
+                        m.super0_new(p1)
                     end sub
                     return instance
                 end function
@@ -494,28 +513,29 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
                 function __Duck_builder()
                     instance = __Bird_builder()
-                    instance.super0_new = instance.new
-                    instance.new = sub(p1)
-                        m.super0_new(p1)
+                    instance.super1_new = instance.new
+                    instance.new = sub(p1, p2)
+                        m.super1_new(p1)
+                        m.p2 = p2
                     end sub
                     return instance
                 end function
-                function Duck(p1)
+                function Duck(p1, p2)
                     instance = __Duck_builder()
-                    instance.new(p1)
+                    instance.new(p1, p2)
                     return instance
                 end function
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
-                    instance.super1_new = instance.new
-                    instance.new = sub(p1)
-                        m.super1_new(p1)
+                    instance.super2_new = instance.new
+                    instance.new = sub(p1, p2)
+                        m.super2_new(p1, p2)
                     end sub
                     return instance
                 end function
-                function BabyDuck(p1)
+                function BabyDuck(p1, p2)
                     instance = __BabyDuck_builder()
-                    instance.new(p1)
+                    instance.new(p1, p2)
                     return instance
                 end function
             `);

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2180,9 +2180,13 @@ export class ClassStatement extends Statement implements TypedefProvider {
      */
     private getConstructorParams(ancestors: ClassStatement[]) {
         for (let ancestor of ancestors) {
-            const ctor = ancestor.getConstructorFunction();
-            if (ctor) return ctor.func.parameters;
+            // @todo: somehow, ancestors can have a list where the last element is null.
+            //        this is exposed by the test named "extending namespaced class transpiles properly".
+            if (ancestor) {
+                const ctor = ancestor.getConstructorFunction();
+                if (ctor) return ctor.func.parameters;
             }
+        }
         return [];
     }
 
@@ -2246,31 +2250,31 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 ];
             } else {
                 const params = this.getConstructorParams(ancestors);
-            const call = new ExpressionStatement(
-                new CallExpression(
-                    new VariableExpression(createToken(TokenKind.Identifier, 'super')),
-                    createToken(TokenKind.LeftParen),
-                    createToken(TokenKind.RightParen),
-                    params.map(x => new VariableExpression(x.name))
-                )
-            );
-            body = [
-                new MethodStatement(
-                    [],
-                    createIdentifier('new'),
-                    new FunctionExpression(
-                        params.map(x => x.clone()),
-                        new Block([call]),
-                        createToken(TokenKind.Sub),
-                        createToken(TokenKind.EndSub),
+                const call = new ExpressionStatement(
+                    new CallExpression(
+                        new VariableExpression(createToken(TokenKind.Identifier, 'super')),
                         createToken(TokenKind.LeftParen),
-                        createToken(TokenKind.RightParen)
+                        createToken(TokenKind.RightParen),
+                        params.map(x => new VariableExpression(x.name))
+                    )
+                );
+                body = [
+                    new MethodStatement(
+                        [],
+                        createIdentifier('new'),
+                        new FunctionExpression(
+                            params.map(x => x.clone()),
+                            new Block([call]),
+                            createToken(TokenKind.Sub),
+                            createToken(TokenKind.EndSub),
+                            createToken(TokenKind.LeftParen),
+                            createToken(TokenKind.RightParen)
+                        ),
+                        null
                     ),
-                    null
-                ),
-                ...this.body
-            ];
-        }
+                    ...this.body
+                ];
+            }
         }
 
         for (let statement of body) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2184,7 +2184,9 @@ export class ClassStatement extends Statement implements TypedefProvider {
             //        this is exposed by the test named "extending namespaced class transpiles properly".
             if (ancestor) {
                 const ctor = ancestor.getConstructorFunction();
-                if (ctor) return ctor.func.parameters;
+                if (ctor) {
+                    return ctor.func.parameters;
+                }
             }
         }
         return [];
@@ -2243,7 +2245,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         let body = this.body;
         //inject an empty "new" method if missing
         if (!this.getConstructorFunction()) {
-            if (ancestors.length == 0) {
+            if (ancestors.length === 0) {
                 body = [
                     createMethodStatement('new', TokenKind.Sub),
                     ...this.body

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2144,7 +2144,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         let stmt = this as ClassStatement;
         while (stmt) {
             if (stmt.parentClassName) {
-                const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
+                const namespace = stmt.findAncestor<NamespaceStatement>(isNamespaceStatement);
                 stmt = state.file.getClassFileLink(
                     stmt.parentClassName.getName(ParseMode.BrighterScript),
                     namespace?.getName(ParseMode.BrighterScript)
@@ -2180,13 +2180,9 @@ export class ClassStatement extends Statement implements TypedefProvider {
      */
     private getConstructorParams(ancestors: ClassStatement[]) {
         for (let ancestor of ancestors) {
-            // @todo: somehow, ancestors can have a list where the last element is null.
-            //        this is exposed by the test named "extending namespaced class transpiles properly".
-            if (ancestor) {
-                const ctor = ancestor.getConstructorFunction();
-                if (ctor) {
-                    return ctor.func.parameters;
-                }
+            const ctor = ancestor?.getConstructorFunction();
+            if (ctor) {
+                return ctor.func.parameters;
             }
         }
         return [];

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-bitwise */
 import type { Token, Identifier } from '../lexer/Token';
 import { CompoundAssignmentOperators, TokenKind } from '../lexer/TokenKind';
-import { type BinaryExpression, type NamespacedVariableNameExpression, FunctionExpression, type FunctionParameterExpression, type LiteralExpression } from './Expression';
+import type { BinaryExpression, NamespacedVariableNameExpression, FunctionParameterExpression, LiteralExpression } from './Expression';
+import { FunctionExpression } from './Expression';
 import { CallExpression, VariableExpression } from './Expression';
 import { util } from '../util';
 import type { Range } from 'vscode-languageserver';

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2320,8 +2320,14 @@ export class ClassStatement extends Statement implements TypedefProvider {
      */
     private getTranspiledClassFunction(state: BrsTranspileState) {
         let result = [] as TranspileResult;
+
         const constructorFunction = this.getConstructorFunction();
-        const constructorParams = constructorFunction ? constructorFunction.func.parameters : [];
+        let constructorParams = [];
+        if (constructorFunction) {
+            constructorParams = constructorFunction.func.parameters;
+        } else {
+            constructorParams = this.getConstructorParams(this.getAncestors(state)[0]);
+        }
 
         result.push(
             state.sourceNode(this.classKeyword, 'function'),


### PR DESCRIPTION
When a child class extends a super class, but does not include its own `new` function, and the parent class has parameters, we are missing those parameters in the child class's factory. 

- [x] unit test
- [x] fix the bug