### PR TITLE
Fix crash when unraveling complex BinaryReferenceType

### DIFF
--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -426,7 +426,7 @@ export class BinaryOperatorReferenceType extends BscType {
                             return () => undefined;
                         }
                     } else {
-                        resultType = binaryOpResolver(this.leftType, this.operator, this.rightType);
+                        resultType = binaryOpResolver(this.leftType, this.operator, this.rightType) ?? DynamicType.instance;
                         this.cachedType = resultType;
                     }
 


### PR DESCRIPTION
Fixes a crash related to BinaryReferenceType. 

![image](https://github.com/user-attachments/assets/d188665d-3a9f-494f-8eb2-81ba87ac6831)
