### PR TITLE
Fixes How BinaryOperators work on Unions

### DIFF
--- a/src/bscPlugin/hover/HoverProcessor.spec.ts
+++ b/src/bscPlugin/hover/HoverProcessor.spec.ts
@@ -829,16 +829,16 @@ describe('HoverProcessor', () => {
                     if deviceInfo.getClockFormat() = "24h" then
                         hour = stringUtil.pad(hour)
                         ' "22:01" | "01:01"
-                        return substitute("{0}:{1}", hour, minutes as string)
+                        return substitute("{0}:{1}", hour as string, minutes as string)
                     else
                         hour = hour mod 12
                         if hour = 0 then hour = 12
                         ' "10:01 AM" | "1:01 AM"
-                        return substitute("{0}:{1} {2}", hour, minutes as string, meridiem)
+                        return substitute("{0}:{1} {2}", hour.toStr(), minutes as string, meridiem)
                     end if
                 end function
             `);
-            const expectedHourHoverStr = `hour as dynamic`;
+            const expectedHourHoverStr = `hour as integer or string`;
 
             program.validate();
             expectZeroDiagnostics(program);

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -3487,6 +3487,18 @@ describe('ScopeValidator', () => {
                 DiagnosticMessages.operatorTypeMismatch('=', 'uninitialized', 'invalid').message
             ]);
         });
+
+        it('allows string comparisons with object', () => {
+            program.setFile<BrsFile>('source/main.brs', `
+                sub test(x as object)
+                    if x <> "test"
+                        print x
+                    end if
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('memberAccessibilityMismatch', () => {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -139,4 +139,11 @@ export abstract class BscType {
         }
         this.hasAddedBuiltInInterfaces = true;
     }
+
+    /**
+     * The level of priority of this type when in a binary operation
+     * For example Float is higher priority than integer, so Float + Int => Float
+     * Lower numbers have higher priority
+     */
+    readonly binaryOpPriorityLevel: number = 0;
 }

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -41,6 +41,8 @@ export class DoubleType extends BscType {
     public isEqual(targetType: BscType): boolean {
         return isDoubleType(targetType);
     }
+
+    readonly binaryOpPriorityLevel = 1;
 }
 
 BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('double', DoubleType.instance);

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -50,6 +50,8 @@ export class DynamicType extends BscType {
     getMemberType(memberName: string, options: GetTypeOptions) {
         return DynamicType.instance;
     }
+
+
 }
 
 BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('dynamic', DynamicType.instance);

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -42,6 +42,8 @@ export class FloatType extends BscType {
     public isEqual(targetType: BscType): boolean {
         return isFloatType(targetType);
     }
+
+    readonly binaryOpPriorityLevel = 2;
 }
 
 BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('float', FloatType.instance);

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -41,6 +41,8 @@ export class IntegerType extends BscType {
     isEqual(otherType: BscType) {
         return isIntegerType(otherType);
     }
+
+    readonly binaryOpPriorityLevel = 4;
 }
 
 BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('integer', IntegerType.instance);

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -41,6 +41,8 @@ export class LongIntegerType extends BscType {
     isEqual(targetType: BscType): boolean {
         return isLongIntegerType(targetType);
     }
+
+    readonly binaryOpPriorityLevel = 3;
 }
 
 BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('longinteger', LongIntegerType.instance);

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -426,7 +426,7 @@ export class BinaryOperatorReferenceType extends BscType {
                             return () => undefined;
                         }
                     } else {
-                        resultType = binaryOpResolver(this.leftType, this.operator, this.rightType);
+                        resultType = binaryOpResolver(this.leftType, this.operator, this.rightType) ?? DynamicType.instance;
                         this.cachedType = resultType;
                     }
 

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -64,7 +64,7 @@ export class UnionType extends BscType {
     }
 
     isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData): boolean {
-        if (isDynamicType(targetType) || isObjectType(targetType)) {
+        if (isDynamicType(targetType) || isObjectType(targetType) || this === targetType) {
             return true;
         }
         if (isEnumTypeCompatible(this, targetType, data)) {
@@ -86,7 +86,6 @@ export class UnionType extends BscType {
             }
         }
 
-
         return false;
     }
     toString(): string {
@@ -105,6 +104,9 @@ export class UnionType extends BscType {
     isEqual(targetType: BscType): boolean {
         if (!isUnionType(targetType)) {
             return false;
+        }
+        if (this === targetType) {
+            return true;
         }
         return this.isTypeCompatible(targetType) && targetType.isTypeCompatible(this);
     }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -12,7 +12,7 @@ import { NamespaceType } from './types/NamespaceType';
 import { ClassType } from './types/ClassType';
 import { ReferenceType } from './types/ReferenceType';
 import { SymbolTypeFlag } from './SymbolTypeFlag';
-import { BooleanType, DoubleType, DynamicType, FloatType, IntegerType, InvalidType, LongIntegerType, StringType, TypedFunctionType, UnionType, VoidType } from './types';
+import { BooleanType, DoubleType, DynamicType, FloatType, IntegerType, InvalidType, LongIntegerType, ObjectType, StringType, TypedFunctionType, UnionType, VoidType } from './types';
 import { TokenKind } from './lexer/TokenKind';
 import { createToken } from './astUtils/creators';
 import { createDottedIdentifier, createVariableExpression } from './astUtils/creators';
@@ -1121,6 +1121,10 @@ describe('util', () => {
             myUnion.addType(myUnion);
             expectTypeToBe(util.binaryOperatorResultType(myUnion, createToken(TokenKind.Plus), myUnion), DynamicType);
         });
+
+        it('handles object Types', () => {
+            expectTypeToBe(util.binaryOperatorResultType(new ObjectType(), createToken(TokenKind.Plus), IntegerType.instance), IntegerType);
+        });
     });
 
     describe('unaryOperatorResultType', () => {
@@ -1144,6 +1148,10 @@ describe('util', () => {
             expect(util.unaryOperatorResultType(notToken, StringType.instance)).to.be.undefined;
             expectTypeToBe(util.unaryOperatorResultType(notToken, LongIntegerType.instance), LongIntegerType);
             expect(util.unaryOperatorResultType(notToken, VoidType.instance)).to.be.undefined;
+        });
+
+        it('handles object Types', () => {
+            expectTypeToBe(util.unaryOperatorResultType(createToken(TokenKind.Minus), new ObjectType()), ObjectType);
         });
     });
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -12,7 +12,7 @@ import { NamespaceType } from './types/NamespaceType';
 import { ClassType } from './types/ClassType';
 import { ReferenceType } from './types/ReferenceType';
 import { SymbolTypeFlag } from './SymbolTypeFlag';
-import { BooleanType, DoubleType, DynamicType, FloatType, IntegerType, InvalidType, LongIntegerType, StringType, TypedFunctionType, VoidType } from './types';
+import { BooleanType, DoubleType, DynamicType, FloatType, IntegerType, InvalidType, LongIntegerType, StringType, TypedFunctionType, UnionType, VoidType } from './types';
 import { TokenKind } from './lexer/TokenKind';
 import { createToken } from './astUtils/creators';
 import { createDottedIdentifier, createVariableExpression } from './astUtils/creators';
@@ -1099,6 +1099,27 @@ describe('util', () => {
 
             // "and" / "or" are bitwise operators with number
             expectTypeToBe(util.binaryOperatorResultType(IntegerType.instance, createToken(TokenKind.Or), DynamicType.instance), IntegerType);
+        });
+
+        it('handles union types ', () => {
+            const floatIntUnion = new UnionType([IntegerType.instance, FloatType.instance]);
+            expectTypeToBe(util.binaryOperatorResultType(floatIntUnion, createToken(TokenKind.Plus), DoubleType.instance), DoubleType);
+        });
+
+        it('handles 2 union types', () => {
+            const floatIntUnion = new UnionType([IntegerType.instance, FloatType.instance]);
+            expectTypeToBe(util.binaryOperatorResultType(floatIntUnion, createToken(TokenKind.Plus), floatIntUnion), FloatType);
+        });
+
+        it('handles union types with diverse member types', () => {
+            const myUnion = new UnionType([FloatType.instance, StringType.instance, BooleanType.instance]);
+            expectTypeToBe(util.binaryOperatorResultType(myUnion, createToken(TokenKind.Plus), myUnion), DynamicType);
+        });
+
+        it('handles union types with self-referencing unions', () => {
+            const myUnion = new UnionType([FloatType.instance, StringType.instance, DynamicType.instance]);
+            myUnion.addType(myUnion);
+            expectTypeToBe(util.binaryOperatorResultType(myUnion, createToken(TokenKind.Plus), myUnion), DynamicType);
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1556,10 +1556,10 @@ export class Util {
         rightType = getUniqueType([rightType], unionTypeFactory);
 
         if (isUnionType(leftType)) {
-            leftType = this.getHighestPriorityNumberType(leftType.types);
+            leftType = this.getHighestPriorityType(leftType.types);
         }
         if (isUnionType(rightType)) {
-            rightType = this.getHighestPriorityNumberType(rightType.types);
+            rightType = this.getHighestPriorityType(rightType.types);
         }
 
         if (isVoidType(leftType) || isVoidType(rightType) || isUninitializedType(leftType) || isUninitializedType(rightType)) {
@@ -1734,7 +1734,7 @@ export class Util {
         return undefined;
     }
 
-    public getHighestPriorityNumberType(types: BscType[], depth = 0): BscType {
+    public getHighestPriorityType(types: BscType[], depth = 0): BscType {
         let result: BscType;
         if (depth > 4) {
             // shortcut for very complicated types, or self-referencing union types
@@ -1744,7 +1744,7 @@ export class Util {
             if (isUnionType(type)) {
                 type = getUniqueType([type], unionTypeFactory);
                 if (isUnionType(type)) {
-                    type = this.getHighestPriorityNumberType(type.types, depth + 1);
+                    type = this.getHighestPriorityType(type.types, depth + 1);
                 }
             }
             if (!result) {
@@ -1778,9 +1778,14 @@ export class Util {
      */
     public unaryOperatorResultType(operator: Token, exprType: BscType): BscType {
 
+        if (isUnionType(exprType)) {
+            exprType = this.getHighestPriorityType(exprType.types);
+        }
+
         if (isVoidType(exprType) || isInvalidType(exprType) || isUninitializedType(exprType)) {
             return undefined;
         }
+
 
         if (isDynamicType(exprType)) {
             return exprType;

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ import type { CallExpression, CallfuncExpression, DottedGetExpression, FunctionP
 import { LogLevel, createLogger } from './logging';
 import { isToken, type Identifier, type Locatable, type Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
-import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isCallfuncExpression, isClassType, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLiteralString, isLongIntegerType, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isPrimitiveType, isReferenceType, isStatement, isStringType, isTypeExpression, isTypedArrayExpression, isTypedFunctionType, isUninitializedType, isUnionType, isVariableExpression, isVoidType, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
+import { isAnyReferenceType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isCallfuncExpression, isClassType, isDottedGetExpression, isDoubleType, isDynamicType, isEnumMemberType, isExpression, isFloatType, isIndexedGetExpression, isInvalidType, isLiteralString, isLongIntegerType, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isStatement, isStringType, isTypeExpression, isTypedArrayExpression, isTypedFunctionType, isUninitializedType, isUnionType, isVariableExpression, isVoidType, isXmlAttributeGetExpression, isXmlFile } from './astUtils/reflection';
 import { WalkMode } from './astUtils/visitors';
 import { SourceNode } from 'source-map';
 import * as requireRelative from 'require-relative';
@@ -1572,6 +1572,15 @@ export class Util {
         if (isEnumMemberType(rightType)) {
             rightType = rightType.underlyingType;
         }
+
+        // treat object type like dynamic
+        if (isObjectType(leftType)) {
+            leftType = DynamicType.instance;
+        }
+        if (isObjectType(rightType)) {
+            rightType = DynamicType.instance;
+        }
+
         let hasDouble = isDoubleType(leftType) || isDoubleType(rightType);
         let hasFloat = isFloatType(leftType) || isFloatType(rightType);
         let hasLongInteger = isLongIntegerType(leftType) || isLongIntegerType(rightType);
@@ -1766,6 +1775,9 @@ export class Util {
             if (isInvalidType(type)) {
                 return type;
             }
+            if (isObjectType(type) && !isDynamicType(type)) {
+                result = type;
+            }
             if (isDynamicType(type)) {
                 result = type;
             }
@@ -1787,7 +1799,7 @@ export class Util {
         }
 
 
-        if (isDynamicType(exprType)) {
+        if (isDynamicType(exprType) || isObjectType(exprType)) {
             return exprType;
         }
 


### PR DESCRIPTION
New logic:
- the result of a binary op on unions depends on what types are in the union
- Basically, the "highest priority" type wins
- If two types are "equal priority", but not the same, treat it as Dynamic
-  `(float or integer) + (Integer) => Float`
- Treats "ObjectType" basically like "DynamicType"
