### PR TITLE
Add `validate` flag to ProgramBuilder.run()

### DIFF
--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -222,7 +222,7 @@ describe('ProgramBuilder', () => {
                 createPackage: false,
                 deploy: false,
                 copyToStaging: false,
-                skipInitialValidation: true,
+                validate: false,
                 //both files should want to be the `source/lib.brs` file...but only the last one should win
                 files: ['source/**/*']
             });

--- a/src/ProgramBuilder.spec.ts
+++ b/src/ProgramBuilder.spec.ts
@@ -189,6 +189,47 @@ describe('ProgramBuilder', () => {
             expectZeroDiagnostics(builder);
             expect(builder.program.getFile(s``));
         });
+
+        it('runs initial validation by default', async () => {
+            //undo the vfs for this test
+            sinon.restore();
+            fsExtra.outputFileSync(`${rootDir}/source/lib1.brs`, 'sub doSomething()\nprint "lib1"\nend sub');
+
+            const stub = sinon.stub(builder as any, 'validateProject').callsFake(() => { });
+
+            await builder.run({
+                rootDir: rootDir,
+                createPackage: false,
+                deploy: false,
+                copyToStaging: false,
+                //both files should want to be the `source/lib.brs` file...but only the last one should win
+                files: ['source/**/*']
+            });
+            expectZeroDiagnostics(builder);
+            //validate was called
+            expect(stub.callCount).to.eql(1);
+        });
+
+        it('skips initial validation', async () => {
+            //undo the vfs for this test
+            sinon.restore();
+            fsExtra.outputFileSync(`${rootDir}/source/lib1.brs`, 'sub doSomething()\nprint "lib1"\nend sub');
+
+            const stub = sinon.stub(builder as any, 'validateProject').callsFake(() => { });
+
+            await builder.run({
+                rootDir: rootDir,
+                createPackage: false,
+                deploy: false,
+                copyToStaging: false,
+                skipInitialValidation: true,
+                //both files should want to be the `source/lib.brs` file...but only the last one should win
+                files: ['source/**/*']
+            });
+            expectZeroDiagnostics(builder);
+            //validate was not called
+            expect(stub.callCount).to.eql(0);
+        });
     });
 
     it('uses a unique logger for each builder', async () => {

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -94,7 +94,7 @@ export class ProgramBuilder {
         ];
     }
 
-    public async run(options: BsConfig) {
+    public async run(options: BsConfig & { skipInitialValidation?: boolean }) {
         if (options?.logLevel) {
             this.logger.logLevel = options.logLevel;
         }
@@ -137,10 +137,14 @@ export class ProgramBuilder {
 
         if (this.options.watch) {
             this.logger.log('Starting compilation in watch mode...');
-            await this.runOnce();
+            await this.runOnce({
+                skipValidation: options?.skipInitialValidation
+            });
             this.enableWatchMode();
         } else {
-            await this.runOnce();
+            await this.runOnce({
+                skipValidation: options?.skipInitialValidation
+            });
         }
     }
 
@@ -264,14 +268,17 @@ export class ProgramBuilder {
     /**
      * Run the entire process exactly one time.
      */
-    private runOnce() {
+    private runOnce(options?: { skipValidation?: boolean }) {
         //clear the console
         this.clearConsole();
         let cancellationToken = { isCanceled: false };
         //wait for the previous run to complete
         let runPromise = this.cancelLastRun().then(() => {
             //start the new run
-            return this._runOnce(cancellationToken);
+            return this._runOnce({
+                cancellationToken: cancellationToken,
+                skipValidation: options?.skipValidation
+            });
         }) as any;
 
         //a function used to cancel this run
@@ -347,18 +354,20 @@ export class ProgramBuilder {
      * Run the process once, allowing cancelability.
      * NOTE: This should only be called by `runOnce`.
      */
-    private async _runOnce(cancellationToken: { isCanceled: any }) {
+    private async _runOnce(options: { cancellationToken: { isCanceled: any }; skipValidation: boolean }) {
         let wereDiagnosticsPrinted = false;
         try {
             //maybe cancel?
-            if (cancellationToken.isCanceled === true) {
+            if (options?.cancellationToken?.isCanceled === true) {
                 return -1;
             }
-            //validate program
-            this.validateProject();
+            //validate program?
+            if (options?.skipValidation !== true) {
+                this.validateProject();
+            }
 
             //maybe cancel?
-            if (cancellationToken.isCanceled === true) {
+            if (options?.cancellationToken?.isCanceled === true) {
                 return -1;
             }
 
@@ -376,7 +385,7 @@ export class ProgramBuilder {
             await this.createPackageIfEnabled();
 
             //maybe cancel?
-            if (cancellationToken.isCanceled === true) {
+            if (options?.cancellationToken?.isCanceled === true) {
                 return -1;
             }
 


### PR DESCRIPTION
Adds a flag to the `ProgramBuilder.run()` method that will enable/disable validation. This can be useful when trying to inspect various aspects of a project but you don't care about validation. Currently restricted to the `ProgramBuilder.run()` function but may be expanded to bsconfig and cli features in the future. It's also marked unstable because we have a specific purpose for this flag at the moment, all other behavior is undefined.