### PR TITLE
Add lookup tables to DiagnosticsManager to speed up diagnostic clearing

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -16,11 +16,4 @@ export class Cache<TKey = any, TValue = any> extends Map<TKey, TValue> {
             return super.get(key) as R;
         }
     }
-
-    /**
-     * Get the item with the specified key.
-     */
-    public get<R extends TValue = TValue>(key: TKey) {
-        return super.get(key) as R;
-    }
 }

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -255,7 +255,7 @@ export class CrossScopeValidator {
     }
 
     resolutionsMap = new Map<UnresolvedSymbol, Set<{ scope: Scope; sourceFile: BscFile; providedSymbol: BscSymbol }>>();
-    providedTreeMap = new Map<Scope, { duplicatesMap: Map<string, Set<FileSymbolPair>>; providedTree: ProvidedNode }>();
+    providedTreeMap = new Map<string, { duplicatesMap: Map<string, Set<FileSymbolPair>>; providedTree: ProvidedNode }>();
 
 
     private componentsMap = new Map<string, FileSymbolPair>();
@@ -274,10 +274,11 @@ export class CrossScopeValidator {
     }
 
     getProvidedTree(scope: Scope) {
-        if (this.providedTreeMap.has(scope)) {
-            return this.providedTreeMap.get(scope);
+        const lowerScopeName = scope.name?.toLowerCase();
+        if (this.providedTreeMap.has(lowerScopeName)) {
+            return this.providedTreeMap.get(lowerScopeName);
         }
-        const providedTree = new ProvidedNode('');//, this.componentsMap);
+        const providedTree = new ProvidedNode('');
         const duplicatesMap = new Map<string, Set<FileSymbolPair>>();
 
         const referenceTypesMap = new Map<{ symbolName: string; file: BscFile; symbolObj: ProvidedSymbol }, Array<{ name: string; namespacedName?: string }>>();
@@ -376,7 +377,7 @@ export class CrossScopeValidator {
         }
 
         const result = { duplicatesMap: duplicatesMap, providedTree: providedTree };
-        this.providedTreeMap.set(scope, result);
+        this.providedTreeMap.set(lowerScopeName, result);
         return result;
     }
 

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -274,9 +274,8 @@ export class CrossScopeValidator {
     }
 
     getProvidedTree(scope: Scope) {
-        const lowerScopeName = scope.name?.toLowerCase();
-        if (this.providedTreeMap.has(lowerScopeName)) {
-            return this.providedTreeMap.get(lowerScopeName);
+        if (this.providedTreeMap.has(scope.name)) {
+            return this.providedTreeMap.get(scope.name);
         }
         const providedTree = new ProvidedNode('');
         const duplicatesMap = new Map<string, Set<FileSymbolPair>>();
@@ -377,7 +376,7 @@ export class CrossScopeValidator {
         }
 
         const result = { duplicatesMap: duplicatesMap, providedTree: providedTree };
-        this.providedTreeMap.set(lowerScopeName, result);
+        this.providedTreeMap.set(scope.name, result);
         return result;
     }
 

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -326,6 +326,39 @@ describe('DiagnosticFilterer', () => {
         ]);
     });
 
+    describe('isFileFiltered', () => {
+        it('should find files that are completely filtered by src', () => {
+            filterer.options = options;
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/lib/some/file.brs`, destPath: `source/some/file.brs` })).true;
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/notlib/other/file.brs`, destPath: `source/other/file.brs` })).false;
+        });
+
+        it('should find files that are completely filtered by dest', () => {
+            filterer.options = {
+                rootDir: rootDir,
+                diagnosticFilters: [
+                    { files: [{ dest: 'source/remove/**/*.*' }] }
+                ]
+            };
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/source/some/file.brs`, destPath: `source/remove/some/file.brs` })).true;
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/source/other/file.brs`, destPath: `source/keep/other/file.brs` })).false;
+        });
+
+        it('should find files that are completely filtered by src, with negative filtering', () => {
+            filterer.options = {
+                rootDir: rootDir,
+                diagnosticFilters: [
+                    //ignore all codes from lib
+                    { files: 'lib/**/*.brs' },
+                    //un-ignore specific errors from lib/special
+                    { files: '!lib/special/**/*.brs' }
+                ]
+            };
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/lib/some/file.brs`, destPath: `source/some/file.brs` })).true;
+            expect(filterer.isFileFiltered({ srcPath: `${rootDir}/lib/special/file.brs`, destPath: `source/special/file.brs` })).false;
+        });
+    });
+
 });
 
 function getDiagnostic(code: number | string, srcPath: string, destPath?: string) {

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -12,6 +12,7 @@ import chalk from 'chalk';
 import type { Logger } from './logging';
 import { LogLevel, createLogger } from './logging';
 import type { Program } from './Program';
+import type { BrsFile } from './files/BrsFile';
 
 interface DiagnosticWithContexts {
     diagnostic: BsDiagnosticWithKey;
@@ -127,7 +128,7 @@ export class DiagnosticManager {
      */
     public getDiagnostics() {
         const doDiagnosticsGathering = () => {
-            const diagnostics = this.getNonSuppresedDiagnostics();
+            const diagnostics = this.getNonSuppressedDiagnostics();
             const filteredDiagnostics = this.logger?.time(LogLevel.debug, ['filter diagnostics'], () => {
                 return this.filterDiagnostics(diagnostics);
             }) ?? this.filterDiagnostics(diagnostics);
@@ -143,7 +144,7 @@ export class DiagnosticManager {
         return this.logger?.time(LogLevel.info, ['DiagnosticsManager.getDiagnostics()'], doDiagnosticsGathering) ?? doDiagnosticsGathering();
     }
 
-    private getNonSuppresedDiagnostics() {
+    private getNonSuppressedDiagnostics() {
         const results = [] as Array<BsDiagnostic>;
         for (const cachedDiagnostic of this.diagnosticsCache.values()) {
             const diagnostic = { ...cachedDiagnostic.diagnostic };
@@ -428,6 +429,14 @@ export class DiagnosticManager {
                 target.push(ri);
             }
         }
+    }
+
+    public shouldFilterFile(file: BrsFile): boolean {
+        if (this.diagnosticFilterer.options !== this.options) {
+            this.diagnosticFilterer.options = this.options;
+        }
+        this.diagnosticFilterer.isFileFiltered(file);
+        return false;
     }
 
 }

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -12,7 +12,6 @@ import chalk from 'chalk';
 import type { Logger } from './logging';
 import { LogLevel, createLogger } from './logging';
 import type { Program } from './Program';
-import { forEach } from 'benchmark';
 
 /**
  * Manages all diagnostics for a program.

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1850,6 +1850,9 @@ export class Program {
                 file.editor.undoAll();
             }
         });
+
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        console.log('TYPES CREATED', global['TypesCreated']);
     }
 
     /**

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1852,7 +1852,7 @@ export class Program {
         });
 
         // eslint-disable-next-line @typescript-eslint/dot-notation
-        console.log('TYPES CREATED', global['TypesCreated']);
+        //console.log('TYPES CREATED', global['TypesCreated']);
     }
 
     /**

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -871,6 +871,8 @@ export class Program {
                 this.crossScopeValidation.clearResolutionsForFile(file);
             }
 
+            this.diagnostics.clearForFile(file.srcPath);
+
             //if this is a component, remove it from our components map
             if (isXmlFile(file)) {
                 this.logger.debug('Unregistering component', file.srcPath);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -76,6 +76,11 @@ export class Program {
         plugins?: PluginInterface,
         diagnosticsManager?: DiagnosticManager
     ) {
+        // eslint-disable-next-line
+        global['namespaceContainersCreated'] = {};
+        // eslint-disable-next-line
+        global['namespaceContainersCreatedByScope'] = {};
+
         this.options = util.normalizeConfig(options);
         this.logger = logger ?? createLogger(options);
         this.plugins = plugins || new PluginInterface([], { logger: this.logger });
@@ -1826,6 +1831,11 @@ export class Program {
             for (const file of event.files) {
                 file.editor.undoAll();
             }
+
+            // eslint-disable-next-line
+            console.log(global['namespaceContainersCreated']);
+            // eslint-disable-next-line
+            console.log(global['namespaceContainersCreatedByScope']);
         });
     }
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1204,7 +1204,7 @@ export class Program {
             .filter(file => file !== undefined) as T[];
     }
 
-    private getFilePathCache = new Map<string, { path: string, isDestMap?: boolean }>();
+    private getFilePathCache = new Map<string, { path: string; isDestMap?: boolean }>();
 
     /**
      * Get the file at the given path

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -76,11 +76,6 @@ export class Program {
         plugins?: PluginInterface,
         diagnosticsManager?: DiagnosticManager
     ) {
-        // eslint-disable-next-line
-        global['namespaceContainersCreated'] = {};
-        // eslint-disable-next-line
-        global['namespaceContainersCreatedByScope'] = {};
-
         this.options = util.normalizeConfig(options);
         this.logger = logger ?? createLogger(options);
         this.plugins = plugins || new PluginInterface([], { logger: this.logger });
@@ -1831,11 +1826,6 @@ export class Program {
             for (const file of event.files) {
                 file.editor.undoAll();
             }
-
-            // eslint-disable-next-line
-            console.log(global['namespaceContainersCreated']);
-            // eslint-disable-next-line
-            console.log(global['namespaceContainersCreatedByScope']);
         });
     }
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -565,7 +565,6 @@ export class Scope {
                     }
                 }
             }
-            this.logDebug('getAllFiles', () => result.map(x => x.destPath));
             return result;
         });
     }

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -744,15 +744,6 @@ export class Scope {
                         symbolTable: new SymbolTable(`Namespace Scope Aggregate: '${nsContainer.fullName}'`),
                         firstInstance: nsContainer
                     };
-
-                    // eslint-disable-next-line
-                    if (!global['namespaceContainersCreatedByScope'][this.name]) {
-                        // eslint-disable-next-line
-                        global['namespaceContainersCreatedByScope'][this.name] = 0;
-                    }
-                    // eslint-disable-next-line
-                    global['namespaceContainersCreatedByScope'][this.name]++;
-
                     namespaceLookup.set(lowerNamespaceName, newScopeNsContainer);
                 }
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -782,7 +782,7 @@ export class Scope {
             return false;
         }
 
-        this.useFileCachesForFileLinkLookups = true;//!validationOptions.initialValidation;
+        this.useFileCachesForFileLinkLookups = !validationOptions.initialValidation;
 
         this.program.logger.time(LogLevel.debug, [this._debugLogComponentName, 'validate()'], () => {
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -713,8 +713,6 @@ export class Scope {
      */
     public getOwnCallables(): CallableContainer[] {
         let result = [] as CallableContainer[];
-        this.logDebug('getOwnCallables() files: ', () => this.getOwnFiles().map(x => x.destPath));
-
         //get callables from own files
         this.enumerateOwnFiles((file) => {
             if (isBrsFile(file)) {

--- a/src/bscPlugin/CallExpressionInfo.ts
+++ b/src/bscPlugin/CallExpressionInfo.ts
@@ -147,7 +147,7 @@ export class CallExpressionInfo {
 
     private getNamespace(): NamespaceContainer {
         let scope = this.file.program.getFirstScopeForFile(this.file);
-        return scope.namespaceLookup.get(this.dotPart);
+        return scope.namespaceLookup.get(this.dotPart)?.firstInstance;
     }
 
     private getParameterIndex() {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -537,7 +537,7 @@ export class ScopeValidator {
             const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
             if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
                 this.addMultiScopeDiagnostic({
-                    ...DiagnosticMessages.argumentTypeMismatch(argType.toString(), paramType.toString(), compatibilityData),
+                    ...DiagnosticMessages.argumentTypeMismatch(argType?.toString(), paramType?.toString(), compatibilityData),
                     location: arg.location
                 });
             }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -537,7 +537,7 @@ export class ScopeValidator {
             const isAllowedArgConversion = this.checkAllowedArgConversions(paramType, argType);
             if (!isAllowedArgConversion && !paramType?.isTypeCompatible(argType, compatibilityData)) {
                 this.addMultiScopeDiagnostic({
-                    ...DiagnosticMessages.argumentTypeMismatch(argType?.toString(), paramType?.toString(), compatibilityData),
+                    ...DiagnosticMessages.argumentTypeMismatch(argType?.toString() ?? 'unknown', paramType?.toString() ?? 'unknown', compatibilityData),
                     location: arg.location
                 });
             }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -152,6 +152,10 @@ export class ScopeValidator {
         this.event.scope.enumerateOwnFiles((file) => {
             if (isBrsFile(file)) {
 
+                if (this.event.program.diagnostics.shouldFilterFile(file)) {
+                    return;
+                }
+
                 fileWalkStopWatch.reset();
                 fileWalkStopWatch.start();
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -125,7 +125,7 @@ export class ScopeValidator {
         for (const key in metrics) {
             logs.push(`${key}=${chalk.yellow(metrics[key].toString())}`);
         }
-        this.event.program.logger.info(`Validation Metrics: ${logs.join(', ')}`);
+        this.event.program.logger.debug(`Validation Metrics (Scope: ${this.event.scope.name}): ${logs.join(', ')}`);
     }
 
     public reset() {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -665,7 +665,7 @@ export class ScopeValidator {
             ? this.getNodeTypeWrapper(file, binaryExpr.right, getTypeOpts)
             : this.getNodeTypeWrapper(file, binaryExpr.value, getTypeOpts);
 
-        if (!leftType.isResolvable() || !rightType.isResolvable()) {
+        if (!leftType || !rightType || !leftType.isResolvable() || !rightType.isResolvable()) {
             // Can not find the type. error handled elsewhere
             return;
         }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1277,15 +1277,6 @@ export class BrsFile implements BscFile {
                     lowerLoopName += '.' + lowerPartName;
                 }
                 if (!namespaceLookup.has(lowerLoopName)) {
-
-                    // eslint-disable-next-line
-                    if (!global['namespaceContainersCreated'][this.srcPath]) {
-                        // eslint-disable-next-line
-                        global['namespaceContainersCreated'][this.srcPath] = 0;
-                    }
-                    // eslint-disable-next-line
-                    global['namespaceContainersCreated'][this.srcPath]++;
-
                     namespaceLookup.set(lowerLoopName, {
                         isTopLevel: i === 0,
                         file: this,

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1088,7 +1088,7 @@ describe('XmlFile', () => {
             program.validate();
             expectZeroDiagnostics(program);
             const scope = program.getComponentScope('ChildComponent')!;
-            expect([...scope.namespaceLookup.keys()].sort()).to.eql([
+            expect([...scope.namespaceNameSet.keys()].sort()).to.eql([
                 'lib',
                 'parent'
             ]);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,8 +6,8 @@ import type { TypedFunctionType } from './types/TypedFunctionType';
 import type { ParseMode } from './parser/Parser';
 import type { Program } from './Program';
 import type { ProgramBuilder } from './ProgramBuilder';
-import type { ClassStatement, ConstStatement, EnumStatement, FunctionStatement, NamespaceStatement } from './parser/Statement';
-import type { AstNode, Expression, Statement } from './parser/AstNode';
+import type { FunctionStatement, NamespaceStatement } from './parser/Statement';
+import type { AstNode, Expression } from './parser/AstNode';
 import type { TranspileState } from './parser/TranspileState';
 import type { SourceNode } from 'source-map';
 import type { BscType } from './types/BscType';
@@ -1098,15 +1098,15 @@ export interface NamespaceContainer {
     nameRange: Range;
     lastPartName: string;
     lastPartNameLower: string;
-    functionStatements: Map<string, FunctionStatement>;
     isTopLevel: boolean;
     namespaceStatements?: NamespaceStatement[];
-    statements?: Statement[];
-    classStatements?: Map<string, ClassStatement>;
-    enumStatements?: Map<string, EnumStatement>;
-    constStatements?: Map<string, ConstStatement>;
-    namespaces?: Map<string, NamespaceContainer>;
     symbolTable: SymbolTable;
+}
+
+export interface ScopeNamespaceContainer {
+    namespaceContainers: NamespaceContainer[];
+    symbolTable: SymbolTable;
+    firstInstance: NamespaceContainer;
 }
 
 /**

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -5,6 +5,9 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { ExtraSymbolData, TypeCompatibilityData } from '../interfaces';
 import { isArrayType, isInheritableType, isReferenceType } from '../astUtils/reflection';
 
+
+// eslint-disable-next-line @typescript-eslint/dot-notation
+global['TypesCreated'] = 0;
 export abstract class BscType {
 
     public readonly memberTable: SymbolTable;
@@ -15,6 +18,8 @@ export abstract class BscType {
     constructor(name = '') {
         this.__identifier = `${this.constructor.name}${name ? ': ' + name : ''}`;
         this.memberTable = new SymbolTable(this.__identifier);
+        global['TypesCreated']++;
+
     }
 
     pushMemberProvider(provider: SymbolTableProvider) {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -18,6 +18,7 @@ export abstract class BscType {
     constructor(name = '') {
         this.__identifier = `${this.constructor.name}${name ? ': ' + name : ''}`;
         this.memberTable = new SymbolTable(this.__identifier);
+        // eslint-disable-next-line @typescript-eslint/dot-notation
         global['TypesCreated']++;
 
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2785,6 +2785,23 @@ export class Util {
         }
         return resultType;
     }
+
+    public findCommonObjects<T>(...arrays: T[][]): T[] {
+        if (arrays.length === 0) {
+            return [];
+        }
+
+        // Start with the first array
+        let commonObjects = arrays[0];
+
+        // Iterate through the rest of the arrays
+        for (let i = 1; i < arrays.length; i++) {
+            commonObjects = commonObjects.filter(item => arrays[i].includes(item));
+        }
+
+        return commonObjects;
+    }
+
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -2785,23 +2785,6 @@ export class Util {
         }
         return resultType;
     }
-
-    public findCommonObjects<T>(...arrays: T[][]): T[] {
-        if (arrays.length === 0) {
-            return [];
-        }
-
-        // Start with the first array
-        let commonObjects = arrays[0];
-
-        // Iterate through the rest of the arrays
-        for (let i = 1; i < arrays.length; i++) {
-            commonObjects = commonObjects.filter(item => arrays[i].includes(item));
-        }
-
-        return commonObjects;
-    }
-
 }
 
 /**


### PR DESCRIPTION
TBH, I'm not sure if this will speed up validation. However, there are many times in the validation process when the Diagnostic Manager needs to clear all diagnostics based on scope, file, tag, etc. Previously, this was done by looping all diagnostics, so if there are lots, it probably went slower and slower. This change should make it much more quick to find the diagnostics that need to be cleared.


Also added some more fine-grained Scope Validation metrics that are printed out with log-level debug:

```
[02:25:25:633 PM] [prj0] Validating scope components/search/SearchRow.xml
[02:25:25:634 PM] [prj0] Validating scope components/search/SearchRow.xml finished. (1.46ms)
[02:25:25:634 PM] [prj0] components/search/SearchRow.xml segment metrics:
[02:25:25:634 PM] [prj0]  -  components/search/SearchRow.brs 11
[02:25:25:634 PM] [prj0] components/search/SearchRow.xml total segments validated 11
[02:25:25:634 PM] [prj0] Validation Metrics (Scope: components/search/SearchRow.xml): fileWalkTime=0.953ms, flagDuplicateFunctionTime=0.21ms, classValidationTime=0.13ms, scriptImportValidationTime=0.40ms, xmlValidationTime=0.17ms
[02:25:25:634 PM] [prj0] BscPlugin onScopeValidate finished. (1.72ms)
```
