### PR TITLE
Reduce BscType creation

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -171,10 +171,10 @@ export class Program {
         this.globalScope.symbolTable.addSymbol('double', builtInSymbolData, DoubleType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('dynamic', builtInSymbolData, DynamicType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('float', builtInSymbolData, FloatType.instance, SymbolTypeFlag.typetime);
-        this.globalScope.symbolTable.addSymbol('function', builtInSymbolData, new FunctionType(), SymbolTypeFlag.typetime);
+        this.globalScope.symbolTable.addSymbol('function', builtInSymbolData, FunctionType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('integer', builtInSymbolData, IntegerType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('longinteger', builtInSymbolData, LongIntegerType.instance, SymbolTypeFlag.typetime);
-        this.globalScope.symbolTable.addSymbol('object', builtInSymbolData, new ObjectType(), SymbolTypeFlag.typetime);
+        this.globalScope.symbolTable.addSymbol('object', builtInSymbolData, ObjectType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('string', builtInSymbolData, StringType.instance, SymbolTypeFlag.typetime);
         this.globalScope.symbolTable.addSymbol('void', builtInSymbolData, VoidType.instance, SymbolTypeFlag.typetime);
 
@@ -1851,8 +1851,19 @@ export class Program {
             }
         });
 
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        //console.log('TYPES CREATED', global['TypesCreated']);
+        //eslint-disable-next-line @typescript-eslint/dot-notation
+        console.log('TYPES CREATED', global['TypesCreated']);
+        let totalTypesCreated = 0;
+        //eslint-disable-next-line @typescript-eslint/dot-notation
+        for (const key in global['TypesCreated']) {
+            //eslint-disable-next-line @typescript-eslint/dot-notation
+            if (Object.hasOwn(global['TypesCreated'], key)) {
+                //eslint-disable-next-line @typescript-eslint/dot-notation
+                totalTypesCreated += global['TypesCreated'][key];
+
+            }
+        }
+        console.log('TOTAL TYPES CREATED', totalTypesCreated);
     }
 
     /**

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -887,6 +887,7 @@ export class Scope {
         this._allNamespaceTypeTable = new SymbolTable(`Scope NamespaceTypes ${this.name}`);
         for (const file of this.getAllFiles()) {
             if (isBrsFile(file)) {
+                file.ast?.getTypeCache().clear();
                 this.linkSymbolTableDisposables.push(
                     file.parser.symbolTable.pushParentProvider(() => this.symbolTable)
                 );

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -887,7 +887,6 @@ export class Scope {
         this._allNamespaceTypeTable = new SymbolTable(`Scope NamespaceTypes ${this.name}`);
         for (const file of this.getAllFiles()) {
             if (isBrsFile(file)) {
-                file.ast?.getTypeCache().clear();
                 this.linkSymbolTableDisposables.push(
                     file.parser.symbolTable.pushParentProvider(() => this.symbolTable)
                 );

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -478,7 +478,6 @@ export function isBuiltInType(value: any, name: string): value is InterfaceType 
     return isInterfaceType(value) && value.name.toLowerCase() === name.toLowerCase() && value.isBuiltIn;
 }
 
-
 const nativeTypeKinds = [
     BscTypeKind.DynamicType,
     BscTypeKind.ObjectType,

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -20,172 +20,172 @@ type GlobalCallable = Pick<Callable, 'name' | 'shortDescription' | 'type' | 'fil
 let mathFunctions: GlobalCallable[] = [{
     name: 'Abs',
     shortDescription: 'Returns the absolute value of the argument.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Atn',
     shortDescription: 'Returns the arctangent (in radians) of the argument.',
     documentation: '`ATN(X)` returns "the angle whose tangent is X". To get arctangent in degrees, multiply `ATN(X)` by `57.29578`.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Cdbl',
     shortDescription: 'Returns a single precision float representation of the argument. Someday may return double.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new IntegerType(),
+        type: IntegerType.instance,
         isOptional: false
     }]
 }, {
     name: 'Cint',
     shortDescription: 'Returns an integer representation of the argument, rounding up from midpoints. CINT(2.1) returns 2; CINT(2.5) returns 3; CINT(-2.2) returns -2; CINT(-2.5) returns -2; CINT(-2.6) returns -3.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Cos',
     shortDescription: 'Returns the cosine of the argument (argument must be in radians). To obtain the cosine of X when X is in degrees, use CGS(X*.01745329).',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Csng',
     shortDescription: 'Returns a single-precision float representation of the argument.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new IntegerType(),
+        type: IntegerType.instance,
         isOptional: false
     }]
 }, {
     name: 'Exp',
     shortDescription: 'Returns the "natural exponential" of X, that is, ex. This is the inverse of the LOG function, so X=EXP(LOG(X)).',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Fix',
     shortDescription: 'Returns a truncated representation of the argument. All digits to the right of the decimal point are simply chopped off, so the resultant value is an integer. For non-negative X, FIX(X)=lNT(X). For negative values of X, FIX(X)=INT(X)+1. For example, FIX(2.2) returns 2, and FIX(-2.2) returns -2.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Int',
     shortDescription: 'Returns an integer representation of the argument, using the largest whole number that is not greater than the argument.. INT(2.5) returns 2; INT(-2.5) returns -3; and INT(1000101.23) returns 10000101.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Log',
     shortDescription: 'Returns the natural logarithm of the argument, that is, loge(x) or ln(x). This is the inverse of the EXP function, so LOG(EXP(X)) = X. To find the logarithm of a number to another base b, use the formula logb(X) = loge(X) / loge(b). For example, LOG(32767) / LOG(2) returns the logarithm to base 2 of 32767.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Rnd',
     shortDescription: 'Generates a pseudo-random number using the current pseudo-random "seed number" (generated internally and not accessible to user).returns an integer between 1 and integer inclusive . For example, RND(55) returns a pseudo-random integer greater than zero and less than 56.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'range',
-        type: new IntegerType(),
+        type: IntegerType.instance,
         isOptional: false
     }]
 }, {
     name: 'Rnd',
     shortDescription: 'Generates a pseudo-random number using the current pseudo-random "seed number" (generated internally and not accessible to user). Returns a float value between 0 and 1.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: '0',
-        type: new IntegerType(),
+        type: IntegerType.instance,
         isOptional: false
     }]
 }, {
     name: 'Sgn',
     shortDescription: 'The "sign" function: returns -1 for X negative, 0 for X zero, and +1 for X positive.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Sgn',
     shortDescription: 'The "sign" function: returns -1 for X negative, 0 for X zero, and +1 for X positive.',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new IntegerType(),
+        type: IntegerType.instance,
         isOptional: false
     }]
 }, {
     name: 'Sin',
     shortDescription: 'Returns the sine of the argument (argument must be in radians). To obtain the sine of X when X is in degrees, use SIN(X*.01745329).',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Sqr',
     shortDescription: 'Returns the square root of the argument. SQR(X) is the same as X ^ (1/2), only faster.',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }, {
     name: 'Tan',
     shortDescription: 'Returns the tangent of the argument (argument must be in radians). To obtain the tangent of X when X is in degrees, use TAN(X*.01745329).',
-    type: new TypedFunctionType(new FloatType()),
+    type: new TypedFunctionType(FloatType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new FloatType(),
+        type: FloatType.instance,
         isOptional: false
     }]
 }];
@@ -193,114 +193,114 @@ let mathFunctions: GlobalCallable[] = [{
 let runtimeFunctions: GlobalCallable[] = [{
     name: 'CreateObject',
     shortDescription: 'Creates a BrightScript Component of class classname specified. Return invalid if the object creation fails. Some Objects have optional parameters in their constructor that are passed after name.',
-    type: new TypedFunctionType(new ObjectType()),
+    type: new TypedFunctionType(ObjectType.instance),
     file: globalFile,
     params: [{
         name: 'name',
-        type: new StringType(),
+        type: StringType.instance,
         isOptional: false
     }, {
         name: 'param2',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: true
     }, {
         name: 'param3',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: true
     }, {
         name: 'param4',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: true
     }, {
         name: 'param5',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: true
     }, {
         name: 'param6',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: true
     }]
 }, {
     name: 'Type',
     shortDescription: 'Returns the type of a variable and/or object. See the BrightScript Component specification for a list of types.',
-    type: new TypedFunctionType(new StringType()),
+    type: new TypedFunctionType(StringType.instance),
     file: globalFile,
     params: [{
         name: 'variable',
-        type: new ObjectType(),
+        type: ObjectType.instance,
         isOptional: false
     }, {
         name: 'version',
-        type: new StringType(),
+        type: StringType.instance,
         isOptional: true
     }]
 }, {
     name: 'GetGlobalAA',
     shortDescription: 'Each script has a global Associative Array. It can be fetched with this function. ',
-    type: new TypedFunctionType(new ObjectType()),
+    type: new TypedFunctionType(ObjectType.instance),
     file: globalFile,
     params: []
 }, {
     name: 'Box',
     shortDescription: 'Box() will return an object version of an intrinsic type, or pass through an object if given one.',
-    type: new TypedFunctionType(new ObjectType()),
+    type: new TypedFunctionType(ObjectType.instance),
     file: globalFile,
     params: [{
         name: 'x',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isOptional: false
     }]
 }, {
     name: 'Run',
     shortDescription: `The Run function can be used to compile and run a script dynamically.\nThe file specified by that path is compiled and run.\nArguments may be passed to the script's Main function, and that script may return a result value.'`,
-    type: new TypedFunctionType(new DynamicType()),
+    type: new TypedFunctionType(DynamicType.instance),
     file: globalFile,
     params: [{
         name: 'filename',
-        type: new StringType(),
+        type: StringType.instance,
         isOptional: false
     }, {
         name: 'arg',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isRestArgument: true,
         isOptional: false
     }]
 }, {
     name: 'Run',
     shortDescription: `The Run function can be used to compile and run a script dynamically.\nAll files specified are compiled together, then run.\nArguments may be passed to the script's Main function, and that script may return a result value.'`,
-    type: new TypedFunctionType(new DynamicType()),
+    type: new TypedFunctionType(DynamicType.instance),
     file: globalFile,
     params: [{
         name: 'filename',
-        type: new ArrayType(new StringType()),
+        type: new ArrayType(StringType.instance),
         isOptional: false
     }, {
         name: 'arg',
-        type: new DynamicType(),
+        type: DynamicType.instance,
         isRestArgument: true,
         isOptional: true
     }]
 }, {
     name: 'Eval',
     shortDescription: `Eval can be used to run a code snippet in the context of the current function. It performs a compile, and then the bytecode execution.\nIf a compilation error occurs, no bytecode execution is performed, and Eval returns an roList with one or more compile errors. Each list entry is an roAssociativeArray with ERRNO and ERRSTR keys describing the error.\nIf compilation succeeds, bytecode execution is performed and the integer runtime error code is returned. These are the same error codes as returned by GetLastRunRuntimeError().\nEval() can be usefully in two cases. The first is when you need to dynamically generate code at runtime.\nThe other is if you need to execute a statement that could result in a runtime error, but you don't want code execution to stop. '`,
-    type: new TypedFunctionType(new DynamicType()),
+    type: new TypedFunctionType(DynamicType.instance),
     file: globalFile,
     isDeprecated: true,
     params: [{
         name: 'code',
-        type: new StringType(),
+        type: StringType.instance,
         isOptional: false
     }]
 }, {
     name: 'GetLastRunCompileError',
     shortDescription: 'Returns an roList of compile errors, or invalid if no errors. Each list entry is an roAssociativeArray with the keys: ERRNO, ERRSTR, FILESPEC, and LINENO.',
-    type: new TypedFunctionType(new ObjectType()),
+    type: new TypedFunctionType(ObjectType.instance),
     file: globalFile,
     params: []
 }, {
     name: 'GetLastRunRuntimeError',
     shortDescription: 'Returns an error code result after the last script Run().These are normal:\\,&hFF==ERR_OKAY\\n&hFC==ERR_NORMAL_END\\n&hE2==ERR_VALUE_RETURN',
-    type: new TypedFunctionType(new IntegerType()),
+    type: new TypedFunctionType(IntegerType.instance),
     file: globalFile,
     params: []
 }];
@@ -309,131 +309,131 @@ let globalUtilityFunctions: GlobalCallable[] = [
     {
         name: 'Sleep',
         shortDescription: 'This function causes the script to pause for the specified time, without wasting CPU cycles. There are 1000 milliseconds in one second.',
-        type: new TypedFunctionType(new VoidType()),
+        type: new TypedFunctionType(VoidType.instance),
         file: globalFile,
         params: [{
             name: 'milliseconds',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Wait',
         shortDescription: 'This function waits on objects that are "waitable" (those that have a MessagePort interface). Wait() returns the event object that was posted to the message port. If timeout is zero, "wait" will wait for ever. Otherwise, Wait will return after timeout milliseconds if no messages are received. In this case, Wait returns a type "invalid".',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'timeout',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'port',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }]
     }, {
         name: 'GetInterface',
         shortDescription: 'Each BrightScript Component has one or more interfaces. This function returns a value of type "Interface". \nNote that generally BrightScript Components allow you to skip the interface specification. In which case, the appropriate interface within the object is used. This works as long as the function names within the interfaces are unique.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'object',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'ifname',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'FindMemberFunction',
         shortDescription: 'Returns the interface from the object that provides the specified function, or invalid if not found.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'object',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'functionName',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'UpTime',
         shortDescription: 'Returns the uptime of the system since the last reboot in seconds.',
-        type: new TypedFunctionType(new FloatType()),
+        type: new TypedFunctionType(FloatType.instance),
         file: globalFile,
         params: [{
             name: 'dummy',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'RebootSystem',
         shortDescription: 'Requests the system to perform a soft reboot. The Roku platform has disabled this feature.',
-        type: new TypedFunctionType(new VoidType()),
+        type: new TypedFunctionType(VoidType.instance),
         file: globalFile,
         params: []
     }, {
         name: 'ListDir',
         shortDescription: 'Returns a List object containing the contents of the directory path specified.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'path',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'ReadAsciiFile',
         shortDescription: 'This function reads the specified file and returns the data as a string.\nThe file can be encoded as either UTF-8 (which includes the 7-bit ASCII subset) or UTF-16.\nAn empty string is returned if the file can not be read.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'filePath',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'WriteAsciiFile',
         shortDescription: 'This function writes the specified string data to a file at the specified location.\nThe string data is written as UTF-8 encoded (which includes the 7-bit ASCII subset).\nThe function returns true if the file was successfully written.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'filePath',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'text',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'CopyFile',
         shortDescription: 'Make a copy of a file.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'source',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'destination',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'MoveFile',
         shortDescription: 'Rename a file.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'source',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'destination',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
@@ -450,75 +450,75 @@ A '*' matches zero or more arbitrary characters.
 The character class '[...]' matches any single character specified within the brackets. The closing bracket is treated as a member of the character class if it immediately follows the opening bracket. i.e. '[]]' matches a single close bracket. Within the class '-' can be used to specify a range unless it is the first or last character. e.g. '[A-Cf-h]' is equivalent to '[ABCfgh]'.
 A character class can be negated by specifying '^' as the first character. To match a literal '^' place it elsewhere within the class.
 The characters '?', '*' and '[' lose their special meaning if preceded by a single '\\'. A single '\\' can be matched as '\\\\'.`,
-        type: new TypedFunctionType(new ArrayType(new StringType())),
+        type: new TypedFunctionType(new ArrayType(StringType.instance)),
         file: globalFile,
         params: [{
             name: 'path',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'pattern_in',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'DeleteFile',
         shortDescription: 'Delete the specified file.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'file',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'DeleteDirectory',
         shortDescription: 'Deletes the specified directory.  It is only possible to delete an empty directory.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'dir',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'CreateDirectory',
         shortDescription: 'Creates the specified Directory. Only one directory can be created at a time',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'dir',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'FormatDrive',
         shortDescription: 'Formats a specified drive using the specified filesystem.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'drive',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'fs_type',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'StrToI',
         shortDescription: 'Return the integer value of the string, or 0 if nothing is parsed.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'str',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'RunGarbageCollector',
         shortDescription: `This function runs the garbage collector. It returns and Associative Array with some statistics regarding the garbage collection. \nSee the Garbage Collection section of the manual for more detail. You don't normally need to call this function.`,
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
     }, {
@@ -529,16 +529,16 @@ The characters '?', '*' and '[' lose their special meaning if preceded by a sing
 Any roAssociativeArray objects in the returned objects will be case sensitive. As of Roku OS 9.4, to return a case-insensitive structure, set the flags parameter to "i".
 If the "i" option is used, and the jsonString includes multiple keys that match case-insensitively, duplicates are overwritten and only the last matching values are preserved.
 An error will be returned if arrays/associative arrays are nested more than 256 levels deep.`,
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'jsonString',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         },
         {
             name: 'flags',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: true
         }]
     }, {
@@ -553,11 +553,11 @@ An error will be returned if arrays/associative arrays are nested more than 256 
 If an error occurs an empty string will be returned.
 
 Normally non-ASCII characters are escaped in the output string as "\\uXXXX" where XXXX is the hexadecimal representation of the Unicode character value.  If flags=1, non-ASCII characters are not escaped.`,
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'object',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'flags',
@@ -571,11 +571,11 @@ Normally non-ASCII characters are escaped in the output string as "\\uXXXX" wher
 
 In some cases you may want to include a placeholder marker in a localizable string that gets dynamically substituted with a value at runtime.
 One way to accomplish that is to use the Replace method on the string value returned from the Tr() lookup.`,
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'source',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }
@@ -585,31 +585,31 @@ let globalStringFunctions: GlobalCallable[] = [
     {
         name: 'UCase',
         shortDescription: 'Converts the string to all upper case.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'LCase',
         shortDescription: 'Converts the string to all lower case.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'Asc',
         shortDescription: 'Returns the Unicode ("ASCII") value for the first character of the specified string\n An empty string argument will return 0.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'letter',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
@@ -622,178 +622,178 @@ let globalStringFunctions: GlobalCallable[] = [
 By using Chr, you can create strings containing characters which cannot be contained in quotes, such as newline or the quote character itself.
 
  print (Chr(34) + "hello" + Chr(34))  ' prints: "hello"`,
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'ch',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Instr',
         shortDescription: 'Returns the position of the first instances of substring within text, starting at the specified start position.\nReturns 0 if the substring is not found. Unlike the ifString.Instr() method, the first position is 1.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'start',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'text',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'substring',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'Left',
         shortDescription: 'Returns the first n characters of s. ',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'n',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Len',
         shortDescription: 'Returns the number of characters in the specified string.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'Mid',
         shortDescription: 'Returns a substring of s with length n and starting at position p.\nn may be omitted, in which case the string starting at p and ending at the end of the string is returned.\nUnlike the ifString.Mid() method, the first character in the string is position 1.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'p',
             //description: '1-based position',
             isOptional: false,
-            type: new IntegerType()
+            type: IntegerType.instance
         }, {
             name: 'n',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: true
         }]
     }, {
         name: 'Right',
         shortDescription: 'Returns the last n characters of s.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 's',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'n',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Str',
         shortDescription: 'Converts a value to a string. Str(A), for example, returns a string equal to the decimal representation of the numeric value of A.\nNote: for non-negative numbers, a leading blank is inserted before the value string as a sign placeholder.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'value',
-            type: new FloatType(),
+            type: FloatType.instance,
             isOptional: false
         }]
     }, {
         name: 'StrI',
         shortDescription: 'Converts a value to a string. Str(A), for example, returns a string equal to the decimal representation of the numeric value of A.\nNote: for non-negative numbers, a leading blank is inserted before the value string as a sign placeholder.. If the radix parameter is provided, then converts the integer value into a string representation using the given radix.\nIf radix is not 2 .. 36 then an empty string is returned.\nNote that the returned string does not include a base prefix and uses lowercase letters to represent those digits in bases greater than 10.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'value',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'radix',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: true
         }]
     }, {
         name: 'string',
         shortDescription: 'Returns a string composed of n copies of the second argument concatenated together.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'n',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'str',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'StringI',
         shortDescription: 'Returns a string composed of n copies of the character whose Unicode value is the second argument.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'n',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'ch',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Val',
         shortDescription: 'Performs the inverse of the STR function: returns the number represented by the characters in a string argument.\nFor example, if A$="12" and B$="34" then VAL(A$+ "."+B$) returns the number 12.34. If radix is provided as the second parameter, it returns the integer value from parsing the string with the specified radix.\nRadix should be 2 .. 36 or the special value 0 (which automatically identified hexadecimal or octal numbers based on 0x or 0 prefixes respectively).\nLeading whitespace is ignored then as much of the rest of the string will be parsed as valid.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'str',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'radix',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: true
         }]
     }, {
         name: 'Substitute',
         shortDescription: 'Replaces all instances of {0} or ^0 in str with arg0.  Similarly, replaces all instances of {1} or ^1 with arg1, {2} or ^2 with arg2, and {3} or ^3 with arg3.',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'str',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'arg0',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'arg1',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: true
         }, {
             name: 'arg2',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: true
         }, {
             name: 'arg3',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: true
         }]
     }
@@ -804,95 +804,95 @@ let programStatementFunctions = [
     {
         name: 'Tab',
         shortDescription: 'Moves the cursor to the specified position on the current line (modulo the width of your console if you specify TAB positions greater than the console width). TAB may be used several times in a PRINT list. No punctuation is required after a TAB modifier. Numerical expressions may be used to specify a TAB position. TAB cannot be used to move the cursor to the left. If the cursor is beyond the specified position, the TAB is ignored.',
-        type: new TypedFunctionType(new VoidType()),
+        type: new TypedFunctionType(VoidType.instance),
         file: globalFile,
         params: [{
             name: 'expression',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
         name: 'Pos',
         shortDescription: 'Returns a number from 0 to window width, indicating the current cursor position on the cursor. Requires a "dummy argument" (any numeric expression).',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'x',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
         //TODO this is a temporary fix for library imported files. Eventually this should be moved into `Roku_Ads.brs` and handled by the `Library` statement
     }, {
         name: 'Roku_Ads',
         shortDescription: 'The main entry point for instantiating the ad interface. This object manages ad server requests, parses ad structure, schedules and renders ads, and triggers tracking beacons.\n\nThe Roku ad parser/renderer object returned has global scope because it is meant to represent interaction with external resources (the ad server and any tracking services) that have persistence and state independent of the ad rendering within a client application.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
         //TODO this is a temporary fix for library imported files. Eventually this should be moved into `Roku_Event_Dispatcher.brs` and handled by the `Library` statement
     }, {
         name: 'Roku_Event_Dispatcher',
         shortDescription: 'Use the Roku Event Dispatcher in your channel\'s authentication workflow to send authentication events. See: https://developer.roku.com/docs/developer-program/discovery/search/prioritizing-authenticated-channels-in-roku-search.md',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
     }, { //TODO Same as the Roku_Ads.brs (RAF) library above, the following functions are from the 'v30/bslCore.brs' library
         name: 'bslBrightScriptErrorCodes',
         shortDescription: 'Returns an roAssociativeArray with name value pairs of the error name and corresponding integer value, for example ERR_OKAY = &hFF.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
     }, {
         name: 'bslGeneralConstants',
         shortDescription: 'Returns an roAssociativeArray with name value pairs of system constants, for example MAX_INT = 2147483647.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
     }, {
         name: 'bslUniversalControlEventCodes',
         shortDescription: 'Returns an roAssociativeArray with name value pairs of the remote key code (buttons) constants, for example BUTTON_SELECT_PRESSED = 6.',
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: []
     },
     {
         name: 'AsciiToHex',
         shortDescription: 'Returns the hex encoded string, for example AsciiToHex("Hi!") = "486921".',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'ascii',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'HexToAscii',
         shortDescription: 'Returns a string that is the hex decoded string, for example HexToAscii("486921") = "Hi!".',
-        type: new TypedFunctionType(new StringType()),
+        type: new TypedFunctionType(StringType.instance),
         file: globalFile,
         params: [{
             name: 'hex',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     },
     {
         name: 'HexToInteger',
         shortDescription: 'Returns the integer value of the passed in hex string.',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'hex',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'HexToInteger',
         shortDescription: 'Returns a string that is the hex decoded string, for example HexToAscii("486921") = "Hi!".',
-        type: new TypedFunctionType(new IntegerType()),
+        type: new TypedFunctionType(IntegerType.instance),
         file: globalFile,
         params: [{
             name: 'hex',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
@@ -904,47 +904,47 @@ ExtraInfo: roAssociativeArray
 Regions: roAssociativeArray of name, roRegions pairs
 Animations: roAssociativeArray of name, roArray of roRegion pairs.
 Backgrounds: roAssociativeArray of name, path pairs.`,
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'filename',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }]
     }, {
         name: 'dfDrawMessage',
         shortDescription: 'dest is an roScreen/roBitmap/roRegion and region is an roRegion.\nGreys the entire dest region and draws it the region centered on the drawable dest.',
-        type: new TypedFunctionType(new VoidType()),
+        type: new TypedFunctionType(VoidType.instance),
         file: globalFile,
         params: [{
             name: 'dest',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'region',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }]
     }, {
         name: 'dfDrawImage',
         shortDescription: 'Returns True if successful.\nCreates a bitmap out of the image stored in the filename "path" and draws it at position (x,y) of the drawable dest.',
-        type: new TypedFunctionType(new BooleanType()),
+        type: new TypedFunctionType(BooleanType.instance),
         file: globalFile,
         params: [{
             name: 'dest',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'path',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'x',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'y',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
@@ -961,27 +961,27 @@ Right: right region if there is a pillar box area on the right
 Upper: upper region if there is a letterbox area at thetop
 Lower: lower region if there is a letterbox area at the bottom
 When using these regions as drawables, your graphics will be translated and clipped to these regions.`,
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'screen',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }, {
             name: 'topx',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'topy',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'width',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }, {
             name: 'height',
-            type: new IntegerType(),
+            type: IntegerType.instance,
             isOptional: false
         }]
     }, {
@@ -990,15 +990,15 @@ When using these regions as drawables, your graphics will be translated and clip
 backgroundName is a key for the Backgrounds roAssociative array of backgrounds.
 Backgrounds is an roAssociative array of background name keys and file path string values
 This function creates an roBitmap out of the background image file and returns a region the size of the entire roBitmap.`,
-        type: new TypedFunctionType(new ObjectType()),
+        type: new TypedFunctionType(ObjectType.instance),
         file: globalFile,
         params: [{
             name: 'backgroundName',
-            type: new StringType(),
+            type: StringType.instance,
             isOptional: false
         }, {
             name: 'backgrounds',
-            type: new ObjectType(),
+            type: ObjectType.instance,
             isOptional: false
         }]
     }

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -5,15 +5,12 @@ import { CancellationTokenSource } from 'vscode-languageserver';
 import { InternalWalkMode } from '../astUtils/visitors';
 import type { SymbolTable } from '../SymbolTable';
 import type { BrsTranspileState } from './BrsTranspileState';
-import type { GetTypeOptions, TranspileResult, TypeChainEntry } from '../interfaces';
+import type { GetTypeOptions, TranspileResult } from '../interfaces';
 import type { AnnotationExpression } from './Expression';
 import util from '../util';
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import type { Token } from '../lexer/Token';
-import type { Cache } from '../Cache';
-
-export type TypeCache = Cache<AstNode, { type: BscType; typeChain: TypeChainEntry[] }>;
 
 /**
  * A BrightScript AST node
@@ -66,19 +63,6 @@ export abstract class AstNode {
         //and the top-level node will always have a SymbolTable. So we'll never hit this undefined,
         //but it is not so easy to convince the typechecker of this.
         return undefined as any;
-    }
-
-    public typeCache?: TypeCache;
-
-    public getTypeCache(): TypeCache {
-        let node: AstNode = this;
-        while (node) {
-            if (node.typeCache) {
-                this.typeCache = node.typeCache;
-                return node.typeCache;
-            }
-            node = node.parent!;
-        }
     }
 
     /**

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -415,6 +415,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     }
 
     public getType(options: GetTypeOptions): TypedFunctionType {
+        //return this.getTypeCache().getOrAdd(this, () => {
         //if there's a defined return type, use that
         let returnType: BscType;
 
@@ -453,6 +454,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         options.typeChain?.push(new TypeChainEntry({ name: funcName, type: resultType, data: options.data, astNode: this }));
         return resultType;
+        //  });
     }
 
     public clone() {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -11,7 +11,7 @@ import * as fileUrl from 'file-url';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isInvalidType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression, isVoidType } from '../astUtils/reflection';
+import { isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallExpression, isCallableType, isCallfuncExpression, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isInvalidType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNativeType, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isUnaryExpression, isVariableExpression, isVoidType } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -2520,7 +2520,11 @@ export class TypeExpression extends Expression implements TypedefProvider {
     public readonly location: Location;
 
     public transpile(state: BrsTranspileState): TranspileResult {
-        return [this.getType({ flags: SymbolTypeFlag.typetime }).toTypeString()];
+        const exprType = this.getType({ flags: SymbolTypeFlag.typetime });
+        if (isNativeType(exprType)) {
+            return this.expression.transpile(state);
+        }
+        return [exprType.toTypeString()];
     }
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -415,7 +415,6 @@ export class FunctionExpression extends Expression implements TypedefProvider {
     }
 
     public getType(options: GetTypeOptions): TypedFunctionType {
-        //return this.getTypeCache().getOrAdd(this, () => {
         //if there's a defined return type, use that
         let returnType: BscType;
 
@@ -454,7 +453,6 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
         options.typeChain?.push(new TypeChainEntry({ name: funcName, type: resultType, data: options.data, astNode: this }));
         return resultType;
-        //  });
     }
 
     public clone() {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -17,7 +17,7 @@ import { createIdentifier, createInvalidLiteral, createMethodStatement, createTo
 import { DynamicType } from '../types/DynamicType';
 import type { BscType } from '../types/BscType';
 import { SymbolTable } from '../SymbolTable';
-import type { AstNode, Expression } from './AstNode';
+import type { Expression } from './AstNode';
 import { AstNodeKind, Statement } from './AstNode';
 import { ClassType } from '../types/ClassType';
 import { EnumMemberType, EnumType } from '../types/EnumType';
@@ -28,8 +28,6 @@ import { TypedFunctionType } from '../types/TypedFunctionType';
 import { ArrayType } from '../types/ArrayType';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import brsDocParser from './BrightScriptDocParser';
-import { Cache } from '../Cache';
-
 export class EmptyStatement extends Statement {
     constructor(options?: { range?: Location }
     ) {
@@ -74,9 +72,6 @@ export class Body extends Statement implements TypedefProvider {
     public readonly kind = AstNodeKind.Body;
 
     public readonly symbolTable = new SymbolTable('Body', () => this.parent?.getSymbolTable());
-
-    public readonly typeCache = new Cache<AstNode, { type: BscType; typeChain: TypeChainEntry[] }>();
-
 
     public get location() {
         if (!this._location) {
@@ -2542,7 +2537,6 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
     }
 
     public getType(options: GetTypeOptions): TypedFunctionType {
-        // const result = this.getTypeCache().getOrAdd(this, () => {
         //if there's a defined return type, use that
         let returnType = this.returnTypeExpression?.getType(options);
         const isSub = this.tokens.functionType?.kind === TokenKind.Sub || !returnType;
@@ -2563,7 +2557,6 @@ export class InterfaceMethodStatement extends Statement implements TypedefProvid
         resultType.setName(funcName);
         options.typeChain?.push(new TypeChainEntry({ name: resultType.name, type: resultType, data: options.data, astNode: this }));
         return resultType;
-        //  });
     }
 
     public clone() {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3431,7 +3431,7 @@ export class FieldStatement extends Statement implements TypedefProvider {
 
             let type = this.getType({ flags: SymbolTypeFlag.typetime });
             if (isInvalidType(type) || isVoidType(type) || isUninitializedType(type)) {
-                type = new DynamicType();
+                type = DynamicType.instance;
             }
 
             result.push(

--- a/src/types/BooleanType.ts
+++ b/src/types/BooleanType.ts
@@ -6,16 +6,10 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class BooleanType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
-
     public readonly kind = BscTypeKind.BooleanType;
     public isBuiltIn = true;
 
-    public static instance = new BooleanType('boolean');
+    public static instance = new BooleanType();
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
@@ -28,7 +22,7 @@ export class BooleanType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'boolean';
+        return 'boolean';
     }
 
     public toTypeString(): string {

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -7,7 +7,7 @@ import { isArrayType, isInheritableType, isReferenceType } from '../astUtils/ref
 
 
 // eslint-disable-next-line @typescript-eslint/dot-notation
-global['TypesCreated'] = 0;
+global['TypesCreated'] = {};
 export abstract class BscType {
 
     public readonly memberTable: SymbolTable;
@@ -19,8 +19,12 @@ export abstract class BscType {
         this.__identifier = `${this.constructor.name}${name ? ': ' + name : ''}`;
         this.memberTable = new SymbolTable(this.__identifier);
         // eslint-disable-next-line @typescript-eslint/dot-notation
-        global['TypesCreated']++;
-
+        if (!global['TypesCreated'][this.constructor.name]) {
+            // eslint-disable-next-line @typescript-eslint/dot-notation
+            global['TypesCreated'][this.constructor.name] = 0;
+        }
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        global['TypesCreated'][this.constructor.name]++;
     }
 
     pushMemberProvider(provider: SymbolTableProvider) {

--- a/src/types/DoubleType.ts
+++ b/src/types/DoubleType.ts
@@ -7,15 +7,9 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class DoubleType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
-
     public readonly kind = BscTypeKind.DoubleType;
 
-    public static instance = new DoubleType('double');
+    public static instance = new DoubleType();
 
     public isBuiltIn = true;
 
@@ -30,7 +24,7 @@ export class DoubleType extends BscType {
         );
     }
     public toString() {
-        return this.typeText ?? 'double';
+        return 'double';
     }
 
     public toTypeString(): string {

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -5,11 +5,6 @@ import { BscTypeKind } from './BscTypeKind';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 
 export class DynamicType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
 
     public readonly kind = BscTypeKind.DynamicType;
 
@@ -38,7 +33,7 @@ export class DynamicType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'dynamic';
+        return 'dynamic';
     }
 
     public toTypeString(): string {

--- a/src/types/FloatType.ts
+++ b/src/types/FloatType.ts
@@ -6,15 +6,10 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class FloatType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
 
     public readonly kind = BscTypeKind.FloatType;
 
-    public static instance = new FloatType('float');
+    public static instance = new FloatType();
 
     public isBuiltIn = true;
 
@@ -31,7 +26,7 @@ export class FloatType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'float';
+        return 'float';
     }
 
     public toTypeString(): string {

--- a/src/types/FunctionType.ts
+++ b/src/types/FunctionType.ts
@@ -7,13 +7,9 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class FunctionType extends BaseFunctionType {
-    constructor(public typeText?: string) {
-        super();
-    }
-
     public readonly kind = BscTypeKind.FunctionType;
 
-    public static instance = new FunctionType('function');
+    public static instance = new FunctionType();
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         if (
@@ -34,7 +30,7 @@ export class FunctionType extends BaseFunctionType {
     }
 
     public toTypeString(): string {
-        return this.typeText ?? 'function';
+        return 'function';
     }
 
     isEqual(targetType: BscType) {
@@ -45,4 +41,4 @@ export class FunctionType extends BaseFunctionType {
     }
 }
 
-BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('function', new FunctionType());
+BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('function', FunctionType.instance);

--- a/src/types/IntegerType.ts
+++ b/src/types/IntegerType.ts
@@ -6,15 +6,9 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class IntegerType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
-
     public readonly kind = BscTypeKind.IntegerType;
 
-    public static instance = new IntegerType('integer');
+    public static instance = new IntegerType();
 
     public isBuiltIn = true;
 
@@ -30,7 +24,7 @@ export class IntegerType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'integer';
+        return 'integer';
     }
 
     public toTypeString(): string {

--- a/src/types/LongIntegerType.ts
+++ b/src/types/LongIntegerType.ts
@@ -6,15 +6,9 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class LongIntegerType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
-
     public readonly kind = BscTypeKind.LongIntegerType;
 
-    public static instance = new LongIntegerType('longinteger');
+    public static instance = new LongIntegerType();
 
     public isBuiltIn = true;
 
@@ -30,7 +24,7 @@ export class LongIntegerType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'longinteger';
+        return 'longinteger';
     }
 
     public toTypeString(): string {

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -7,11 +7,6 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import { DynamicType } from './DynamicType';
 
 export class ObjectType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
 
     public readonly kind = BscTypeKind.ObjectType;
 
@@ -22,8 +17,10 @@ export class ObjectType extends BscType {
         return !!targetType;
     }
 
+    public static instance = new ObjectType();
+
     public toString() {
-        return this.typeText ?? 'object';
+        return 'object';
     }
 
     public toTypeString(): string {
@@ -33,7 +30,7 @@ export class ObjectType extends BscType {
     getMemberType(name: string, options: GetTypeOptions) {
         // TODO: How should we handle accessing properties of an object?
         // For example, we could add fields as properties to m.top, but there could be other members added programmatically
-        return super.getMemberType(name, options) ?? DynamicType.instance;
+        return DynamicType.instance;
     }
 
     isEqual(otherType: BscType) {
@@ -42,4 +39,4 @@ export class ObjectType extends BscType {
 }
 
 
-BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('object', new ObjectType('object'));
+BuiltInInterfaceAdder.primitiveTypeInstanceCache.set('object', ObjectType.instance);

--- a/src/types/StringType.ts
+++ b/src/types/StringType.ts
@@ -6,11 +6,6 @@ import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
 import type { TypeCompatibilityData } from '../interfaces';
 
 export class StringType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
 
     public readonly kind = BscTypeKind.StringType;
 
@@ -18,7 +13,7 @@ export class StringType extends BscType {
     /**
      * A static instance that can be used to reduce memory and constructor costs, since there's nothing unique about this
      */
-    public static instance = new StringType('string');
+    public static instance = new StringType();
 
     public isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData) {
         return (
@@ -32,7 +27,7 @@ export class StringType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'string';
+        return 'string';
     }
 
     public toTypeString(): string {

--- a/src/types/VoidType.ts
+++ b/src/types/VoidType.ts
@@ -7,15 +7,10 @@ import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
 import { DynamicType } from './DynamicType';
 
 export class VoidType extends BscType {
-    constructor(
-        public typeText?: string
-    ) {
-        super();
-    }
 
     public readonly kind = BscTypeKind.VoidType;
 
-    public static instance = new VoidType('void');
+    public static instance = new VoidType();
 
     public isBuiltIn = true;
 
@@ -29,7 +24,7 @@ export class VoidType extends BscType {
     }
 
     public toString() {
-        return this.typeText ?? 'void';
+        return 'void';
     }
 
     public toTypeString(): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1341,67 +1341,67 @@ export class Util {
         // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
         switch (token.kind) {
             case TokenKind.Boolean:
-                return new BooleanType(token.text);
+                return BooleanType.instance;
             case TokenKind.True:
             case TokenKind.False:
                 return BooleanType.instance;
             case TokenKind.Double:
-                return new DoubleType(token.text);
+                return DoubleType.instance;
             case TokenKind.DoubleLiteral:
                 return DoubleType.instance;
             case TokenKind.Dynamic:
-                return new DynamicType(token.text);
+                return DynamicType.instance;
             case TokenKind.Float:
-                return new FloatType(token.text);
+                return FloatType.instance;
             case TokenKind.FloatLiteral:
                 return FloatType.instance;
             case TokenKind.Function:
-                return new FunctionType(token.text);
+                return FunctionType.instance;
             case TokenKind.Integer:
-                return new IntegerType(token.text);
+                return IntegerType.instance;
             case TokenKind.IntegerLiteral:
                 return IntegerType.instance;
             case TokenKind.Invalid:
-                return new InvalidType(token.text);
+                return InvalidType.instance;
             case TokenKind.LongInteger:
-                return new LongIntegerType(token.text);
+                return LongIntegerType.instance;
             case TokenKind.LongIntegerLiteral:
                 return LongIntegerType.instance;
             case TokenKind.Object:
-                return new ObjectType(token.text);
+                return ObjectType.instance;
             case TokenKind.String:
-                return new StringType(token.text);
+                return StringType.instance;
             case TokenKind.StringLiteral:
             case TokenKind.TemplateStringExpressionBegin:
             case TokenKind.TemplateStringExpressionEnd:
             case TokenKind.TemplateStringQuasi:
                 return StringType.instance;
             case TokenKind.Void:
-                return new VoidType(token.text);
+                return VoidType.instance;
             case TokenKind.Identifier:
                 switch (token.text.toLowerCase()) {
                     case 'boolean':
-                        return new BooleanType(token.text);
+                        return BooleanType.instance;
                     case 'double':
-                        return new DoubleType(token.text);
+                        return DoubleType.instance;
                     case 'dynamic':
-                        return new DynamicType(token.text);
+                        return DynamicType.instance;
                     case 'float':
-                        return new FloatType(token.text);
+                        return FloatType.instance;
                     case 'function':
-                        return new FunctionType(token.text);
+                        return FunctionType.instance;
                     case 'integer':
-                        return new IntegerType(token.text);
+                        return IntegerType.instance;
                     case 'invalid':
-                        return new InvalidType(token.text);
+                        return InvalidType.instance;
                     case 'longinteger':
-                        return new LongIntegerType(token.text);
+                        return LongIntegerType.instance;
                     case 'object':
-                        return new ObjectType(token.text);
+                        return ObjectType.instance;
                     case 'string':
-                        return new StringType(token.text);
+                        return StringType.instance;
                     case 'void':
-                        return new VoidType(token.text);
+                        return VoidType.instance;
                 }
         }
     }

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -142,7 +142,7 @@ export class BsClassValidator {
                         //mismatched member type (field/method in child, opposite in ancestor)
                         if (memberType !== ancestorMemberKind) {
                             const childFieldType = member.getType({ flags: SymbolTypeFlag.typetime });
-                            let ancestorMemberType: BscType = new DynamicType();
+                            let ancestorMemberType: BscType = DynamicType.instance;
                             if (isFieldStatement(ancestorAndMember.member)) {
                                 ancestorMemberType = ancestorAndMember.member.getType({ flags: SymbolTypeFlag.typetime });
                             } else if (isMethodStatement(ancestorAndMember.member)) {
@@ -162,7 +162,7 @@ export class BsClassValidator {
 
                         //child field has same name as parent
                         if (isFieldStatement(member)) {
-                            let ancestorMemberType: BscType = new DynamicType();
+                            let ancestorMemberType: BscType = DynamicType.instance;
                             if (isFieldStatement(ancestorAndMember.member)) {
                                 ancestorMemberType = ancestorAndMember.member.getType({ flags: SymbolTypeFlag.typetime });
                             } else if (isMethodStatement(ancestorAndMember.member)) {


### PR DESCRIPTION
Uses static instances for all native types.

Also adds some debug logging on build:

```
TYPES CREATED {
  DynamicType: 1,
  VoidType: 1,
  StringType: 1,
  IntegerType: 1,
  InvalidType: 1,
  UninitializedType: 1,
  FunctionType: 1,
  BooleanType: 1,
  DoubleType: 1,
  FloatType: 1,
  LongIntegerType: 1,
  ObjectType: 1,
  ComponentType: 285,
  TypedFunctionType: 50301,
  ArrayType: 1704,
  UnionType: 845,
  AssociativeArrayType: 3206,
  InterfaceType: 349,
  ReferenceType: 10153,
  ArrayDefaultTypeReferenceType: 40,
  TypePropertyReferenceType: 1327,
  ClassType: 48,
  EnumMemberType: 138,
  EnumType: 22,
  BinaryOperatorReferenceType: 131,
  ParamTypeFromValueReferenceType: 35,
  NamespaceType: 80
}
TOTAL TYPES CREATED 68676
```