### PR TITLE
Adds metrics to ScopeValidation for the validation walk

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4013,7 +4013,7 @@ describe('ScopeValidator', () => {
             expectDiagnosticsIncludes(program, [DiagnosticMessages.mismatchArgumentCount(1, 0).message]);
         });
 
-        it('validates only parts of files that need revalidation on scope validation', () => {
+        it.only('validates only parts of files that need revalidation on scope validation', () => {
             function validateFile(file: BrsFile) {
                 const validateFileEvent = {
                     program: program,


### PR DESCRIPTION
Adds debug log line like this:

```
Validation Walk Metrics (Scope: source): AssignmentStatement=12.321ms (1563), AstNode=2.899ms (1539), AugmentedAssignmentStatement=0.407ms (24), BinaryExpression=17.163ms (1767), CallExpression=30.524ms (3800), CallfuncExpression=0.060ms (2), DottedGetExpression=12.310ms (4191), DottedSetStatement=6.284ms (377), ForEachStatement=0.481ms (147), FunctionExpression=1.508ms (893), FunctionParameterExpression=10.127ms (1254), IncrementStatement=0.034ms (3), ReturnStatement=15.526ms (976), UnaryExpression=0.773ms (238), VariableExpression=24.405ms (10535)
```
Where for each kind of expression/statement validation, it says the total time and the number of times it was performed

Using this to try to figure out which kinds of expression validations are the worst performing

