### PR TITLE
Scope validation part timing metrics

### DIFF
--- a/src/AstValidationSegmenter.ts
+++ b/src/AstValidationSegmenter.ts
@@ -321,7 +321,13 @@ export class AstValidationSegmenter {
 
 
     hasUnvalidatedSegments() {
-        return Array.from(this.validatedSegments.values()).includes(false);
+        for (const validated of this.validatedSegments.values()) {
+            if (!validated) {
+                return true;
+            }
+
+        }
+        return false;
     }
 
 

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -322,8 +322,17 @@ export class DiagnosticManager {
 
         let searchData = Array.from(this.diagnosticsCache.values());
         searchData = this.getSearchIntersection(needToMatch.tag, searchData, needToMatch.tag ? this.tagMap.get(filter.tag?.toLowerCase()) : null);
+        if (searchData.length === 0) {
+            return;
+        }
         searchData = this.getSearchIntersection(needToMatch.scope, searchData, needToMatch.scope ? this.scopeMap.get(filter.scope?.name?.toLowerCase()) : null, true);
+        if (searchData.length === 0) {
+            return;
+        }
         searchData = this.getSearchIntersection(needToMatch.fileUri, searchData, needToMatch.fileUri ? this.fileUriMap.get(util.pathToUri(filter.fileUri).toLowerCase()) : null);
+        if (searchData.length === 0) {
+            return;
+        }
         searchData = this.getSearchIntersection(needToMatch.segment, searchData, needToMatch.segment ? this.segmentMap.get(filter.segment) : null);
 
         for (const { diagnostic, contexts } of searchData ?? []) {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4013,7 +4013,7 @@ describe('ScopeValidator', () => {
             expectDiagnosticsIncludes(program, [DiagnosticMessages.mismatchArgumentCount(1, 0).message]);
         });
 
-        it.only('validates only parts of files that need revalidation on scope validation', () => {
+        it('validates only parts of files that need revalidation on scope validation', () => {
             function validateFile(file: BrsFile) {
                 const validateFileEvent = {
                     program: program,

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4013,7 +4013,7 @@ describe('ScopeValidator', () => {
             expectDiagnosticsIncludes(program, [DiagnosticMessages.mismatchArgumentCount(1, 0).message]);
         });
 
-        it('validates only parts of files that need revalidation on scope validation', () => {
+        it.only('validates only parts of files that need revalidation on scope validation', () => {
             function validateFile(file: BrsFile) {
                 const validateFileEvent = {
                     program: program,

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -177,7 +177,6 @@ export class ScopeValidator {
                     return;
                 }
 
-
                 const validationVisitor = createVisitor({
                     VariableExpression: (varExpr) => {
                         this.addValidationKindMetric('VariableExpression', () => {


### PR DESCRIPTION
Adds debug log line like this:

```
Validation Walk Metrics (Scope: source): AssignmentStatement=12.321ms (1563), AstNode=2.899ms (1539), AugmentedAssignmentStatement=0.407ms (24), BinaryExpression=17.163ms (1767), CallExpression=30.524ms (3800), CallfuncExpression=0.060ms (2), DottedGetExpression=12.310ms (4191), DottedSetStatement=6.284ms (377), ForEachStatement=0.481ms (147), FunctionExpression=1.508ms (893), FunctionParameterExpression=10.127ms (1254), IncrementStatement=0.034ms (3), ReturnStatement=15.526ms (976), UnaryExpression=0.773ms (238), VariableExpression=24.405ms (10535)
```
Where for each kind of expression/statement validation, it says the total time and the number of times it was performed

Using this to try to figure out which kinds of expression validations are the worst performing