### PR TITLE
Backport v1 typecast syntax to v0

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -182,6 +182,9 @@ export function isCatchStatement(element: AstNode | undefined): element is Catch
 }
 export function isThrowStatement(element: AstNode | undefined): element is ThrowStatement {
     return element?.constructor.name === 'ThrowStatement';
+}
+export function isTypecastStatement(element: AstNode | undefined): element is TypecastStatement {
+    return element?.constructor?.name === 'TypecastStatement';
 }
 
 // Expressions reflection

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -273,7 +273,8 @@ export class BrsFileValidator {
                     !isCommentStatement(statement) &&
                     !isLibraryStatement(statement) &&
                     !isImportStatement(statement) &&
-                    !isConstStatement(statement)
+                    !isConstStatement(statement) &&
+                    !isTypecastStatement(statement)
                 ) {
                     this.event.file.addDiagnostic({
                         ...DiagnosticMessages.unexpectedStatementOutsideFunction(),

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4256,6 +4256,20 @@ describe('BrsFile', () => {
                 end sub
             `);
         });
+
+        it('allows typecast statements', () => {
+            testTranspile(`
+                typecast m as whatever
+
+                sub foo(node as object)
+                    print node[m.keyProp]
+                end sub
+            `, `
+                sub foo(node as object)
+                    print node[m.keyProp]
+                end sub
+            `);
+        });
     });
 
     it('allows up to 63 function params', () => {

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -163,6 +163,7 @@ export enum TokenKind {
     EndInterface = 'EndInterface',
     Const = 'Const',
     Continue = 'Continue',
+    Typecast = 'Typecast',
 
     //brighterscript source literals
     LineNumLiteral = 'LineNumLiteral',
@@ -326,7 +327,8 @@ export const Keywords: Record<string, TokenKind> = {
     throw: TokenKind.Throw,
     'end interface': TokenKind.EndInterface,
     endinterface: TokenKind.EndInterface,
-    const: TokenKind.Const
+    const: TokenKind.Const,
+    typecast: TokenKind.Typecast
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -453,7 +455,8 @@ export const AllowedProperties = [
     TokenKind.Throw,
     TokenKind.EndInterface,
     TokenKind.Const,
-    TokenKind.Continue
+    TokenKind.Continue,
+    TokenKind.Typecast
 ];
 
 /** List of TokenKind that are allowed as local var identifiers. */
@@ -488,7 +491,8 @@ export const AllowedLocalIdentifiers = [
     TokenKind.Catch,
     TokenKind.EndTry,
     TokenKind.Const,
-    TokenKind.Continue
+    TokenKind.Continue,
+    TokenKind.Typecast
 ];
 
 export const BrighterScriptSourceLiterals = [

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -54,7 +54,8 @@ import {
     StopStatement,
     ThrowStatement,
     TryCatchStatement,
-    WhileStatement
+    WhileStatement,
+    TypecastStatement
 } from './Statement';
 import type { DiagnosticInfo } from '../DiagnosticMessages';
 import { DiagnosticMessages } from '../DiagnosticMessages';
@@ -1098,6 +1099,10 @@ export class Parser {
             return this.importStatement();
         }
 
+        if (this.check(TokenKind.Typecast) && this.checkAnyNext(TokenKind.Identifier, ...this.allowedLocalIdentifiers)) {
+            return this.typecastStatement();
+        }
+
         if (this.check(TokenKind.Stop)) {
             return this.stopStatement();
         }
@@ -1535,6 +1540,29 @@ export class Parser {
 
         this._references.importStatements.push(importStatement);
         return importStatement;
+    }
+
+    private typecastStatement() {
+        this.warnIfNotBrighterScriptMode('typecast statements');
+        const typecastToken = this.advance();
+        const obj = this.identifier(...this.allowedLocalIdentifiers);
+        const asToken = this.advance();
+        const typeToken = this.typeToken();
+        return new TypecastStatement({
+            typecast: typecastToken,
+            obj: obj,
+            as: asToken,
+            type: typeToken
+        });
+
+        /* this.diagnostics.push({
+             ...DiagnosticMessages.expectedIdentifier('typecast'),
+             location: {
+                 uri: typecastToken.location.uri,
+                 range: util.createBoundingRange(typecastToken, this.peek())
+             }
+         });
+         throw this.lastDiagnosticAsError();*/
     }
 
     private annotationExpression() {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3243,3 +3243,58 @@ export class ContinueStatement extends Statement {
         );
     }
 }
+
+export class TypecastStatement extends Statement {
+    constructor(options: {
+        typecast?: Token;
+        obj: Token;
+        as?: Token;
+        type: Token;
+    }
+    ) {
+        super();
+        this.tokens = {
+            typecast: options.typecast,
+            obj: options.obj,
+            as: options.as,
+            type: options.type
+        };
+        this.range = util.createBoundingRange(
+            this.tokens.typecast,
+            this.tokens.obj,
+            this.tokens.as,
+            this.tokens.type
+        );
+    }
+
+    public readonly tokens: {
+        readonly typecast?: Token;
+        readonly obj: Token;
+        readonly as?: Token;
+        readonly type: Token;
+    };
+
+    public readonly typecastExpression: Expression;
+
+
+    public readonly range: Range;
+
+    transpile(state: BrsTranspileState) {
+        return [];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+
+    public clone() {
+        return this.finalizeClone(
+            new TypecastStatement({
+                typecast: util.cloneToken(this.tokens.typecast),
+                obj: util.cloneToken(this.tokens.obj),
+                as: util.cloneToken(this.tokens.as),
+                type: util.cloneToken(this.tokens.type)
+            })
+        );
+    }
+}


### PR DESCRIPTION
Parses and then ignores any use of the typecast statement, eg.

```
typecast m as SomeInterface
```


Addresses #1416