### PR TITLE
Fix watch mode errors on subsequent saves

### DIFF
--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2586,7 +2586,7 @@ export class MethodStatement extends FunctionStatement {
             thisQualifiedName.text = 'm.' + field.name?.text;
             if (field.initialValue) {
                 newStatements.push(
-                    new AssignmentStatement(field.equal, thisQualifiedName, field.initialValue)
+                    new AssignmentStatement(field.equal, thisQualifiedName, field.initialValue.clone())
                 );
             } else {
                 //if there is no initial value, set the initial value to `invalid`


### PR DESCRIPTION
This PR attempts to fix a watch mode issue where field initialisers will trigger diagnostic errors.

Note: this is still a draft because fixing this with `.clone()` breaks enums. Still how to fix that.