### PR TITLE
Adds diagnosticFiltersV0Compatibility flag to BSConfig.json

### DIFF
--- a/bsconfig.schema.json
+++ b/bsconfig.schema.json
@@ -109,7 +109,7 @@
             "default": false
         },
         "deploy": {
-            "description": "If true, after a successful buld, the project will be deployed to the roku specified in host",
+            "description": "If true, after a successful build, the project will be deployed to the roku specified in host",
             "type": "boolean"
         },
         "host": {
@@ -232,6 +232,11 @@
                     }
                 ]
             }
+        },
+        "diagnosticFiltersV0Compatibility": {
+            "description": "Use the deprecated diagnosticFilters format from v0. This is useful for backwards compatibility.",
+            "type": "boolean",
+            "default": false
         },
         "plugins": {
             "description": "A list of node scripts or npm modules to add extra diagnostics or transform the AST.",

--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -131,6 +131,11 @@ export interface BsConfig {
     diagnosticFilters?: Array<string | number | { files?: string | Array<string | { src: string } | { dest: string }>; codes?: Array<number | string> }>;
 
     /**
+     * Use the deprecated diagnosticFilters format from v0. This is useful for backwards compatibility.
+     */
+    diagnosticFiltersV0Compatibility?: boolean;
+
+    /**
      * Specify what diagnostic types should be printed to the console. Defaults to 'warn'
      */
     diagnosticLevel?: 'info' | 'hint' | 'warn' | 'error';

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -359,6 +359,280 @@ describe('DiagnosticFilterer', () => {
         });
     });
 
+    describe('v0 compatibility', () => {
+        let filterer: DiagnosticFilterer;
+        let options = {
+            rootDir: rootDir,
+            diagnosticFiltersV0Compatibility: true,
+            diagnosticFilters: [
+                //ignore these codes globally
+                { codes: [1, 2, 3, 'X4'] },
+                //ignore all codes from lib
+                { src: 'lib/**/*.brs' },
+                //ignore all codes from `packages` with absolute path
+                { src: `${rootDir}/packages/**/*.brs` },
+                //ignore specific codes for main.brs
+                { src: 'source/main.brs', codes: [4] }
+            ]
+        };
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        beforeEach(() => {
+            filterer = new DiagnosticFilterer();
+        });
+
+        describe('filter', () => {
+
+            it('removes duplicates', () => {
+                let diagnostic = getDiagnostic(100, `${rootDir}/source/common.brs`);
+                expect(
+                    filterer.filter(options, [diagnostic, diagnostic])
+                ).to.eql([diagnostic]);
+            });
+
+            it('uses global code filter', () => {
+                expect(
+                    filterer.filter(options, [
+                        getDiagnostic(1, `${rootDir}/source/common.brs`),
+                        getDiagnostic(2, `${rootDir}/source/common.brs`),
+                        getDiagnostic(4, `${rootDir}/source/common.brs`),
+                        getDiagnostic('X4', `${rootDir}/source/common.brs`)
+                    ]).map(x => x.code)
+                ).to.eql([4]);
+            });
+
+            it('works with relative src globs', () => {
+                expect(
+                    filterer.filter(options, [
+                        getDiagnostic(10, `${rootDir}/source/common.brs`), //keep
+                        getDiagnostic(11, `${rootDir}/lib/a.brs`), //remove
+                        getDiagnostic(12, `${rootDir}/lib/a/b/b.brs`), //remove
+                        getDiagnostic(13, `${rootDir}/lib/a/b/c/c.brs`) //remove
+                    ]).map(x => x.code)
+                ).to.eql([10]);
+            });
+
+            it('works with absolute src globs', () => {
+                expect(
+                    filterer.filter(options, [
+                        getDiagnostic(10, `${rootDir}/source/common.brs`), //keep
+                        getDiagnostic(11, `${rootDir}/packages/a.brs`), //remove
+                        getDiagnostic(12, `${rootDir}/packages/a/b/b.brs`), //remove
+                        getDiagnostic(13, `${rootDir}/packages/a/b/c/c.brs`), //remove
+                        getDiagnostic('X14', `${rootDir}/packages/a/b/c/c.brs`) //remove
+                    ]).map(x => x.code)
+                ).to.eql([10]);
+            });
+
+            it('works with single file src glob', () => {
+                expect(
+                    filterer.filter(options, [
+                        getDiagnostic(4, `${rootDir}/source/main.brs`), //remove
+                        getDiagnostic(11, `${rootDir}/common/a.brs`), //keep
+                        getDiagnostic(12, `${rootDir}/common/a/b/b.brs`), //keep
+                        getDiagnostic(13, `${rootDir}/common/a/b/c/c.brs`), //keep
+                        getDiagnostic('X14', `${rootDir}/common/a/b/c/c.brs`) //keep
+                    ]).map(x => x.code)
+                ).to.eql([11, 12, 13, 'X14']);
+            });
+
+            describe('with negative globs', () => {
+                let optionsWithNegatives = {
+                    rootDir: rootDir,
+                    diagnosticFiltersV0Compatibility: true,
+                    diagnosticFilters: [
+                        //ignore these codes globally
+                        { codes: [1, 2] },
+                        3,
+                        4,
+                        //ignore all codes from lib
+                        { src: 'lib/**/*.brs' },
+                        //un-ignore specific errors from lib/special
+                        { src: '!lib/special/**/*.brs', codes: [1, 2, 3] },
+                        //re-ignore errors from one extra special file
+                        { src: 'lib/special/all-reignored.brs' },
+                        //un-ignore all codes from third special file
+                        { src: '!lib/special/all-unignored.brs' },
+                        //un-ignore code 5 globally
+                        { src: '!*/**/*', codes: [5] },
+                        //re-ignore code 10 globally, overriding previous unignores
+                        { codes: [10] }
+                    ]
+                };
+
+                it('should unignore specific error codes for specific files', () => {
+                    expect(
+                        filterer.filter(optionsWithNegatives, [
+                            getDiagnostic(1, `${rootDir}/lib/special/a.brs`), //keep
+                            getDiagnostic(3, `${rootDir}/lib/special/a.brs`), //keep
+                            getDiagnostic(7, `${rootDir}/lib/special/a.brs`) //remove
+                        ]).map(x => x.code)
+                    ).to.eql([1, 3]);
+                });
+
+                it('should unignore all codes from specific file', () => {
+                    expect(
+                        filterer.filter(optionsWithNegatives, [
+                            getDiagnostic(1, `${rootDir}/lib/special/all-unignored.brs`), //keep
+                            getDiagnostic(2, `${rootDir}/lib/special/all-unignored.brs`), //keep
+                            getDiagnostic(3, `${rootDir}/lib/special/all-unignored.brs`), //keep
+                            getDiagnostic(4, `${rootDir}/lib/special/all-unignored.brs`) //keep
+                        ]).map(x => x.code)
+                    ).to.eql([1, 2, 3, 4]);
+                });
+
+                it('should re-ignore errors', () => {
+                    expect(
+                        filterer.filter(optionsWithNegatives, [
+                            getDiagnostic(1, `${rootDir}/lib/special/all-reignored.brs`), //remove
+                            getDiagnostic(10, `${rootDir}/lib/special/a.brs`) //remove
+                        ]).map(x => x.code)
+                    ).to.eql([]);
+                });
+
+                it('should unignore errors globally by using "*/**/*" glob', () => {
+                    expect(
+                        filterer.filter(optionsWithNegatives, [
+                            getDiagnostic(5, `${rootDir}/lib/a/b/c.brs`) //keep
+                        ]).map(x => x.code)
+                    ).to.eql([5]);
+                });
+            });
+        });
+        describe('standardizeDiagnosticFilters', () => {
+            it('handles null and falsey diagnostic filters', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: <any>[null, undefined, false, true]
+                    })
+                ).to.eql([]);
+            });
+
+            it('handles a completely empty diagnostic filter', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: <any>[{}]
+                    })
+                ).to.eql([]);
+            });
+
+            it('handles number diagnostic filters', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: [1, 2, 3]
+                    })
+                ).to.eql([
+                    { codes: [1], isNegative: false },
+                    { codes: [2], isNegative: false },
+                    { codes: [3], isNegative: false }
+                ]);
+            });
+
+            it('handles standard diagnostic filters', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: [{ src: 'file.brs', codes: [1, 2, 'X3'] }] as any
+                    })
+                ).to.eql([{ src: 'file.brs', codes: [1, 2, 'X3'], isNegative: false }]);
+            });
+
+            it('handles string-only diagnostic filter object', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: [{ src: 'file.brs' }] as any
+                    })
+                ).to.eql([{ src: 'file.brs', isNegative: false }]);
+            });
+
+            it('handles code-only diagnostic filter object', () => {
+                expect(filterer.getDiagnosticFilters({
+                    diagnosticFiltersV0Compatibility: true,
+                    diagnosticFilters: [{ codes: [1, 2, 'X3'] }]
+                })).to.eql([
+                    { codes: [1, 2, 'X3'], isNegative: false }
+                ]);
+            });
+
+            it('handles string diagnostic filter', () => {
+                expect(
+                    filterer.getDiagnosticFilters({
+                        diagnosticFiltersV0Compatibility: true,
+                        diagnosticFilters: ['file.brs']
+                    })
+                ).to.eql([{ src: 'file.brs', isNegative: false }]);
+            });
+
+            it('converts ignoreErrorCodes to diagnosticFilters', () => {
+                expect(filterer.getDiagnosticFilters({
+                    diagnosticFiltersV0Compatibility: true,
+                    ignoreErrorCodes: [1, 2, 'X3']
+                })).to.eql([
+                    { codes: [1, 2, 'X3'], isNegative: false }
+                ]);
+            });
+
+            it('handles negative globs in bare strings', () => {
+                expect(filterer.getDiagnosticFilters({
+                    diagnosticFiltersV0Compatibility: true,
+                    diagnosticFilters: ['!file.brs']
+                })).to.eql([
+                    { src: 'file.brs', isNegative: true }
+                ]);
+            });
+
+            it('handles negative globs in objects', () => {
+                expect(filterer.getDiagnosticFilters({
+                    diagnosticFiltersV0Compatibility: true,
+                    diagnosticFilters: [
+                        {
+                            src: '!file.brs'
+                        }
+                    ] as any
+                })).to.eql([
+                    { src: 'file.brs', isNegative: true }
+                ]);
+            });
+
+            it('handles negative globs with codes', () => {
+                expect(filterer.getDiagnosticFilters({
+                    diagnosticFiltersV0Compatibility: true,
+                    diagnosticFilters: [
+                        {
+                            src: '!file.brs',
+                            codes: [1, 2, 3]
+                        }
+                    ] as any
+                })).to.eql([
+                    { src: 'file.brs', codes: [1, 2, 3], isNegative: true }
+                ]);
+            });
+        });
+
+        it('only filters by file once per unique file (case-insensitive)', () => {
+            const stub = sinon.stub(filterer as any, 'filterFile').returns(null);
+            filterer.filter(options, [
+                getDiagnostic(1, s`${rootDir}/source/common1.brs`),
+                getDiagnostic(2, s`${rootDir}/source/Common1.brs`),
+                getDiagnostic(3, s`${rootDir}/source/common2.brs`),
+                getDiagnostic(4, s`${rootDir}/source/Common2.brs`)
+            ]);
+            expect(stub.callCount).to.eql(2);
+            const fileList = stub.getCalls().map(x => x.args[1]);
+            expect(fileList).to.eql([
+                util.pathToUri(s`${rootDir.toLowerCase()}/source/common1.brs`).toLowerCase(),
+                util.pathToUri(s`${rootDir.toLowerCase()}/source/common2.brs`).toLowerCase()
+            ]);
+        });
+    });
+
 });
 
 function getDiagnostic(code: number | string, srcPath: string, destPath?: string) {

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -230,6 +230,10 @@ export class DiagnosticFilterer {
     }
 
     public getDiagnosticFilters(config: BsConfig) {
+        if (config.diagnosticFiltersV0Compatibility) {
+            return this.getDiagnosticFiltersV0(config);
+        }
+
         let globalIgnoreCodes: (number | string)[] = [...config.ignoreErrorCodes ?? []];
         let diagnosticFilters = [...config.diagnosticFilters ?? []];
 
@@ -290,6 +294,76 @@ export class DiagnosticFilterer {
                             }
                         }
                     }
+                }
+            }
+        }
+        return result;
+    }
+
+    private getDiagnosticFiltersV0(config: BsConfig) {
+        let globalIgnoreCodes: (number | string)[] = [...config.ignoreErrorCodes ?? []];
+        let diagnosticFilters = [...config.diagnosticFilters ?? []];
+
+        let result: NormalizedFilter[] = [];
+
+        //include a filter for all global ignore codes
+        //this comes first, because negative patterns will override ignoreErrorCodes
+        if (globalIgnoreCodes.length > 0) {
+            result.push({
+                codes: globalIgnoreCodes,
+                isNegative: false
+            });
+        }
+
+        for (let filter of diagnosticFilters) {
+            if (typeof filter === 'number') {
+                result.push({
+                    codes: [filter],
+                    isNegative: false
+                });
+                continue;
+            }
+
+            if (typeof filter === 'string') {
+                const isNegative = filter.startsWith('!');
+                const trimmedFilter = isNegative ? filter.slice(1) : filter;
+
+                result.push({
+                    src: trimmedFilter,
+                    isNegative: isNegative
+                });
+                continue;
+            }
+
+            //filter out bad inputs
+            if (!filter || typeof filter !== 'object') {
+                continue;
+            }
+
+            //code-only filter
+            if ('codes' in filter && !('src' in filter) && Array.isArray(filter.codes)) {
+                result.push({
+                    codes: filter.codes,
+                    isNegative: false
+                });
+                continue;
+            }
+
+            if ('src' in filter && typeof filter.src === 'string') {
+                const isNegative = filter.src.startsWith('!');
+                const trimmedFilter = isNegative ? filter.src.slice(1) : filter.src;
+
+                if ('codes' in filter) {
+                    result.push({
+                        src: trimmedFilter,
+                        codes: filter.codes,
+                        isNegative: isNegative
+                    });
+                } else {
+                    result.push({
+                        src: trimmedFilter,
+                        isNegative: isNegative
+                    });
                 }
             }
         }


### PR DESCRIPTION
Adds the `diagnosticFiltersV0Compatibility` flag to BSConfig

When that is true, the method `DiagnosticsFilterer.getDiagnosticFilters` will use the v0 format for the `diagnosticFilters` option.


Also re-added all the `DiagnosticsFilterer` tests from v0, with that flag turned on.
