### PR TITLE
Adds Alias statement syntax from v1 to v0

### DIFF
--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -186,6 +186,9 @@ export function isThrowStatement(element: AstNode | undefined): element is Throw
 export function isTypecastStatement(element: AstNode | undefined): element is TypecastStatement {
     return element?.constructor?.name === 'TypecastStatement';
 }
+export function isAliasStatement(element: AstNode | undefined): element is AliasStatement {
+    return element?.constructor?.name === 'AliasStatement';
+}
 
 // Expressions reflection
 /**
@@ -275,6 +278,7 @@ export function isTypedefProvider(element: any): element is TypedefProvider {
 export function isTypeCastExpression(element: any): element is TypeCastExpression {
     return element?.constructor.name === 'TypeCastExpression';
 }
+
 
 // BscType reflection
 export function isStringType(value: any): value is StringType {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isAliasStatement, isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -274,7 +274,8 @@ export class BrsFileValidator {
                     !isLibraryStatement(statement) &&
                     !isImportStatement(statement) &&
                     !isConstStatement(statement) &&
-                    !isTypecastStatement(statement)
+                    !isTypecastStatement(statement) &&
+                    !isAliasStatement(statement)
                 ) {
                     this.event.file.addDiagnostic({
                         ...DiagnosticMessages.unexpectedStatementOutsideFunction(),

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -164,6 +164,7 @@ export enum TokenKind {
     Const = 'Const',
     Continue = 'Continue',
     Typecast = 'Typecast',
+    Alias = 'Alias',
 
     //brighterscript source literals
     LineNumLiteral = 'LineNumLiteral',
@@ -328,7 +329,8 @@ export const Keywords: Record<string, TokenKind> = {
     'end interface': TokenKind.EndInterface,
     endinterface: TokenKind.EndInterface,
     const: TokenKind.Const,
-    typecast: TokenKind.Typecast
+    typecast: TokenKind.Typecast,
+    alias: TokenKind.Alias
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -456,7 +458,8 @@ export const AllowedProperties = [
     TokenKind.EndInterface,
     TokenKind.Const,
     TokenKind.Continue,
-    TokenKind.Typecast
+    TokenKind.Typecast,
+    TokenKind.Alias
 ];
 
 /** List of TokenKind that are allowed as local var identifiers. */
@@ -492,7 +495,8 @@ export const AllowedLocalIdentifiers = [
     TokenKind.EndTry,
     TokenKind.Const,
     TokenKind.Continue,
-    TokenKind.Typecast
+    TokenKind.Typecast,
+    TokenKind.Alias
 ];
 
 export const BrighterScriptSourceLiterals = [

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3276,7 +3276,6 @@ export class TypecastStatement extends Statement {
 
     public readonly typecastExpression: Expression;
 
-
     public readonly range: Range;
 
     transpile(state: BrsTranspileState) {
@@ -3298,3 +3297,57 @@ export class TypecastStatement extends Statement {
         );
     }
 }
+
+export class AliasStatement extends Statement {
+    constructor(options: {
+        alias?: Token;
+        name: Token;
+        equals?: Token;
+        value: Token;
+    }
+    ) {
+        super();
+        this.tokens = {
+            alias: options.alias,
+            name: options.name,
+            equals: options.equals,
+            value: options.value
+        };
+        this.range = util.createBoundingRange(
+            this.tokens.alias,
+            this.tokens.name,
+            this.tokens.equals,
+            this.tokens.value
+        );
+    }
+
+    public readonly tokens: {
+        readonly alias?: Token;
+        readonly name: Token;
+        readonly equals?: Token;
+        readonly value: Token;
+    };
+
+    public readonly range: Range;
+
+    transpile(state: BrsTranspileState) {
+        return [];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+
+
+    public clone() {
+        return this.finalizeClone(
+            new AliasStatement({
+                alias: util.cloneToken(this.tokens.alias),
+                name: util.cloneToken(this.tokens.name),
+                equals: util.cloneToken(this.tokens.equals),
+                value: util.cloneToken(this.tokens.value)
+            })
+        );
+    }
+}
+


### PR DESCRIPTION
Makes the alias statement syntax used in v1 acceptable in v0, but then ignores it and doesn't do anything. It is empty in transpiles.