### PR TITLE
Fixed getClosestExpression bug to return undefined when position not found

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -26,6 +26,7 @@ import { URI } from 'vscode-uri';
 import undent from 'undent';
 import { tempDir, rootDir } from '../testHelpers.spec';
 import * as fileUrl from 'file-url';
+import { LiteralExpression } from '../parser/Expression';
 
 let sinon = sinonImport.createSandbox();
 
@@ -4306,6 +4307,30 @@ describe('BrsFile', () => {
             ...DiagnosticMessages.tooManyCallableParameters(65, 63),
             range: util.createRange(1, 648, 1, 651)
         }]);
+    });
+
+    describe('getClosestExpression', () => {
+        it('returns undefined for missing Position', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub Main()
+                    if true THEN
+                        print "works"
+                    end if
+                end sub
+            `);
+            expect(file.getClosestExpression(undefined)).to.be.undefined;
+        });
+
+        it('returns the closest expression at Position', () => {
+            const file = program.setFile<BrsFile>('source/main.bs', `
+                sub Main()
+                    if true THEN
+                        print "works"
+                    end if
+                end sub
+            `);
+            expect(file.getClosestExpression({ line: 3, character: 34 })).to.be.instanceOf(LiteralExpression);
+        });
     });
 
 });

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -209,6 +209,9 @@ export class BrsFile {
      * Walk the AST and find the expression that this token is most specifically contained within
      */
     public getClosestExpression(position: Position) {
+        if (typeof position?.line !== 'number') {
+            return undefined;
+        }
         const handle = new CancellationTokenSource();
         let containingNode: AstNode;
         this.ast.walk((node) => {


### PR DESCRIPTION
Fixed a bug in `BrsFile.getClosestExpression()` that was returning the last expression in the AST when given an undefined position. Now we return `undefined` if the position or position.line is undefined, which should make more sense and also save a little processing time because we can exit early instead of traversing the entire AST tree