### PR TITLE
Fixes issue when cancelling an in-progress validation

### DIFF
--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -19,13 +19,14 @@ import type { SinonSpy } from 'sinon';
 import { createSandbox } from 'sinon';
 import { SymbolTypeFlag } from './SymbolTypeFlag';
 import { AssetFile } from './files/AssetFile';
-import type { ProvideFileEvent, CompilerPlugin, BeforeProvideFileEvent, AfterProvideFileEvent, BeforeFileAddEvent, AfterFileAddEvent, BeforeFileRemoveEvent, AfterFileRemoveEvent, ScopeValidationOptions } from './interfaces';
+import type { ProvideFileEvent, CompilerPlugin, BeforeProvideFileEvent, AfterProvideFileEvent, BeforeFileAddEvent, AfterFileAddEvent, BeforeFileRemoveEvent, AfterFileRemoveEvent, ScopeValidationOptions, AfterFileValidateEvent, BeforeScopeValidateEvent, OnScopeValidateEvent, BeforeFileValidateEvent, OnFileValidateEvent, AfterScopeValidateEvent } from './interfaces';
 import { StringType, TypedFunctionType, DynamicType, FloatType, IntegerType, InterfaceType, ArrayType, BooleanType, DoubleType, UnionType } from './types';
 import { AssociativeArrayType } from './types/AssociativeArrayType';
 import { ComponentType } from './types/ComponentType';
 import * as path from 'path';
 import undent from 'undent';
 import { Scope } from './Scope';
+import PluginInterface from './PluginInterface';
 
 const sinon = createSandbox();
 
@@ -845,6 +846,142 @@ describe('Program', () => {
                 error = e as any;
             }
             expect(error?.message).to.eql('Crash for test');
+        });
+
+        describe('cancelled', () => {
+
+            type eventName = 'beforeFileValidate' | 'onFileValidate' | 'afterFileValidate' | 'beforeScopeValidate' | 'onScopeValidate' | 'afterScopeValidate';
+            interface CancellationPluginOptions {
+                cancelOn?: eventName[];
+                eventWhenCancelled?: BeforeFileValidateEvent | OnFileValidateEvent | AfterFileValidateEvent | BeforeScopeValidateEvent | OnScopeValidateEvent | AfterScopeValidateEvent;
+                cancelTokenSource: CancellationTokenSource;
+            }
+
+            function getCancellationPlugin(option: CancellationPluginOptions): CompilerPlugin {
+                return {
+                    name: 'cancelPlugin',
+                    beforeFileValidate: (event) => {
+                        if (option?.cancelOn.includes('beforeFileValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    },
+                    onFileValidate: (event) => {
+                        if (option?.cancelOn.includes('onFileValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    },
+                    afterFileValidate: (event) => {
+                        if (option?.cancelOn.includes('afterFileValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    },
+                    beforeScopeValidate: (event) => {
+                        if (option?.cancelOn.includes('beforeScopeValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    },
+                    onScopeValidate: (event) => {
+                        if (option?.cancelOn.includes('onScopeValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    },
+                    afterScopeValidate: (event) => {
+                        if (option?.cancelOn.includes('afterScopeValidate')) {
+                            option.eventWhenCancelled = event;
+                            option.cancelTokenSource.cancel();
+                        }
+                    }
+                };
+            }
+
+            it('should be cancellable', async () => {
+                const options: CancellationPluginOptions = { cancelOn: [], eventWhenCancelled: null, cancelTokenSource: new CancellationTokenSource() };
+                const cancelPlugin = getCancellationPlugin(options);
+                program.plugins.add(cancelPlugin);
+
+                program.setFile('source/file1.bs', `
+                    function foo() as integer
+                        return 1
+                    end function
+                `);
+                program.setFile('source/file2.bs', `
+                    function bar() as boolean
+                        return true
+                    end function
+                `);
+                // do an initial validation
+                program.validate();
+                expectZeroDiagnostics(program);
+                options.cancelOn = ['afterFileValidate'];
+
+                // change file
+                program.setFile('source/file2.bs', `
+                    function bar() as integer
+                        return true
+                    end function
+                `);
+                options.cancelTokenSource = new CancellationTokenSource();
+                await program.validate({ async: true, cancellationToken: options.cancelTokenSource.token });
+                const event = options.eventWhenCancelled as AfterFileValidateEvent;
+                expect(event).not.to.undefined;
+                expect(event.file.srcPath).includes('file2.bs');
+            });
+
+            it('scope validation should contain symbols from previous cancellations', async () => {
+                const options: CancellationPluginOptions = { cancelOn: [], eventWhenCancelled: null, cancelTokenSource: new CancellationTokenSource() };
+                const cancelPlugin = getCancellationPlugin(options);
+                program.plugins.add(cancelPlugin);
+
+                program.setFile('source/file1.bs', `
+                    function foo() as integer
+                        return 1
+                    end function
+                `);
+                program.setFile('source/file2.bs', `
+                    function bar() as boolean
+                        return true
+                    end function
+                `);
+                // do an initial validation
+                program.validate();
+                expectZeroDiagnostics(program);
+                options.cancelOn = ['beforeScopeValidate'];
+
+                // change file2
+                program.setFile('source/file2.bs', `
+                    function bar() as integer
+                        return true
+                    end function
+                `);
+                options.cancelTokenSource = new CancellationTokenSource();
+                await program.validate({ async: true, cancellationToken: options.cancelTokenSource.token });
+                //cancelled before scope validation, so source scope should be unvalidated
+                const sourceScope = program.getScopeByName('source');
+                expect(sourceScope.isValidated).to.be.false;
+
+                // change file1
+                program.setFile('source/file1.bs', `
+                    function foo(x as integer) as integer
+                        return x
+                    end function
+                `);
+
+                options.cancelOn = ['onScopeValidate'];
+                options.cancelTokenSource = new CancellationTokenSource();
+                await program.validate({ async: true, cancellationToken: options.cancelTokenSource.token });
+                const event = options.eventWhenCancelled as OnScopeValidateEvent;
+                // Event details has info from both changes at scope validation step
+                const srcPaths = event.changedFiles.map(file => file.srcPath);
+                expect(srcPaths.length).to.eq(2);
+                const changedFunctions = Array.from(event.changedSymbols.get(SymbolTypeFlag.runtime).values());
+                expect(changedFunctions).to.include('foo');
+                expect(changedFunctions).to.include('bar');
+            });
         });
     });
 

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -26,7 +26,6 @@ import { ComponentType } from './types/ComponentType';
 import * as path from 'path';
 import undent from 'undent';
 import { Scope } from './Scope';
-import PluginInterface from './PluginInterface';
 
 const sinon = createSandbox();
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1188,7 +1188,6 @@ export class Program {
                 scope.validate(this.currentScopeValidationOptions);
             })
             .forEach(() => scopesToValidate, (scope) => {
-                //sort the scope names so we get consistent results
                 this.plugins.emit('afterScopeValidate', {
                     program: this,
                     scope: scope

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -909,6 +909,24 @@ export class Program {
 
     private validatePromise: Promise<void> | undefined;
 
+
+    private validationDetails: {
+        brsFilesValidated: BrsFile[];
+        xmlFilesValidated: XmlFile[];
+        changedSymbols: Map<SymbolTypeFlag, Set<string>>;
+        changedComponentTypes: string[];
+        scopesToValidate: Scope[];
+        filesToBeValidatedInScopeContext: Set<BscFile>;
+
+    } = {
+            brsFilesValidated: [],
+            xmlFilesValidated: [],
+            changedSymbols: new Map<SymbolTypeFlag, Set<string>>(),
+            changedComponentTypes: [],
+            scopesToValidate: [],
+            filesToBeValidatedInScopeContext: new Set<BscFile>()
+        };
+
     /**
      * Traverse the entire project, and validate all scopes
      */
@@ -934,17 +952,19 @@ export class Program {
 
         let beforeProgramValidateWasEmitted = false;
 
+        const brsFilesValidated: BrsFile[] = this.validationDetails.brsFilesValidated;
+        const xmlFilesValidated: XmlFile[] = this.validationDetails.xmlFilesValidated;
+        const changedSymbols = this.validationDetails.changedSymbols;
+        const changedComponentTypes = this.validationDetails.changedComponentTypes;
+        const scopesToValidate = this.validationDetails.scopesToValidate;
+        const filesToBeValidatedInScopeContext = this.validationDetails.filesToBeValidatedInScopeContext;
+
         //validate every file
-        const brsFilesValidated: BrsFile[] = [];
-        const xmlFilesValidated: XmlFile[] = [];
-        const changedSymbols = new Map<SymbolTypeFlag, Set<string>>();
-        const changedComponentTypes: string[] = [];
 
         let logValidateEnd = (status?: string) => { };
 
         //will be populated later on during the correspnding sequencer event
         let filesToProcess: BscFile[];
-        let filesToBeValidatedInScopeContext: Set<BscFile>;
 
         const sequencer = new Sequencer({
             name: 'program.validate',
@@ -976,6 +996,10 @@ export class Program {
                 //return the list of files that need to be processed
                 () => {
                     filesToProcess = Object.values(this.files).sort(firstBy(x => x.srcPath)).filter(x => !x.isValidated);
+                    for (const file of filesToProcess) {
+                        filesToBeValidatedInScopeContext.add(file);
+                    }
+
                     return filesToProcess;
                 },
                 (file) => {
@@ -1073,7 +1097,11 @@ export class Program {
                             changedSymbolSet.add(change);
                         }
                     }
-                    changedSymbols.set(flag, changedSymbolSet);
+                    if (!changedSymbols.has(flag)) {
+                        changedSymbols.set(flag, changedSymbolSet);
+                    } else {
+                        changedSymbols.set(flag, new Set([...changedSymbols.get(flag), ...changedSymbolSet]));
+                    }
                 }
 
                 // update changed symbol set with any changed component
@@ -1100,7 +1128,11 @@ export class Program {
                     }
                 } while (foundDependentTypes);
 
-                changedSymbols.set(SymbolTypeFlag.typetime, new Set([...changedTypeSymbols, ...dependentTypesChanged]));
+                changedSymbols.set(SymbolTypeFlag.typetime, new Set([...changedSymbols.get(SymbolTypeFlag.typetime), ...changedTypeSymbols, ...dependentTypesChanged]));
+
+                // can reset filesValidatedList, because they are no longer needed
+                this.validationDetails.brsFilesValidated = [];
+                this.validationDetails.xmlFilesValidated = [];
             })
             .once(() => {
                 if (this.options.logLevel === LogLevel.debug) {
@@ -1109,7 +1141,6 @@ export class Program {
                     const changedTypetime = Array.from(changedSymbols.get(SymbolTypeFlag.typetime)).sort();
                     this.logger.debug('Changed Symbols (typeTime):', changedTypetime.join(', '));
                 }
-                filesToBeValidatedInScopeContext = new Set<BscFile>(filesToProcess);
 
                 const scopesToCheck = this.getScopesForCrossScopeValidation(changedComponentTypes.length > 0);
                 this.crossScopeValidation.buildComponentsMap();
@@ -1122,11 +1153,15 @@ export class Program {
                 this.currentScopeValidationOptions = {
                     filesToBeValidatedInScopeContext: filesToBeValidatedInScopeContext,
                     changedSymbols: changedSymbols,
-                    changedFiles: filesToProcess,
+                    changedFiles: Array.from(filesToBeValidatedInScopeContext),
                     initialValidation: this.isFirstValidation
                 };
+
+                //can reset changedComponent types
+                this.validationDetails.changedComponentTypes = [];
             })
             .forEach(() => filesToBeValidatedInScopeContext, (file) => {
+
                 for (const file of filesToBeValidatedInScopeContext) {
                     if (isBrsFile(file)) {
                         file.validationSegmenter.unValidateAllSegments();
@@ -1139,11 +1174,35 @@ export class Program {
             .forEach(() => this.getSortedScopeNames(), (scopeName) => {
                 //sort the scope names so we get consistent results
                 let scope = this.scopes[scopeName];
+                if (scope.shouldValidate(this.currentScopeValidationOptions)) {
+                    scopesToValidate.push(scope);
+                    this.plugins.emit('beforeScopeValidate', {
+                        program: this,
+                        scope: scope
+                    });
+                }
+            })
+            .forEach(() => this.getSortedScopeNames(), (scopeName) => {
+                //sort the scope names so we get consistent results
+                let scope = this.scopes[scopeName];
                 scope.validate(this.currentScopeValidationOptions);
+            })
+            .forEach(() => scopesToValidate, (scope) => {
+                //sort the scope names so we get consistent results
+                this.plugins.emit('afterScopeValidate', {
+                    program: this,
+                    scope: scope
+                });
             })
             .once(() => {
                 this.detectDuplicateComponentNames();
                 this.isFirstValidation = false;
+
+                // can reset other validation details
+                this.validationDetails.changedSymbols = new Map<SymbolTypeFlag, Set<string>>();
+                this.validationDetails.scopesToValidate = [];
+                this.validationDetails.filesToBeValidatedInScopeContext = new Set<BscFile>();
+
             })
             .onCancel(() => {
                 logValidateEnd('cancelled');


### PR DESCRIPTION
Basic change was for all the data that was needed in later steps of the validation process is moved to the Program level, and only cleared once it's been used
