### PR TITLE
Support plugin factory detecting brighterscript version

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -104,8 +104,8 @@ end function
 function __Duck_builder()
     instance = __Animal_builder()
     instance.super0_new = instance.new
-    instance.new = sub()
-        m.super0_new()
+    instance.new = sub(name as string)
+        m.super0_new(name)
     end sub
     instance.super0_move = instance.move
     instance.move = sub(distanceInMeters as integer)
@@ -114,16 +114,16 @@ function __Duck_builder()
     end sub
     return instance
 end function
-function Duck()
+function Duck(name as string)
     instance = __Duck_builder()
-    instance.new()
+    instance.new(name)
     return instance
 end function
 function __BabyDuck_builder()
     instance = __Duck_builder()
     instance.super1_new = instance.new
-    instance.new = sub()
-        m.super1_new()
+    instance.new = sub(name as string)
+        m.super1_new(name)
     end sub
     instance.super1_move = instance.move
     instance.move = sub(distanceInMeters as integer)
@@ -132,9 +132,9 @@ function __BabyDuck_builder()
     end sub
     return instance
 end function
-function BabyDuck()
+function BabyDuck(name as string)
     instance = __BabyDuck_builder()
-    instance.new()
+    instance.new(name)
     return instance
 end function
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -334,7 +334,7 @@ Here's a small example:
 
 ```typescript
 export default function (pluginOptions: PluginOptions) {
-    if(semver.major(pluginOptions.version) === '1') {
+    if(semver.major(pluginOptions?.version) === '1') {
         return {
             name: 'v1 version of your plugin!'
         };

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -151,7 +151,7 @@ The top level object is the `ProgramBuilder` which runs the overall process: pre
 Here are some important interfaces. You can view them in the code at [this link](https://github.com/rokucommunity/brighterscript/blob/ddcb7b2cd219bd9fecec93d52fbbe7f9b972816b/src/interfaces.ts#L190:~:text=export%20interface%20CompilerPlugin%20%7B).
 
 ```typescript
-export type CompilerPluginFactory = () => CompilierPlugin;
+export type CompilerPluginFactory = (options?: PluginFactoryOptions) => CompilierPlugin;
 
 export interface CompilerPlugin {
     name: string;
@@ -313,6 +313,39 @@ interface CallableContainer {
     scope: Scope;
 }
 ```
+
+### PluginFactory
+To register a plugin, you need to have a default export that returns a factory. BrighterScript will call this factory once for every instance of a program that needs the plugin. This means that you might have multiple instances of a plugin in one NodeJS process (one for each brighterscript project).
+
+```typescript
+export default function () {
+    return {
+        name: 'Name of your plugin'
+    };
+}
+```
+
+### BrighterScript v1 compatability
+There is currently a v1 rewrite of BrighterScript which includes some significant breaking changes. This has caused challenges with brighterscript plugins, as you need to maintain separate versions for v0 and v1. You can utilize the `pluginOptions.version` property in your factory to determine what brighterscript version is running your plugin, and adjust accordingly.
+
+This options object is only available starting with brighterscript `v0.69.4` and `v1.0.0-alpha.45`. It's important to support backwards compatibility that an `undefined` `version` value be treated as a v0 plugin.
+
+Here's a small example:
+
+```typescript
+export default function (pluginOptions: PluginOptions) {
+    if(semver.major(pluginOptions.version) === '1') {
+        return {
+            name: 'v1 version of your plugin!'
+        };
+    } else {
+        return {
+            name: 'v0 version of your plugin'
+        };
+    }
+}
+```
+
 
 ## Plugin API
 

--- a/scripts/compile-doc-examples.ts
+++ b/scripts/compile-doc-examples.ts
@@ -86,7 +86,7 @@ class DocCompiler {
     private customProcessing(docPath: string, contents: string) {
         const docName = docPath.split(/[\/\\]/).pop().toLowerCase();
         if (docName === 'plugins.md') {
-            const regexp = /export interface CompilerPlugin(.|\r?\n)*?}/;
+            const regexp = /export interface Plugin(.|\r?\n)*?}/;
             //load the CompilerPlugin original source code
             const [latestInterface] = regexp.exec(
                 fsExtra.readFileSync(`${__dirname}/../src/interfaces.ts`).toString()

--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -1,4 +1,4 @@
-import type { CompilerPlugin } from './interfaces';
+import type { Plugin } from './interfaces';
 import { LogLevel, createLogger } from './logging';
 import type { Logger } from './logging';
 /*
@@ -22,25 +22,25 @@ export type PluginEventArgs<T> = {
     Required<T>[K] extends (...args: any[]) => any ? Parameters<Required<T>[K]> : never
 };
 
-export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> {
+export default class PluginInterface<T extends Plugin = Plugin> {
 
     constructor();
     /**
      * @deprecated use the `options` parameter pattern instead
      */
     constructor(
-        plugins?: CompilerPlugin[],
+        plugins?: Plugin[],
         logger?: Logger
     );
     constructor(
-        plugins?: CompilerPlugin[],
+        plugins?: Plugin[],
         options?: {
             logger?: Logger;
             suppressErrors?: boolean;
         }
     );
     constructor(
-        private plugins?: CompilerPlugin[],
+        private plugins?: Plugin[],
         options?: {
             logger?: Logger;
             suppressErrors?: boolean;
@@ -88,7 +88,7 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
     /**
      * Add a plugin to the beginning of the list of plugins
      */
-    public addFirst<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
+    public addFirst<T extends Plugin = Plugin>(plugin: T) {
         if (!this.has(plugin)) {
             this.plugins.unshift(plugin);
         }
@@ -98,18 +98,18 @@ export default class PluginInterface<T extends CompilerPlugin = CompilerPlugin> 
     /**
      * Add a plugin to the end of the list of plugins
      */
-    public add<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
+    public add<T extends Plugin = Plugin>(plugin: T) {
         if (!this.has(plugin)) {
             this.plugins.push(plugin);
         }
         return plugin;
     }
 
-    public has(plugin: CompilerPlugin) {
+    public has(plugin: Plugin) {
         return this.plugins.includes(plugin);
     }
 
-    public remove<T extends CompilerPlugin = CompilerPlugin>(plugin: T) {
+    public remove<T extends Plugin = Plugin>(plugin: T) {
         if (this.has(plugin)) {
             this.plugins.splice(this.plugins.indexOf(plugin));
         }

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -20,7 +20,7 @@ import { isBrsFile } from './astUtils/reflection';
 import type { LiteralExpression } from './parser/Expression';
 import type { AstEditor } from './astUtils/AstEditor';
 import { tempDir, rootDir, stagingDir } from './testHelpers.spec';
-import type { BsDiagnostic, CompilerPlugin } from './interfaces';
+import type { BsDiagnostic, Plugin } from './interfaces';
 import { createLogger } from './logging';
 import { Scope } from './Scope';
 import undent from 'undent';
@@ -273,7 +273,7 @@ describe('Program', () => {
                         cancel.cancel();
                     }
                 }
-            } as CompilerPlugin;
+            } as Plugin;
             //add a plugin that monitors where we are in the process, so we can cancel the validate at the correct time
             program.plugins.add(plugin);
 

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,5 +1,5 @@
 import { isBrsFile, isXmlFile } from '../astUtils/reflection';
-import type { BeforeFileTranspileEvent, CompilerPlugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from '../interfaces';
+import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from '../interfaces';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { CompletionsProcessor } from './completions/CompletionsProcessor';
@@ -15,7 +15,7 @@ import { ScopeValidator } from './validation/ScopeValidator';
 import { XmlFileValidator } from './validation/XmlFileValidator';
 import { WorkspaceSymbolProcessor } from './symbols/WorkspaceSymbolProcessor';
 
-export class BscPlugin implements CompilerPlugin {
+export class BscPlugin implements Plugin {
     public name = 'BscPlugin';
 
     public onGetCodeActions(event: OnGetCodeActionsEvent) {

--- a/src/examples/plugins/removePrint.ts
+++ b/src/examples/plugins/removePrint.ts
@@ -1,6 +1,6 @@
 import { isBrsFile } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
-import type { BeforeFileTranspileEvent, CompilerPlugin } from '../../interfaces';
+import type { BeforeFileTranspileEvent, Plugin } from '../../interfaces';
 
 export default function plugin() {
     return {
@@ -19,5 +19,5 @@ export default function plugin() {
                 }
             }
         }
-    } as CompilerPlugin;
+    } as Plugin;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -186,9 +186,24 @@ export interface CommentFlag {
 
 type ValidateHandler = (scope: Scope, files: BscFile[], callables: CallableContainerMap) => void;
 
-export type CompilerPluginFactory = () => CompilerPlugin;
+export interface PluginFactoryOptions {
+    /**
+     * What version of brighterscript is activating this plugin? (Useful for picking different plugins or behavior based on the version of brighterscript)
+     */
+    version: string;
+}
+export type PluginFactory = (options?: PluginFactoryOptions) => Plugin;
+/**
+ * @deprecated use `PluginFactory` instead
+ */
+export type CompilerPluginFactory = PluginFactory;
 
-export interface CompilerPlugin {
+/**
+ * @deprecated use `Plugin` instead
+ */
+export type CompilerPlugin = Plugin;
+
+export interface Plugin {
     name: string;
     //program events
     beforeProgramCreate?: (builder: ProgramBuilder) => void;

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -3,7 +3,7 @@ import * as EventEmitter from 'eventemitter3';
 import util, { standardizePath as s } from '../util';
 import * as path from 'path';
 import type { ProjectConfig, ActivateResponse, LspDiagnostic, LspProject } from './LspProject';
-import type { CompilerPlugin, Hover, MaybePromise } from '../interfaces';
+import type { Plugin, Hover, MaybePromise } from '../interfaces';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { URI } from 'vscode-uri';
 import { Deferred } from '../deferred';
@@ -102,7 +102,7 @@ export class Project implements LspProject {
                     diagnostics: diagnostics
                 });
             }
-        } as CompilerPlugin);
+        } as Plugin);
 
         //if we found a deprecated brsconfig.json, add a diagnostic warning the user
         if (this.bsconfigPath && path.basename(this.bsconfigPath) === 'brsconfig.json') {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -637,7 +637,7 @@ describe('util', () => {
             expect(stub.callCount).to.equal(0);
         });
 
-        it.only('passes factory options', () => {
+        it('passes factory options', () => {
             fsExtra.writeFileSync(pluginPath, `
                 module.exports.default = function(options) {
                     return {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -636,6 +636,22 @@ describe('util', () => {
             //does not warn about factory pattern
             expect(stub.callCount).to.equal(0);
         });
+
+        it.only('passes factory options', () => {
+            fsExtra.writeFileSync(pluginPath, `
+                module.exports.default = function(options) {
+                    return {
+                        name: 'AwesomePlugin',
+                        initOptions: options
+                    };
+                };
+            `);
+            sinon.stub(console, 'warn').callThrough();
+            const plugins = util.loadPlugins(cwd, [pluginPath]);
+            expect((plugins[0] as any).initOptions).to.eql({
+                version: util.getBrighterScriptVersion()
+            });
+        });
     });
 
     describe('copyBslibToStaging', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,7 @@ import { URI } from 'vscode-uri';
 import * as xml2js from 'xml2js';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
 import { DiagnosticMessages } from './DiagnosticMessages';
-import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, CompilerPluginFactory, CompilerPlugin, ExpressionInfo, TranspileResult, MaybePromise, DisposableLike } from './interfaces';
+import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, Plugin, ExpressionInfo, TranspileResult, MaybePromise, DisposableLike, PluginFactory } from './interfaces';
 import { BooleanType } from './types/BooleanType';
 import { DoubleType } from './types/DoubleType';
 import { DynamicType } from './types/DynamicType';
@@ -40,6 +40,17 @@ import { components, events, interfaces } from './roku-types';
 export class Util {
     public clearConsole() {
         // process.stdout.write('\x1Bc');
+    }
+
+    /**
+     * Get the version of brighterscript
+     */
+    public getBrighterScriptVersion() {
+        try {
+            return fsExtra.readJsonSync(`${__dirname}/../package.json`).version;
+        } catch {
+            return undefined;
+        }
     }
 
     /**
@@ -1220,15 +1231,15 @@ export class Util {
     /**
      * Load and return the list of plugins
      */
-    public loadPlugins(cwd: string, pathOrModules: string[], onError?: (pathOrModule: string, err: Error) => void): CompilerPlugin[] {
+    public loadPlugins(cwd: string, pathOrModules: string[], onError?: (pathOrModule: string, err: Error) => void): Plugin[] {
         const logger = createLogger();
-        return pathOrModules.reduce<CompilerPlugin[]>((acc, pathOrModule) => {
+        return pathOrModules.reduce<Plugin[]>((acc, pathOrModule) => {
             if (typeof pathOrModule === 'string') {
                 try {
                     const loaded = requireRelative(pathOrModule, cwd);
-                    const theExport: CompilerPlugin | CompilerPluginFactory = loaded.default ? loaded.default : loaded;
+                    const theExport: Plugin | PluginFactory = loaded.default ? loaded.default : loaded;
 
-                    let plugin: CompilerPlugin | undefined;
+                    let plugin: Plugin | undefined;
 
                     // legacy plugins returned a plugin object. If we find that, then add a warning
                     if (typeof theExport === 'object') {
@@ -1237,7 +1248,9 @@ export class Util {
 
                         // the official plugin format is a factory function that returns a new instance of a plugin.
                     } else if (typeof theExport === 'function') {
-                        plugin = theExport();
+                        plugin = theExport({
+                            version: this.getBrighterScriptVersion()
+                        });
                     } else {
                         //this should never happen; somehow an invalid plugin has made it into here
                         throw new Error(`TILT: Encountered an invalid plugin: ${String(plugin)}`);


### PR DESCRIPTION
Provide plugin factories with the bsc version. This will allow plugins to determine which features to support, or even load completely separate plugins for v0 and v1. 

Here are the docs on this feature: https://github.com/rokucommunity/brighterscript/blob/plugin-factory-version/docs/plugins.md#brighterscript-v1-compatability

Also fixed a small docs bug in classes.md (it came for free when updating the plugin docs)