### PR TITLE
Import `performance` from `perf_hooks` to work on node <16

### DIFF
--- a/src/common/Sequencer.ts
+++ b/src/common/Sequencer.ts
@@ -2,6 +2,7 @@ import type { CancellationToken } from 'vscode-languageserver-protocol';
 import { util } from '../util';
 import { EventEmitter } from 'eventemitter3';
 import * as parseMilliseconds from 'parse-ms';
+import { performance } from 'perf_hooks';
 
 /**
  * Supports running a series of actions in sequence, either synchronously or asynchronously


### PR DESCRIPTION
Apparently the global `performance` object wasn't introduced until node 16. Let's import it from `perf_hooks` so we have less reasons to block backwards compatibility.