### PR TITLE
Flag incorrect return statements in functions and subs

### DIFF
--- a/src/CodeActionUtil.ts
+++ b/src/CodeActionUtil.ts
@@ -23,6 +23,10 @@ export class CodeActionUtil {
                 edit.changes![uri].push(
                     TextEdit.replace(change.range, change.newText)
                 );
+            } else if (change.type === 'delete') {
+                edit.changes![uri].push(
+                    TextEdit.del(change.range)
+                );
             }
         }
         const action = CodeAction.create(obj.title, edit, obj.kind);
@@ -50,7 +54,7 @@ export interface CodeActionShorthand {
     diagnostics?: Diagnostic[];
     kind?: CodeActionKind;
     isPreferred?: boolean;
-    changes: Array<InsertChange | ReplaceChange>;
+    changes: Array<InsertChange | ReplaceChange | DeleteChange>;
 }
 
 export interface InsertChange {
@@ -66,5 +70,12 @@ export interface ReplaceChange {
     type: 'replace';
     range: Range;
 }
+
+export interface DeleteChange {
+    filePath: string;
+    type: 'delete';
+    range: Range;
+}
+
 
 export const codeActionUtil = new CodeActionUtil();

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -726,7 +726,6 @@ export let DiagnosticMessages = {
         severity: DiagnosticSeverity.Error
     }),
     /**
-     *
      * @param name for function calls where we can't find the name of the function
      * @param fullName if a namespaced name, this is the full name `alpha.beta.charlie`, otherwise it's the same as `name`
      */
@@ -737,6 +736,16 @@ export let DiagnosticMessages = {
             name: name,
             fullName: fullName ?? name
         },
+        severity: DiagnosticSeverity.Error
+    }),
+    voidFunctionMayNotReturnValue: (functionType = 'function') => ({
+        message: `Void ${functionType} may not return a value`,
+        code: 1141,
+        severity: DiagnosticSeverity.Error
+    }),
+    nonVoidFunctionMustReturnValue: (functionType = 'function') => ({
+        message: `Non-void ${functionType} must return a value`,
+        code: 1142,
         severity: DiagnosticSeverity.Error
     })
 };

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -632,9 +632,9 @@ describe('Program', () => {
         it('supports using `m` vars in parameter default values', () => {
             //call a function that doesn't exist
             program.setFile({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
-                sub findNode(nodeId as string, parentNode = m.top as object)
+                function findNode(nodeId as string, parentNode = m.top as object)
                     return parentNode.findNode(nodeId)
-                end sub
+                end function
             `);
 
             program.validate();

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -317,8 +317,7 @@ describe('CodeActionsProcessor', () => {
     });
 
     describe('void function return value', () => {
-
-        it('suggests deleting the return value', () => {
+        it('suggests deleting the return value and converting the sub to a function', () => {
             const file = program.setFile('source/main.brs', `
                 sub test()
                     'should not have a return value here...
@@ -327,7 +326,7 @@ describe('CodeActionsProcessor', () => {
             `);
 
             // return tr|ue
-            testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Remove return value`]);
+            testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Convert sub to function`, `Remove return value`]);
         });
     });
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -315,4 +315,19 @@ describe('CodeActionsProcessor', () => {
         // print alpha|.firstAction()
         testGetCodeActions(file, util.createRange(2, 27, 2, 27), [`import "pkg:/source/first.bs"`]);
     });
+
+    describe('void function return value', () => {
+
+        it('suggests deleting the return value', () => {
+            const file = program.setFile('source/main.brs', `
+                sub test()
+                    'should not have a return value here...
+                    return true
+                end sub
+            `);
+
+            // return tr|ue
+            testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Remove return value`]);
+        });
+    });
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -328,5 +328,17 @@ describe('CodeActionsProcessor', () => {
             // return tr|ue
             testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Convert sub to function`, `Remove return value`]);
         });
+
+        it('suggests deleting the return type from void function', () => {
+            const file = program.setFile('source/main.brs', `
+                function test() as void
+                    'should not have a return value here...
+                    return true
+                end function
+            `);
+
+            // return tr|ue
+            testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Remove return type from function declaration`, `Remove return value`]);
+        });
     });
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -341,4 +341,30 @@ describe('CodeActionsProcessor', () => {
             testGetCodeActions(file, util.createRange(3, 29, 3, 29), [`Remove return type from function declaration`, `Remove return value`]);
         });
     });
+
+    describe('typed function/sub empty return', () => {
+        it('suggests deleting the return value and converting the sub to a function', () => {
+            const file = program.setFile('source/main.brs', `
+                function test()
+                    'need a return value here...
+                    return
+                end function
+            `);
+
+            // ret|urn
+            testGetCodeActions(file, util.createRange(3, 23, 3, 23), [`Add void return type to function declaration`, `Convert function to sub`]);
+        });
+
+        it('suggests deleting the return type from void function', () => {
+            const file = program.setFile('source/main.brs', `
+                sub test() as integer
+                    'need a return value here...
+                    return
+                end sub
+            `);
+
+            // ret|urn
+            testGetCodeActions(file, util.createRange(3, 23, 3, 23), [`Remove return type from sub declaration`]);
+        });
+    });
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -24,6 +24,8 @@ export class CodeActionsProcessor {
                 this.suggestClassImports(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.xmlComponentMissingExtendsAttribute) {
                 this.addMissingExtends(diagnostic as any);
+            } else if (diagnostic.code === DiagnosticCodeMap.voidFunctionMayNotReturnValue) {
+                this.addVoidFunctionReturnSuggestions(diagnostic);
             }
         }
     }
@@ -142,4 +144,25 @@ export class CodeActionsProcessor {
             })
         );
     }
+
+    private addVoidFunctionReturnSuggestions(diagnostic: Diagnostic) {
+        this.event.codeActions.push(
+            codeActionUtil.createCodeAction({
+                title: `Remove return value`,
+                diagnostics: [diagnostic],
+                kind: CodeActionKind.QuickFix,
+                changes: [{
+                    type: 'delete',
+                    filePath: this.event.file.srcPath,
+                    range: util.createRange(
+                        diagnostic.range.start.line,
+                        diagnostic.range.start.character + 'return'.length,
+                        diagnostic.range.end.line,
+                        diagnostic.range.end.character
+                    )
+                }]
+            })
+        );
+    }
+
 }

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -202,7 +202,28 @@ export class CodeActionsProcessor {
                     })
                 );
             }
+
+            //function `as void` return type. Suggest removing the return type
+            if (func.functionType.kind === TokenKind.Function && func.returnTypeToken.kind === TokenKind.Void) {
+                this.event.codeActions.push(
+                    codeActionUtil.createCodeAction({
+                        title: `Remove return type from function declaration`,
+                        diagnostics: [diagnostic],
+                        kind: CodeActionKind.QuickFix,
+                        changes: [{
+                            type: 'delete',
+                            filePath: this.event.file.srcPath,
+                            // )| as void|
+                            range: util.createRange(
+                                func.rightParen.range.start.line,
+                                func.rightParen.range.start.character + 1,
+                                func.returnTypeToken.range.end.line,
+                                func.returnTypeToken.range.end.character
+                            )
+                        }]
+                    })
+                );
+            }
         }
     }
-
 }

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -28,7 +28,9 @@ export class CodeActionsProcessor {
             } else if (diagnostic.code === DiagnosticCodeMap.xmlComponentMissingExtendsAttribute) {
                 this.addMissingExtends(diagnostic as any);
             } else if (diagnostic.code === DiagnosticCodeMap.voidFunctionMayNotReturnValue) {
-                this.addVoidFunctionReturnSuggestions(diagnostic);
+                this.addVoidFunctionReturnActions(diagnostic);
+            } else if (diagnostic.code === DiagnosticCodeMap.nonVoidFunctionMustReturnValue) {
+                this.addNonVoidFunctionReturnActions(diagnostic);
             }
         }
     }
@@ -148,7 +150,7 @@ export class CodeActionsProcessor {
         );
     }
 
-    private addVoidFunctionReturnSuggestions(diagnostic: Diagnostic) {
+    private addVoidFunctionReturnActions(diagnostic: Diagnostic) {
         this.event.codeActions.push(
             codeActionUtil.createCodeAction({
                 title: `Remove return value`,
@@ -204,7 +206,7 @@ export class CodeActionsProcessor {
             }
 
             //function `as void` return type. Suggest removing the return type
-            if (func.functionType.kind === TokenKind.Function && func.returnTypeToken.kind === TokenKind.Void) {
+            if (func.functionType.kind === TokenKind.Function && func.returnTypeToken?.kind === TokenKind.Void) {
                 this.event.codeActions.push(
                     codeActionUtil.createCodeAction({
                         title: `Remove return type from function declaration`,
@@ -220,6 +222,92 @@ export class CodeActionsProcessor {
                                 func.returnTypeToken.range.end.line,
                                 func.returnTypeToken.range.end.character
                             )
+                        }]
+                    })
+                );
+            }
+        }
+    }
+
+    private addNonVoidFunctionReturnActions(diagnostic: Diagnostic) {
+        if (isBrsFile(this.event.file)) {
+            const expression = this.event.file.getClosestExpression(diagnostic.range.start);
+            const func = expression.findAncestor<FunctionExpression>(isFunctionExpression);
+
+            //`sub as <non-void type>`, suggest removing the return type
+            if (func.functionType.kind === TokenKind.Sub && func.returnTypeToken && func.returnTypeToken?.kind !== TokenKind.Void) {
+                this.event.codeActions.push(
+                    codeActionUtil.createCodeAction({
+                        title: `Remove return type from sub declaration`,
+                        diagnostics: [diagnostic],
+                        kind: CodeActionKind.QuickFix,
+                        changes: [{
+                            type: 'delete',
+                            filePath: this.event.file.srcPath,
+                            // )| as void|
+                            range: util.createRange(
+                                func.rightParen.range.start.line,
+                                func.rightParen.range.start.character + 1,
+                                func.returnTypeToken.range.end.line,
+                                func.returnTypeToken.range.end.character
+                            )
+                        }]
+                    })
+                );
+            }
+
+            //function with no return type.
+            if (func.functionType.kind === TokenKind.Function && !func.returnTypeToken) {
+                //find tokens for `as` and `void` in the file if possible
+                let asText: string;
+                let voidText: string;
+                let subText: string;
+                let endSubText: string;
+                for (const token of this.event.file.parser.tokens) {
+                    if (asText && voidText && subText && endSubText) {
+                        break;
+                    }
+                    if (token?.kind === TokenKind.As) {
+                        asText = token?.text;
+                    } else if (token?.kind === TokenKind.Void) {
+                        voidText = token?.text;
+                    } else if (token?.kind === TokenKind.Sub) {
+                        subText = token?.text;
+                    } else if (token?.kind === TokenKind.EndSub) {
+                        endSubText = token?.text;
+                    }
+                }
+
+                //suggest converting to `as void`
+                this.event.codeActions.push(
+                    codeActionUtil.createCodeAction({
+                        title: `Add void return type to function declaration`,
+                        diagnostics: [diagnostic],
+                        kind: CodeActionKind.QuickFix,
+                        changes: [{
+                            type: 'insert',
+                            filePath: this.event.file.srcPath,
+                            position: func.rightParen.range.end,
+                            newText: ` ${asText ?? 'as'} ${voidText ?? 'void'}`
+                        }]
+                    })
+                );
+                //suggest converting to sub
+                this.event.codeActions.push(
+                    codeActionUtil.createCodeAction({
+                        title: `Convert function to sub`,
+                        diagnostics: [diagnostic],
+                        kind: CodeActionKind.QuickFix,
+                        changes: [{
+                            type: 'replace',
+                            filePath: this.event.file.srcPath,
+                            range: func.functionType.range,
+                            newText: subText ?? 'sub'
+                        }, {
+                            type: 'replace',
+                            filePath: this.event.file.srcPath,
+                            range: func.end.range,
+                            newText: endSubText ?? 'end sub'
                         }]
                     })
                 );

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -319,4 +319,175 @@ describe('BrsFileValidator', () => {
             range: util.createRange(4, 20, 4, 30)
         }]);
     });
+
+    describe('function return values', () => {
+
+        it('catches sub with return value', () => {
+            program.setFile('source/main.brs', `
+                sub test()
+                    return true
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('sub'),
+                range: util.createRange(2, 20, 2, 31)
+            }]);
+        });
+
+        it('catches sub as void with return value', () => {
+            program.setFile('source/main.brs', `
+                sub test() as void
+                    return true
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('sub'),
+                range: util.createRange(2, 20, 2, 31)
+            }]);
+        });
+
+        it('catches function as void with return value', () => {
+            program.setFile('source/main.brs', `
+                function test() as void
+                    return true
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('function'),
+                range: util.createRange(2, 20, 2, 31)
+            }]);
+        });
+
+        it('catches sub as <type> without return value', () => {
+            program.setFile('source/main.brs', `
+                sub test() as integer
+                    return
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('sub'),
+                range: util.createRange(2, 20, 2, 26)
+            }]);
+        });
+
+        it('catches function without return value', () => {
+            program.setFile('source/main.brs', `
+                function test()
+                    return
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('function'),
+                range: util.createRange(2, 20, 2, 26)
+            }]);
+        });
+
+        it('catches function as <type> without return value', () => {
+            program.setFile('source/main.brs', `
+                function test() as integer
+                    return
+                end function
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('function'),
+                range: util.createRange(2, 20, 2, 26)
+            }]);
+        });
+
+        it('catches anon sub with return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = sub()
+                        return true
+                    end sub
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('sub'),
+                range: util.createRange(3, 24, 3, 35)
+            }]);
+        });
+
+        it('catches sub as void with return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = sub() as void
+                        return true
+                    end sub
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('sub'),
+                range: util.createRange(3, 24, 3, 35)
+            }]);
+        });
+
+        it('catches function as void with return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = function() as void
+                        return true
+                    end function
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.voidFunctionMayNotReturnValue('function'),
+                range: util.createRange(3, 24, 3, 35)
+            }]);
+        });
+
+        it('catches sub as <type> without return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = sub() as integer
+                        return
+                    end sub
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('sub'),
+                range: util.createRange(3, 24, 3, 30)
+            }]);
+        });
+
+        it('catches function without return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = function()
+                        return
+                    end function
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('function'),
+                range: util.createRange(3, 24, 3, 30)
+            }]);
+        });
+
+        it('catches function as <type> without return value', () => {
+            program.setFile('source/main.brs', `
+                sub main()
+                    test = function() as integer
+                        return
+                    end function
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.nonVoidFunctionMustReturnValue('function'),
+                range: util.createRange(3, 24, 3, 30)
+            }]);
+        });
+    });
 });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2274,9 +2274,9 @@ describe('BrsFile', () => {
                         print (1 + 2)
                     end sub
 
-                    sub test(p1)
+                    function test(p1)
                         return p1
-                    end sub
+                    end function
                 `);
             });
 
@@ -2532,7 +2532,7 @@ describe('BrsFile', () => {
 
         it('handles when only some of the statements have `then`', () => {
             testTranspile(`
-                sub main()
+                function main()
                     if true
                     else if true then
                     else if true
@@ -2541,7 +2541,7 @@ describe('BrsFile', () => {
                             return true
                         end if
                     end if
-                end sub
+                end function
             `);
         });
 


### PR DESCRIPTION
void functions and subs may not have a return value. non-void functions and subs _must_ have a return value. This PR adds the following features:

- [x] diagnostic when return a value from void functions or subs
- [x] diagnostic when missing a return value from non-void functions or subs
- [x] code action for deleting return value
- [x] code action for converting sub to function
- [x] code action for removing `as void` from function
- [x] code action for removing `as <type>` from sub 
