### PR TITLE
Fix ScopeValidator crash

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -678,7 +678,7 @@ export class ScopeValidator {
 
         if (accessibilityIsOk && !expectedLHSType?.isTypeCompatible(actualRHSType, compatibilityData)) {
             this.addMultiScopeDiagnostic({
-                ...DiagnosticMessages.assignmentTypeMismatch(actualRHSType.toString(), expectedLHSType.toString(), compatibilityData),
+                ...DiagnosticMessages.assignmentTypeMismatch(actualRHSType?.toString() ?? 'unknown', expectedLHSType?.toString() ?? 'unknown', compatibilityData),
                 location: dottedSetStmt.location
             });
         }


### PR DESCRIPTION
Created [this ticket](https://github.com/rokucommunity/brighterscript/issues/1464) to number the issue.

Encountered a crash here when migrating to 1.0 due to some syntax that was okay in 0.69 but very not-okay in 1.0.
After I applied this hotfix locally, the errors displayed correctly in the Problems panel / build output, and I was able to fix the problematic syntax (and go back to using the published 1.0 release without this hotfix). 

Fix provided by @markwpearce