### PR TITLE
Fix erraneous diagnostic for component name on first validation

### DIFF
--- a/src/CrossScopeValidator.spec.ts
+++ b/src/CrossScopeValidator.spec.ts
@@ -23,6 +23,24 @@ describe('CrossScopeValidator', () => {
         program.dispose();
     });
 
+    it('handles prop access from component interface when inside a typecast', () => {
+        program.options.autoImportComponentScript = true;
+        program.setFile('components/CustomButton.xml', trim`
+            <component name="CustomButton" extends="Group">
+                <interface>
+                    <field id="buttonProp" type="string" />
+                </interface>
+            </component>
+        `);
+        program.setFile('components/CustomButton.bs', `
+            sub test()
+                thing = (m.button as roSGNodeCustomButton).buttonProp
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
     describe('providedNodes', () => {
         it('builds a tree', () => {
             program.setFile<BrsFile>('source/file1.bs', `

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -277,7 +277,7 @@ export class CrossScopeValidator {
         if (this.providedTreeMap.has(scope.name)) {
             return this.providedTreeMap.get(scope.name);
         }
-        const providedTree = new ProvidedNode('');
+        const providedTree = new ProvidedNode('', this.componentsMap);
         const duplicatesMap = new Map<string, Set<FileSymbolPair>>();
 
         const referenceTypesMap = new Map<{ symbolName: string; file: BscFile; symbolObj: ProvidedSymbol }, Array<{ name: string; namespacedName?: string }>>();
@@ -499,7 +499,7 @@ export class CrossScopeValidator {
             const typeName = 'rosgnode' + componentName;
             const component = this.program.getComponent(componentName);
             const componentSymbol = this.program.globalScope.symbolTable.getSymbol(typeName, SymbolTypeFlag.typetime)?.[0];
-            if (componentSymbol && component && componentSymbol.type?.isBuiltIn) {
+            if (componentSymbol && component) {
                 this.componentsMap.set(typeName, { file: component.file, symbol: componentSymbol });
             }
         }

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -461,9 +461,10 @@ export class CrossScopeValidator {
     }
 
     clearResolutionsForScopes(scopes: Scope[]) {
+        const lowerScopeNames = scopes.map(scope => scope.name.toLowerCase());
         for (const [symbol, resolutionInfos] of this.resolutionsMap.entries()) {
             for (const info of resolutionInfos.values()) {
-                if (scopes.includes(info.scope)) {
+                if (lowerScopeNames.includes(info.scope.name.toLowerCase())) {
                     resolutionInfos.delete(info);
                 }
             }

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -461,10 +461,10 @@ export class CrossScopeValidator {
     }
 
     clearResolutionsForScopes(scopes: Scope[]) {
-        const lowerScopeNames = scopes.map(scope => scope.name.toLowerCase());
+        const lowerScopeNames = new Set(scopes.map(scope => scope.name.toLowerCase()));
         for (const [symbol, resolutionInfos] of this.resolutionsMap.entries()) {
             for (const info of resolutionInfos.values()) {
-                if (lowerScopeNames.includes(info.scope.name.toLowerCase())) {
+                if (lowerScopeNames.has(info.scope.name.toLowerCase())) {
                     resolutionInfos.delete(info);
                 }
             }


### PR DESCRIPTION
Fixes a bug with component interface names not being recognized inside of typecasts, when accessing a property on that object, but only on first startup. 