### PR TITLE
Add missing content node fields

### DIFF
--- a/scripts/scrape-roku-docs.ts
+++ b/scripts/scrape-roku-docs.ts
@@ -664,12 +664,12 @@ class Runner {
     }
 
     /**
-     * ContentNode fields are a special case becuase the fields are listed in a different markdown file:
+     * ContentNode fields are a special case because the fields are listed in a different markdown file:
      * https://developer.roku.com/docs/developer-program/getting-started/architecture/content-metadata.md
      */
     private async buildContentNodeFields() {
         const manager = await new TokenManager().process(this.getContentNodeDocApiUrl());
-        let keepGoing = true;
+
         const fields: SceneGraphNodeField[] = [
             ...this.getContentNodeFields(manager, ['attributes', 'type', 'values', 'example'], 2),
             ...this.getContentNodeFields(manager, ['attribute', 'type', 'values', 'example'], 2),
@@ -677,6 +677,60 @@ class Runner {
 
         ];
         this.result.nodes['contentnode'].fields = fields;
+
+        //add any missing fields
+        function addIfMissing(newFields: SceneGraphNodeField[]) {
+            for (const field of newFields) {
+                const existingField = fields.find(x => x.name === field.name);
+                if (!existingField) {
+                    fields.push(field);
+                }
+            }
+        }
+
+        addIfMissing([{
+            name: 'action',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'For upgrades/downgrades only. Set this to "Upgrade" or "Downgrade" to change the subscription plan from a previous purchase (for example, myOrder.action = "Upgrade"). The required values are case-sensitive; do not pass "upgrade" or "downgrade". See On-device upgrade and downgrade for more information.'
+        }, {
+            name: 'priceDisplay',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'The original price of the product. Do not include a currency symbol (for example, set this to "3.99" instead of "$3.99").'
+        }, {
+            name: 'price',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'The original price of the product. Do not include a currency symbol (for example, set this to "3.99" instead of "$3.99").'
+        }, {
+            name: 'couponCode',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'An alphanumeric string entered by the customer to receive a discounted price on the product.'
+        }, {
+            name: 'contentKey',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'The publisher-specific SKU (or other unique identifier) for the product.'
+        }, {
+            name: 'orderId',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: '',
+            description: 'The orderID returned by Roku in the RequestPartnerOrderStatus content node.'
+        }, {
+            name: 'drmParams',
+            type: 'string',
+            accessPermission: 'READ_WRITE',
+            default: 'invalid',
+            description: 'The original price of the product. Do not include a currency symbol (for example, set this to "3.99" instead of "$3.99").'
+        }]);
     }
 
     private getContentNodeFields(manager: TokenManager, searchHeaders: string[], descriptionIndex: number, propertyMap?: { name?: string; type?: string }) {

--- a/src/roku-types/data.json
+++ b/src/roku-types/data.json
@@ -1,5 +1,5 @@
 {
-    "generatedDate": "2025-04-23T15:16:20.732Z",
+    "generatedDate": "2025-04-24T15:48:08.626Z",
     "nodes": {
         "animation": {
             "description": "Extends [**AnimationBase**](https://developer.roku.com/docs/references/scenegraph/abstract-nodes/animationbase.md\n\nThe Animation node class provides animations of renderable nodes, by applying interpolator functions to the values in specified renderable node fields. For an animation to take effect, an Animation node definition must include a child field interpolator node ([FloatFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/floatfieldinterpolator.md\"FloatFieldInterpolator\"), [Vector2DFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/vector2dfieldinterpolator.md\"Vector2DFieldInterpolator\"), [ColorFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/colorfieldinterpolator.md\"ColorFieldInterpolator\")) definition for each renderable node field that is animated.\n\nThe Animation node class provides a simple linear interpolator function, where the animation takes place smoothly and simply from beginning to end. The Animation node class also provides several more complex interpolator functions to allow custom animation effects. For example, you can move a graphic image around the screen at differing speeds and curved trajectories at different times in the animation by specifying the appropriate function in the easeFunction field (quadratic and exponential are two examples of functions that can be specified). The interpolator functions are divided into two parts: the beginning of the animation (ease-in), and the end of the animation (ease-out). You can apply a specified interpolator function to either or both ease-in and ease-out, or specify no function for either or both (which is the linear function). You can also change the portion of the animation that is ease-in and ease-out to arbitrary fractional values for a quadratic interpolator function applied to both ease-in and ease-out.",
@@ -1189,6 +1189,13 @@
             "fields": [
                 {
                     "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "For upgrades/downgrades only. Set this to \"Upgrade\" or \"Downgrade\" to change the subscription plan from a previous purchase (for example, myOrder.action = \"Upgrade\"). The required values are case-sensitive; do not pass \"upgrade\" or \"downgrade\". See On-device upgrade and downgrade for more information.",
+                    "name": "action",
+                    "type": "string"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
                     "default": "not specified",
                     "description": "List of Actor Names or Individual Actor Name",
                     "name": "Actors",
@@ -1315,10 +1322,24 @@
                 },
                 {
                     "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "The publisher-specific SKU (or other unique identifier) for the product.",
+                    "name": "contentKey",
+                    "type": "string"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
                     "default": "not specified",
                     "description": "Although ContentType accepts type String, the return value is of type \\[roInt\\](https://developer.roku.com/docs/references/brightscript/components/roint.md. See table below.\n\n| Content Type | Return Value |\n| --- | --- |\n| audio | 5 |\n| episode | 4 |\n| movie | 1 |\n| not set or not supported | 0 |\n| season | 3 |\n| series | 2 |",
                     "name": "ContentType",
                     "type": "String"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "An alphanumeric string entered by the customer to receive a discounted price on the product.",
+                    "name": "couponCode",
+                    "type": "string"
                 },
                 {
                     "accessPermission": "READ_WRITE",
@@ -1333,6 +1354,13 @@
                     "description": "List of Director Names",
                     "name": "Directors",
                     "type": "roArray"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
+                    "default": "invalid",
+                    "description": "The original price of the product. Do not include a currency symbol (for example, set this to \"3.99\" instead of \"$3.99\").",
+                    "name": "drmParams",
+                    "type": "string"
                 },
                 {
                     "accessPermission": "READ_WRITE",
@@ -1553,6 +1581,13 @@
                 },
                 {
                     "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "The orderID returned by Roku in the RequestPartnerOrderStatus content node.",
+                    "name": "orderId",
+                    "type": "string"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
                     "default": "not specified",
                     "description": "PlayStart defines the start position of the content, in seconds. Starting from Roku OS 8.0, content metadata supports negative PlayStart values. This feature allows the media players to start playbacks distanced from the edge of the live stream",
                     "name": "PlayStart",
@@ -1564,6 +1599,20 @@
                     "description": "Specifies the audio codec that should be used during playback. The Media Player will select and report to the app only those audio renditions that are encoded with the specified codec. Renditions that are encoded with a different codec are ignored. Possible values of this attribute are \"aac\", \"ac3\" and \"eac3\".",
                     "name": "PreferredAudioCodec",
                     "type": "String"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "The original price of the product. Do not include a currency symbol (for example, set this to \"3.99\" instead of \"$3.99\").",
+                    "name": "price",
+                    "type": "string"
+                },
+                {
+                    "accessPermission": "READ_WRITE",
+                    "default": "",
+                    "description": "The original price of the product. Do not include a currency symbol (for example, set this to \"3.99\" instead of \"$3.99\").",
+                    "name": "priceDisplay",
+                    "type": "string"
                 },
                 {
                     "accessPermission": "READ_WRITE",


### PR DESCRIPTION
Adds several missing contentNode fields.
- action
- priceDisplay
- price
- couponCode
- contentKey
- orderId
- drmParams
- 
Fixes #1471 