### PR TITLE
Better Support for Union of Functions and CallFuncs

### DIFF
--- a/src/CrossScopeValidator.spec.ts
+++ b/src/CrossScopeValidator.spec.ts
@@ -369,7 +369,7 @@ describe('CrossScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('otherFunc', `source, components${path.sep}Widget.xml`).message
+                DiagnosticMessages.incompatibleSymbolDefinition('otherFunc', { scopes: ['source', `components${path.sep}Widget.xml`] }).message
             ]);
         });
 
@@ -408,7 +408,7 @@ describe('CrossScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('alpha.beta.otherFunc', `source, components${path.sep}Widget.xml`).message
+                DiagnosticMessages.incompatibleSymbolDefinition('alpha.beta.otherFunc', { scopes: ['source', `components${path.sep}Widget.xml`] }).message
             ]);
         });
 
@@ -449,7 +449,7 @@ describe('CrossScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('otherFunc', `source, components${path.sep}Widget.xml`).message
+                DiagnosticMessages.incompatibleSymbolDefinition('otherFunc', { scopes: ['source', `components${path.sep}Widget.xml`] }).message
             ]);
         });
 
@@ -495,7 +495,7 @@ describe('CrossScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('iface2', `source, components${path.sep}Widget.xml`).message
+                DiagnosticMessages.incompatibleSymbolDefinition('iface2', { scopes: ['source', `components${path.sep}Widget.xml`] }).message
             ]);
         });
     });

--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -629,9 +629,9 @@ export class CrossScopeValidator {
             const incompatibleScopes = resolution.incompatibleScopes;
             if (incompatibleScopes.size > 1) {
                 const typeChainResult = util.processTypeChain(symbol.typeChain);
-                const scopeListName = [...incompatibleScopes.values()].map(s => s.name).join(', ');
+                const scopeList = [...incompatibleScopes.values()].map(s => s.name);
                 this.program.diagnostics.register({
-                    ...DiagnosticMessages.incompatibleSymbolDefinition(typeChainResult.fullChainName, scopeListName),
+                    ...DiagnosticMessages.incompatibleSymbolDefinition(typeChainResult.fullChainName, { scopes: scopeList }),
                     location: typeChainResult.location
                 }, {
                     tags: [CrossScopeValidatorDiagnosticTag]

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -2717,6 +2717,64 @@ describe('Scope', () => {
                 expect(mainFnScope).to.exist;
             });
 
+            it('should use the union of types in union of interfaces', () => {
+                const mainFile = program.setFile<BrsFile>('source/main.bs', `
+                    sub unionOfFuncs(thing as IfaceA or IfaceB)
+                        data = thing.data
+                        print data
+                    end sub
+
+                    interface IfaceA
+                        data as string
+                    end interface
+
+                    interface IfaceB
+                        data as integer
+                    end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const mainFnScope = mainFile.getFunctionScopeAtPosition(util.createPosition(2, 24));
+                const sourceScope = program.getScopeByName('source');
+                expect(sourceScope).to.exist;
+                sourceScope.linkSymbolTable();
+                expect(mainFnScope).to.exist;
+                const mainSymbolTable = mainFnScope.symbolTable;
+                const dataType = mainSymbolTable.getSymbolType('data', { flags: SymbolTypeFlag.runtime }) as UnionType;
+                expectTypeToBe(dataType, UnionType);
+                expect(dataType.types).includes(StringType.instance);
+                expect(dataType.types).includes(IntegerType.instance);
+            });
+
+            it('should use the union of return types of a union of functions', () => {
+                const mainFile = program.setFile<BrsFile>('source/main.bs', `
+                    sub unionOfFuncs(thing as IfaceA or IfaceB)
+                        result = thing.getData()
+                        print result
+                    end sub
+
+                    interface IfaceA
+                        function getData() as string
+                    end interface
+
+                    interface IfaceB
+                        function getData() as integer
+                    end interface
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+                const mainFnScope = mainFile.getFunctionScopeAtPosition(util.createPosition(2, 24));
+                const sourceScope = program.getScopeByName('source');
+                expect(sourceScope).to.exist;
+                sourceScope.linkSymbolTable();
+                expect(mainFnScope).to.exist;
+                const mainSymbolTable = mainFnScope.symbolTable;
+                const resultType = mainSymbolTable.getSymbolType('result', { flags: SymbolTypeFlag.runtime }) as UnionType;
+                expectTypeToBe(resultType, UnionType);
+                expect(resultType.types.map(t => t.toString())).includes(StringType.instance.toString());
+                expect(resultType.types.map(t => t.toString())).includes(IntegerType.instance.toString());
+            });
+
         });
 
         describe('type casts', () => {

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -928,17 +928,6 @@ describe('Scope', () => {
             it('warns when local var has same name as built-in function', () => {
                 program.setFile(`source/main.brs`, `
                     sub main()
-                        str = 12345
-                        print str ' prints "12345" (i.e. our local variable is allowed to shadow the built-in function name)
-                    end sub
-                `);
-                program.validate();
-                expectZeroDiagnostics(program);
-            });
-
-            it('warns when local var has same name as built-in function', () => {
-                program.setFile(`source/main.brs`, `
-                    sub main()
                         str = 6789
                         print str(12345) ' prints "12345" (i.e. our local variable did not override the callable global function)
                     end sub

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -454,7 +454,7 @@ export function isInheritableType(target): target is InheritableType {
 }
 
 export function isCallableType(target): target is BaseFunctionType {
-    return isCallableType(target) || isTypedFunctionType(target) || isDynamicType(target);
+    return isFunctionTypeLike(target) || isTypedFunctionType(target) || (isDynamicType(target) && !isAnyReferenceType(target));
 }
 
 export function isAnyReferenceType(target): target is AnyReferenceType {

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -454,7 +454,7 @@ export function isInheritableType(target): target is InheritableType {
 }
 
 export function isCallableType(target): target is BaseFunctionType {
-    return isFunctionType(target) || isTypedFunctionType(target);
+    return isCallableType(target) || isTypedFunctionType(target) || isDynamicType(target);
 }
 
 export function isAnyReferenceType(target): target is AnyReferenceType {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4501,7 +4501,7 @@ describe('ScopeValidator', () => {
         });
     });
 
-    describe('callFunc', () => {
+    describe.only('callFunc', () => {
         it('allows access to member of return type when return type is custom node', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -5088,6 +5088,241 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectZeroDiagnostics(program);
+        });
+
+        it('allows callfunc operator on dynamic type', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc(anything)
+                    anything@.someFunc()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows callfunc operator on roSGNode type', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNode)
+                    node@.someFunc()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+
+        it('disallows callfunc operator on non-callfuncable type', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc(i as integer, s as string, b as boolean)
+                    i@.someFunc()
+                    s@.someFunc()
+                    b@.someFunc()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'integer').message,
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'string').message,
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'boolean').message
+            ]);
+        });
+
+
+        it('disallows callfunc operator on non-callfuncable type', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc(i as integer, s as string, b as boolean)
+                    i@.someFunc()
+                    s@.someFunc()
+                    b@.someFunc()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'integer').message,
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'string').message,
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'boolean').message
+            ]);
+        });
+
+        it('allows callfunc operator on union of dynamic types', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc()
+                    u = invalid
+                    if rnd() > 0.5
+                        u = getComponent1()
+                    else
+                        u = getComponent2()
+                    end if
+
+                    u@.someFunc()
+                end sub
+            `);
+
+            program.setFile('source/test2.bs', `
+                function getComponent1() as dynamic
+                    return 2 ' unknown to be integer outside of function
+                end function
+            `);
+
+            program.setFile('source/test3.bs', `
+                function getComponent2() as dynamic
+                    return 3 ' unknown to be integer outside of function
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('disallows callfunc operator on union of non-callfuncable types', () => {
+            program.setFile('source/test.bs', `
+                sub doCallfunc()
+                    if rnd() > 0.5
+                        u = 1
+                    else
+                        u = "hello"
+                    end if
+
+                    u@.someFunc()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('someFunc', null, 'integer or string').message
+            ]);
+        });
+
+        it('allows callfunc on union of known components, with valid func', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="getName" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                function getName() as string
+                    return "John Doe"
+                end function
+            `);
+
+            program.setFile('components/Widget2.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget2" extends="Group">
+                    <script uri="Widget2.bs"/>
+                    <interface>
+                        <function name="getName" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget2.bs', `
+                function getName() as string
+                    return "John Doe"
+                end function
+            `);
+
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNodeWidget or roSGNodeWidget2)
+                    node@.getName()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('disallows callfunc on union of known components, with invalid func', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="getName" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                function getName() as string
+                    return "John Doe"
+                end function
+            `);
+
+            program.setFile('components/Widget2.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget2" extends="Group">
+                    <script uri="Widget2.bs"/>
+                    <interface>
+                        <function name="getNumber" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget2.bs', `
+                function getNumber() as float
+                    return 3.14
+                end function
+            `);
+
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNodeWidget or roSGNodeWidget2)
+                    node@.getName()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.cannotFindCallFuncFunction('getName', '', 'roSGNodeWidget or roSGNodeWidget2').message
+            ]);
+        });
+
+        it.only('uses the returns types of a callfunc on a union type', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="getData" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                function getData() as string
+                    return "John Doe"
+                end function
+            `);
+
+            program.setFile('components/Widget2.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget2" extends="Group">
+                    <script uri="Widget2.bs"/>
+                    <interface>
+                        <function name="getData" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget2.bs', `
+                function getData() as float
+                    return 3.14
+                end function
+            `);
+
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNodeWidget or roSGNodeWidget2)
+                    takesFloat(node@.getData())
+                end sub
+
+                sub takesFloat(x as float)
+                    print x
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.incompatibleSymbolDefinition('getData', 'roSGNodeWidget or roSGNodeWidget2').message
+            ]);
         });
     });
 });

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -7,7 +7,7 @@ import type { TypeCompatibilityData } from '../../interfaces';
 import { IntegerType } from '../../types/IntegerType';
 import { StringType } from '../../types/StringType';
 import type { BrsFile } from '../../files/BrsFile';
-import { FloatType, InterfaceType } from '../../types';
+import { FloatType, InterfaceType, TypedFunctionType, VoidType } from '../../types';
 import { SymbolTypeFlag } from '../../SymbolTypeFlag';
 import { AssociativeArrayType } from '../../types/AssociativeArrayType';
 import undent from 'undent';
@@ -4501,7 +4501,63 @@ describe('ScopeValidator', () => {
         });
     });
 
-    describe.only('callFunc', () => {
+    describe('notCallable', () => {
+
+        it('finds when trying to call on a non-function', () => {
+            program.setFile('source/test.bs', `
+                sub someFunc(widget as roSGNodePoster)
+                    print widget.width()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.notCallable('widget.width').message
+            ]);
+        });
+
+        it('allows trying to call a dynamic', () => {
+            program.setFile('source/test.bs', `
+                sub someFunc(widget)
+                    print widget()
+                    print widget.whatever()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('allows trying to call a function param', () => {
+            program.setFile('source/test.bs', `
+                sub someFunc(widget as function)
+                    print widget()
+                    print widget().whatever()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('finds other non-callables', () => {
+            program.setFile('source/test.bs', `
+                sub someFunc(input as float)
+                    print input()
+                    a = "hello"
+                    print a()
+                    print 12345()
+                    print "string"()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.notCallable('input').message,
+                DiagnosticMessages.notCallable('a').message,
+                DiagnosticMessages.notCallable('12345').message,
+                DiagnosticMessages.notCallable('"string"').message
+            ]);
+        });
+    });
+
+    describe('callFunc', () => {
         it('allows access to member of return type when return type is custom node', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -5148,7 +5204,7 @@ describe('ScopeValidator', () => {
             program.setFile('source/test.bs', `
                 sub doCallfunc()
                     u = invalid
-                    if rnd() > 0.5
+                    if rnd(0) > 0.5
                         u = getComponent1()
                     else
                         u = getComponent2()
@@ -5176,7 +5232,7 @@ describe('ScopeValidator', () => {
         it('disallows callfunc operator on union of non-callfuncable types', () => {
             program.setFile('source/test.bs', `
                 sub doCallfunc()
-                    if rnd() > 0.5
+                    if rnd(0) > 0.5
                         u = 1
                     else
                         u = "hello"
@@ -5277,7 +5333,7 @@ describe('ScopeValidator', () => {
             ]);
         });
 
-        it.only('uses the returns types of a callfunc on a union type', () => {
+        it('uses return type of union of functions', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="Widget" extends="Group">
@@ -5321,7 +5377,58 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('getData', 'roSGNodeWidget or roSGNodeWidget2').message
+                DiagnosticMessages.argumentTypeMismatch('string or float', 'float').message
+            ]);
+        });
+
+        it('disallows callfunc on union with incompatible func types', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="doStuff" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                sub doStuff(input as string)
+                    print "hello " + input
+                end sub
+            `);
+
+            program.setFile('components/Widget2.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget2" extends="Group">
+                    <script uri="Widget2.bs"/>
+                    <interface>
+                        <function name="doStuff" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget2.bs', `
+                sub doStuff(input as float)
+                    print input + 3.14
+                end sub
+            `);
+
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNodeWidget or roSGNodeWidget2, input)
+                    node@.doStuff(input)
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.incompatibleSymbolDefinition('node.doStuff', {
+                    isUnion: true,
+                    data: {
+                        expectedType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', FloatType.instance, false),
+                        actualType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', FloatType.instance, false),
+                        parameterMismatches: [{ index: 0, data: { expectedType: StringType.instance, actualType: FloatType.instance } }]
+                    }
+                }).message
             ]);
         });
     });

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4502,7 +4502,6 @@ describe('ScopeValidator', () => {
     });
 
     describe('notCallable', () => {
-
         it('finds when trying to call on a non-function', () => {
             program.setFile('source/test.bs', `
                 sub someFunc(widget as roSGNodePoster)
@@ -5421,12 +5420,74 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.incompatibleSymbolDefinition('node.doStuff', {
+                DiagnosticMessages.incompatibleSymbolDefinition('node@.doStuff', {
                     isUnion: true,
                     data: {
                         expectedType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', FloatType.instance, false),
                         actualType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', FloatType.instance, false),
                         parameterMismatches: [{ index: 0, data: { expectedType: StringType.instance, actualType: FloatType.instance } }]
+                    }
+                }).message
+            ]);
+        });
+
+        it('disallows callfunc on union with incompatible func types, that have the same signature', () => {
+            program.setFile('components/Widget.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget" extends="Group">
+                    <script uri="Widget.bs"/>
+                    <interface>
+                        <function name="doStuff" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget.bs', `
+                interface MyStuff
+                    data as boolean
+                end interface
+
+                sub doStuff(input as MyStuff)
+                    print "hello " + input.data.toStr()
+                end sub
+            `);
+
+            program.setFile('components/Widget2.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Widget2" extends="Group">
+                    <script uri="Widget2.bs"/>
+                    <interface>
+                        <function name="doStuff" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/Widget2.bs', `
+                interface MyStuff
+                    data as integer
+                end interface
+
+                sub doStuff(input as MyStuff)
+                    print input.data + 3.14
+                end sub
+            `);
+
+            program.setFile('source/test.bs', `
+                sub doCallfunc(node as roSGNodeWidget or roSGNodeWidget2, input)
+                    node@.doStuff(input)
+                end sub
+            `);
+            program.validate();
+            const stuff1IFace = new InterfaceType('MyStuff');
+            const stuff2IFace = new InterfaceType('MyStuff');
+
+            expectDiagnostics(program, [
+                DiagnosticMessages.incompatibleSymbolDefinition('node@.doStuff', {
+                    isUnion: true,
+                    data: {
+                        expectedType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', stuff1IFace, false),
+                        actualType: new TypedFunctionType(VoidType.instance).setName('doStuff').setSub(true).addParameter('input', stuff2IFace, false),
+                        parameterMismatches: [{ index: 0, data: { expectedType: stuff1IFace, actualType: stuff2IFace } }]
                     }
                 }).message
             ]);

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,5 +1,5 @@
 import { DiagnosticTag, type Range } from 'vscode-languageserver';
-import { isAliasStatement, isAssignmentStatement, isAssociativeArrayType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isComponentType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isReturnStatement, isStringTypeLike, isTypedFunctionType, isUnionType, isVariableExpression, isVoidType, isXmlScope } from '../../astUtils/reflection';
+import { isAliasStatement, isAssignmentStatement, isAssociativeArrayType, isBinaryExpression, isBooleanType, isBrsFile, isCallExpression, isCallableType, isClassStatement, isClassType, isComponentType, isDottedGetExpression, isDynamicType, isEnumMemberType, isEnumType, isFunctionExpression, isFunctionParameterExpression, isFunctionTypeLike, isLiteralExpression, isNamespaceStatement, isNamespaceType, isNewExpression, isNumberType, isObjectType, isPrimitiveType, isReferenceType, isReturnStatement, isStringTypeLike, isTypedFunctionType, isUnionType, isVariableExpression, isVoidType, isXmlScope } from '../../astUtils/reflection';
 import type { DiagnosticInfo } from '../../DiagnosticMessages';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -523,14 +523,6 @@ export class ScopeValidator {
             return;
         }
 
-        if (!isComponentType(callerType)) {
-            this.addMultiScopeDiagnostic({
-                ...DiagnosticMessages.cannotFindCallFuncFunction(methodName, functionFullname, callerType.toString()),
-                location: callErrorLocation
-            });
-            return;
-        }
-
         const funcType = util.getCallFuncType(expression, methodToken, { flags: SymbolTypeFlag.runtime, ignoreCall: true });
         if (!funcType?.isResolvable()) {
             this.addMultiScopeDiagnostic({
@@ -545,7 +537,14 @@ export class ScopeValidator {
      * Detect calls to functions with the incorrect number of parameters, or wrong types of arguments
      */
     private validateFunctionCall(file: BrsFile, funcType: BscType, callErrorLocation: Location, args: Expression[], argOffset = 0) {
-        if (!funcType?.isResolvable() || !isTypedFunctionType(funcType)) {
+        if (!funcType?.isResolvable() || !isCallableType(funcType)) {
+            if (isUnionType(funcType)) {
+
+            }
+            return;
+        }
+
+        if (!isTypedFunctionType(funcType)) {
             return;
         }
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -36,8 +36,6 @@ import { VoidType } from '../../types/VoidType';
 import { LogLevel } from '../../Logger';
 import { Stopwatch } from '../../Stopwatch';
 import chalk from 'chalk';
-import { UnionType } from '../../types/UnionType';
-import { getUniqueType } from '../../types/helpers';
 
 /**
  * The lower-case names of all platform-included scenegraph nodes

--- a/src/globalCallables.ts
+++ b/src/globalCallables.ts
@@ -252,27 +252,13 @@ let runtimeFunctions: GlobalCallable[] = [{
     }]
 }, {
     name: 'Run',
-    shortDescription: `The Run function can be used to compile and run a script dynamically.\nThe file specified by that path is compiled and run.\nArguments may be passed to the script's Main function, and that script may return a result value.'`,
-    type: new TypedFunctionType(DynamicType.instance),
-    file: globalFile,
-    params: [{
-        name: 'filename',
-        type: StringType.instance,
-        isOptional: false
-    }, {
-        name: 'arg',
-        type: DynamicType.instance,
-        isRestArgument: true,
-        isOptional: false
-    }]
-}, {
-    name: 'Run',
     shortDescription: `The Run function can be used to compile and run a script dynamically.\nAll files specified are compiled together, then run.\nArguments may be passed to the script's Main function, and that script may return a result value.'`,
     type: new TypedFunctionType(DynamicType.instance),
     file: globalFile,
+    isDeprecated: true,
     params: [{
         name: 'filename',
-        type: new ArrayType(StringType.instance),
+        type: new UnionType([new ArrayType(StringType.instance), StringType.instance]),
         isOptional: false
     }, {
         name: 'arg',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1105,6 +1105,12 @@ export interface TypeChainProcessResult {
 export interface TypeCompatibilityData {
     missingFields?: { name: string; expectedType: BscType }[];
     fieldMismatches?: { name: string; expectedType: BscType; actualType: BscType }[];
+    parameterMismatches?: { index: number; expectedOptional?: boolean; actualOptional?: boolean; data: TypeCompatibilityData }[];
+    returnTypeMismatch?: TypeCompatibilityData;
+    expectedParamCount?: number;
+    actualParamCount?: number;
+    expectedVariadic?: boolean;
+    actualVariadic?: boolean;
     depth?: number;
     // override for diagnostic message - useful for Arrays with different default types
     actualType?: BscType;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -215,6 +215,9 @@ export class CallExpression extends Expression {
             }
             return calleeType.returnType;
         }
+        if (util.isUnionOfFunctions(calleeType, true)) {
+            return util.getReturnTypeOfUnionOfFunctions(calleeType);
+        }
         if (!isReferenceType(calleeType) && (calleeType as BaseFunctionType)?.returnType?.isResolvable()) {
             return (calleeType as BaseFunctionType).returnType;
         }

--- a/src/types/BscType.ts
+++ b/src/types/BscType.ts
@@ -48,6 +48,22 @@ export abstract class BscType {
         return this.memberTable;
     }
 
+    addCallFuncMember(name: string, data: ExtraSymbolData, type: BscType, flags: SymbolTypeFlag) {
+        throw new Error('Method not implemented.');
+    }
+
+    getCallFuncMemberType(name: string, options: GetSymbolTypeOptions) {
+        throw new Error('Method not implemented.');
+    }
+
+    getCallFuncMemberTable() {
+        throw new Error('Method not implemented.');
+    }
+
+    getCallFuncType(name: string, options: GetSymbolTypeOptions) {
+        return undefined;
+    }
+
     isResolvable(): boolean {
         return true;
     }

--- a/src/types/DynamicType.ts
+++ b/src/types/DynamicType.ts
@@ -1,8 +1,9 @@
-import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
+import type { TypeCompatibilityData } from '../interfaces';
 import { isDynamicType, isUninitializedType, isVoidType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
+import type { GetSymbolTypeOptions } from '../SymbolTable';
 
 export class DynamicType extends BscType {
 
@@ -44,7 +45,11 @@ export class DynamicType extends BscType {
         return isDynamicType(targetType);
     }
 
-    getMemberType(memberName: string, options: GetTypeOptions) {
+    getMemberType(memberName: string, options: GetSymbolTypeOptions) {
+        return DynamicType.instance;
+    }
+
+    getCallFuncType(name: string, options: GetSymbolTypeOptions) {
         return DynamicType.instance;
     }
 

--- a/src/types/TypedFunctionType.ts
+++ b/src/types/TypedFunctionType.ts
@@ -37,6 +37,11 @@ export class TypedFunctionType extends BaseFunctionType {
         return this;
     }
 
+    public setSub(isSub: boolean) {
+        this.isSub = isSub;
+        return this;
+    }
+
     public addParameter(name: string, type: BscType, isOptional: boolean) {
         this.params.push({
             name: name,
@@ -98,28 +103,57 @@ export class TypedFunctionType extends BaseFunctionType {
         for (let i = 0; i < len; i++) {
             let myParam = this.params[i];
             let targetParam = targetType.params[i];
+            const paramTypeData: TypeCompatibilityData = {};
             if (allowOptionalParamDifferences && !myParam && targetParam.isOptional) {
                 // target func has MORE (optional) params... that's ok
                 break;
             }
 
-            if (!myParam || !targetParam || !predicate(targetParam.type, myParam.type, data)) {
+            if (!myParam || !targetParam || !predicate(myParam.type, targetParam.type, paramTypeData)) {
+                data = data ?? {};
+                data.parameterMismatches = data.parameterMismatches ?? [];
+                paramTypeData.expectedType = paramTypeData.expectedType ?? myParam?.type;
+                paramTypeData.actualType = paramTypeData.actualType ?? targetParam?.type;
+                if (!targetParam || !myParam) {
+                    data.expectedParamCount = this.params.filter(p => !p.isOptional).length;
+                    data.actualParamCount = targetType.params.filter(p => !p.isOptional).length;
+                }
+                data.parameterMismatches.push({ index: i, data: paramTypeData });
+                data.expectedType = this;
+                data.actualType = targetType;
                 return false;
             }
-            if (!allowOptionalParamDifferences && myParam.isOptional !== targetParam.isOptional) {
-                return false;
-            } else if (!myParam.isOptional && targetParam.isOptional) {
+            if ((!allowOptionalParamDifferences && myParam.isOptional !== targetParam.isOptional) ||
+                (!myParam.isOptional && targetParam.isOptional)) {
+                data = data ?? {};
+                data.parameterMismatches = data.parameterMismatches ?? [];
+                data.parameterMismatches.push({ index: i, expectedOptional: myParam.isOptional, actualOptional: targetParam.isOptional, data: paramTypeData });
+                data.expectedType = this;
+                data.actualType = targetType;
                 return false;
             }
         }
         //compare return type
+        const returnTypeData: TypeCompatibilityData = {};
         if (!this.returnType || !targetType.returnType || !predicate(this.returnType, targetType.returnType, data)) {
+            data = data ?? {};
+            returnTypeData.expectedType = returnTypeData.expectedType ?? this.returnType;
+            returnTypeData.actualType = returnTypeData.actualType ?? targetType.returnType;
+            data.returnTypeMismatch = returnTypeData;
+            data.expectedType = this;
+            data.actualType = targetType;
             return false;
         }
+        //compare Variadic
         if (this.isVariadic !== targetType.isVariadic) {
+            data = data ?? {};
+            data.expectedVariadic = this.isVariadic;
+            data.actualVariadic = targetType.isVariadic;
+            data.expectedType = this;
+            data.actualType = targetType;
             return false;
         }
-        //made it here, all params and return type  pass predicate
+        //made it here, all params and return type pass predicate
         return true;
     }
 }

--- a/src/types/TypedFunctionType.ts
+++ b/src/types/TypedFunctionType.ts
@@ -86,12 +86,13 @@ export class TypedFunctionType extends BaseFunctionType {
 
     isEqual(targetType: BscType, data: TypeCompatibilityData = {}) {
         if (isTypedFunctionType(targetType)) {
-            if (this.toString().toLowerCase() === targetType.toString().toLowerCase()) {
+            const checkNames = data?.allowNameEquality ?? true;
+            if (checkNames && this.toString().toLowerCase() === targetType.toString().toLowerCase()) {
                 // this function has the same param names and types and return type as the target
                 return true;
             }
             return this.checkParamsAndReturnValue(targetType, false, (t1, t2, predData = {}) => {
-                return t1.isEqual(t2, { ...predData, allowNameEquality: true });
+                return t1.isEqual(t2, { ...predData, allowNameEquality: checkNames });
             }, data);
         }
         return false;

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -2,7 +2,7 @@ import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
 import { isDynamicType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
-import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, getUniqueType, isEnumTypeCompatible } from './helpers';
+import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, findTypeUnionDeepCheck, getUniqueType, isEnumTypeCompatible } from './helpers';
 import { BscTypeKind } from './BscTypeKind';
 import type { TypeCacheEntry } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
@@ -86,7 +86,7 @@ export class UnionType extends BscType {
                         if (!innerTypesMemberTypes || innerTypesMemberTypes.includes(undefined)) {
                             return undefined;
                         }
-                        return getUniqueType(findTypeUnion(referenceTypeInnerMemberTypes), unionTypeFactory);
+                        return getUniqueType(findTypeUnionDeepCheck(referenceTypeInnerMemberTypes), unionTypeFactory);
                     },
                     setCachedType: (innerName: string, innerCacheEntry: TypeCacheEntry, innerOptions: GetTypeOptions) => {
                         // TODO: is this even cachable? This is a NO-OP for now, and it shouldn't hurt anything
@@ -97,7 +97,7 @@ export class UnionType extends BscType {
                 };
             });
         }
-        const resultCallFuncType = getUniqueType(findTypeUnion(innerTypesMemberTypes), unionTypeFactory);
+        const resultCallFuncType = getUniqueType(findTypeUnionDeepCheck(innerTypesMemberTypes), unionTypeFactory, false);
 
 
         if (isTypedFunctionType(resultCallFuncType)) {

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,8 +1,8 @@
 import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
-import { isDynamicType, isObjectType, isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
-import { findTypeUnion, getUniqueType, isEnumTypeCompatible } from './helpers';
+import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, getUniqueType, isEnumTypeCompatible } from './helpers';
 import { BscTypeKind } from './BscTypeKind';
 import type { TypeCacheEntry } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
@@ -18,9 +18,12 @@ export class UnionType extends BscType {
         public types: BscType[]
     ) {
         super(joinTypesString(types));
+        this.callFuncAssociatedTypesTable = new SymbolTable(`Union: CallFuncAssociatedTypes`);
     }
 
     public readonly kind = BscTypeKind.UnionType;
+
+    public readonly callFuncAssociatedTypesTable: SymbolTable;
 
     public addType(type: BscType) {
         this.types.push(type);
@@ -37,6 +40,10 @@ export class UnionType extends BscType {
 
     private getMemberTypeFromInnerTypes(name: string, options: GetTypeOptions) {
         return this.types.map((innerType) => innerType?.getMemberType(name, options));
+    }
+
+    private getCallFuncFromInnerTypes(name: string, options: GetTypeOptions) {
+        return this.types.map((innerType) => innerType?.getCallFuncType(name, options));
     }
 
     getMemberType(name: string, options: GetTypeOptions) {
@@ -65,6 +72,44 @@ export class UnionType extends BscType {
         }
         return getUniqueType(findTypeUnion(innerTypesMemberTypes), unionTypeFactory);
     }
+
+    getCallFuncType(name: string, options: GetTypeOptions) {
+        const innerTypesMemberTypes = this.getCallFuncFromInnerTypes(name, options);
+        if (!innerTypesMemberTypes || innerTypesMemberTypes.includes(undefined)) {
+            // We don't have any members of any inner types that match
+            // so instead, create reference type that will
+            return new ReferenceType(name, name, options.flags, () => {
+                return {
+                    name: `UnionType CallFunc MemberTable: '${this.__identifier}'`,
+                    getSymbolType: (innerName: string, innerOptions: GetTypeOptions) => {
+                        const referenceTypeInnerMemberTypes = this.getCallFuncFromInnerTypes(name, options);
+                        if (!innerTypesMemberTypes || innerTypesMemberTypes.includes(undefined)) {
+                            return undefined;
+                        }
+                        return getUniqueType(findTypeUnion(referenceTypeInnerMemberTypes), unionTypeFactory);
+                    },
+                    setCachedType: (innerName: string, innerCacheEntry: TypeCacheEntry, innerOptions: GetTypeOptions) => {
+                        // TODO: is this even cachable? This is a NO-OP for now, and it shouldn't hurt anything
+                    },
+                    addSibling: (symbolTable: SymbolTable) => {
+                        // TODO: I don't know what this means in this context?
+                    }
+                };
+            });
+        }
+        const resultCallFuncType = getUniqueType(findTypeUnion(innerTypesMemberTypes), unionTypeFactory);
+
+
+        if (isTypedFunctionType(resultCallFuncType)) {
+            const typesToCheck = [...resultCallFuncType.params.map(p => p.type), resultCallFuncType.returnType];
+
+            for (const type of typesToCheck) {
+                addAssociatedTypesTableAsSiblingToMemberTable(type, this.callFuncAssociatedTypesTable, SymbolTypeFlag.runtime);
+            }
+        }
+        return resultCallFuncType;
+    }
+
 
     isTypeCompatible(targetType: BscType, data?: TypeCompatibilityData): boolean {
         if (isDynamicType(targetType) || isObjectType(targetType) || this === targetType) {

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -8,6 +8,7 @@ import type { TypeCacheEntry } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { BuiltInInterfaceAdder } from './BuiltInInterfaceAdder';
+import { util } from '../util';
 
 export function unionTypeFactory(types: BscType[]) {
     return new UnionType(types);
@@ -108,6 +109,10 @@ export class UnionType extends BscType {
             }
         }
         return resultCallFuncType;
+    }
+
+    get returnType() {
+        return util.getReturnTypeOfUnionOfFunctions(this);
     }
 
 

--- a/src/types/helper.spec.ts
+++ b/src/types/helper.spec.ts
@@ -7,12 +7,14 @@ import { FloatType } from './FloatType';
 import { IntegerType } from './IntegerType';
 import { StringType } from './StringType';
 import { UnionType, unionTypeFactory } from './UnionType';
-import { findTypeIntersection, findTypeUnion, getUniqueType, getUniqueTypesFromArray } from './helpers';
+import { findTypeIntersection, findTypeUnion, getUniqueType, getUniqueTypesFromArray, reduceTypesToMostGeneric } from './helpers';
 import { InterfaceType } from './InterfaceType';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
 import { DoubleType } from './DoubleType';
 import { BooleanType } from './BooleanType';
 import { EnumType, EnumMemberType } from './EnumType';
+import { ReferenceType, TypePropertyReferenceType } from './ReferenceType';
+import { SymbolTable } from '../SymbolTable';
 
 
 describe('findTypeIntersection', () => {
@@ -86,6 +88,16 @@ describe('getUniqueTypesFromArray', () => {
         expect(intersection.length).to.eq(2);
         expect(intersection).to.include(klass);
         expect(intersection).to.include(subklass);
+    });
+
+    it('should not reduce TypePropertyReferenceTypes', () => {
+        const table = new SymbolTable('test');
+        const refType1 = new ReferenceType('func1', 'func1', SymbolTypeFlag.runtime, () => table);
+        const retRefType1 = new TypePropertyReferenceType(refType1, 'returnType');
+        const refType2 = new ReferenceType('func2', 'func2', SymbolTypeFlag.runtime, () => table);
+        const retRefType2 = new TypePropertyReferenceType(refType2, 'returnType');
+        const uniqueTypes = getUniqueTypesFromArray([retRefType1, retRefType2]);
+        expect(uniqueTypes.length).to.eq(2);
     });
 });
 
@@ -171,4 +183,17 @@ describe('isEnumTypeCompatible', () => {
     });
 
 
+});
+
+describe('reduceTypesToMostGeneric', () => {
+
+    it('should not reduce TypePropertyReferenceTypes', () => {
+        const table = new SymbolTable('test');
+        const refType1 = new ReferenceType('func1', 'func1', SymbolTypeFlag.runtime, () => table);
+        const retRefType1 = new TypePropertyReferenceType(refType1, 'returnType');
+        const refType2 = new ReferenceType('func2', 'func2', SymbolTypeFlag.runtime, () => table);
+        const retRefType2 = new TypePropertyReferenceType(refType2, 'returnType');
+        const genericTypes = reduceTypesToMostGeneric([retRefType1, retRefType2]);
+        expect(genericTypes.length).to.eq(2);
+    });
 });

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,5 @@
 import type { TypeCompatibilityData } from '../interfaces';
-import { isAnyReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isInterfaceType, isReferenceType, isUnionType, isVoidType } from '../astUtils/reflection';
+import { isAnyReferenceType, isArrayDefaultTypeReferenceType, isDynamicType, isEnumMemberType, isEnumType, isInheritableType, isInterfaceType, isReferenceType, isTypePropertyReferenceType, isUnionType, isVoidType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import type { UnionType } from './UnionType';
 import type { SymbolTable } from '../SymbolTable';
@@ -39,6 +39,9 @@ export function getUniqueTypesFromArray(types: BscType[], allowNameEquality = tr
     return types?.filter((currentType, currentIndex) => {
         if (!currentType) {
             return false;
+        }
+        if ((isTypePropertyReferenceType(currentType) || isArrayDefaultTypeReferenceType(currentType)) && !currentType.isResolvable()) {
+            return true;
         }
         const latestIndex = types.findIndex((checkType) => {
             return currentType.isEqual(checkType, { allowNameEquality: allowNameEquality });
@@ -105,7 +108,7 @@ export function reduceTypesToMostGeneric(types: BscType[], allowNameEquality = t
             }
             const checkType = uniqueTypes[j].type;
 
-            if (currentType.isEqual(uniqueTypes[j].type, { allowNameEquality: allowNameEquality })) {
+            if (currentType.isResolvable() && currentType.isEqual(uniqueTypes[j].type, { allowNameEquality: allowNameEquality })) {
                 uniqueTypes[j].shouldIgnore = true;
             } else if (isInheritableType(currentType) && isInheritableType(checkType)) {
                 if (currentType.isTypeDescendent(checkType)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2760,28 +2760,28 @@ export class Util {
         } else if (isCallExpression(callExpr) && isDottedGetExpression(callExpr.callee)) {
             calleeType = callExpr.callee.obj.getType({ ...options, flags: SymbolTypeFlag.runtime, ignoreCall: false });
         }
-        if (isComponentType(calleeType) || isReferenceType(calleeType)) {
-            const funcType = (calleeType as ComponentType).getCallFuncType?.(methodName, options);
-            if (funcType) {
-                options.typeChain?.push(new TypeChainEntry({
-                    name: methodName,
-                    type: funcType,
-                    data: options.data,
-                    location: methodNameToken.location,
-                    separatorToken: createToken(TokenKind.Callfunc),
-                    astNode: callExpr
-                }));
-                if (options.ignoreCall) {
-                    result = funcType;
-                } else if (isCallableType(funcType) && (!isReferenceType(funcType.returnType) || funcType.returnType.isResolvable())) {
-                    result = funcType.returnType;
-                } else if (!isReferenceType(funcType) && (funcType as any)?.returnType?.isResolvable()) {
-                    result = (funcType as any).returnType;
-                } else {
-                    result = new TypePropertyReferenceType(funcType, 'returnType');
-                }
+        //if (isComponentType(calleeType) || isReferenceType(calleeType)) {
+        const funcType = (calleeType as ComponentType).getCallFuncType?.(methodName, options);
+        if (funcType) {
+            options.typeChain?.push(new TypeChainEntry({
+                name: methodName,
+                type: funcType,
+                data: options.data,
+                location: methodNameToken.location,
+                separatorToken: createToken(TokenKind.Callfunc),
+                astNode: callExpr
+            }));
+            if (options.ignoreCall) {
+                result = funcType;
+            } else if (isCallableType(funcType) && (!isReferenceType(funcType.returnType) || funcType.returnType.isResolvable())) {
+                result = funcType.returnType;
+            } else if (!isReferenceType(funcType) && (funcType as any)?.returnType?.isResolvable()) {
+                result = (funcType as any).returnType;
+            } else {
+                result = new TypePropertyReferenceType(funcType, 'returnType');
             }
         }
+        // }
         if (isVoidType(result)) {
             // CallFunc will always return invalid, even if function called is `as void`
             result = DynamicType.instance;


### PR DESCRIPTION
- Updates all BscTypes so they can potentially support CallFuncs. Will allow future work that will enable Interfaces to have Callfuncs (eg... `interface IMyComponent extends roSGNodeMyComponent` could bring in the callfuncs available in `roSGNodeMyComponent`)
- Particularly, support for checking a UnionType for callfuncs
- Extra work has been done to modify Diagnostic messaging so that if you try to use a function in a union, where the functions are incompatible, so it gives better messaging.

Examples:

<img width="938" alt="image" src="https://github.com/user-attachments/assets/5093ad49-ab74-4b6b-8764-19d2f03a037e" />


<img width="901" alt="image" src="https://github.com/user-attachments/assets/b0b1eb2e-1c69-42a4-8115-8ff75a7b1f55" />


Todo:

 - [x] Make sure assignments of a union of functions use the correct return type