### PR TITLE
Add `bsc0` cli binary name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       },
       "bin": {
         "bsc": "dist/cli.js",
-        "bscv0": "dist/cli.js"
+        "bsc0": "dist/cli.js"
       },
       "devDependencies": {
         "@guyplusplus/turndown-plugin-gfm": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "yargs": "^16.2.0"
       },
       "bin": {
-        "bsc": "dist/cli.js"
+        "bsc": "dist/cli.js",
+        "bscv0": "dist/cli.js"
       },
       "devDependencies": {
         "@guyplusplus/turndown-plugin-gfm": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bin": {
-    "bsc": "dist/cli.js"
+    "bsc": "dist/cli.js",
+    "bscv0": "dist/cli.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "typings": "dist/index.d.ts",
   "bin": {
     "bsc": "dist/cli.js",
-    "bscv0": "dist/cli.js"
+    "bsc0": "dist/cli.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a `bsc0` binary for allowing bsc v0 and v1 to exist simultaneously in node_modules, since the behavior is undefined right now which version of brighterscript would execute when running `bsc` on its own in that situation. 