### PR TITLE
Better diagnostic null location handling

### DIFF
--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -184,7 +184,7 @@ export class DiagnosticManager {
 
             }
             diagnostic.relatedInformation = relatedInformation;
-            if (!diagnostic.location) {
+            if (!diagnostic.location?.uri) {
                 diagnostic.location = this.locationResolver?.(cachedDiagnostic);
                 if (diagnostic.location) {
                     //if we found a location, tweak the message a bit to let devs know this was not the original location

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -1573,6 +1573,33 @@ describe('Program', () => {
                 DiagnosticMessages.cannotFindFunction('C')
             ]);
         });
+
+        it('attaches locationless diagnostic to the nearest xml file', () => {
+            const xmlFile = program.setFile('components/MainScene.xml', trim`
+                <component name="MainScene" extends="Scene">
+                </component>
+            `);
+            program.diagnostics.register({
+                message: 'test'
+            } as any, {
+                scope: program.getFirstScopeForFile(xmlFile)
+            });
+            expectDiagnostics(program, [{
+                message: 'test (location unknown, added here for visibility)',
+                location: util.createLocation(0, 0, 0, 100, xmlFile.srcPath)
+            }]);
+        });
+
+        it('attaches locationless diagnostic to the nearest manifest file', () => {
+            const manifestFile = program.setFile('manifest', trim``);
+            program.diagnostics.register({
+                message: 'test'
+            } as any);
+            expectDiagnostics(program, [{
+                message: 'test (location unknown, added here for visibility)',
+                location: util.createLocation(0, 0, 0, 100, manifestFile.srcPath)
+            }]);
+        });
     });
 
     describe('getCompletions', () => {

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -36,6 +36,8 @@ import type { BscFile } from '../files/BscFile';
 import type { ComponentType } from '../types/ComponentType';
 import type { AssociativeArrayType } from '../types/AssociativeArrayType';
 import { TokenKind } from '../lexer/TokenKind';
+import type { Program } from '../Program';
+import type { Project } from '../lsp/Project';
 
 // File reflection
 export function isBrsFile(file: BscFile | undefined): file is BrsFile {
@@ -57,6 +59,15 @@ export function isBscFile(file: (BscFile | BscFile | XmlFile | AssetFile | undef
 
 export function isXmlScope(scope: (Scope | undefined)): scope is XmlScope {
     return scope?.constructor.name === 'XmlScope';
+}
+
+
+export function isProgram(arg: any): arg is Program {
+    return arg?.constructor.name === 'Program';
+}
+
+export function isProject(arg: any): arg is Project {
+    return arg?.constructor.name === 'Project';
 }
 
 

--- a/src/lsp/Project.spec.ts
+++ b/src/lsp/Project.spec.ts
@@ -256,4 +256,22 @@ describe('Project', () => {
             await project['getConfigFilePath'](undefined);
         });
     });
+
+    describe('getDiagnostics', () => {
+        it('does not crash when diagnostic is missing location', async () => {
+            await project.activate({
+                projectPath: rootDir
+            } as any);
+            await project.validate();
+
+            //register a diagnostic with no location
+            project['builder'].diagnostics.register({
+                message: 'test diagnostic',
+                location: undefined
+            });
+
+            //this should not throw
+            project.getDiagnostics();
+        });
+    });
 });

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -190,14 +190,21 @@ export class Project implements LspProject {
     }
 
     public getDiagnostics(): LspDiagnostic[] {
-        const diagnostics = this.builder.getDiagnostics();
-        return diagnostics.map(x => {
-            const srcPath = util.uriToPath(x.location.uri);
-            return {
-                ...util.toDiagnostic(x, srcPath),
-                uri: x.location.uri
-            };
-        });
+        const result: LspDiagnostic[] = [];
+        for (const diagnostic of this.builder.getDiagnostics()) {
+            //skip diagnostics that have no location
+            if (!diagnostic?.location?.uri) {
+                this.logger.debug('Skipping diagnostic that has no location', diagnostic);
+                continue;
+            }
+
+            const srcPath = util.uriToPath(diagnostic.location.uri);
+            result.push({
+                ...util.toDiagnostic(diagnostic, srcPath),
+                uri: diagnostic.location.uri
+            });
+        }
+        return result;
     }
 
     /**

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -234,7 +234,7 @@ describe('ProjectManager', () => {
             }]);
             expectDiagnostics(await onNextDiagnostics(), [
                 DiagnosticMessages.cannotFindName('nameNotDefined').message,
-                'Test diagnostic'
+                'Test diagnostic (location unknown, added here for visibility)'
             ]);
         });
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -7,7 +7,7 @@ import { expect } from './chai-config.spec';
 import type { CodeActionShorthand } from './CodeActionUtil';
 import { codeActionUtil } from './CodeActionUtil';
 import type { BrsFile } from './files/BrsFile';
-import { Program } from './Program';
+import type { Program } from './Program';
 import { standardizePath as s } from './util';
 import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';


### PR DESCRIPTION
Fixes #1487 by excluding diagnostics that don't have location. Also improves the situation by trying to attach diagnostics to other related locations if we couldn't find a valid location. 