### PR TITLE
bsc1 cli binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       },
       "bin": {
         "bsc": "dist/cli.js",
-        "bsc0": "dist/cli.js"
+        "bsc1": "dist/cli.js"
       },
       "devDependencies": {
         "@guyplusplus/turndown-plugin-gfm": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bin": {
-    "bsc": "dist/cli.js"
+    "bsc": "dist/cli.js",
+    "bsc1": "dist/cli.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a `bsc1` binary for coexistence with bsc v0 node modules.