### PR TITLE
Union Return type consistency

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4256,7 +4256,7 @@ describe('BrsFile', () => {
 
     describe('union types', () => {
 
-        it('use most reducible type for union of primitives', async () => {
+        it('use dynamic for union of unlike primitives', async () => {
             await testTranspile(`
                 function test1() as string or integer
                     return "hello"
@@ -4278,11 +4278,11 @@ describe('BrsFile', () => {
                     return "hello"
                 end function
 
-                function test2() as double
+                function test2() as dynamic
                     return 1.23
                 end function
 
-                function test3() as longinteger
+                function test3() as dynamic
                     return 5
                 end function
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4254,6 +4254,73 @@ describe('BrsFile', () => {
         });
     });
 
+    describe('union types', () => {
+
+        it('use most reducible type for union of primitives', async () => {
+            await testTranspile(`
+                function test1() as string or integer
+                    return "hello"
+                end function
+
+                function test2() as double or float
+                    return 1.23
+                end function
+
+                function test3() as integer or longinteger
+                    return 5
+                end function
+
+                function test4() as integer or integer or integer
+                    return 5
+                end function
+            `, `
+                function test1() as dynamic
+                    return "hello"
+                end function
+
+                function test2() as double
+                    return 1.23
+                end function
+
+                function test3() as longinteger
+                    return 5
+                end function
+
+                function test4() as integer
+                    return 5
+                end function
+            `);
+        });
+
+        it('use object for union of object', async () => {
+            await testTranspile(`
+                function test1() as object
+                    return 1
+                end function
+
+                function test2() as object or object
+                    return 1
+                end function
+
+                function test3() as object or object or object
+                    return 1
+                end function
+                `, `
+                function test1() as object
+                    return 1
+                end function
+
+                function test2() as object
+                    return 1
+                end function
+
+                function test3() as object
+                    return 1
+                end function
+            `);
+        });
+    });
+
     describe('callfunc operator', () => {
         describe('transpile', () => {
             it('does not produce diagnostics on plain roSGNode', () => {

--- a/src/types/UnionType.spec.ts
+++ b/src/types/UnionType.spec.ts
@@ -11,7 +11,6 @@ import { isReferenceType, isTypePropertyReferenceType, isUnionType } from '../as
 import { TypedFunctionType } from './TypedFunctionType';
 import { SymbolTable } from '../SymbolTable';
 import { ReferenceType } from './ReferenceType';
-import { integer } from 'vscode-languageserver-types';
 import { DoubleType } from './DoubleType';
 import { LongIntegerType } from './LongIntegerType';
 import { ObjectType } from './ObjectType';

--- a/src/types/UnionType.spec.ts
+++ b/src/types/UnionType.spec.ts
@@ -195,15 +195,26 @@ describe('UnionType', () => {
     });
 
     describe('toTypeString', () => {
-        it('should reduce primitive types to the most generic if reducible', () => {
-            let ut = new UnionType([FloatType.instance, IntegerType.instance]);
+        it('should give single type when unions of same type', () => {
+            let ut = new UnionType([FloatType.instance, FloatType.instance]);
             expect(ut.toTypeString()).to.eq('float');
-            ut = new UnionType([FloatType.instance, IntegerType.instance, DoubleType.instance]);
-            expect(ut.toTypeString()).to.eq('double');
-            ut = new UnionType([LongIntegerType.instance, IntegerType.instance]);
+            ut = new UnionType([IntegerType.instance, IntegerType.instance, IntegerType.instance]);
+            expect(ut.toTypeString()).to.eq('integer');
+            ut = new UnionType([LongIntegerType.instance, LongIntegerType.instance]);
             expect(ut.toTypeString()).to.eq('longinteger');
-            ut = new UnionType([DoubleType.instance, LongIntegerType.instance]);
+            ut = new UnionType([DoubleType.instance, DoubleType.instance]);
             expect(ut.toTypeString()).to.eq('double');
+        });
+
+        it('should give dynamic if types are not the same', () => {
+            let ut = new UnionType([FloatType.instance, IntegerType.instance]);
+            expect(ut.toTypeString()).to.eq('dynamic');
+            ut = new UnionType([FloatType.instance, IntegerType.instance, DoubleType.instance]);
+            expect(ut.toTypeString()).to.eq('dynamic');
+            ut = new UnionType([LongIntegerType.instance, IntegerType.instance]);
+            expect(ut.toTypeString()).to.eq('dynamic');
+            ut = new UnionType([DoubleType.instance, LongIntegerType.instance]);
+            expect(ut.toTypeString()).to.eq('dynamic');
         });
 
         it('should reduce object types to object', () => {

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,5 +1,5 @@
 import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
-import { isDynamicType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isNumberType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, findTypeUnionDeepCheck, getUniqueType, isEnumTypeCompatible } from './helpers';
@@ -144,7 +144,25 @@ export class UnionType extends BscType {
     toString(): string {
         return joinTypesString(this.types);
     }
+
+    /**
+     * Used for transpilation
+     */
     toTypeString(): string {
+        if (this.types.length === 0) {
+            return 'dynamic';
+        }
+        if (this.types.length === 1) {
+            return this.types[0].toTypeString();
+        }
+        const allNumbers = this.types.filter(t => isNumberType(t));
+        if (allNumbers.length === this.types.length) {
+            return util.getHighestPriorityType(this.types).toTypeString();
+        }
+        const allObjectType = this.types.filter(t => isObjectType(t));
+        if (allObjectType.length === this.types.length) {
+            return 'object';
+        }
         return 'dynamic';
     }
 

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -2,7 +2,7 @@ import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
 import { isDynamicType, isNumberType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
-import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, findTypeUnionDeepCheck, getUniqueType, isEnumTypeCompatible } from './helpers';
+import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, findTypeUnionDeepCheck, getAllTypesFromUnionType, getUniqueType, isEnumTypeCompatible } from './helpers';
 import { BscTypeKind } from './BscTypeKind';
 import type { TypeCacheEntry } from '../SymbolTable';
 import { SymbolTable } from '../SymbolTable';
@@ -149,18 +149,21 @@ export class UnionType extends BscType {
      * Used for transpilation
      */
     toTypeString(): string {
-        if (this.types.length === 0) {
+        const flattenedTypes = getAllTypesFromUnionType(this);
+
+        if (flattenedTypes.length === 0) {
             return 'dynamic';
         }
-        if (this.types.length === 1) {
-            return this.types[0].toTypeString();
+        if (flattenedTypes.length === 1) {
+            return flattenedTypes[0].toTypeString();
         }
-        const allNumbers = this.types.filter(t => isNumberType(t));
-        if (allNumbers.length === this.types.length) {
-            return util.getHighestPriorityType(this.types).toTypeString();
+
+        const allNumbers = flattenedTypes.filter(t => isNumberType(t));
+        if (allNumbers.length === flattenedTypes.length) {
+            return util.getHighestPriorityType(flattenedTypes).toTypeString();
         }
-        const allObjectType = this.types.filter(t => isObjectType(t));
-        if (allObjectType.length === this.types.length) {
+        const allObjectType = flattenedTypes.filter(t => isObjectType(t));
+        if (allObjectType.length === flattenedTypes.length) {
             return 'object';
         }
         return 'dynamic';

--- a/src/types/UnionType.ts
+++ b/src/types/UnionType.ts
@@ -1,5 +1,5 @@
 import type { GetTypeOptions, TypeCompatibilityData } from '../interfaces';
-import { isDynamicType, isNumberType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
+import { isDynamicType, isObjectType, isTypedFunctionType, isUnionType } from '../astUtils/reflection';
 import { BscType } from './BscType';
 import { ReferenceType } from './ReferenceType';
 import { addAssociatedTypesTableAsSiblingToMemberTable, findTypeUnion, findTypeUnionDeepCheck, getAllTypesFromUnionType, getUniqueType, isEnumTypeCompatible } from './helpers';
@@ -149,22 +149,10 @@ export class UnionType extends BscType {
      * Used for transpilation
      */
     toTypeString(): string {
-        const flattenedTypes = getAllTypesFromUnionType(this);
+        const uniqueTypeStrings = new Set<string>(getAllTypesFromUnionType(this).map(t => t.toTypeString()));
 
-        if (flattenedTypes.length === 0) {
-            return 'dynamic';
-        }
-        if (flattenedTypes.length === 1) {
-            return flattenedTypes[0].toTypeString();
-        }
-
-        const allNumbers = flattenedTypes.filter(t => isNumberType(t));
-        if (allNumbers.length === flattenedTypes.length) {
-            return util.getHighestPriorityType(flattenedTypes).toTypeString();
-        }
-        const allObjectType = flattenedTypes.filter(t => isObjectType(t));
-        if (allObjectType.length === flattenedTypes.length) {
-            return 'object';
+        if (uniqueTypeStrings.size === 1) {
+            return uniqueTypeStrings.values().next().value;
         }
         return 'dynamic';
     }


### PR DESCRIPTION
Fixes #1488

If a union can be reduced to a primitive type, use that type for transpilation.
