### PR TITLE
Improve `bsconfig.json` auto-discovery

### DIFF
--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -152,7 +152,7 @@ describe('ProjectManager', () => {
             fsExtra.outputFileSync(`${rootDir}/subdir/bsconfig.json`, '');
             await manager.syncProjects([{
                 workspaceFolder: rootDir,
-                excludePatterns: ['subdir/**/*']
+                excludePatterns: ['**/subdir/**/*']
             }]);
             expect(
                 manager.projects.map(x => x.projectPath)

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -646,8 +646,8 @@ export class ProjectManager {
      * If none are found, then the workspaceFolder itself is treated as a project
      */
     private async getProjectPaths(workspaceConfig: WorkspaceConfig) {
-        //get the list of exclude patterns, and negate them (so they actually work like excludes)
-        const excludePatterns = (workspaceConfig.excludePatterns ?? []).map(x => s`!${x}`);
+        //get the list of exclude patterns, negate them so they actually work like excludes), and coerce to forward slashes since that's what fast-glob expects
+        const excludePatterns = (workspaceConfig.excludePatterns ?? []).map(x => s`!${x}`.replace(/[\\/]+/g, '/'));
 
         let files = await fastGlob(['**/bsconfig.json', ...excludePatterns], {
             cwd: workspaceConfig.workspaceFolder,

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -648,18 +648,20 @@ export class ProjectManager {
     private async getProjectPaths(workspaceConfig: WorkspaceConfig) {
         //get the list of exclude patterns, and negate them (so they actually work like excludes)
         const excludePatterns = (workspaceConfig.excludePatterns ?? []).map(x => s`!${x}`);
-        let files = await rokuDeploy.getFilePaths([
-            '**/bsconfig.json',
-            //exclude all files found in `files.exclude`
-            ...excludePatterns
-        ], workspaceConfig.workspaceFolder);
+
+        let files = await fastGlob(['**/bsconfig.json', ...excludePatterns], {
+            cwd: workspaceConfig.workspaceFolder,
+            followSymbolicLinks: false,
+            absolute: true,
+            onlyFiles: true
+        });
 
         //filter the files to only include those that are allowed by the path filterer
-        files = this.pathFilterer.filter(files, x => x.src);
+        files = this.pathFilterer.filter(files);
 
         //if we found at least one bsconfig.json, then ALL projects must have a bsconfig.json.
         if (files.length > 0) {
-            return files.map(file => s`${path.dirname(file.src)}`);
+            return files.map(file => s`${path.dirname(file)}`);
         }
 
         //look for roku project folders


### PR DESCRIPTION
## Problems

There are issues with `bsconfig.json` auto-discovery:

- Language server may crash with large monorepos making use of symlinks; implementation uses `rokuDeploy.getFilePaths` which is quite inefficient for our need,
- `bsconfig.json` are looked into Search-excluded locations.

## Changes

- replaces `rokuDeploy.getFilePaths` with a direct `fastGlob` call with `followSymbolicLinks` disabled,
- add Search `exclude` to the filters

## Behaviour change

Some users may rely on symlinks or search-hidden locations; this can be worked around by adding manually folders in the Workspace.