### PR TITLE
Improve manifests discovery

### DIFF
--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -667,13 +667,14 @@ export class ProjectManager {
         //look for roku project folders
         let rokuLikeDirs = (await Promise.all(
             //find all folders containing a `manifest` file
-            (await rokuDeploy.getFilePaths([
-                '**/manifest',
-                ...excludePatterns
-
-                //is there at least one .bs|.brs file under the `/source` folder?
-            ], workspaceConfig.workspaceFolder)).map(async manifestEntry => {
-                const manifestDir = path.dirname(manifestEntry.src);
+            (await fastGlob(['**/manifest', ...excludePatterns], {
+                cwd: workspaceConfig.workspaceFolder,
+                followSymbolicLinks: false,
+                absolute: true,
+                onlyFiles: true
+            })).map(async manifestEntry => {
+                const manifestDir = path.dirname(manifestEntry);
+                //TODO validate that manifest is a Roku manifest
                 const files = await rokuDeploy.getFilePaths([
                     'source/**/*.{brs,bs}',
                     ...excludePatterns


### PR DESCRIPTION
Similarly to #1512 the language server is using `roku-deploy` to discover `manifest` files. This also causes issues.

This PR uses `fast-glob` directly.

Note: the discovery mechanism doesn't do any validation that the `manifest` files found are in fact Roku manifests. It is unsafe when the extension is used with non-Roku projects.