### PR TITLE
Add `enableDiscovery` language server option

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -17,13 +17,13 @@ import { createVisitor, WalkMode } from './astUtils/visitors';
 import { tempDir, rootDir } from './testHelpers.spec';
 import { URI } from 'vscode-uri';
 import { BusyStatusTracker } from './BusyStatusTracker';
-import type { BscFile, WorkspaceConfigWithExtras } from '.';
+import type { BscFile } from '.';
 import type { Project } from './lsp/Project';
 import { LogLevel, Logger, createLogger } from './logging';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { standardizePath } from 'roku-deploy';
 import undent from 'undent';
-import { ProjectManager } from './lsp/ProjectManager';
+import { ProjectManager, type WorkspaceConfig } from './lsp/ProjectManager';
 
 const sinon = createSandbox();
 
@@ -167,7 +167,7 @@ describe('LanguageServer', () => {
     });
 
     describe('onDidChangeConfiguration', () => {
-        async function doTest(startingConfigs: WorkspaceConfigWithExtras[], endingConfigs: WorkspaceConfigWithExtras[]) {
+        async function doTest(startingConfigs: WorkspaceConfig[], endingConfigs: WorkspaceConfig[]) {
             (server as any)['connection'] = connection;
             server['workspaceConfigsCache'] = new Map(startingConfigs.map(x => [x.workspaceFolder, x]));
 
@@ -188,7 +188,8 @@ describe('LanguageServer', () => {
             await doTest([{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -196,7 +197,8 @@ describe('LanguageServer', () => {
             }], [{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -210,7 +212,8 @@ describe('LanguageServer', () => {
             await doTest([], [{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -224,7 +227,8 @@ describe('LanguageServer', () => {
             await doTest([{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -232,7 +236,8 @@ describe('LanguageServer', () => {
             }, {
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/project2`,
@@ -240,7 +245,8 @@ describe('LanguageServer', () => {
             }], [{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -254,7 +260,8 @@ describe('LanguageServer', () => {
             await doTest([{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'trace'
                 },
                 workspaceFolder: workspacePath,
@@ -262,7 +269,8 @@ describe('LanguageServer', () => {
             }], [{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -649,18 +657,19 @@ describe('LanguageServer', () => {
     });
 
     describe('rebuildPathFilterer', () => {
-        let workspaceConfigs: WorkspaceConfigWithExtras[] = [];
+        let workspaceConfigs: WorkspaceConfig[] = [];
         beforeEach(() => {
             workspaceConfigs = [
                 {
                     bsconfigPath: undefined,
                     languageServer: {
-                        enableThreading: true,
+                        enableThreading: false,
+                        enableDiscovery: true,
                         logLevel: 'info'
                     },
                     workspaceFolder: workspacePath,
                     excludePatterns: []
-                } as WorkspaceConfigWithExtras
+                }
             ];
             server['connection'] = connection as any;
             sinon.stub(server as any, 'getWorkspaceConfigs').callsFake(() => Promise.resolve(workspaceConfigs));
@@ -736,7 +745,8 @@ describe('LanguageServer', () => {
             workspaceConfigs = [{
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/flavor1`,
@@ -744,12 +754,13 @@ describe('LanguageServer', () => {
             }, {
                 bsconfigPath: undefined,
                 languageServer: {
-                    enableThreading: true,
+                    enableThreading: false,
+                    enableDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/flavor2`,
                 excludePatterns: []
-            }] as WorkspaceConfigWithExtras[];
+            }];
             fsExtra.outputFileSync(s`${workspaceConfigs[0].workspaceFolder}/.gitignore`, undent`
                 dist/
             `);

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -17,13 +17,14 @@ import { createVisitor, WalkMode } from './astUtils/visitors';
 import { tempDir, rootDir } from './testHelpers.spec';
 import { URI } from 'vscode-uri';
 import { BusyStatusTracker } from './BusyStatusTracker';
-import type { BscFile } from '.';
+import type { BscFile } from './interfaces';
 import type { Project } from './lsp/Project';
 import { LogLevel, Logger, createLogger } from './logging';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { standardizePath } from 'roku-deploy';
 import undent from 'undent';
-import { ProjectManager, type WorkspaceConfig } from './lsp/ProjectManager';
+import { ProjectManager } from './lsp/ProjectManager';
+import type { WorkspaceConfig } from './lsp/ProjectManager';
 
 const sinon = createSandbox();
 

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -62,6 +62,10 @@ export class LanguageServer {
      */
     public static enableThreadingDefault = true;
     /**
+     * The default project discovery setting for the language server. Can be overridden by per-workspace settings
+     */
+    public static enableDiscoveryDefault = true;
+    /**
      * The language server protocol connection, used to send and receive all requests and responses
      */
     private connection = undefined as Connection;
@@ -417,7 +421,7 @@ export class LanguageServer {
      * Get a list of workspaces, and their configurations.
      * Get only the settings for the workspace that are relevant to the language server. We do this so we can cache this object for use in change detection in the future.
      */
-    private async getWorkspaceConfigs(): Promise<WorkspaceConfigWithExtras[]> {
+    private async getWorkspaceConfigs(): Promise<WorkspaceConfig[]> {
         //get all workspace folders (we'll use these to get settings)
         let workspaces = await Promise.all(
             (await this.connection.workspace.getWorkspaceFolders() ?? []).map(async (x) => {
@@ -429,16 +433,17 @@ export class LanguageServer {
                     bsconfigPath: brightscriptConfig.configFile,
                     languageServer: {
                         enableThreading: brightscriptConfig.languageServer?.enableThreading ?? LanguageServer.enableThreadingDefault,
+                        enableDiscovery: brightscriptConfig.languageServer?.enableDiscovery ?? LanguageServer.enableDiscoveryDefault,
                         logLevel: brightscriptConfig?.languageServer?.logLevel
                     }
 
-                } as WorkspaceConfigWithExtras;
+                };
             })
         );
         return workspaces;
     }
 
-    private workspaceConfigsCache = new Map<string, WorkspaceConfigWithExtras>();
+    private workspaceConfigsCache = new Map<string, WorkspaceConfig>();
 
     @AddStackToErrorMessage
     public async onDidChangeConfiguration(args: DidChangeConfigurationParams) {
@@ -795,6 +800,7 @@ interface BrightScriptClientConfiguration {
     configFile: string;
     languageServer: {
         enableThreading: boolean;
+        enableDiscovery: boolean;
         logLevel: LogLevel | string;
     };
 }
@@ -805,11 +811,3 @@ function logAndIgnoreError(error: Error) {
     }
     console.error(error);
 }
-
-export type WorkspaceConfigWithExtras = WorkspaceConfig & {
-    bsconfigPath: string;
-    languageServer: {
-        enableThreading: boolean;
-        logLevel: LogLevel | string | undefined;
-    };
-};

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -52,17 +52,23 @@ export class BrsFileValidator {
                 this.validateEnumDeclaration(node);
 
                 //register this enum declaration
-                node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                if (node.tokens.name) {
+                    node.parent.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                }
             },
             ClassStatement: (node) => {
                 this.validateDeclarationLocations(node, 'class', () => util.createBoundingRange(node.classKeyword, node.name));
 
                 //register this class
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                if (node.name) {
+                    node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                }
             },
             AssignmentStatement: (node) => {
                 //register this variable
-                node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                if (node.name) {
+                    node.parent.getSymbolTable()?.addSymbol(node.name.text, node.name.range, DynamicType.instance);
+                }
             },
             DottedSetStatement: (node) => {
                 this.validateNoOptionalChainingInVarSet(node, [node.obj]);
@@ -77,11 +83,13 @@ export class BrsFileValidator {
             NamespaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'namespace', () => util.createBoundingRange(node.keyword, node.nameExpression));
 
-                node.parent.getSymbolTable().addSymbol(
-                    node.name.split('.')[0],
-                    node.nameExpression.range,
-                    DynamicType.instance
-                );
+                if (node.name) {
+                    node.parent.getSymbolTable().addSymbol(
+                        node.name.split('.')[0],
+                        node.nameExpression.range,
+                        DynamicType.instance
+                    );
+                }
             },
             FunctionStatement: (node) => {
                 this.validateDeclarationLocations(node, 'function', () => util.createBoundingRange(node.func.functionType, node.name));
@@ -101,11 +109,13 @@ export class BrsFileValidator {
                     const funcType = node.func.getFunctionType();
                     funcType.setName(transpiledNamespaceFunctionName);
 
-                    this.event.file.parser.ast.symbolTable.addSymbol(
-                        transpiledNamespaceFunctionName,
-                        node.name.range,
-                        funcType
-                    );
+                    if (node.name) {
+                        this.event.file.parser.ast.symbolTable.addSymbol(
+                            transpiledNamespaceFunctionName,
+                            node.name.range,
+                            funcType
+                        );
+                    }
                 }
             },
             FunctionExpression: (node) => {
@@ -115,17 +125,23 @@ export class BrsFileValidator {
                 this.validateFunctionParameterCount(node);
             },
             FunctionParameterExpression: (node) => {
-                const paramName = node.name?.text;
-                const symbolTable = node.getSymbolTable();
-                symbolTable?.addSymbol(paramName, node.name.range, node.type);
+                if (node.name) {
+                    const paramName = node.name.text;
+                    const symbolTable = node.getSymbolTable();
+                    symbolTable?.addSymbol(paramName, node.name.range, node.type);
+                }
             },
             InterfaceStatement: (node) => {
                 this.validateDeclarationLocations(node, 'interface', () => util.createBoundingRange(node.tokens.interface, node.tokens.name));
-                node.parent?.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, new InterfaceType(new Map()));
+                if (node.tokens.name) {
+                    node.parent?.getSymbolTable()?.addSymbol(node.tokens.name.text, node.tokens.name.range, new InterfaceType(new Map()));
+                }
             },
             ConstStatement: (node) => {
                 this.validateDeclarationLocations(node, 'const', () => util.createBoundingRange(node.tokens.const, node.tokens.name));
-                node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                if (node.tokens.name) {
+                    node.parent.getSymbolTable().addSymbol(node.tokens.name.text, node.tokens.name.range, DynamicType.instance);
+                }
             },
             CatchStatement: (node) => {
                 node.parent.getSymbolTable().addSymbol(node.exceptionVariable.text, node.exceptionVariable.range, DynamicType.instance);

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -165,6 +165,23 @@ describe('ProjectManager', () => {
             ]);
         });
 
+        it('returns root folder when automatic discovery is disabled', async () => {
+            fsExtra.outputFileSync(`${rootDir}/project1/bsconfig.json`, '');
+            fsExtra.outputFileSync(`${rootDir}/project2/bsconfig.json`, '');
+            await manager.syncProjects([{
+                ...workspaceSettings,
+                languageServer: {
+                    ...workspaceSettings.languageServer,
+                    enableDiscovery: false
+                }
+            }]);
+            expect(
+                manager.projects.map(x => x.projectPath)
+            ).to.eql([
+                s`${rootDir}`
+            ]);
+        });
+
         it('gets diagnostics from plugins added in afterProgramValidate', async () => {
             fsExtra.outputFileSync(`${rootDir}/plugin.js`, `
                 module.exports = function () {

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -646,6 +646,11 @@ export class ProjectManager {
      * If none are found, then the workspaceFolder itself is treated as a project
      */
     private async getProjectPaths(workspaceConfig: WorkspaceConfig) {
+        //automatic discovery disabled?
+        if (!workspaceConfig.languageServer.enableDiscovery) {
+            return [workspaceConfig.workspaceFolder];
+        }
+
         //get the list of exclude patterns, negate them so they actually work like excludes), and coerce to forward slashes since that's what fast-glob expects
         const excludePatterns = (workspaceConfig.excludePatterns ?? []).map(x => s`!${x}`.replace(/[\\/]+/g, '/'));
 

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -14,7 +14,7 @@ import type { FileChange, MaybePromise } from '../interfaces';
 import { BusyStatusTracker } from '../BusyStatusTracker';
 import * as fastGlob from 'fast-glob';
 import { PathCollection, PathFilterer } from './PathFilterer';
-import type { Logger } from '../logging';
+import type { Logger, LogLevel } from '../logging';
 import { createLogger } from '../logging';
 import { Cache } from '../Cache';
 import { ActionQueue } from './ActionQueue';
@@ -284,7 +284,7 @@ export class ProjectManager {
                         projectPath: s`${projectPath}`,
                         workspaceFolder: s`${workspaceConfig.workspaceFolder}`,
                         excludePatterns: workspaceConfig.excludePatterns,
-                        enableThreading: workspaceConfig.enableThreading
+                        enableThreading: workspaceConfig.languageServer.enableThreading
                     }));
                 })
             )).flat(1);
@@ -867,9 +867,22 @@ export interface WorkspaceConfig {
      */
     bsconfigPath?: string;
     /**
-     * Should the projects in this workspace be run in their own dedicated worker threads, or all run on the main thread
+     * Language server configuration options
      */
-    enableThreading?: boolean;
+    languageServer: {
+        /**
+         * Should the projects in this workspace be run in their own dedicated worker threads, or all run on the main thread
+         */
+        enableThreading: boolean;
+        /**
+         * Should the language server automatically discover projects in this workspace?
+         */
+        enableDiscovery: boolean;
+        /**
+         * The log level to use for this workspace
+         */
+        logLevel?: LogLevel | string;
+    };
 }
 
 interface StandaloneProject extends LspProject {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -13,11 +13,19 @@ import type { CodeWithSourceMap } from 'source-map';
 import { getDiagnosticLine } from './diagnosticUtils';
 import { firstBy } from 'thenby';
 import undent from 'undent';
+import type { WorkspaceConfig } from './lsp/ProjectManager';
 
 export const cwd = s`${__dirname}/../`;
 export const tempDir = s`${__dirname}/../.tmp`;
 export const rootDir = s`${tempDir}/rootDir`;
 export const stagingDir = s`${tempDir}/stagingDir`;
+export const workspaceSettings: WorkspaceConfig = {
+    workspaceFolder: rootDir,
+    languageServer: {
+        enableThreading: false,
+        enableDiscovery: true
+    }
+};
 
 export const trim = undent;
 const sinon = createSandbox();

--- a/src/util.ts
+++ b/src/util.ts
@@ -905,7 +905,9 @@ export class Util {
      * If the two items both start on the same line
      */
     public sameStartLine(first: { range: Range }, second: { range: Range }) {
-        if (first && second && first.range.start.line === second.range.start.line) {
+        if (first && second && (first.range !== undefined) && (second.range !== undefined) &&
+            first.range.start.line === second.range.start.line
+        ) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
## Problem with automatic discovery

The language server aggressively tries to discover Roku projects by default.

This is fine for Roku-only developers, and developers working in small to medium repositories.

This is causing issues for developers working on large codebases, like monorepos, and developers working on a lot of non-Roku projects, where the extension goes in the way. For instance in our monorepo, the language server goes out of memory while validating the projects, repeatedly as VS attempts to restart the server.

## Adding a setting allowing to disable automatic discovery

This PR adds an `enableDiscovery` lsp option, which defaults to `true` but can be disabled.

## Uncovered issues

While adding the option, it turned out some refactoring had been done incorrectly; for instance `enableThreading` was never enabled due to incorrect workspace config preparation using unsafe casting.

Fixing the workspace config caused some unit tests to fail (some rather mysteriously).

While fixing the unit tests, I found that we have some questionable logic: why not ensure a `name` token is available in `BrsValidator`?