### PR TITLE
Rename setting to `enableProjectDiscovery`

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -190,7 +190,7 @@ describe('LanguageServer', () => {
             await doTest([{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -198,7 +198,7 @@ describe('LanguageServer', () => {
             }], [{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -212,7 +212,7 @@ describe('LanguageServer', () => {
             await doTest([], [{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -226,7 +226,7 @@ describe('LanguageServer', () => {
             await doTest([{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -234,7 +234,7 @@ describe('LanguageServer', () => {
             }, {
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/project2`,
@@ -242,7 +242,7 @@ describe('LanguageServer', () => {
             }], [{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -256,7 +256,7 @@ describe('LanguageServer', () => {
             await doTest([{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'trace'
                 },
                 workspaceFolder: workspacePath,
@@ -264,7 +264,7 @@ describe('LanguageServer', () => {
             }], [{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: workspacePath,
@@ -513,7 +513,7 @@ describe('LanguageServer', () => {
             const workspaceSettings: BrightScriptClientConfiguration = {
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 projects: [
@@ -543,7 +543,7 @@ describe('LanguageServer', () => {
                     ],
                     languageServer: {
                         enableThreading: false,
-                        enableDiscovery: true,
+                        enableProjectDiscovery: true,
                         logLevel: 'info'
                     }
                 }
@@ -711,7 +711,7 @@ describe('LanguageServer', () => {
                 {
                     languageServer: {
                         enableThreading: false,
-                        enableDiscovery: true,
+                        enableProjectDiscovery: true,
                         logLevel: 'info'
                     },
                     workspaceFolder: workspacePath,
@@ -792,7 +792,7 @@ describe('LanguageServer', () => {
             workspaceConfigs = [{
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/flavor1`,
@@ -800,7 +800,7 @@ describe('LanguageServer', () => {
             }, {
                 languageServer: {
                     enableThreading: false,
-                    enableDiscovery: true,
+                    enableProjectDiscovery: true,
                     logLevel: 'info'
                 },
                 workspaceFolder: s`${tempDir}/flavor2`,

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -64,7 +64,7 @@ export class LanguageServer {
     /**
      * The default project discovery setting for the language server. Can be overridden by per-workspace settings
      */
-    public static enableDiscoveryDefault = true;
+    public static enableProjectDiscoveryDefault = true;
     /**
      * The language server protocol connection, used to send and receive all requests and responses
      */
@@ -433,7 +433,7 @@ export class LanguageServer {
                     projects: this.normalizeProjectPaths(workspaceFolder, brightscriptConfig.projects),
                     languageServer: {
                         enableThreading: brightscriptConfig.languageServer?.enableThreading ?? LanguageServer.enableThreadingDefault,
-                        enableDiscovery: brightscriptConfig.languageServer?.enableDiscovery ?? LanguageServer.enableDiscoveryDefault,
+                        enableProjectDiscovery: brightscriptConfig.languageServer?.enableProjectDiscovery ?? LanguageServer.enableProjectDiscoveryDefault,
                         logLevel: brightscriptConfig?.languageServer?.logLevel
                     }
                 };
@@ -823,7 +823,7 @@ export interface BrightScriptClientConfiguration {
     projects?: (string | BrightScriptProjectConfiguration)[];
     languageServer: {
         enableThreading: boolean;
-        enableDiscovery: boolean;
+        enableProjectDiscovery: boolean;
         logLevel: LogLevel | string;
     };
 }

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -176,7 +176,7 @@ describe('ProjectManager', () => {
                 ...workspaceSettings,
                 languageServer: {
                     ...workspaceSettings.languageServer,
-                    enableDiscovery: false
+                    enableProjectDiscovery: false
                 }
             }]);
             expect(

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -699,7 +699,7 @@ export class ProjectManager {
         }
 
         //automatic discovery disabled?
-        if (!workspaceConfig.languageServer.enableDiscovery) {
+        if (!workspaceConfig.languageServer.enableProjectDiscovery) {
             return [{
                 dir: workspaceConfig.workspaceFolder
             }];
@@ -944,7 +944,7 @@ export interface WorkspaceConfig {
         /**
          * Should the language server automatically discover projects in this workspace?
          */
-        enableDiscovery: boolean;
+        enableProjectDiscovery: boolean;
         /**
          * The log level to use for this workspace
          */

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -23,7 +23,7 @@ export const workspaceSettings: WorkspaceConfig = {
     workspaceFolder: rootDir,
     languageServer: {
         enableThreading: false,
-        enableDiscovery: true
+        enableProjectDiscovery: true
     }
 };
 


### PR DESCRIPTION
Renames the `enableDiscovery` setting to `enableProjectDiscovery` for clarity