### PR TITLE
Fix discovery when `projects` is empty

### DIFF
--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -325,6 +325,20 @@ describe('ProjectManager', () => {
                 s`${rootDir}/project1/bsconfig.json`
             ]);
         });
+
+        it('ignores empty projects array configuration', async () => {
+            fsExtra.outputFileSync(`${rootDir}/project1/bsconfig.json`, '');
+            await manager.syncProjects([{
+                ...workspaceSettings,
+                projects: []
+            }]);
+
+            expect(
+                manager.projects.map(x => x.projectKey).sort()
+            ).to.eql([
+                s`${rootDir}/project1/bsconfig.json`
+            ]);
+        });
     });
 
     describe('getCompletions', () => {

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -655,7 +655,7 @@ export class ProjectManager {
      */
     private async discoverProjectsForWorkspace(workspaceConfig: WorkspaceConfig): Promise<DiscoveredProject[]> {
         //config may provide a list of project paths. If we have these, no other discovery is permitted
-        if (Array.isArray(workspaceConfig.projects)) {
+        if (Array.isArray(workspaceConfig.projects) && workspaceConfig.projects.length > 0) {
             this.logger.debug(`Using project paths from workspace config`, workspaceConfig.projects);
             const projectConfigs = workspaceConfig.projects.reduce<DiscoveredProject[]>((acc, project) => {
                 //skip this project if it's disabled or we don't have a path


### PR DESCRIPTION
Extension defaults `brightscript.projects` to an empty array - it really should be `undefined` but it shows that having an empty array in the settings stops discovery entirely.