### PR TITLE
Fix issues with undefined/null trivia items

### DIFF
--- a/src/PluginInterface.ts
+++ b/src/PluginInterface.ts
@@ -76,7 +76,7 @@ export default class PluginInterface<T extends Plugin = Plugin> {
     /**
      * Call `event` on plugins, but allow the plugins to return promises that will be awaited before the next plugin is notified
      */
-    public async emitAsync<K extends keyof PluginEventArgs<T> & string>(event: K, ...args: PluginEventArgs<T>[K]): Promise< PluginEventArgs<T>[K][0]> {
+    public async emitAsync<K extends keyof PluginEventArgs<T> & string>(event: K, ...args: PluginEventArgs<T>[K]): Promise<PluginEventArgs<T>[K][0]> {
         this.logger.debug(`Emitting async plugin event: ${event}`);
         for (let plugin of this.plugins) {
             if ((plugin as any)[event]) {
@@ -87,7 +87,10 @@ export default class PluginInterface<T extends Plugin = Plugin> {
                         );
                     });
                 } catch (err) {
-                    this.logger?.error(`Error when calling plugin ${plugin.name}.${event}:`, err);
+                    this.logger?.error(`Error when calling plugin ${plugin.name}.${event}:`, (err as Error).stack);
+                    if (!this.suppressErrors) {
+                        throw err;
+                    }
                 }
             }
         }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -921,14 +921,14 @@ export class PrintStatement extends Statement {
         ] as TranspileResult;
 
         //if the first expression has no leading whitespace, add a single space between the `print` and the expression
-        if (this.expressions.length > 0 && !this.expressions[0].leadingTrivia.find(t => t.kind === TokenKind.Whitespace)) {
+        if (this.expressions.length > 0 && !this.expressions[0].leadingTrivia.find(t => t?.kind === TokenKind.Whitespace)) {
             result.push(' ');
         }
 
         // eslint-disable-next-line @typescript-eslint/prefer-for-of
         for (let i = 0; i < this.expressions.length; i++) {
             const expression = this.expressions[i];
-            let leadingWhitespace = expression.leadingTrivia.find(t => t.kind === TokenKind.Whitespace)?.text;
+            let leadingWhitespace = expression.leadingTrivia.find(t => t?.kind === TokenKind.Whitespace)?.text;
             if (leadingWhitespace) {
                 result.push(leadingWhitespace);
                 //if the previous expression was NOT a separator, and this one is not also, add a space between them

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1604,4 +1604,52 @@ describe('util', () => {
             util.isClassUsedAsFunction(new ClassType(undefined), undefined, { flags: SymbolTypeFlag.runtime });
         });
     });
+
+    describe('hasLeadingComments', () => {
+        it('does not crash on undefined trivia', () => {
+            expect(util.hasLeadingComments(undefined)).to.be.false;
+        });
+
+        it('returns false when there are no leading comments', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [];
+            expect(util.hasLeadingComments(token)).to.be.false;
+        });
+
+        it('returns true when there are leading comments', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [createToken(TokenKind.Comment, `'comment`)];
+            expect(util.hasLeadingComments(token)).to.be.true;
+        });
+
+        it('does not crash on unexpected trivia item types', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [undefined, null, 1, true, 'string', {}, createToken(TokenKind.Comment, `'comment`)] as any[];
+            expect(util.hasLeadingComments(token)).to.be.true;
+        });
+    });
+
+    describe('getLeadingComments', () => {
+        it('does not crash on undefined trivia', () => {
+            expect(util.getLeadingComments(undefined)).to.eql([]);
+        });
+
+        it('returns [] when there are no leading comments', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [];
+            expect(util.getLeadingComments(token)).to.eql([]);
+        });
+
+        it('returns true when there are leading comments', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [createToken(TokenKind.Comment, `'comment 1`)];
+            expect(util.getLeadingComments(token)).eql([createToken(TokenKind.Comment, `'comment 1`)]);
+        });
+
+        it('does not crash on unexpected trivia item types', () => {
+            const token = createToken(TokenKind.Identifier);
+            token.leadingTrivia = [undefined, null, 1, true, 'string', {}, createToken(TokenKind.Comment, `'comment 2`)] as any[];
+            expect(util.getLeadingComments(token)).eql([createToken(TokenKind.Comment, `'comment 2`)]);
+        });
+    });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -2683,12 +2683,12 @@ export class Util {
 
     public hasLeadingComments(input: Token | AstNode) {
         const leadingTrivia = isToken(input) ? input?.leadingTrivia : input?.leadingTrivia ?? [];
-        return !!leadingTrivia.find(t => t.kind === TokenKind.Comment);
+        return !!leadingTrivia.find(t => t?.kind === TokenKind.Comment);
     }
 
     public getLeadingComments(input: Token | AstNode) {
         const leadingTrivia = isToken(input) ? input?.leadingTrivia : input?.leadingTrivia ?? [];
-        return leadingTrivia.filter(t => t.kind === TokenKind.Comment);
+        return leadingTrivia.filter(t => t?.kind === TokenKind.Comment);
     }
 
     public isLeadingCommentOnSameLine(line: RangeLike, input: Token | AstNode) {


### PR DESCRIPTION
Fixes several issues related to trivia arrays containing `undefined`. If plugins decide to use `editor.removeProperty` insead of `editor.arraySplice`, then those array entries are turned into `undefined`, and that was crashing the transpiler. This makes those functions more resilient. 

Also updates the plugin docs to have a more accurate comment stripping plugin example.