### PR TITLE
Support transpiling class methods as named functions

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -251,12 +251,13 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Animal_new()
+                    m.species1 = "Animal"
+                    print "From Animal: " + m.species
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.species1 = "Animal"
-                        print "From Animal: " + m.species
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal()
@@ -264,14 +265,15 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Duck_new()
+                    m.super0_new()
+                    m.species2 = "Duck"
+                    print "From Duck: " + m.species
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
-                        m.species2 = "Duck"
-                        print "From Duck: " + m.species
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck()
@@ -293,10 +295,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Animal_new()
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal()
@@ -304,13 +307,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Duck_new()
+                    'comment should not cause double super call
+                    m.super0_new()
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        'comment should not cause double super call
-                        m.super0_new()
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck()
@@ -332,10 +336,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Animal_new()
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal()
@@ -343,13 +348,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Duck_new()
+                    print "I am a statement which does not use m"
+                    m.super0_new()
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        print "I am a statement which does not use m"
-                        m.super0_new()
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck()
@@ -372,11 +378,12 @@ describe('BrsFile BrighterScript classes', () => {
                     className3 = "BabyDuck"
                 end class
             `, `
+                sub __Animal_new()
+                    m.className1 = "Animal"
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.className1 = "Animal"
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal()
@@ -384,13 +391,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Duck_new()
+                    m.super0_new()
+                    m.className2 = "Duck"
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
-                        m.className2 = "Duck"
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck()
@@ -398,13 +406,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __BabyDuck_new()
+                    m.super1_new()
+                    m.className3 = "BabyDuck"
+                end sub
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
                     instance.super1_new = instance.new
-                    instance.new = sub()
-                        m.super1_new()
-                        m.className3 = "BabyDuck"
-                    end sub
+                    instance.new = __BabyDuck_new
                     return instance
                 end function
                 function BabyDuck()
@@ -424,10 +433,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end class
                 end namespace
             `, `
+                sub __Birds_WaterFowl_Duck_new()
+                end sub
                 function __Birds_WaterFowl_Duck_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = __Birds_WaterFowl_Duck_new
                     return instance
                 end function
                 function Birds_WaterFowl_Duck()
@@ -435,12 +445,13 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Birds_WaterFowl_BabyDuck_new()
+                    m.super0_new()
+                end sub
                 function __Birds_WaterFowl_BabyDuck_builder()
                     instance = __Birds_WaterFowl_Duck_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
-                    end sub
+                    instance.new = __Birds_WaterFowl_BabyDuck_new
                     return instance
                 end function
                 function Birds_WaterFowl_BabyDuck()
@@ -456,10 +467,11 @@ describe('BrsFile BrighterScript classes', () => {
                 class Duck
                 end class
             `, `
+                sub __Duck_new()
+                end sub
                 function __Duck_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck()
@@ -487,10 +499,11 @@ describe('BrsFile BrighterScript classes', () => {
                 class BabyDuck extends Duck
                 end class
             `, `
+                sub __Animal_new(p1)
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub(p1)
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal(p1)
@@ -498,12 +511,13 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(p1)
                     return instance
                 end function
+                sub __Bird_new(p1)
+                    m.super0_new(p1)
+                end sub
                 function __Bird_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub(p1)
-                        m.super0_new(p1)
-                    end sub
+                    instance.new = __Bird_new
                     return instance
                 end function
                 function Bird(p1)
@@ -511,13 +525,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(p1)
                     return instance
                 end function
+                sub __Duck_new(p1, p2)
+                    m.super1_new(p1)
+                    m.p2 = p2
+                end sub
                 function __Duck_builder()
                     instance = __Bird_builder()
                     instance.super1_new = instance.new
-                    instance.new = sub(p1, p2)
-                        m.super1_new(p1)
-                        m.p2 = p2
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck(p1, p2)
@@ -525,12 +540,13 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(p1, p2)
                     return instance
                 end function
+                sub __BabyDuck_new(p1, p2)
+                    m.super2_new(p1, p2)
+                end sub
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
                     instance.super2_new = instance.new
-                    instance.new = sub(p1, p2)
-                        m.super2_new(p1, p2)
-                    end sub
+                    instance.new = __BabyDuck_new
                     return instance
                 end function
                 function BabyDuck(p1, p2)
@@ -548,10 +564,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Duck_new(name as string, age as integer)
+                end sub
                 function __Duck_builder()
                     instance = {}
-                    instance.new = sub(name as string, age as integer)
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck(name as string, age as integer)
@@ -576,10 +593,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Animal_new(name as string)
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub(name as string)
-                    end sub
+                    instance.new = __Animal_new
                     return instance
                 end function
                 function Animal(name as string)
@@ -587,13 +605,14 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(name)
                     return instance
                 end function
+                sub __Duck_new(name as string, age as integer)
+                    m.super0_new(name)
+                    m.super0_DoSomething()
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub(name as string, age as integer)
-                        m.super0_new(name)
-                        m.super0_DoSomething()
-                    end sub
+                    instance.new = __Duck_new
                     return instance
                 end function
                 function Duck(name as string, age as integer)
@@ -623,13 +642,15 @@ describe('BrsFile BrighterScript classes', () => {
                     end function
                 end class
             `, `
+                sub __Creature_new(name as string)
+                end sub
+                function __Creature_sayHello(text)
+                    ? text
+                end function
                 function __Creature_builder()
                     instance = {}
-                    instance.new = sub(name as string)
-                    end sub
-                    instance.sayHello = function(text)
-                        ? text
-                    end function
+                    instance.new = __Creature_new
+                    instance.sayHello = __Creature_sayHello
                     return instance
                 end function
                 function Creature(name as string)
@@ -637,19 +658,21 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(name)
                     return instance
                 end function
+                sub __Duck_new(name as string)
+                    m.super0_new(name)
+                end sub
+                function __Duck_sayHello(text)
+                    text = "The duck says " + text
+                    if text <> invalid
+                        m.super0_sayHello(text)
+                    end if
+                end function
                 function __Duck_builder()
                     instance = __Creature_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub(name as string)
-                        m.super0_new(name)
-                    end sub
+                    instance.new = __Duck_new
                     instance.super0_sayHello = instance.sayHello
-                    instance.sayHello = function(text)
-                        text = "The duck says " + text
-                        if text <> invalid
-                            m.super0_sayHello(text)
-                        end if
-                    end function
+                    instance.sayHello = __Duck_sayHello
                     return instance
                 end function
                 function Duck(name as string)
@@ -728,10 +751,11 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Parent_new()
+                end sub
                 function __Parent_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = __Parent_new
                     return instance
                 end function
                 function Parent()
@@ -739,12 +763,13 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __Child_new()
+                    m.super0_new()
+                end sub
                 function __Child_builder()
                     instance = __Parent_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
-                    end sub
+                    instance.new = __Child_new
                     return instance
                 end function
                 function Child()
@@ -766,11 +791,12 @@ describe('BrsFile BrighterScript classes', () => {
                     name = "Bob"
                 end class
             `, `
+                sub __Person_new()
+                    m.name = "Bob"
+                end sub
                 function __Person_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.name = "Bob"
-                    end sub
+                    instance.new = __Person_new
                     return instance
                 end function
                 function Person()
@@ -826,15 +852,17 @@ describe('BrsFile BrighterScript classes', () => {
                     '> Waddling...\\nDewey moved 2 meters\\nFell over...I'm new at this
                 end sub
             `, `
+                sub __Animal_new(name as string)
+                    m.name = invalid
+                    m.name = name
+                end sub
+                sub __Animal_move(distanceInMeters as integer)
+                    print m.name + " moved " + distanceInMeters.ToStr() + " meters"
+                end sub
                 function __Animal_builder()
                     instance = {}
-                    instance.new = sub(name as string)
-                        m.name = invalid
-                        m.name = name
-                    end sub
-                    instance.move = sub(distanceInMeters as integer)
-                        print m.name + " moved " + distanceInMeters.ToStr() + " meters"
-                    end sub
+                    instance.new = __Animal_new
+                    instance.move = __Animal_move
                     return instance
                 end function
                 function Animal(name as string)
@@ -842,17 +870,19 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(name)
                     return instance
                 end function
+                sub __Duck_new(name as string)
+                    m.super0_new(name)
+                end sub
+                sub __Duck_move(distanceInMeters as integer)
+                    print "Waddling..."
+                    m.super0_move(distanceInMeters)
+                end sub
                 function __Duck_builder()
                     instance = __Animal_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub(name as string)
-                        m.super0_new(name)
-                    end sub
+                    instance.new = __Duck_new
                     instance.super0_move = instance.move
-                    instance.move = sub(distanceInMeters as integer)
-                        print "Waddling..."
-                        m.super0_move(distanceInMeters)
-                    end sub
+                    instance.move = __Duck_move
                     return instance
                 end function
                 function Duck(name as string)
@@ -860,17 +890,19 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new(name)
                     return instance
                 end function
+                sub __BabyDuck_new(name as string)
+                    m.super1_new(name)
+                end sub
+                sub __BabyDuck_move(distanceInMeters as integer)
+                    m.super1_move(distanceInMeters)
+                    print "Fell over...I'm new at this"
+                end sub
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
                     instance.super1_new = instance.new
-                    instance.new = sub(name as string)
-                        m.super1_new(name)
-                    end sub
+                    instance.new = __BabyDuck_new
                     instance.super1_move = instance.move
-                    instance.move = sub(distanceInMeters as integer)
-                        m.super1_move(distanceInMeters)
-                        print "Fell over...I'm new at this"
-                    end sub
+                    instance.move = __BabyDuck_move
                     return instance
                 end function
                 function BabyDuck(name as string)
@@ -908,13 +940,15 @@ describe('BrsFile BrighterScript classes', () => {
                     end sub
                 end class
             `, `
+                sub __Duck_new()
+                end sub
+                sub __Duck_walk(meters as integer)
+                    print "Walked " + meters.ToStr() + " meters"
+                end sub
                 function __Duck_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
-                    instance.walk = sub(meters as integer)
-                        print "Walked " + meters.ToStr() + " meters"
-                    end sub
+                    instance.new = __Duck_new
+                    instance.walk = __Duck_walk
                     return instance
                 end function
                 function Duck()
@@ -922,17 +956,19 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __BabyDuck_new()
+                    m.super0_new()
+                end sub
+                sub __BabyDuck_walk(meters as integer)
+                    print "Tripped"
+                    m.super0_walk(meters)
+                end sub
                 function __BabyDuck_builder()
                     instance = __Duck_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new()
-                    end sub
+                    instance.new = __BabyDuck_new
                     instance.super0_walk = instance.walk
-                    instance.walk = sub(meters as integer)
-                        print "Tripped"
-                        m.super0_walk(meters)
-                    end sub
+                    instance.walk = __BabyDuck_walk
                     return instance
                 end function
                 function BabyDuck()
@@ -955,11 +991,12 @@ describe('BrsFile BrighterScript classes', () => {
                     end enum
                 end namespace
             `, `
+                sub __MyNS_HasEnumKlass_new()
+                    m.enumValue = "A"
+                end sub
                 function __MyNS_HasEnumKlass_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.enumValue = "A"
-                    end sub
+                    instance.new = __MyNS_HasEnumKlass_new
                     return instance
                 end function
                 function MyNS_HasEnumKlass()
@@ -989,12 +1026,13 @@ describe('BrsFile BrighterScript classes', () => {
                     end enum
                 end namespace
             `, `
+                sub __MyNS_SubKlass_new()
+                    m.super0_new("B")
+                end sub
                 function __MyNS_SubKlass_builder()
                     instance = __MyNS_SuperKlass_builder()
                     instance.super0_new = instance.new
-                    instance.new = sub()
-                        m.super0_new("B")
-                    end sub
+                    instance.new = __MyNS_SubKlass_new
                     return instance
                 end function
                 function MyNS_SubKlass()
@@ -1002,11 +1040,12 @@ describe('BrsFile BrighterScript classes', () => {
                     instance.new()
                     return instance
                 end function
+                sub __MyNS_SuperKlass_new(enumVal)
+                    print enumVal
+                end sub
                 function __MyNS_SuperKlass_builder()
                     instance = {}
-                    instance.new = sub(enumVal)
-                        print enumVal
-                    end sub
+                    instance.new = __MyNS_SuperKlass_new
                     return instance
                 end function
                 function MyNS_SuperKlass(enumVal)
@@ -1034,16 +1073,17 @@ describe('BrsFile BrighterScript classes', () => {
                     end enum
                 end namespace
             `, `
+                sub __MyNS_HasEnumKlass_new()
+                    m.myArray = [
+                        true
+                        true
+                    ]
+                    m.myArray[0] = true
+                    m.myArray[1] = false
+                end sub
                 function __MyNS_HasEnumKlass_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.myArray = [
-                            true
-                            true
-                        ]
-                        m.myArray[0] = true
-                        m.myArray[1] = false
-                    end sub
+                    instance.new = __MyNS_HasEnumKlass_new
                     return instance
                 end function
                 function MyNS_HasEnumKlass()
@@ -1070,16 +1110,17 @@ describe('BrsFile BrighterScript classes', () => {
                     end enum
                 end namespace
             `, `
+                sub __MyNS_HasEnumKlass_new()
+                    m.myArray = [
+                        true
+                        true
+                    ]
+                    m.myArray[0] = true
+                    m.myArray[1] = false
+                end sub
                 function __MyNS_HasEnumKlass_builder()
                     instance = {}
-                    instance.new = sub()
-                        m.myArray = [
-                            true
-                            true
-                        ]
-                        m.myArray[0] = true
-                        m.myArray[1] = false
-                    end sub
+                    instance.new = __MyNS_HasEnumKlass_new
                     return instance
                 end function
                 function MyNS_HasEnumKlass()
@@ -1197,13 +1238,15 @@ describe('BrsFile BrighterScript classes', () => {
         expect(
             fsExtra.readFileSync(s`${stagingDir}/source/lib.brs`).toString().trimEnd()
         ).to.eql(trim`
+            sub __Being_new()
+            end sub
+            function __Being_think()
+                print "thinking..."
+            end function
             function __Being_builder()
                 instance = {}
-                instance.new = sub()
-                end sub
-                instance.think = function()
-                    print "thinking..."
-                end function
+                instance.new = __Being_new
+                instance.think = __Being_think
                 return instance
             end function
             function Being()
@@ -1211,15 +1254,17 @@ describe('BrsFile BrighterScript classes', () => {
                 instance.new()
                 return instance
             end function
+            sub __Human_new()
+                m.super0_new()
+            end sub
+            function __Human_think()
+                m.super0_think()
+            end function
             function __Human_builder()
                 instance = __Being_builder()
                 instance.super0_new = instance.new
-                instance.new = sub()
-                    m.super0_new()
-                end sub
-                instance.think = function()
-                    m.super0_think()
-                end function
+                instance.new = __Human_new
+                instance.think = __Human_think
                 return instance
             end function
             function Human()
@@ -1687,12 +1732,13 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `, `
+            sub __App_ClassC_new()
+                m.super1_new()
+            end sub
             function __App_ClassC_builder()
                 instance = __App_ClassB_builder()
                 instance.super1_new = instance.new
-                instance.new = sub()
-                    m.super1_new()
-                end sub
+                instance.new = __App_ClassC_new
                 return instance
             end function
             function App_ClassC()
@@ -1715,12 +1761,13 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `, `
+            sub __App_ClassB_new()
+                m.super0_new()
+            end sub
             function __App_ClassB_builder()
                 instance = __ClassA_builder()
                 instance.super0_new = instance.new
-                instance.new = sub()
-                    m.super0_new()
-                end sub
+                instance.new = __App_ClassB_new
                 return instance
             end function
             function App_ClassB()
@@ -1787,11 +1834,12 @@ describe('BrsFile BrighterScript classes', () => {
                 end class
             end namespace
         `, `
+            sub __App_CoreClass_new()
+                print "CoreClass.new()"
+            end sub
             function __App_CoreClass_builder()
                 instance = {}
-                instance.new = sub()
-                    print "CoreClass.new()"
-                end sub
+                instance.new = __App_CoreClass_new
                 return instance
             end function
             function App_CoreClass()
@@ -1799,12 +1847,13 @@ describe('BrsFile BrighterScript classes', () => {
                 instance.new()
                 return instance
             end function
+            sub __App_Logic_FirstClass_new()
+                m.super0_new()
+            end sub
             function __App_Logic_FirstClass_builder()
                 instance = __App_CoreClass_builder()
                 instance.super0_new = instance.new
-                instance.new = sub()
-                    m.super0_new()
-                end sub
+                instance.new = __App_Logic_FirstClass_new
                 return instance
             end function
             function App_Logic_FirstClass()
@@ -1812,12 +1861,13 @@ describe('BrsFile BrighterScript classes', () => {
                 instance.new()
                 return instance
             end function
+            sub __App_Logic_SecondClass_new()
+                m.super1_new()
+            end sub
             function __App_Logic_SecondClass_builder()
                 instance = __App_Logic_FirstClass_builder()
                 instance.super1_new = instance.new
-                instance.new = sub()
-                    m.super1_new()
-                end sub
+                instance.new = __App_Logic_SecondClass_new
                 return instance
             end function
             function App_Logic_SecondClass()
@@ -1825,12 +1875,13 @@ describe('BrsFile BrighterScript classes', () => {
                 instance.new()
                 return instance
             end function
+            sub __App_OtherLogic_FinalClass_new()
+                m.super2_new()
+            end sub
             function __App_OtherLogic_FinalClass_builder()
                 instance = __App_Logic_SecondClass_builder()
                 instance.super2_new = instance.new
-                instance.new = sub()
-                    m.super2_new()
-                end sub
+                instance.new = __App_OtherLogic_FinalClass_new
                 return instance
             end function
             function App_OtherLogic_FinalClass()

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2387,14 +2387,16 @@ describe('BrsFile', () => {
                         ' alpha.charlie()
                     end sub
 
+                    sub __Person_new()
+                        m.name = invalid
+                        print m.name
+                    end sub
+                    sub __Person_test()
+                    end sub
                     function __Person_builder()
                         instance = {}
-                        instance.new = sub()
-                            m.name = invalid
-                            print m.name
-                        end sub
-                        instance.test = sub()
-                        end sub
+                        instance.new = __Person_new
+                        instance.test = __Person_test
                         return instance
                     end function
                     function Person()

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2461,7 +2461,7 @@ export class MethodStatement extends FunctionStatement {
         return this.name.text;
     }
 
-    transpile(state: BrsTranspileState) {
+    transpile(state: BrsTranspileState, name?: Identifier) {
         if (this.name.text.toLowerCase() === 'new') {
             this.ensureSuperConstructorCall(state);
             //TODO we need to undo this at the bottom of this method
@@ -2490,7 +2490,7 @@ export class MethodStatement extends FunctionStatement {
             visitor(statement, undefined);
             statement.walk(visitor, walkOptions);
         }
-        return this.func.transpile(state);
+        return this.func.transpile(state, name);
     }
 
     getTypedef(state: BrsTranspileState) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2037,19 +2037,18 @@ export class ClassStatement extends Statement implements TypedefProvider {
     transpile(state: BrsTranspileState) {
         let result = [] as TranspileResult;
 
+        const className = this.getName(ParseMode.BrightScript).replace(/\./g, '_');
         const ancestors = this.getAncestors(state);
-        const body = this.createNewStatementIfNotExists(ancestors);
+        const body = this.getClassBody(ancestors);
 
         //make the methods
-        result.push(...this.getTranspiledMethods(state, ancestors, body));
+        result.push(...this.getTranspiledMethods(state, className, body));
         //make the builder
-        result.push(...this.getTranspiledBuilder(state, ancestors, body));
-        result.push(
-            '\n',
-            state.indent()
-        );
+        result.push(...this.getTranspiledBuilder(state, className, ancestors, body));
+        result.push('\n', state.indent());
         //make the class assembler (i.e. the public-facing class creator method)
-        result.push(...this.getTranspiledClassFunction(state));
+        result.push(...this.getTranspiledClassFunction(state, className));
+
         return result;
     }
 
@@ -2164,13 +2163,6 @@ export class ClassStatement extends Statement implements TypedefProvider {
         return ancestors;
     }
 
-    private getBuilderName(name: string) {
-        if (name.includes('.')) {
-            name = name.replace(/\./gi, '_');
-        }
-        return `__${name}_builder`;
-    }
-
     /**
      * Get the constructor function for this class (if exists), or undefined if not exist
      */
@@ -2208,16 +2200,17 @@ export class ClassStatement extends Statement implements TypedefProvider {
         return false;
     }
 
-    private createNewStatementIfNotExists(ancestors: ClassStatement[]): Statement[] {
-        let body = [...this.body];
+    /**
+     * Returns a copy of the class' body, with the constructor function added if it doesn't exist.
+     */
+    private getClassBody(ancestors: ClassStatement[]): Statement[] {
+        const body = [];
+        body.push(...this.body);
 
         //inject an empty "new" method if missing
         if (!this.getConstructorFunction()) {
             if (ancestors.length === 0) {
-                body = [
-                    createMethodStatement('new', TokenKind.Sub),
-                    ...this.body
-                ];
+                body.unshift(createMethodStatement('new', TokenKind.Sub));
             } else {
                 const params = this.getConstructorParams(ancestors);
                 const call = new ExpressionStatement(
@@ -2228,7 +2221,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                         params.map(x => new VariableExpression(x.name))
                     )
                 );
-                body = [
+                body.unshift(
                     new MethodStatement(
                         [],
                         createIdentifier('new'),
@@ -2241,29 +2234,25 @@ export class ClassStatement extends Statement implements TypedefProvider {
                             createToken(TokenKind.RightParen)
                         ),
                         null
-                    ),
-                    ...this.body
-                ];
+                    )
+                );
             }
         }
 
         return body;
     }
 
-    private getMethodName(state: BrsTranspileState, method: MethodStatement): Identifier {
-        return {
-            ...method.name,
-            text: '__' + this.getName(ParseMode.BrightScript)!.replace(/\./gi, '_') + '_' + method.name.text
-        };
-    }
-
-    private getTranspiledMethods(state: BrsTranspileState, ancestors: ClassStatement[], body: Statement[]) {
+    /**
+     * These are the methods that are defined in this class. They are transpiled outside of the class body
+     * to ensure they don't appear as "$anon_#" in stack traces and crash logs.
+     */
+    private getTranspiledMethods(state: BrsTranspileState, transpiledClassName: string, body: Statement[]) {
         let result = [] as TranspileResult;
         for (let statement of body) {
             if (isMethodStatement(statement)) {
                 state.classStatement = this;
                 result.push(
-                    ...statement.transpile(state, this.getMethodName(state, statement)),
+                    ...statement.transpile(state, this.getMethodIdentifier(transpiledClassName, statement)),
                     state.newline,
                     state.indent()
                 );
@@ -2278,9 +2267,9 @@ export class ClassStatement extends Statement implements TypedefProvider {
      * This needs to be a separate function so that child classes can call the builder from their parent
      * without instantiating the parent constructor at that point in time.
      */
-    private getTranspiledBuilder(state: BrsTranspileState, ancestors: ClassStatement[], body: Statement[]) {
+    private getTranspiledBuilder(state: BrsTranspileState, transpiledClassName: string, ancestors: ClassStatement[], body: Statement[]) {
         let result = [] as TranspileResult;
-        result.push(`function ${this.getBuilderName(this.getName(ParseMode.BrightScript)!)}()\n`);
+        result.push(`function ${this.getBuilderName(transpiledClassName)}()\n`);
         state.blockDepth++;
         //indent
         result.push(state.indent());
@@ -2292,9 +2281,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                 ancestors[0].getName(ParseMode.BrighterScript)!,
                 ancestorNamespace?.getName(ParseMode.BrighterScript)
             );
-            result.push(
-                'instance = ',
-                this.getBuilderName(fullyQualifiedClassName), '()');
+            result.push(`instance = ${this.getBuilderName(fullyQualifiedClassName.replace(/\./g, '_'))}()`);
         } else {
             //use an empty object.
             result.push('instance = {}');
@@ -2333,7 +2320,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
                     'instance.',
                     state.transpileToken(statement.name),
                     ' = ',
-                    state.transpileToken(this.getMethodName(state, statement)),
+                    state.transpileToken(this.getMethodIdentifier(transpiledClassName, statement)),
                     state.newline,
                     state.indent()
                 );
@@ -2360,7 +2347,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
      * consumers should call to create a new instance of that class.
      * This invokes the builder, gets an instance of the class, then invokes the "new" function on that class.
      */
-    private getTranspiledClassFunction(state: BrsTranspileState) {
+    private getTranspiledClassFunction(state: BrsTranspileState, transpiledClassName: string) {
         let result = [] as TranspileResult;
 
         const constructorFunction = this.getConstructorFunction();
@@ -2394,7 +2381,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
 
         state.blockDepth++;
         result.push(state.indent());
-        result.push(`instance = ${this.getBuilderName(this.getName(ParseMode.BrightScript)!)}()\n`);
+        result.push(`instance = ${this.getBuilderName(transpiledClassName)}()\n`);
 
         result.push(state.indent());
         result.push(`instance.new(`);
@@ -2445,6 +2432,14 @@ export class ClassStatement extends Statement implements TypedefProvider {
             ),
             ['body', 'parentClassName']
         );
+    }
+
+    private getBuilderName(className: string) {
+        return `__${className}_builder`;
+    }
+
+    private getMethodIdentifier(className: string, statement: MethodStatement) {
+        return { ...statement.name, text: `__${className}_${statement.name.text}` };
     }
 }
 


### PR DESCRIPTION
This PR changes the transpiled output of classes from this:

```brightscript
function __MyKlass_builder()
    instance = {}
    instance.new = sub()
    end sub
    instance.abc = function() as integer
    end function
    instance.def = function() as object
    end function
    return instance
end function
function MyKlass()
    instance = __MyKlass_builder()
    instance.new()
    return instance
end function
```

To this:

```brightscript
sub __MyKlass_new()
end sub
function __MyKlass_abc() as integer
end function
function __MyKlass_def() as object
end function
function __MyKlass_builder()
    instance = {}
    instance.new = __MyKlass_new
    instance.abc = __MyKlass_abc
    instance.def = __MyKlass_def
    return instance
end function
function MyKlass()
    instance = __MyKlass_builder()
    instance.new()
    return instance
end function
```

Notes:

- On a call with Bronley and Chris, it was decided that the order of transpilation would be:
  1. Methods (`__[ClassName]_[methodName]`)
  2. Builder (`__[ClassName]_builder`)
  3. Factory (`[ClassName]`)