### PR TITLE
chore: update regex-literal docs about escaping the forward slash

### DIFF
--- a/docs/regex-literals.md
+++ b/docs/regex-literals.md
@@ -11,3 +11,17 @@ transpiles to:
 ```BrightScript
 print CreateObject("roRegex", "hello world", "ig")
 ```
+
+## Considerations
+### Escape the forward slash character
+Since the forward slash character (`/`) indicates the start and end of the expression, you must escape it with a backslash. 
+
+Example:
+```brighterscript
+print /hello\/world/
+```
+
+transpiles to 
+```brightscript
+print CreateObject("roRegex", "hello/world", "ig")
+```


### PR DESCRIPTION
Add some docs for regex literal expressions about needing to escape the forward slash