### PR TITLE
Fix typdef generation of default param func

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2205,6 +2205,19 @@ describe('BrsFile', () => {
     });
 
     describe('transpile', () => {
+        it('namespaced functions default param values in d.bs files are transpiled correctly', () => {
+            testGetTypedef(`
+                namespace alpha
+                    function beta()
+                    end function
+                    function charlie(fn = alpha.beta, fn2 = beta)
+                    end function
+                end namespace
+                function delta(fn = alpha.beta)
+                end function
+            `);
+        });
+
         describe('null tokens', () => {
             it('succeeds when token locations are omitted', () => {
                 doTest(`

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -21,6 +21,13 @@ export abstract class AstNode {
     public abstract transpile(state: BrsTranspileState): TranspileResult;
 
     /**
+     * Get the typedef for this node. (defaults to transpiling the node, should be overridden by subclasses if there's a more specific typedef requirement)
+     */
+    public getTypedef(state: BrsTranspileState) {
+        return this.transpile(state);
+    }
+
+    /**
      * When being considered by the walk visitor, this describes what type of element the current class is.
      */
     public visitMode = InternalWalkMode.visitStatements;

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -460,14 +460,12 @@ export class FunctionParameterExpression extends Expression {
         const results = [this.name.text] as TranspileResult;
 
         if (this.defaultValue) {
-            results.push(' = ', ...this.defaultValue.transpile(state));
+            results.push(' = ', ...(this.defaultValue.getTypedef(state) ?? this.defaultValue.transpile(state)));
         }
 
         if (this.asToken) {
             results.push(' as ');
 
-            // TODO: Is this conditional needed? Will typeToken always exist
-            // so long as `asToken` exists?
             if (this.typeToken) {
                 results.push(this.typeToken.text);
             }
@@ -579,6 +577,15 @@ export class DottedGetExpression extends Expression {
                 state.transpileToken(this.name)
             ];
         }
+    }
+
+    getTypedef(state: BrsTranspileState) {
+        //always transpile the dots for typedefs
+        return [
+            ...this.obj.transpile(state),
+            state.transpileToken(this.dot),
+            state.transpileToken(this.name)
+        ];
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {
@@ -1130,6 +1137,12 @@ export class VariableExpression extends Expression {
             );
         }
         return result;
+    }
+
+    getTypedef(state: BrsTranspileState) {
+        return [
+            state.transpileToken(this.name)
+        ];
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {


### PR DESCRIPTION
Fixes a bug in the typdef generator that was incorrectly transpiling default parameter function parameter references. 

### Old:
`function charlie(fn = alpha.beta)` => `function charlie(fn = alpha_beta)`


### New (correct):
`function charlie(fn = alpha.beta)` => `function charlie(fn = alpha.beta)`
