### PR TITLE
Prevent param names that are reserved words

### DIFF
--- a/src/parser/Parser.Class.spec.ts
+++ b/src/parser/Parser.Class.spec.ts
@@ -6,8 +6,9 @@ import { Parser, ParseMode } from './Parser';
 import type { FunctionStatement, AssignmentStatement, FieldStatement } from './Statement';
 import { ClassStatement } from './Statement';
 import { NewExpression } from './Expression';
-import { expectDiagnosticsIncludes, expectZeroDiagnostics } from '../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics } from '../testHelpers.spec';
 import { isClassStatement } from '../astUtils/reflection';
+import util from '../util';
 
 describe('parser class', () => {
     it('throws exception when used in brightscript scope', () => {
@@ -92,6 +93,45 @@ describe('parser class', () => {
         `);
 
         expect(parser.diagnostics[0]?.message).to.eql(DiagnosticMessages.cannotUseReservedWordAsIdentifier('throw').message);
+    });
+
+    it('does not allow function param named "type"', () => {
+        const parser = Parser.parse(`
+            sub test(type as string)
+            end sub
+        `);
+
+        expectDiagnostics(parser, [{
+            ...DiagnosticMessages.cannotUseReservedWordAsIdentifier('type'),
+            range: util.createRange(1, 21, 1, 25)
+        }]);
+    });
+
+    it('does not allow class method named "type"', () => {
+        const parser = Parser.parse(`
+            class Person
+                sub test(type as string)
+                end sub
+            end class
+        `, { mode: ParseMode.BrighterScript });
+
+        expectDiagnostics(parser, [{
+            ...DiagnosticMessages.cannotUseReservedWordAsIdentifier('type'),
+            range: util.createRange(2, 25, 2, 29)
+        }]);
+    });
+
+    it('does not allow interface method named "type"', () => {
+        const parser = Parser.parse(`
+            interface Person
+                sub test(type as string)
+            end interface
+        `, { mode: ParseMode.BrighterScript });
+
+        expectDiagnostics(parser, [{
+            ...DiagnosticMessages.cannotUseReservedWordAsIdentifier('type'),
+            range: util.createRange(2, 25, 2, 29)
+        }]);
     });
 
     it('supports the try/catch keywords in various places', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -998,6 +998,14 @@ export class Parser {
         // force the name into an identifier so the AST makes some sense
         name.kind = TokenKind.Identifier;
 
+        //add diagnostic if name is a reserved word that cannot be used as an identifier
+        if (DisallowedLocalIdentifiersText.has(name.text.toLowerCase())) {
+            this.diagnostics.push({
+                ...DiagnosticMessages.cannotUseReservedWordAsIdentifier(name.text),
+                range: name.range
+            });
+        }
+
         let typeToken: Token | undefined;
         let defaultValue;
 


### PR DESCRIPTION
Adds validation to prevent using reserved words as parameter names. We already had logic like this for local variable names and functions, but somehow param names got missed. 

<img width="1153" height="237" alt="image" src="https://github.com/user-attachments/assets/0e99b580-109a-4930-9740-0a56cc51f76b" />
