### PR TITLE
Add manual entries for roUtils and roRenderThreadQueue

### DIFF
--- a/scripts/scrape-roku-docs.ts
+++ b/scripts/scrape-roku-docs.ts
@@ -233,7 +233,7 @@ class Runner {
             component.events ??= [];
             component.events.sort(nameComparer);
 
-            component.interfaces.sort(nameComparer);
+            component.interfaces ??= [];
             component.interfaces.sort(nameComparer);
         }
 
@@ -1417,6 +1417,7 @@ class Runner {
             },
             components: {
                 rourltransfer: {
+                    name: 'roUrlTransfer',
                     methods: [{
                         description: 'Sets the roMessagePort to be used to receive events',
                         isDeprecated: true,
@@ -1436,12 +1437,127 @@ class Runner {
                     }]
                 },
                 roregion: {
+                    name: 'roRegion',
                     interfaces: [{
                         name: 'ifDraw2D',
                         url: 'https://developer.roku.com/docs/references/brightscript/interfaces/ifdraw2d.md'
                     }]
+                },
+                routils: {
+                    name: 'roUtils',
+                    methods: [{
+                        name: 'DeepCopy',
+                        description: 'Performs a deep copy of the source node object (it copies the obejct and all of its nested objects). If the source object contains items that are not copyable, they are skipped.',
+                        params: [
+                            {
+                                name: 'data',
+                                default: null,
+                                description: 'The object to be copied',
+                                isRequired: true,
+                                type: 'Object'
+                            }
+                        ],
+                        returnType: 'Object',
+                        returnDescription: 'This function returns a copy of the specified object.'
+                    }, {
+                        name: 'IsSameObject',
+                        description: 'Checks whether two BrightScript objects refer to the same instance and returns a flag indicating the result.',
+                        params: [
+                            {
+                                name: 'data1',
+                                default: null,
+                                description: 'First object',
+                                isRequired: true,
+                                type: 'Object'
+                            },
+                            {
+                                name: 'data2',
+                                default: null,
+                                description: 'Second object',
+                                isRequired: true,
+                                type: 'Object'
+                            }
+                        ],
+                        returnType: 'Boolean',
+                        returnDescription: 'Returns true if data1 and data2 reference the same object; otherwise, this returns false.'
+                    }],
+                    interfaces: []
+                },
+                rorenderthreadqueue: {
+                    name: 'roRenderThreadQueue',
+                    methods: [{
+                        name: 'AddMessageHandler',
+                        description: 'Registers a handler for messages received on the async message channel with the given message ID. The handler is called on the render thread for each message received. You can register multiple handlers for a single ID. In this case, the handlers are called in the order they were registered. This function can only be called on the render thread.',
+                        params: [
+                            {
+                                name: 'message_id',
+                                default: null,
+                                description: 'The ID of the message channel to which this handler should be registered.',
+                                isRequired: true,
+                                type: 'string'
+                            },
+                            {
+                                name: 'handler',
+                                default: null,
+                                description: 'The name of the handler function to be called for each message received.',
+                                isRequired: true,
+                                type: 'string'
+                            }
+                        ],
+                        returnType: 'Object',
+                        returnDescription: 'Returns an object that can be used to unregister the handler, if required, by calling `handle.unregister()`'
+                    }, {
+                        name: 'PostMessage',
+                        description: 'Post a message to the queue. The data is moved and becomes unavailable to the calling thread. The call returns immediately and does not block the calling thread. This function may be called from any thread.',
+                        params: [
+                            {
+                                name: 'message_id',
+                                default: null,
+                                description: 'The ID of the channel to which this message should be posted.',
+                                isRequired: true,
+                                type: 'String'
+                            },
+                            {
+                                name: 'data',
+                                default: null,
+                                description: 'The contents of the message to be passed to any registered handlers. This must be recursively copyable. Non-copyable objects are silently ignored. Copyable objects include:\n - roAssociativeArray\n - roArray\n - integer, long integer\n - string\n - bool\n - float, double\n - invalid\n - roSGNode',
+                                isRequired: true,
+                                type: 'Object'
+                            }
+                        ],
+                        returnType: 'Void',
+                        returnDescription: undefined
+                    }, {
+                        name: 'CopyMessage',
+                        description: 'Copy a message to the queue. The call returns immediately and does not block the calling thread. This function is similar to the `PostMessage()` function, but it copies data instead of moving it.',
+                        params: [
+                            {
+                                name: 'message_id',
+                                default: null,
+                                description: 'The ID of the channel to which this message should be posted.',
+                                isRequired: true,
+                                type: 'String'
+                            },
+                            {
+                                name: 'data',
+                                default: null,
+                                description: 'The contents of the message to be passed to any registered handlers. This must be recursively copyable. Non-copyable objects are silently ignored. Copyable objects include:\n - roAssociativeArray\n - roArray\n - integer, long integer\n - string\n - bool\n - float, double\n - invalid\n - roSGNode',
+                                isRequired: true,
+                                type: 'Object'
+                            }
+                        ],
+                        returnType: 'Void',
+                        returnDescription: undefined
+                    }, {
+                        name: 'NumCopies',
+                        description: 'Returns the total number of objects for the channel that were copied by the PostMessage() function instead of being moved.',
+                        params: [],
+                        returnType: 'Integer',
+                        returnDescription: undefined
+                    }],
+                    interfaces: []
                 }
-            } as Record<string, Partial<BrightScriptComponent>>,
+            } as Record<string, Partial<BrightScriptComponent> & { name: string }>,
             events: {},
             interfaces: {
                 ifsgnodechildren: {

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -148,6 +148,26 @@ describe('BrsFile', () => {
         expectZeroDiagnostics(program);
     });
 
+    it('supports roUtils as a brightscript object', () => {
+        program.setFile('source/main.brs', `
+            sub test()
+                utils = CreateObject("roUtils")
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
+    it('supports roRenderThreadQueue as a brightscript object', () => {
+        program.setFile('source/main.brs', `
+            sub test()
+                utils = CreateObject("roRenderThreadQueue")
+            end sub
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
     it('sets needsTranspiled to true for .bs files', () => {
         //BrightScript
         expect(new BrsFile(`${rootDir}/source/main.brs`, 'source/main.brs', program).needsTranspiled).to.be.false;

--- a/src/roku-types/data.json
+++ b/src/roku-types/data.json
@@ -1,5 +1,5 @@
 {
-    "generatedDate": "2025-10-08T19:37:01.235Z",
+    "generatedDate": "2025-10-10T15:16:43.437Z",
     "nodes": {
         "animation": {
             "description": "Extends [**AnimationBase**](https://developer.roku.com/docs/references/scenegraph/abstract-nodes/animationbase.md\n\nThe Animation node class provides animations of renderable nodes, by applying interpolator functions to the values in specified renderable node fields. For an animation to take effect, an Animation node definition must include a child field interpolator node ([FloatFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/floatfieldinterpolator.md\"FloatFieldInterpolator\"), [Vector2DFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/vector2dfieldinterpolator.md\"Vector2DFieldInterpolator\"), [ColorFieldInterpolator](https://developer.roku.com/docs/references/scenegraph/animation-nodes/colorfieldinterpolator.md\"ColorFieldInterpolator\")) definition for each renderable node field that is animated.\n\nThe Animation node class provides a simple linear interpolator function, where the animation takes place smoothly and simply from beginning to end. The Animation node class also provides several more complex interpolator functions to allow custom animation effects. For example, you can move a graphic image around the screen at differing speeds and curved trajectories at different times in the animation by specifying the appropriate function in the easeFunction field (quadratic and exponential are two examples of functions that can be specified). The interpolator functions are divided into two parts: the beginning of the animation (ease-in), and the end of the animation (ease-out). You can apply a specified interpolator function to either or both ease-in and ease-out, or specify no function for either or both (which is the linear function). You can also change the portion of the animation that is ease-in and ease-out to arbitrary fractional values for a quadratic interpolator function applied to both ease-in and ease-out.",
@@ -8731,6 +8731,84 @@
             "name": "roRemoteInfo",
             "url": "https://developer.roku.com/docs/references/brightscript/components/roremoteinfo.md"
         },
+        "rorenderthreadqueue": {
+            "constructors": [],
+            "events": [],
+            "interfaces": [],
+            "methods": [
+                {
+                    "description": "Registers a handler for messages received on the async message channel with the given message ID. The handler is called on the render thread for each message received. You can register multiple handlers for a single ID. In this case, the handlers are called in the order they were registered. This function can only be called on the render thread.",
+                    "name": "AddMessageHandler",
+                    "params": [
+                        {
+                            "default": null,
+                            "description": "The ID of the message channel to which this handler should be registered.",
+                            "isRequired": true,
+                            "name": "message_id",
+                            "type": "string"
+                        },
+                        {
+                            "default": null,
+                            "description": "The name of the handler function to be called for each message received.",
+                            "isRequired": true,
+                            "name": "handler",
+                            "type": "string"
+                        }
+                    ],
+                    "returnDescription": "Returns an object that can be used to unregister the handler, if required, by calling `handle.unregister()`",
+                    "returnType": "Object"
+                },
+                {
+                    "description": "Post a message to the queue. The data is moved and becomes unavailable to the calling thread. The call returns immediately and does not block the calling thread. This function may be called from any thread.",
+                    "name": "PostMessage",
+                    "params": [
+                        {
+                            "default": null,
+                            "description": "The ID of the channel to which this message should be posted.",
+                            "isRequired": true,
+                            "name": "message_id",
+                            "type": "String"
+                        },
+                        {
+                            "default": null,
+                            "description": "The contents of the message to be passed to any registered handlers. This must be recursively copyable. Non-copyable objects are silently ignored. Copyable objects include:\n - roAssociativeArray\n - roArray\n - integer, long integer\n - string\n - bool\n - float, double\n - invalid\n - roSGNode",
+                            "isRequired": true,
+                            "name": "data",
+                            "type": "Object"
+                        }
+                    ],
+                    "returnType": "Void"
+                },
+                {
+                    "description": "Copy a message to the queue. The call returns immediately and does not block the calling thread. This function is similar to the `PostMessage()` function, but it copies data instead of moving it.",
+                    "name": "CopyMessage",
+                    "params": [
+                        {
+                            "default": null,
+                            "description": "The ID of the channel to which this message should be posted.",
+                            "isRequired": true,
+                            "name": "message_id",
+                            "type": "String"
+                        },
+                        {
+                            "default": null,
+                            "description": "The contents of the message to be passed to any registered handlers. This must be recursively copyable. Non-copyable objects are silently ignored. Copyable objects include:\n - roAssociativeArray\n - roArray\n - integer, long integer\n - string\n - bool\n - float, double\n - invalid\n - roSGNode",
+                            "isRequired": true,
+                            "name": "data",
+                            "type": "Object"
+                        }
+                    ],
+                    "returnType": "Void"
+                },
+                {
+                    "description": "Returns the total number of objects for the channel that were copied by the PostMessage() function instead of being moved.",
+                    "name": "NumCopies",
+                    "params": [],
+                    "returnType": "Integer"
+                }
+            ],
+            "name": "roRenderThreadQueue"
+        },
         "rorsa": {
             "constructors": [
                 {
@@ -9171,6 +9249,51 @@
             ],
             "name": "roUrlTransfer",
             "url": "https://developer.roku.com/docs/references/brightscript/components/rourltransfer.md"
+        },
+        "routils": {
+            "constructors": [],
+            "events": [],
+            "interfaces": [],
+            "methods": [
+                {
+                    "description": "Performs a deep copy of the source node object (it copies the obejct and all of its nested objects). If the source object contains items that are not copyable, they are skipped.",
+                    "name": "DeepCopy",
+                    "params": [
+                        {
+                            "default": null,
+                            "description": "The object to be copied",
+                            "isRequired": true,
+                            "name": "data",
+                            "type": "Object"
+                        }
+                    ],
+                    "returnDescription": "This function returns a copy of the specified object.",
+                    "returnType": "Object"
+                },
+                {
+                    "description": "Checks whether two BrightScript objects refer to the same instance and returns a flag indicating the result.",
+                    "name": "IsSameObject",
+                    "params": [
+                        {
+                            "default": null,
+                            "description": "First object",
+                            "isRequired": true,
+                            "name": "data1",
+                            "type": "Object"
+                        },
+                        {
+                            "default": null,
+                            "description": "Second object",
+                            "isRequired": true,
+                            "name": "data2",
+                            "type": "Object"
+                        }
+                    ],
+                    "returnDescription": "Returns true if data1 and data2 reference the same object; otherwise, this returns false.",
+                    "returnType": "Boolean"
+                }
+            ],
+            "name": "roUtils"
         },
         "rovideoplayer": {
             "constructors": [


### PR DESCRIPTION
Adds language support for the new `roUtils` and `roRenderThreadQueue` components introduced in Roku OS 15.0. 

**Before:**
<img width="1146" height="344" alt="image" src="https://github.com/user-attachments/assets/8d6455e7-16b5-494a-8b99-def5bf087f92" />


**After:**
<img width="873" height="214" alt="image" src="https://github.com/user-attachments/assets/f4d5d2db-9083-4635-8895-befe89bfbe52" />
