### PR TITLE
Make Invalid compatible with typed arrays

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -1832,6 +1832,22 @@ describe('ScopeValidator', () => {
             });
         });
 
+        it('allows using invalid as argument for typed array params', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                sub takesIntArray(arr as integer[])
+                end sub
+
+                sub takesStrArray(arr as string[])
+                end sub
+
+                sub test()
+                    takesIntArray(invalid)
+                    takesStrArray(invalid)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('cannotFindName', () => {
@@ -2962,6 +2978,17 @@ describe('ScopeValidator', () => {
                 spy.getCalls().map(x => (x.args?.[0] as string)?.toString()).filter(x => x?.includes('Error when calling plugin'))
             ).to.eql([]);
         });
+
+        it('allows returning invalid instead of typed array', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                function getNumbers() as integer[]
+                    return invalid
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
     });
 
     describe('returnTypeCoercionMismatch', () => {
@@ -3429,6 +3456,17 @@ describe('ScopeValidator', () => {
                     DiagnosticMessages.assignmentTypeMismatch('Array<string>', 'Array<roAssociativeArray>', typeCompatData).message
                 ]);
             });
+        });
+
+        it('allows assigning invalid to typed arrays', () => {
+            program.setFile<BrsFile>('source/main.bs', `
+                sub test()
+                    intArray as integer[] = invalid
+                    strArray as string[] = invalid
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
         });
     });
 

--- a/src/types/ArrayType.ts
+++ b/src/types/ArrayType.ts
@@ -1,6 +1,6 @@
 
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { isArrayType, isDynamicType, isEnumMemberType, isObjectType } from '../astUtils/reflection';
+import { isArrayType, isDynamicType, isEnumMemberType, isInvalidType, isObjectType } from '../astUtils/reflection';
 import type { TypeCompatibilityData } from '../interfaces';
 import { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
@@ -52,6 +52,8 @@ export class ArrayType extends BscType {
         if (isDynamicType(targetType)) {
             return true;
         } else if (isObjectType(targetType)) {
+            return true;
+        } else if (isInvalidType(targetType)) {
             return true;
         } else if (isUnionTypeCompatible(this, targetType)) {
             return true;


### PR DESCRIPTION
Allows assigning `invalid` to a typed array. Fixes the issue below:

<img width="720" height="211" alt="image" src="https://github.com/user-attachments/assets/0374e895-abe8-4741-9521-5348fd0ac5f0" />


@iBicha 