### PR TITLE
Fix confusing diagnostic when dottedGet follows function call in ExpressionStatement

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -747,6 +747,11 @@ export let DiagnosticMessages = {
         message: `Non-void ${functionType} must return a value`,
         code: 1142,
         severity: DiagnosticSeverity.Error
+    }),
+    propAccessNotPermittedAfterFunctionCallInExpressionStatement: (accessDescription: string) => ({
+        message: `${accessDescription} access not permitted after a function call when used in an expression statement`,
+        code: 1143,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -90,7 +90,10 @@ describe('BrsFile', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.expectedStatementOrFunctionCallButReceivedExpression('DottedGetExpression')
+            {
+                range: util.createRange(2, 22, 2, 31),
+                message: DiagnosticMessages.propAccessNotPermittedAfterFunctionCallInExpressionStatement('Property').message
+            }
         ]);
     });
 
@@ -104,21 +107,27 @@ describe('BrsFile', () => {
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.expectedStatementOrFunctionCallButReceivedExpression('IndexedGetExpression')
+            {
+                range: util.createRange(2, 22, 2, 34),
+                message: DiagnosticMessages.propAccessNotPermittedAfterFunctionCallInExpressionStatement('Index').message
+            }
         ]);
     });
 
-    it('does not show "missing function" diagnostic for `call()["indexedGet"]` as a statement', () => {
+    it('does not show "missing function" diagnostic for `call()@xmlAttr` as a statement', () => {
         program.setFile(`source/main.brs`, `
-            sub test()
-            end sub
             sub main()
                 test()@disabled
+            end sub
+            sub test()
             end sub
         `);
         program.validate();
         expectDiagnostics(program, [
-            DiagnosticMessages.expectedStatementOrFunctionCallButReceivedExpression('XmlAttributeGetExpression')
+            {
+                range: util.createRange(2, 22, 2, 31),
+                message: DiagnosticMessages.propAccessNotPermittedAfterFunctionCallInExpressionStatement('XML attribute').message
+            }
         ]);
     });
 


### PR DESCRIPTION
### Before:

<img width="979" height="701" alt="image" src="https://github.com/user-attachments/assets/c2930fec-b3f2-41bf-9a68-068fcb9c2ee5" />
<img width="1457" height="606" alt="image" src="https://github.com/user-attachments/assets/72db5dd3-64c1-48be-ac05-9273487beba5" />



### After:
<img width="1897" height="603" alt="image" src="https://github.com/user-attachments/assets/18887a8c-c4c2-4aaf-9053-5c6eeaa98a5f" />
