### PR TITLE
Backports TypeStatement syntax from v1 to v0

### DIFF
--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -1475,6 +1475,69 @@ describe('Scope', () => {
                 expectZeroDiagnostics(program);
 
             });
+
+            it('finds type statement types', () => {
+                program.setFile(`source/main.bs`, `
+                    type MyType = integer or string
+
+                    function foo(param as MyType) as MyType
+                        return param
+                    end function
+
+                `);
+                program.validate();
+
+                expectZeroDiagnostics(program);
+            });
+
+            it('finds type statement types from other namespaces', () => {
+                program.setFile(`source/main.bs`, `
+                    namespace MyNamespace
+                        type MyType = integer or string
+                    end namespace
+
+                    function foo(param as MyNamespace.MyType) as MyNamespace.MyType
+                        return param
+                    end function
+                `);
+                program.validate();
+
+                expectZeroDiagnostics(program);
+            });
+
+            it('finds type statement types from other namespaces', () => {
+                program.setFile(`source/main.bs`, `
+                    namespace MyNamespace
+                        type MyType = integer or string
+                    end namespace
+
+                    function foo(param as MyNamespace.MyType) as MyNamespace.MyType
+                        return param
+                    end function
+                `);
+                program.validate();
+
+                expectZeroDiagnostics(program);
+            });
+
+            it('allows type statement types as class member properties', () => {
+                program.setFile(`source/main.bs`, `
+                    namespace MyNamespace
+                        type MyType = integer or string
+                    end namespace
+
+
+                    namespace AnotherNamespace
+                        class MyClass
+                            prop as MyNamespace.MyType
+                        end class
+                    end namespace
+                `);
+                program.validate();
+
+                expectZeroDiagnostics(program);
+            });
+
         });
     });
 

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement, TypeStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -188,6 +188,10 @@ export function isTypecastStatement(element: AstNode | undefined): element is Ty
 }
 export function isAliasStatement(element: AstNode | undefined): element is AliasStatement {
     return element?.constructor?.name === 'AliasStatement';
+}
+
+export function isTypeStatement(element: AstNode | undefined): element is TypeStatement {
+    return element?.constructor?.name === 'TypeStatement';
 }
 
 // Expressions reflection

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import type { CancellationToken } from 'vscode-languageserver';
-import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, ClassMethodStatement, ClassFieldStatement, EnumStatement, EnumMemberStatement, DimStatement, TryCatchStatement, CatchStatement, ThrowStatement, InterfaceStatement, InterfaceFieldStatement, InterfaceMethodStatement, FieldStatement, MethodStatement, ConstStatement, ContinueStatement, TypeStatement } from '../parser/Statement';
 import type { AALiteralExpression, AAMemberExpression, AnnotationExpression, ArrayLiteralExpression, BinaryExpression, CallExpression, CallfuncExpression, DottedGetExpression, EscapedCharCodeLiteralExpression, FunctionExpression, FunctionParameterExpression, GroupingExpression, IndexedGetExpression, LiteralExpression, NamespacedVariableNameExpression, NewExpression, NullCoalescingExpression, RegexLiteralExpression, SourceLiteralExpression, TaggedTemplateStringExpression, TemplateStringExpression, TemplateStringQuasiExpression, TernaryExpression, UnaryExpression, VariableExpression, XmlAttributeGetExpression } from '../parser/Expression';
 import { isExpression, isStatement } from './reflection';
 import type { AstEditor } from './AstEditor';
@@ -175,6 +175,7 @@ export function createVisitor(
         EnumStatement?: (statement: EnumStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         EnumMemberStatement?: (statement: EnumMemberStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         ConstStatement?: (statement: ConstStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
+        TypeStatement?: (statement: TypeStatement, parent?: Statement, owner?: any, key?: any) => Statement | void;
         //expressions
         BinaryExpression?: (expression: BinaryExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;
         CallExpression?: (expression: CallExpression, parent?: AstNode, owner?: any, key?: any) => Expression | void;

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -1,4 +1,4 @@
-import { isAliasStatement, isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
+import { isAliasStatement, isBody, isClassStatement, isCommentStatement, isConstStatement, isDottedGetExpression, isDottedSetStatement, isEnumStatement, isForEachStatement, isForStatement, isFunctionExpression, isFunctionStatement, isImportStatement, isIndexedGetExpression, isIndexedSetStatement, isInterfaceStatement, isLibraryStatement, isLiteralExpression, isNamespaceStatement, isTypecastStatement, isTypeStatement, isUnaryExpression, isWhileStatement } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
@@ -318,7 +318,8 @@ export class BrsFileValidator {
                     !isImportStatement(statement) &&
                     !isConstStatement(statement) &&
                     !isTypecastStatement(statement) &&
-                    !isAliasStatement(statement)
+                    !isAliasStatement(statement) &&
+                    !isTypeStatement(statement)
                 ) {
                     this.event.file.addDiagnostic({
                         ...DiagnosticMessages.unexpectedStatementOutsideFunction(),

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4438,6 +4438,36 @@ describe('BrsFile', () => {
                 `);
             });
         });
+
+        describe('type statements interfaces', () => {
+            it('transpiles statement to nothing', () => {
+                testTranspile(`
+                     type number = integer or float
+
+                    sub foo()
+                        print "hello"
+                    end sub
+                `, `
+                    sub foo()
+                        print "hello"
+                    end sub
+                `);
+            });
+
+            it('transpiles type statement to object', () => {
+                testTranspile(`
+                     type number = integer or float
+
+                    sub foo(node as number)
+                        print node[m.keyProp]
+                    end sub
+                `, `
+                    sub foo(node as object)
+                        print node[m.keyProp]
+                    end sub
+                `);
+            });
+        });
     });
 
     it('allows up to 63 function params', () => {

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -330,7 +330,8 @@ export const Keywords: Record<string, TokenKind> = {
     endinterface: TokenKind.EndInterface,
     const: TokenKind.Const,
     typecast: TokenKind.Typecast,
-    alias: TokenKind.Alias
+    alias: TokenKind.Alias,
+    type: TokenKind.Type
 };
 //hide the constructor prototype method because it causes issues
 Keywords.constructor = undefined;
@@ -496,7 +497,8 @@ export const AllowedLocalIdentifiers = [
     TokenKind.Const,
     TokenKind.Continue,
     TokenKind.Typecast,
-    TokenKind.Alias
+    TokenKind.Alias,
+    TokenKind.Type
 ];
 
 export const BrighterScriptSourceLiterals = [

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -3375,3 +3375,70 @@ export class AliasStatement extends Statement {
     }
 }
 
+export class TypeStatement extends Statement {
+    constructor(options: {
+        type?: Token;
+        name: Token;
+        equals?: Token;
+        value: Token;
+    }
+    ) {
+        super();
+        this.tokens = {
+            type: options.type,
+            name: options.name,
+            equals: options.equals,
+            value: options.value
+        };
+        this.range = util.createBoundingRange(
+            this.tokens.type,
+            this.tokens.name,
+            this.tokens.equals,
+            this.tokens.value
+        );
+    }
+
+    public readonly tokens: {
+        readonly type?: Token;
+        readonly name: Token;
+        readonly equals?: Token;
+        readonly value: Token;
+    };
+
+    public readonly range: Range;
+
+    transpile(state: BrsTranspileState) {
+        return [];
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        //nothing to walk
+    }
+
+    public get fullName() {
+        const name = this.tokens.name?.text;
+        if (name) {
+            const namespace = this.findAncestor<NamespaceStatement>(isNamespaceStatement);
+            if (namespace) {
+                let namespaceName = namespace.getName(ParseMode.BrighterScript);
+                return `${namespaceName}.${name}`;
+            } else {
+                return name;
+            }
+        } else {
+            //return undefined which will allow outside callers to know that this doesn't have a name
+            return undefined;
+        }
+    }
+
+    public clone() {
+        return this.finalizeClone(
+            new TypeStatement({
+                type: util.cloneToken(this.tokens.type),
+                name: util.cloneToken(this.tokens.name),
+                equals: util.cloneToken(this.tokens.equals),
+                value: util.cloneToken(this.tokens.value)
+            })
+        );
+    }
+}

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -325,7 +325,7 @@ export class BsClassValidator {
                             const currentNamespaceName = namespace?.getName(ParseMode.BrighterScript);
                             //check if this custom type is in our class map
                             const isBuiltInType = util.isBuiltInType(lowerFieldTypeName);
-                            if (!isBuiltInType && !this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName)) {
+                            if (!isBuiltInType && !this.getClassByName(lowerFieldTypeName, currentNamespaceName) && !this.scope.hasInterface(lowerFieldTypeName) && !this.scope.hasEnum(lowerFieldTypeName) && !this.scope.hasTypeStatementType(lowerFieldTypeName)) {
                                 this.diagnostics.push({
                                     ...DiagnosticMessages.cannotFindType(fieldTypeName),
                                     range: statement.type?.range ?? statement.range,


### PR DESCRIPTION
Supports adding custom types using the `type <name> = <other type>` syntax

