### PR TITLE
Back ports intersection type and grouped type expressions

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4313,6 +4313,103 @@ describe('BrsFile', () => {
             `);
         });
 
+
+        it('allows intersectiion types for primitives', () => {
+            testTranspile(`
+                sub main(x as string and float, y as object and float or string)
+                end sub
+            `, `
+                sub main(x as dynamic, y as dynamic)
+                end sub
+            `);
+        });
+
+        it('allows intersection types for classes, interfaces', () => {
+            testTranspile(`
+                interface IFaceA
+                    name as string
+                    data as integer
+                end interface
+
+                interface IFaceB
+                    name as string
+                    value as float
+                end interface
+
+                sub main(x as IFaceA and IFaceB)
+                end sub
+            `, `
+                sub main(x as dynamic)
+                end sub
+            `);
+        });
+
+        it('allows intersection types for classes, interfaces', () => {
+            testTranspile(`
+                namespace alpha.beta
+                    interface IFaceA
+                        name as string
+                        data as integer
+                    end interface
+
+                    interface IFaceB
+                        name as string
+                        value as float
+                    end interface
+                end namespace
+
+                sub main(x as alpha.beta.IFaceA and alpha.beta.IFaceB)
+                end sub
+            `, `
+                sub main(x as dynamic)
+                end sub
+            `);
+        });
+
+        it('allows intersection types of arrays', () => {
+            testTranspile(`
+                namespace alpha.beta
+                    interface IFaceA
+                        name as string
+                        data as integer
+                    end interface
+
+                    interface IFaceB
+                        name as string
+                        value as float
+                    end interface
+                end namespace
+
+                sub main(x as alpha.beta.IFaceA[][] and alpha.beta.IFaceB[] and ifStringOps)
+                end sub
+            `, `
+                sub main(x as dynamic)
+                end sub
+            `);
+        });
+
+        it('allows grouped expression in types types', () => {
+            testTranspile(`
+                namespace alpha.beta
+                    interface IFaceA
+                        name as string
+                        data as integer
+                    end interface
+
+                    interface IFaceB
+                        name as string
+                        value as float
+                    end interface
+                end namespace
+
+                sub main(x as (alpha.beta.IFace and alpha.beta.IFaceB)[] or ifStringOps)
+                end sub
+            `, `
+                sub main(x as dynamic)
+                end sub
+            `);
+        });
+
         it('allows built-in types for return values', () => {
             testTranspile(`
                 function makeLabel(text as string) as roSGNodeLabel
@@ -4468,6 +4565,7 @@ describe('BrsFile', () => {
                 `);
             });
         });
+
     });
 
     it('allows up to 63 function params', () => {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -2800,11 +2800,11 @@ export class Parser {
      */
     private typeToken(ignoreDiagnostics = false): Token {
         let typeToken: Token;
-        let lookForUnions = true;
-        let isAUnion = false;
+        let lookForCompounds = true;
+        let isACompound = false;
         let resultToken;
-        while (lookForUnions) {
-            lookForUnions = false;
+        while (lookForCompounds) {
+            lookForCompounds = false;
 
             if (this.checkAny(...DeclarableTypes)) {
                 // Token is a built in type
@@ -2814,6 +2814,9 @@ export class Parser {
                     if (this.check(TokenKind.LeftCurlyBrace)) {
                         // could be an inline interface
                         typeToken = this.inlineInterface();
+                    } else if (this.check(TokenKind.LeftParen)) {
+                        // could be an inline interface
+                        typeToken = this.groupedTypeExpression();
                     } else {
                         // see if we can get a namespaced identifer
                         const qualifiedType = this.getNamespacedVariableNameExpression(ignoreDiagnostics);
@@ -2837,15 +2840,15 @@ export class Parser {
                     resultToken = createToken(TokenKind.Dynamic, null, typeToken.range);
                 }
 
-                if (this.check(TokenKind.Or)) {
-                    lookForUnions = true;
+                if (this.checkAny(TokenKind.Or, TokenKind.And)) {
+                    lookForCompounds = true;
                     let orToken = this.advance();
                     resultToken = createToken(TokenKind.Dynamic, null, util.createBoundingRange(resultToken, typeToken, orToken));
-                    isAUnion = true;
+                    isACompound = true;
                 }
             }
         }
-        if (isAUnion) {
+        if (isACompound) {
             resultToken = createToken(TokenKind.Dynamic, null, util.createBoundingRange(resultToken, typeToken));
         }
         return resultToken;
@@ -2919,6 +2922,16 @@ export class Parser {
         const completeInlineInterfaceToken = createToken(TokenKind.Dynamic, null, util.createBoundingRange(...memberTokens));
 
         return completeInlineInterfaceToken;
+    }
+
+    private groupedTypeExpression() {
+        const leftParen = this.advance();
+        const typeToken = this.typeToken();
+        const rightParen = this.consume(
+            DiagnosticMessages.expectedToken(TokenKind.RightParen),
+            TokenKind.RightParen
+        );
+        return createToken(TokenKind.Dynamic, null, util.createBoundingRange(leftParen, typeToken, rightParen));
     }
 
     private primary(): Expression {


### PR DESCRIPTION
- Allows v1 style intersection type syntax
- Allows v1 style grouped type expressions
- transpiles these to `dynamic`
- No type validation, just syntax updates