### PR TITLE
added selection range provider support to lsp capabilities

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -26,7 +26,8 @@ import type {
     CompletionList,
     CancellationToken,
     DidChangeConfigurationParams,
-    DidChangeConfigurationRegistrationOptions
+    DidChangeConfigurationRegistrationOptions,
+    SelectionRangeParams
 } from 'vscode-languageserver/node';
 import {
     SemanticTokensRequest,
@@ -221,6 +222,7 @@ export class LanguageServer {
                 },
                 definitionProvider: true,
                 hoverProvider: true,
+                selectionRangeProvider: true,
                 executeCommandProvider: {
                     commands: [
                         CustomCommands.TranspileFile
@@ -561,6 +563,14 @@ export class LanguageServer {
 
         const result = await this.projectManager.getWorkspaceSymbol();
         return result;
+    }
+
+    @AddStackToErrorMessage
+    public async onSelectionRanges(params: SelectionRangeParams) {
+        this.logger.debug('onSelectionRanges', params);
+
+        const srcPath = util.uriToPath(params.textDocument.uri);
+        return this.projectManager.getSelectionRanges({ srcPath: srcPath, positions: params.positions });
     }
 
     @AddStackToErrorMessage

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1,14 +1,14 @@
 import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
-import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, DocumentSymbol, CancellationToken } from 'vscode-languageserver';
+import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, DocumentSymbol, CancellationToken, SelectionRange } from 'vscode-languageserver';
 import { CancellationTokenSource, CompletionItemKind } from 'vscode-languageserver';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
 import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from './interfaces';
+import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent, ProvideSelectionRangesEvent } from './interfaces';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
@@ -1062,6 +1062,28 @@ export class Program {
         } else {
             return undefined;
         }
+    }
+
+    /**
+     * Get the selection ranges for the given positions in a file. Used for expand/shrink selection.
+     * @param srcPath path to the file
+     * @param positions the positions to get selection ranges for
+     */
+    public getSelectionRanges(srcPath: string, positions: Position[]): SelectionRange[] {
+        const file = this.getFile(srcPath);
+        if (file) {
+            const event: ProvideSelectionRangesEvent = {
+                program: this,
+                file: file,
+                positions: positions,
+                selectionRanges: []
+            };
+            this.plugins.emit('beforeProvideSelectionRanges', event);
+            this.plugins.emit('provideSelectionRanges', event);
+            this.plugins.emit('afterProvideSelectionRanges', event);
+            return event.selectionRanges;
+        }
+        return [];
     }
 
     /**

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,5 +1,5 @@
 import { isBrsFile, isXmlFile } from '../astUtils/reflection';
-import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from '../interfaces';
+import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent, ProvideSelectionRangesEvent } from '../interfaces';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { CompletionsProcessor } from './completions/CompletionsProcessor';
@@ -14,6 +14,7 @@ import { ProgramValidator } from './validation/ProgramValidator';
 import { ScopeValidator } from './validation/ScopeValidator';
 import { XmlFileValidator } from './validation/XmlFileValidator';
 import { WorkspaceSymbolProcessor } from './symbols/WorkspaceSymbolProcessor';
+import { SelectionRangesProcessor } from './selectionRanges/SelectionRangesProcessor';
 
 export class BscPlugin implements Plugin {
     public name = 'BscPlugin';
@@ -44,6 +45,10 @@ export class BscPlugin implements Plugin {
 
     public provideReferences(event: ProvideReferencesEvent) {
         new ReferencesProvider(event).process();
+    }
+
+    public provideSelectionRanges(event: ProvideSelectionRangesEvent) {
+        new SelectionRangesProcessor(event).process();
     }
 
     public onGetSemanticTokens(event: OnGetSemanticTokensEvent) {

--- a/src/bscPlugin/selectionRanges/SelectionRangesProcessor.spec.ts
+++ b/src/bscPlugin/selectionRanges/SelectionRangesProcessor.spec.ts
@@ -1,0 +1,355 @@
+import { expect } from '../../chai-config.spec';
+import { Program } from '../../Program';
+import { util } from '../../util';
+import { rootDir, trim } from '../../testHelpers.spec';
+import type { SelectionRange } from 'vscode-languageserver-types';
+
+describe('SelectionRangesProcessor', () => {
+    let program: Program;
+
+    beforeEach(() => {
+        program = new Program({ rootDir: rootDir });
+    });
+
+    afterEach(() => {
+        program.dispose();
+    });
+
+    /**
+     * Flatten a SelectionRange linked list (innermost → outermost) into an array
+     * of `[startLine, startChar, endLine, endChar]` tuples for easy assertion.
+     */
+    function flatten(sr: SelectionRange | undefined): Array<[number, number, number, number]> {
+        const result: Array<[number, number, number, number]> = [];
+        let current: SelectionRange | undefined = sr;
+        while (current) {
+            const { start, end } = current.range;
+            result.push([start.line, start.character, end.line, end.character]);
+            current = current.parent;
+        }
+        return result;
+    }
+
+    /**
+     * Extract the substring of `code` that a `[startLine, startChar, endLine, endChar]` range covers.
+     */
+    function getText(code: string, range: [number, number, number, number]): string {
+        const lines = code.split('\n');
+        const [startLine, startChar, endLine, endChar] = range;
+        if (startLine === endLine) {
+            return lines[startLine].slice(startChar, endChar);
+        }
+        const parts = [lines[startLine].slice(startChar)];
+        for (let i = startLine + 1; i < endLine; i++) {
+            parts.push(lines[i]);
+        }
+        parts.push(lines[endLine].slice(0, endChar));
+        return parts.join('\n');
+    }
+
+    function getSelectionRange(code: string, line: number, character: number) {
+        const file = program.setFile('source/main.brs', code);
+        program.validate();
+        const ranges = program.getSelectionRanges(file.pathAbsolute, [util.createPosition(line, character)]);
+        return ranges[0];
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic identifier / variable
+    // -------------------------------------------------------------------------
+
+    it('expands from identifier token to assignment statement to function', () => {
+        const code = trim`
+            sub main()
+                name = "hello"
+            end sub
+        `;
+
+        // cursor on 'n' of 'name' (line 1, col 4)
+        const sr = getSelectionRange(code, 1, 4);
+        const steps = flatten(sr);
+
+        expect(getText(code, steps[0])).to.equal('name', 'first step should be the identifier token');
+        expect(getText(code, steps[1])).to.equal('name = "hello"', 'second step should be the assignment statement');
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the full sub');
+    });
+
+    // -------------------------------------------------------------------------
+    // String literal
+    // -------------------------------------------------------------------------
+
+    it('expands from string literal to assignment to function', () => {
+        const code = trim`
+            sub main()
+                name = "hello"
+            end sub
+        `;
+
+        // cursor inside "hello" — col 12 is 'h'
+        const sr = getSelectionRange(code, 1, 12);
+        const steps = flatten(sr);
+
+        expect(getText(code, steps[0])).to.equal('"hello"', 'first step should be the string literal');
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the full sub');
+    });
+
+    // -------------------------------------------------------------------------
+    // Dotted-get expression (member access)
+    // -------------------------------------------------------------------------
+
+    it('expands name token then full dotted-get chain', () => {
+        const code = trim`
+            sub main()
+                x = m.top.value
+            end sub
+        `;
+
+        // cursor in the middle of 'value' — col 16
+        const sr = getSelectionRange(code, 1, 16);
+        const steps = flatten(sr);
+
+        expect(getText(code, steps[0])).to.equal('value', 'first step is the name token of the dotted-get');
+        expect(getText(code, steps[1])).to.equal('m.top.value', 'second step is the full dotted-get expression');
+    });
+
+    // -------------------------------------------------------------------------
+    // Function call expression
+    // -------------------------------------------------------------------------
+
+    it('expands from argument to full function call expression', () => {
+        const code = trim`
+            sub main()
+                foo("hello")
+            end sub
+        `;
+
+        // cursor on 'h' inside "hello" — col 9
+        const sr = getSelectionRange(code, 1, 9);
+        const steps = flatten(sr);
+
+        expect(getText(code, steps[0])).to.equal('"hello"', 'first step is the string arg');
+        const hasCallRange = steps.some(r => getText(code, r) === 'foo("hello")');
+        expect(hasCallRange).to.be.true;
+    });
+
+    // -------------------------------------------------------------------------
+    // Nested function / function expression
+    // -------------------------------------------------------------------------
+
+    it('expands from nested function body through inner function to outer sub', () => {
+        const code = trim`
+            sub outer()
+                inner = function()
+                    x = 1
+                end function
+            end sub
+        `;
+
+        // cursor on 'x' — line 2, col 8
+        const sr = getSelectionRange(code, 2, 8);
+        const steps = flatten(sr);
+
+        // Should have at least 4 steps: token → stmt → inner fn → outer sub
+        expect(steps.length).to.be.at.least(4);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the full outer sub');
+    });
+
+    // -------------------------------------------------------------------------
+    // If / else blocks
+    // -------------------------------------------------------------------------
+
+    it('expands from inside an if block to the enclosing sub', () => {
+        const code = trim`
+            sub main()
+                if true then
+                    x = 1
+                end if
+            end sub
+        `;
+
+        // cursor on 'x' — line 2, col 8
+        const sr = getSelectionRange(code, 2, 8);
+        const steps = flatten(sr);
+
+        expect(steps.length).to.be.at.least(3);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the full sub');
+    });
+
+    // -------------------------------------------------------------------------
+    // For loop
+    // -------------------------------------------------------------------------
+
+    it('expands from inside a for loop body to the enclosing sub', () => {
+        const code = trim`
+            sub main()
+                for i = 0 to 10
+                    x = 1
+                end for
+            end sub
+        `;
+
+        // cursor on 'x' — line 2, col 8
+        const sr = getSelectionRange(code, 2, 8);
+        const steps = flatten(sr);
+
+        expect(steps.length).to.be.at.least(3);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the full sub');
+    });
+
+    // -------------------------------------------------------------------------
+    // Class
+    // -------------------------------------------------------------------------
+
+    it('expands from class method body through method to class', () => {
+        const code = trim`
+            class MyClass
+                function greet() as string
+                    return "hello"
+                end function
+            end class
+        `;
+
+        // cursor on 'h' in "hello" — line 2, col 16
+        const sr = getSelectionRange(code, 2, 16);
+        const steps = flatten(sr);
+
+        expect(steps.length).to.be.at.least(3);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the whole class');
+    });
+
+    // -------------------------------------------------------------------------
+    // Namespace
+    // -------------------------------------------------------------------------
+
+    it('expands from namespace function body to namespace', () => {
+        const code = trim`
+            namespace MyApp
+                sub doThing()
+                    x = 1
+                end sub
+            end namespace
+        `;
+
+        // cursor on 'x' — line 2, col 8
+        const sr = getSelectionRange(code, 2, 8);
+        const steps = flatten(sr);
+
+        expect(steps.length).to.be.at.least(4);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the whole namespace');
+    });
+
+    // -------------------------------------------------------------------------
+    // Multiple positions in one request
+    // -------------------------------------------------------------------------
+
+    it('handles multiple positions in one request', () => {
+        const code = trim`
+            sub main()
+                a = 1
+                b = 2
+            end sub
+        `;
+        const file = program.setFile('source/multi.brs', code);
+        program.validate();
+
+        const ranges = program.getSelectionRanges(file.pathAbsolute, [
+            util.createPosition(1, 4), // cursor on 'a'
+            util.createPosition(2, 4) // cursor on 'b'
+        ]);
+        expect(ranges).to.have.length(2);
+        expect(ranges[0]).to.exist;
+        expect(ranges[1]).to.exist;
+
+        const steps0 = flatten(ranges[0]);
+        const steps1 = flatten(ranges[1]);
+        expect(getText(code, steps0[0])).to.equal('a', 'first position selects identifier "a"');
+        expect(getText(code, steps1[0])).to.equal('b', 'second position selects identifier "b"');
+    });
+
+    // -------------------------------------------------------------------------
+    // BrighterScript: enum
+    // -------------------------------------------------------------------------
+
+    it('expands inside an enum member value to the whole enum', () => {
+        const code = trim`
+            enum Direction
+                up = "up"
+                down = "down"
+            end enum
+        `;
+
+        // cursor on 'u' inside "up" on line 1 — col 10
+        const sr = getSelectionRange(code, 1, 10);
+        const steps = flatten(sr);
+
+        expect(steps.length).to.be.at.least(2);
+        expect(getText(code, steps[steps.length - 1])).to.equal(code, 'outermost step should be the whole enum');
+    });
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    it('returns empty array for a position outside any node', () => {
+        const code = trim`
+            sub main()
+            end sub
+        `;
+        const file = program.setFile('source/empty.brs', code);
+        program.validate();
+        // position far past the last line — should not throw
+        const ranges = program.getSelectionRanges(file.pathAbsolute, [util.createPosition(99, 0)]);
+        expect(Array.isArray(ranges)).to.be.true;
+    });
+
+    it('returns empty array for unknown file', () => {
+        const ranges = program.getSelectionRanges('/does/not/exist.brs', [util.createPosition(0, 0)]);
+        expect(ranges).to.eql([]);
+    });
+
+    it('does not return duplicate consecutive ranges', () => {
+        const code = trim`
+            sub main()
+                x = 1
+            end sub
+        `;
+        const sr = getSelectionRange(code, 1, 4);
+        const steps = flatten(sr);
+
+        // Verify no two consecutive steps have identical ranges
+        for (let i = 1; i < steps.length; i++) {
+            const prev = steps[i - 1];
+            const curr = steps[i];
+            const sameRange = prev[0] === curr[0] && prev[1] === curr[1] &&
+                prev[2] === curr[2] && prev[3] === curr[3];
+            expect(sameRange).to.be.false;
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // Plugin extensibility
+    // -------------------------------------------------------------------------
+
+    it('allows plugins to contribute custom selection ranges', () => {
+        const customRange = util.createRange(0, 0, 0, 10);
+        program.plugins.add({
+            name: 'test-plugin',
+            provideSelectionRanges: (event) => {
+                event.selectionRanges.push({ range: customRange });
+            }
+        });
+
+        const code = trim`
+            sub main()
+            end sub
+        `;
+        const file = program.setFile('source/plugin.brs', code);
+        program.validate();
+
+        const ranges = program.getSelectionRanges(file.pathAbsolute, [util.createPosition(0, 4)]);
+        // The bsc plugin should push a range, and the test plugin pushed another
+        expect(ranges.length).to.be.at.least(2);
+        const hasCustom = ranges.some(r => r.range.start.line === 0 && r.range.end.character === 10);
+        expect(hasCustom).to.be.true;
+    });
+});

--- a/src/bscPlugin/selectionRanges/SelectionRangesProcessor.ts
+++ b/src/bscPlugin/selectionRanges/SelectionRangesProcessor.ts
@@ -1,0 +1,83 @@
+import { SelectionRange } from 'vscode-languageserver-types';
+import type { Range, Position } from 'vscode-languageserver-protocol';
+import { isBrsFile } from '../../astUtils/reflection';
+import type { ProvideSelectionRangesEvent } from '../../interfaces';
+import type { AstNode } from '../../parser/AstNode';
+
+export class SelectionRangesProcessor {
+    public constructor(
+        public event: ProvideSelectionRangesEvent
+    ) { }
+
+    public process() {
+        if (!isBrsFile(this.event.file)) {
+            return;
+        }
+
+        for (const position of this.event.positions) {
+            const selectionRange = this.buildSelectionRange(position);
+            if (selectionRange) {
+                this.event.selectionRanges.push(selectionRange);
+            }
+        }
+    }
+
+    private buildSelectionRange(position: Position): SelectionRange | undefined {
+        const file = this.event.file;
+        if (!isBrsFile(file)) {
+            return undefined;
+        }
+
+        // Find the deepest AST node containing this position
+        const innerNode = file.ast.findChildAtPosition(position);
+        if (!innerNode?.range) {
+            return undefined;
+        }
+
+        const ranges: Range[] = [];
+
+        // Many BrightScript AST nodes store identifier names as raw Tokens (not child
+        // AstNodes), so findChildAtPosition stops at the enclosing statement/expression.
+        // To give the first expansion step a tight "identifier only" range — matching
+        // the JS/TS smart-select behaviour — we look up the exact lexer token at the
+        // cursor position and use its range as the initial step.
+        const token = file.getTokenAt(position);
+        if (token?.range && !rangesEqual(token.range, innerNode.range)) {
+            ranges.push(token.range);
+        }
+
+        // Walk up the AST parent chain, collecting each node's range.
+        // Skip duplicate consecutive ranges (e.g. a Block whose range equals its
+        // only child statement, or an ExpressionStatement === its expression).
+        let node: AstNode | undefined = innerNode;
+        while (node) {
+            const nodeRange = node.range;
+            if (nodeRange && !rangesEqual(nodeRange, ranges[ranges.length - 1])) {
+                ranges.push(nodeRange);
+            }
+            node = node.parent;
+        }
+
+        if (ranges.length === 0) {
+            return undefined;
+        }
+
+        // Build the SelectionRange linked list from outermost → innermost.
+        // LSP: the innermost range has `.parent` pointing outward.
+        let selectionRange: SelectionRange | undefined;
+        for (let i = ranges.length - 1; i >= 0; i--) {
+            selectionRange = SelectionRange.create(ranges[i], selectionRange);
+        }
+        return selectionRange;
+    }
+}
+
+function rangesEqual(a: Range | undefined, b: Range | undefined): boolean {
+    if (!a || !b) {
+        return false;
+    }
+    return a.start.line === b.start.line &&
+        a.start.character === b.start.character &&
+        a.end.line === b.end.line &&
+        a.end.character === b.end.character;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Range, Diagnostic, CodeAction, Position, CompletionItem, Location, DocumentSymbol, WorkspaceSymbol, Disposable, FileChangeType } from 'vscode-languageserver-protocol';
+import type { Range, Diagnostic, CodeAction, Position, CompletionItem, Location, DocumentSymbol, WorkspaceSymbol, Disposable, FileChangeType, SelectionRange } from 'vscode-languageserver-protocol';
 import type { Scope } from './Scope';
 import type { BrsFile } from './files/BrsFile';
 import type { XmlFile } from './files/XmlFile';
@@ -309,6 +309,20 @@ export interface Plugin {
     afterProvideWorkspaceSymbols?(event: AfterProvideWorkspaceSymbolsEvent): any;
 
 
+    /**
+     * Called before the `provideSelectionRanges` hook
+     */
+    beforeProvideSelectionRanges?(event: BeforeProvideSelectionRangesEvent): any;
+    /**
+     * Provide the selection ranges for the given positions in a file. Used for expand/shrink selection.
+     */
+    provideSelectionRanges?(event: ProvideSelectionRangesEvent): any;
+    /**
+     * Called after `provideSelectionRanges`. Use this if you want to intercept or sanitize the selection range data provided by bsc or other plugins.
+     */
+    afterProvideSelectionRanges?(event: AfterProvideSelectionRangesEvent): any;
+
+
     onGetSemanticTokens?: PluginHandler<OnGetSemanticTokensEvent>;
     //scope events
     afterScopeCreate?: (scope: Scope) => void;
@@ -444,6 +458,26 @@ export interface ProvideWorkspaceSymbolsEvent {
 }
 export type BeforeProvideWorkspaceSymbolsEvent = ProvideWorkspaceSymbolsEvent;
 export type AfterProvideWorkspaceSymbolsEvent = ProvideWorkspaceSymbolsEvent;
+
+
+export interface ProvideSelectionRangesEvent<TFile = BscFile> {
+    program: Program;
+    /**
+     * The file that the `selectionRange` request was invoked in
+     */
+    file: TFile;
+    /**
+     * The list of positions for which selection ranges are requested
+     */
+    positions: Position[];
+    /**
+     * The result list of selection ranges. One entry per position in `positions`.
+     * Each SelectionRange is a linked list from innermost to outermost via the `.parent` property.
+     */
+    selectionRanges: SelectionRange[];
+}
+export type BeforeProvideSelectionRangesEvent<TFile = BscFile> = ProvideSelectionRangesEvent<TFile>;
+export type AfterProvideSelectionRangesEvent<TFile = BscFile> = ProvideSelectionRangesEvent<TFile>;
 
 
 export interface OnGetSemanticTokensEvent<T extends BscFile = BscFile> {

--- a/src/lsp/LspProject.ts
+++ b/src/lsp/LspProject.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, Position, Range, Location, DocumentSymbol, WorkspaceSymbol, CodeAction, CompletionList } from 'vscode-languageserver-protocol';
+import type { Diagnostic, Position, Range, Location, DocumentSymbol, WorkspaceSymbol, CodeAction, CompletionList, SelectionRange } from 'vscode-languageserver-protocol';
 import type { Hover, MaybePromise, SemanticToken } from '../interfaces';
 import type { DocumentAction, DocumentActionWithStatus } from './DocumentManager';
 import type { FileTranspileResult, SignatureInfoObj } from '../Program';
@@ -141,6 +141,11 @@ export interface LspProject {
      * Get all of the code actions for the specified file and range
      */
     getCodeActions(options: { srcPath: string; range: Range }): Promise<CodeAction[]>;
+
+    /**
+     * Get the selection ranges for the given positions in the specified file
+     */
+    getSelectionRanges(options: { srcPath: string; positions: Position[] }): MaybePromise<SelectionRange[]>;
 
     /**
      * Get the completions for the specified file and position

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -417,6 +417,13 @@ export class Project implements LspProject {
         }
     }
 
+    public async getSelectionRanges(options: { srcPath: string; positions: Position[] }) {
+        await this.onIdle();
+        if (this.builder.program.hasFile(options.srcPath)) {
+            return this.builder.program.getSelectionRanges(options.srcPath, options.positions);
+        }
+    }
+
     public async getCodeActions(options: { srcPath: string; range: Range }) {
         await this.onIdle();
 

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -6,7 +6,7 @@ import type { LspDiagnostic, LspProject, ProjectConfig } from './LspProject';
 import { Project } from './Project';
 import { WorkerThreadProject } from './worker/WorkerThreadProject';
 import { FileChangeType } from 'vscode-languageserver-protocol';
-import type { Hover, Position, Range, Location, SignatureHelp, DocumentSymbol, SymbolInformation, WorkspaceSymbol, CompletionList, CancellationToken } from 'vscode-languageserver-protocol';
+import type { Hover, Position, Range, Location, SignatureHelp, DocumentSymbol, SymbolInformation, WorkspaceSymbol, CompletionList, CancellationToken, SelectionRange } from 'vscode-languageserver-protocol';
 import { Deferred } from '../deferred';
 import type { DocumentActionWithStatus, FlushEvent } from './DocumentManager';
 import { DocumentManager } from './DocumentManager';
@@ -666,6 +666,20 @@ export class ProjectManager {
             (result) => !!result
         );
         return result;
+    }
+
+    @TrackBusyStatus
+    public async getSelectionRanges(options: { srcPath: string; positions: Position[] }): Promise<SelectionRange[]> {
+        //wait for all pending syncs to finish
+        await this.onIdle();
+
+        //Ask every project for selection ranges, keep whichever one responds first with a non-empty result
+        let result = await util.promiseRaceMatch(
+            this.projects.map(x => x.getSelectionRanges(options)),
+            //keep the first non-empty result
+            (result) => result?.length > 0
+        );
+        return result ?? [];
     }
 
     /**

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -10,7 +10,7 @@ import type { Hover, MaybePromise, SemanticToken } from '../../interfaces';
 import type { DocumentAction, DocumentActionWithStatus } from '../DocumentManager';
 import { Deferred } from '../../deferred';
 import type { FileTranspileResult, SignatureInfoObj } from '../../Program';
-import type { Position, Range, Location, DocumentSymbol, WorkspaceSymbol, CodeAction, CompletionList } from 'vscode-languageserver-protocol';
+import type { Position, Range, Location, DocumentSymbol, WorkspaceSymbol, CodeAction, CompletionList, SelectionRange } from 'vscode-languageserver-protocol';
 import type { Logger } from '../../logging';
 import { createLogger } from '../../logging';
 import * as fsExtra from 'fs-extra';
@@ -242,6 +242,10 @@ export class WorkerThreadProject implements LspProject {
 
     public async getCodeActions(options: { srcPath: string; range: Range }): Promise<CodeAction[]> {
         return this.sendStandardRequest<CodeAction[]>('getCodeActions', options);
+    }
+
+    public async getSelectionRanges(options: { srcPath: string; positions: Position[] }): Promise<SelectionRange[]> {
+        return this.sendStandardRequest<SelectionRange[]>('getSelectionRanges', options);
     }
 
     public async getCompletions(options: { srcPath: string; position: Position }): Promise<CompletionList> {


### PR DESCRIPTION
Implements the LSP [textDocument/selectionRange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange) request, which allows clients to request a set of expanded selection ranges for given cursor positions. Each response is a linked list of ranges from innermost to outermost, giving clients a syntactically-aware path from the cursor outward through the AST.

The server now advertises selectionRangeProvider: true in its capabilities. When a request comes in, it finds the deepest AST node at each position, prepends the exact lexer token range as the tightest step (handling cases like AssignmentStatement.name which is stored as a raw Token rather than a child AST node), then walks the .parent chain collecting each node's range — deduplicating any consecutive identical ranges along the way.