### PR TITLE
added source fix all code action support

### DIFF
--- a/src/CodeActionUtil.ts
+++ b/src/CodeActionUtil.ts
@@ -57,6 +57,24 @@ export interface CodeActionShorthand {
     changes: Array<InsertChange | ReplaceChange | DeleteChange>;
 }
 
+/**
+ * Represents a single named "source fix all" action that a plugin contributes.
+ * Each action becomes a separate entry in VS Code's Source Actions menu.
+ * Plugins are responsible for merging all their changes into the `changes` array.
+ */
+export interface SourceFixAllCodeAction {
+    title: string;
+    /**
+     * The LSP code action kind. Should start with `source.fixAll`.
+     * Use a sub-kind like `source.fixAll.brighterscript.imports` to create
+     * a distinct named entry in the Source Actions menu.
+     * Defaults to `source.fixAll.brighterscript`.
+     */
+    kind?: string;
+    isPreferred?: boolean;
+    changes: Array<InsertChange | ReplaceChange | DeleteChange>;
+}
+
 export interface InsertChange {
     filePath: string;
     newText: string;

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -214,7 +214,10 @@ export class LanguageServer {
                 } as SemanticTokensOptions,
                 referencesProvider: true,
                 codeActionProvider: {
-                    codeActionKinds: [CodeActionKind.Refactor]
+                    codeActionKinds: [
+                        CodeActionKind.QuickFix,
+                        CodeActionKind.SourceFixAll
+                    ]
                 },
                 signatureHelpProvider: {
                     triggerCharacters: ['(', ',']
@@ -627,8 +630,23 @@ export class LanguageServer {
         this.logger.debug('onCodeAction', params);
 
         const srcPath = util.uriToPath(params.textDocument.uri);
-        const result = await this.projectManager.getCodeActions({ srcPath: srcPath, range: params.range });
-        return result;
+        const requestedKinds = params.context?.only ?? [];
+
+        // In LSP, kinds are hierarchical: 'source' matches 'source.fixAll.*', 'quickfix' matches 'quickfix.*'.
+        // A requested kind K matches an action kind A if A.startsWith(K) or K.startsWith(A).
+        // When context.only is absent the client wants everything, so we fetch both.
+        const matchesKind = (actionKind: string) => requestedKinds.length === 0 ||
+            requestedKinds.some(kind => actionKind.startsWith(kind) || kind.startsWith(actionKind));
+
+        const wantsQuickFix = matchesKind(CodeActionKind.QuickFix);
+        const wantsFixAll = matchesKind(CodeActionKind.SourceFixAll);
+
+        const [quickFixes, fixAllActions] = await Promise.all([
+            wantsQuickFix ? this.projectManager.getCodeActions({ srcPath: srcPath, range: params.range }) : [],
+            wantsFixAll ? this.projectManager.getFixAllCodeActions({ srcPath: srcPath }) : []
+        ]);
+
+        return [...(quickFixes ?? []), ...(fixAllActions ?? [])];
     }
 
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -8,7 +8,9 @@ import { Scope } from './Scope';
 import { DiagnosticMessages } from './DiagnosticMessages';
 import { BrsFile } from './files/BrsFile';
 import { XmlFile } from './files/XmlFile';
-import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from './interfaces';
+import type { BsDiagnostic, File, FileReference, FileObj, BscFile, SemanticToken, AfterFileTranspileEvent, FileLink, ProvideHoverEvent, ProvideCompletionsEvent, Hover, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent, OnGetSourceFixAllCodeActionsEvent } from './interfaces';
+import type { SourceFixAllCodeAction } from './CodeActionUtil';
+import { codeActionUtil } from './CodeActionUtil';
 import { standardizePath as s, util } from './util';
 import { XmlScope } from './XmlScope';
 import { DiagnosticFilterer } from './DiagnosticFilterer';
@@ -1091,6 +1093,33 @@ export class Program {
             });
         }
         return codeActions;
+    }
+
+    /**
+     * Compute "source fix all" code actions for the given file.
+     * Fires the `onGetSourceFixAllCodeActions` plugin event with all diagnostics for the file (no range filter),
+     * then converts each contributed SourceFixAllCodeAction into an LSP CodeAction.
+     */
+    public getSourceFixAllCodeActions(srcPath: string): CodeAction[] {
+        const actions: SourceFixAllCodeAction[] = [];
+        const file = this.getFile(srcPath);
+        if (file) {
+            const diagnostics = this
+                .getDiagnostics()
+                .filter(x => x.file === file);
+            const scopes = this.getScopesForFile(file);
+            this.plugins.emit('onGetSourceFixAllCodeActions', {
+                program: this,
+                file: file,
+                diagnostics: diagnostics,
+                scopes: scopes,
+                actions: actions
+            } as OnGetSourceFixAllCodeActionsEvent);
+        }
+        return actions.map(action => codeActionUtil.createCodeAction({
+            ...action,
+            kind: action.kind ?? 'source.fixAll.brighterscript' as any
+        }));
     }
 
     /**

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,7 +1,8 @@
 import { isBrsFile, isXmlFile } from '../astUtils/reflection';
-import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from '../interfaces';
+import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, OnGetSourceFixAllCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent } from '../interfaces';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
+import { FixAllCodeActionsProcessor } from './codeActions/FixAllCodeActionsProcessor';
 import { CompletionsProcessor } from './completions/CompletionsProcessor';
 import { DefinitionProvider } from './definition/DefinitionProvider';
 import { DocumentSymbolProcessor } from './symbols/DocumentSymbolProcessor';
@@ -20,6 +21,10 @@ export class BscPlugin implements Plugin {
 
     public onGetCodeActions(event: OnGetCodeActionsEvent) {
         new CodeActionsProcessor(event).process();
+    }
+
+    public onGetSourceFixAllCodeActions(event: OnGetSourceFixAllCodeActionsEvent) {
+        new FixAllCodeActionsProcessor(event).process();
     }
 
     public provideHover(event: ProvideHoverEvent) {

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -11,6 +11,7 @@ import { util } from '../../util';
 import { isBrsFile, isFunctionExpression } from '../../astUtils/reflection';
 import type { FunctionExpression } from '../../parser/Expression';
 import { TokenKind } from '../../lexer/TokenKind';
+import { getMissingExtendsInsertPosition, getRemoveReturnValueChange } from './codeActionHelpers';
 
 export class CodeActionsProcessor {
     public constructor(
@@ -105,9 +106,7 @@ export class CodeActionsProcessor {
 
     private addMissingExtends(diagnostic: DiagnosticMessageType<'xmlComponentMissingExtendsAttribute'>) {
         const srcPath = this.event.file.srcPath;
-        const { component } = (this.event.file as XmlFile).parser.ast;
-        //inject new attribute after the final attribute, or after the `<component` if there are no attributes
-        const pos = (component.attributes[component.attributes.length - 1] ?? component.tag).range.end;
+        const pos = getMissingExtendsInsertPosition(this.event.file as XmlFile);
         this.event.codeActions.push(
             codeActionUtil.createCodeAction({
                 title: `Extend "Group"`,
@@ -156,18 +155,23 @@ export class CodeActionsProcessor {
                 title: `Remove return value`,
                 diagnostics: [diagnostic],
                 kind: CodeActionKind.QuickFix,
-                changes: [{
-                    type: 'delete',
-                    filePath: this.event.file.srcPath,
-                    range: util.createRange(
-                        diagnostic.range.start.line,
-                        diagnostic.range.start.character + 'return'.length,
-                        diagnostic.range.end.line,
-                        diagnostic.range.end.character
-                    )
-                }]
+                changes: [getRemoveReturnValueChange(diagnostic, this.event.file.srcPath)]
             })
         );
+
+        // If there are multiple instances in this file, offer a "fix all" quickfix that appears
+        // directly in the lightbulb (same as ESLint's "Fix all 'rule-name' problems" pattern)
+        const allInFile = this.event.program.getDiagnostics()
+            .filter(x => x.file === this.event.file && x.code === diagnostic.code);
+        if (allInFile.length > 1) {
+            this.event.codeActions.push(
+                codeActionUtil.createCodeAction({
+                    title: `Fix all: Remove void return values`,
+                    kind: CodeActionKind.QuickFix,
+                    changes: allInFile.map(d => getRemoveReturnValueChange(d, this.event.file.srcPath))
+                })
+            );
+        }
         if (isBrsFile(this.event.file)) {
             const expression = this.event.file.getClosestExpression(diagnostic.range.start);
             const func = expression.findAncestor<FunctionExpression>(isFunctionExpression);

--- a/src/bscPlugin/codeActions/FixAllCodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/FixAllCodeActionsProcessor.ts
@@ -1,0 +1,73 @@
+import type { BsDiagnostic } from '../../interfaces';
+import { DiagnosticCodeMap } from '../../DiagnosticMessages';
+import type { DiagnosticMessageType } from '../../DiagnosticMessages';
+import type { XmlFile } from '../../files/XmlFile';
+import type { OnGetSourceFixAllCodeActionsEvent } from '../../interfaces';
+import { isXmlFile } from '../../astUtils/reflection';
+import { getMissingExtendsInsertPosition, getRemoveReturnValueChange } from './codeActionHelpers';
+
+export class FixAllCodeActionsProcessor {
+    public constructor(
+        public event: OnGetSourceFixAllCodeActionsEvent
+    ) { }
+
+    public process() {
+        const byCode = new Map<number | string, BsDiagnostic[]>();
+        for (const diagnostic of this.event.diagnostics) {
+            const key = diagnostic.code;
+            if (!byCode.has(key)) {
+                byCode.set(key, []);
+            }
+            byCode.get(key).push(diagnostic);
+        }
+
+        const missingExtends = byCode.get(DiagnosticCodeMap.xmlComponentMissingExtendsAttribute);
+        if (missingExtends) {
+            this.processMissingExtends(missingExtends as DiagnosticMessageType<'xmlComponentMissingExtendsAttribute'>[]);
+        }
+
+        const voidFunctionReturns = byCode.get(DiagnosticCodeMap.voidFunctionMayNotReturnValue);
+        if (voidFunctionReturns) {
+            this.processVoidFunctionReturnActions(voidFunctionReturns);
+        }
+    }
+
+    /**
+     * For every `voidFunctionMayNotReturnValue` diagnostic in this file,
+     * remove the return value expression, leaving the bare `return` keyword.
+     */
+    private processVoidFunctionReturnActions(diagnostics: BsDiagnostic[]) {
+        const changes = diagnostics.map(diagnostic => getRemoveReturnValueChange(diagnostic, this.event.file.srcPath));
+        this.event.actions.push({
+            title: 'Remove all void return values',
+            kind: 'source.fixAll.brighterscript',
+            isPreferred: true,
+            changes: changes
+        });
+    }
+
+    /**
+     * For every `xmlComponentMissingExtendsAttribute` diagnostic in this file,
+     * insert `extends="Group"` — the same choice marked `isPreferred` in the
+     * per-diagnostic quick-fix.
+     */
+    private processMissingExtends(diagnostics: DiagnosticMessageType<'xmlComponentMissingExtendsAttribute'>[]) {
+        if (!isXmlFile(this.event.file)) {
+            return;
+        }
+
+        const changes = diagnostics.map(() => ({
+            type: 'insert' as const,
+            filePath: this.event.file.srcPath,
+            position: getMissingExtendsInsertPosition(this.event.file as XmlFile),
+            newText: ' extends="Group"'
+        }));
+
+        this.event.actions.push({
+            title: 'Add missing extends attributes',
+            kind: 'source.fixAll.brighterscript',
+            isPreferred: true,
+            changes: changes
+        });
+    }
+}

--- a/src/bscPlugin/codeActions/codeActionHelpers.ts
+++ b/src/bscPlugin/codeActions/codeActionHelpers.ts
@@ -1,0 +1,31 @@
+import type { Diagnostic } from 'vscode-languageserver';
+import type { XmlFile } from '../../files/XmlFile';
+import { util } from '../../util';
+
+/**
+ * Returns the position at which an `extends` attribute should be inserted for
+ * a component that is missing one: after the last existing attribute, or after
+ * the `<component` tag itself if there are no attributes yet.
+ */
+export function getMissingExtendsInsertPosition(file: XmlFile) {
+    const { component } = file.parser.ast;
+    return (component.attributes[component.attributes.length - 1] ?? component.tag).range.end;
+}
+
+/**
+ * Returns the delete change that removes the return value from a `return <expr>`
+ * statement flagged by `voidFunctionMayNotReturnValue`. Leaves the bare `return`
+ * keyword in place.
+ */
+export function getRemoveReturnValueChange(diagnostic: Diagnostic, filePath: string) {
+    return {
+        type: 'delete' as const,
+        filePath: filePath,
+        range: util.createRange(
+            diagnostic.range.start.line,
+            diagnostic.range.start.character + 'return'.length,
+            diagnostic.range.end.line,
+            diagnostic.range.end.character
+        )
+    };
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,7 @@ import type { BscType } from './types/BscType';
 import type { AstEditor } from './astUtils/AstEditor';
 import type { Token } from './lexer/Token';
 import type { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver';
+import type { SourceFixAllCodeAction } from './CodeActionUtil';
 
 export interface BsDiagnostic extends Diagnostic {
     file: BscFile;
@@ -218,6 +219,14 @@ export interface Plugin {
     afterProgramTranspile?: (program: Program, entries: TranspileObj[], editor: AstEditor) => void;
     beforeProgramDispose?: PluginHandler<BeforeProgramDisposeEvent>;
     onGetCodeActions?: PluginHandler<OnGetCodeActionsEvent>;
+    /**
+     * Emitted when VS Code requests "source fix all" source actions for a file.
+     * Plugins push one or more `SourceFixAllCodeAction` objects onto `event.actions`,
+     * each representing a distinct named group that will appear in the Source Actions menu.
+     * Plugins are responsible for assembling and merging all changes within each action.
+     */
+    // For possible future use, but not currently implemented:
+    onGetSourceFixAllCodeActions?: PluginHandler<OnGetSourceFixAllCodeActionsEvent>;
 
     /**
      * Emitted before the program starts collecting completions
@@ -346,6 +355,19 @@ export interface OnGetCodeActionsEvent {
     scopes: Scope[];
     diagnostics: BsDiagnostic[];
     codeActions: CodeAction[];
+}
+
+export interface OnGetSourceFixAllCodeActionsEvent {
+    program: Program;
+    file: BscFile;
+    /** All diagnostics for this file (not range-filtered) */
+    diagnostics: BsDiagnostic[];
+    scopes: Scope[];
+    /**
+     * Plugins push one or more SourceFixAllCodeAction objects here.
+     * Each becomes a distinct named entry in VS Code's Source Actions menu.
+     */
+    actions: SourceFixAllCodeAction[];
 }
 
 export interface ProvideCompletionsEvent<TFile extends BscFile = BscFile> {

--- a/src/lsp/LspProject.ts
+++ b/src/lsp/LspProject.ts
@@ -143,6 +143,11 @@ export interface LspProject {
     getCodeActions(options: { srcPath: string; range: Range }): Promise<CodeAction[]>;
 
     /**
+     * Get all "fix all" source actions for the specified file
+     */
+    getSourceFixAllCodeActions(options: { srcPath: string }): Promise<CodeAction[]>;
+
+    /**
      * Get the completions for the specified file and position
      */
     getCompletions(options: { srcPath: string; position: Position }): Promise<CompletionList>;

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -432,6 +432,14 @@ export class Project implements LspProject {
         }
     }
 
+    public async getSourceFixAllCodeActions(options: { srcPath: string }) {
+        await this.onIdle();
+
+        if (this.builder.program.hasFile(options.srcPath)) {
+            return this.builder.program.getSourceFixAllCodeActions(options.srcPath);
+        }
+    }
+
     public async getCompletions(options: { srcPath: string; position: Position }): Promise<CompletionList> {
         await this.onIdle();
 

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -668,6 +668,18 @@ export class ProjectManager {
         return result;
     }
 
+    @TrackBusyStatus
+    public async getFixAllCodeActions(options: { srcPath: string }) {
+        //wait for all pending syncs to finish
+        await this.onIdle();
+
+        let result = await util.promiseRaceMatch(
+            this.projects.map(x => x.getSourceFixAllCodeActions(options)),
+            (result) => !!result
+        );
+        return result;
+    }
+
     /**
      * Scan a given workspace for all `bsconfig.json` files. If at least one is found, then only folders who have bsconfig.json are returned.
      * If none are found, then the workspaceFolder itself is treated as a project

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -244,6 +244,10 @@ export class WorkerThreadProject implements LspProject {
         return this.sendStandardRequest<CodeAction[]>('getCodeActions', options);
     }
 
+    public async getSourceFixAllCodeActions(options: { srcPath: string }): Promise<CodeAction[]> {
+        return this.sendStandardRequest<CodeAction[]>('getFixAllCodeActions', options);
+    }
+
     public async getCompletions(options: { srcPath: string; position: Position }): Promise<CompletionList> {
         return this.sendStandardRequest<CompletionList>('getCompletions', options);
     }


### PR DESCRIPTION
## Summary

Adds LSP `source.fixAll` code action support so plugins can contribute file-wide "fix all" actions that show up directly in VS Code's Source Actions menu (the same lightbulb slot ESLint uses for "Fix all auto-fixable problems"). Also lets `editor.codeActionsOnSave` with `source.fixAll.brighterscript` run them on save.

## Why

Per-diagnostic quickfixes are great for one occurrence, but when a file has many violations of the same rule, repeatedly invoking the lightbulb is tedious. VS Code already has a dedicated UX for this via `CodeActionKind.SourceFixAll`. brighterscript previously didn't surface anything in that slot, so users had no one-click way to clean up all instances of a rule in a file.

## What changed

### New plugin extension point

- `Plugin.onGetSourceFixAllCodeActions?: PluginHandler<OnGetSourceFixAllCodeActionsEvent>` ([interfaces.ts](src/interfaces.ts))
- `OnGetSourceFixAllCodeActionsEvent` carries the program, file, all diagnostics for that file (no range filter), the scopes, and an `actions` array for plugins to push into.
- New `SourceFixAllCodeAction` shape ([CodeActionUtil.ts](src/CodeActionUtil.ts)) — `{ title, kind?, isPreferred?, changes }`. `kind` defaults to `source.fixAll.brighterscript`; plugins can use a sub-kind like `source.fixAll.brighterscript.imports` to register a distinct named entry.

### LSP plumbing

- `LanguageServer` now advertises `CodeActionKind.SourceFixAll` alongside `QuickFix` ([LanguageServer.ts](src/LanguageServer.ts)).
- `onCodeAction` decides which pipeline(s) to run based on the client's `context.only` filter: standard quickfixes go through the existing `getCodeActions` path, fix-all actions go through the new `getFixAllCodeActions` path. When the client doesn't filter, both run.
- `Program.getSourceFixAllCodeActions(srcPath)` fires the new plugin event and converts each contributed `SourceFixAllCodeAction` into an LSP `CodeAction` ([Program.ts](src/Program.ts)).
- Wired through `Project`, `ProjectManager`, and `WorkerThreadProject` so it works in both single-thread and worker-thread modes.

### Built-in source fix-all actions

[FixAllCodeActionsProcessor.ts](src/bscPlugin/codeActions/FixAllCodeActionsProcessor.ts) ships two out of the box, both surfaced under the Source Actions menu:

- **Remove all void return values** — fixes every `voidFunctionMayNotReturnValue` in the file by removing the return value expression and leaving the bare `return`.
- **Add missing extends attributes** — adds `extends="Group"` to every component missing the attribute (matches the `isPreferred` per-diagnostic quickfix).

Shared change-builders live in [codeActionHelpers.ts](src/bscPlugin/codeActions/codeActionHelpers.ts) so the per-diagnostic quickfixes and the fix-all aggregator stay in sync.

## Plugin compatibility

Pure addition. `onGetSourceFixAllCodeActions` is optional, so existing plugins need no changes. Plugins that want to participate add the handler and push entries into `event.actions`.

## Test plan

- [ ] `npm run test:nocover` passes
- [ ] `npx eslint` clean on touched files
- [ ] Manually verify in VS Code: Source Actions menu shows the new entries on a file with multiple matching diagnostics, and `editor.codeActionsOnSave` with `source.fixAll.brighterscript` runs them on save