### PR TITLE
Add CDATA LSP support for SceneGraph XML files

### DIFF
--- a/src/Program.ts
+++ b/src/Program.ts
@@ -617,6 +617,11 @@ export class Program {
                         inlineFile.isSynthetic = true;
                         inlineFile.parentXmlFile = xmlFile;
                         inlineFile.cdataScript = script;
+                        script.cdataTranspile = (state) => {
+                            return inlineFile.needsTranspiled
+                                ? this.transpileSyntheticBrsFileToSourceNode(inlineFile, state.srcPath)
+                                : undefined;
+                        };
                     }
                 }
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -158,6 +158,13 @@ export class Program {
     public files = {} as Record<string, BscFile>;
     private pkgMap = {} as Record<string, BscFile>;
 
+    /**
+     * Metadata for synthetic BrsFiles extracted from CDATA blocks.
+     * Keyed by the synthetic file's pkgPath (lowercase).
+     * Used to remap diagnostics back to the correct position in the parent XML file.
+     */
+    private syntheticFileMeta = new Map<string, { xmlFile: XmlFile; cdataRange: Range }>();
+
     private scopes = {} as Record<string, Scope>;
 
     protected addScope(scope: Scope) {
@@ -299,7 +306,41 @@ export class Program {
             });
 
             this.logger.info(`diagnostic counts: total=${chalk.yellow(diagnostics.length.toString())}, after filter=${chalk.yellow(filteredDiagnostics.length.toString())}`);
-            return filteredDiagnostics;
+            return this.remapSyntheticFileDiagnostics(filteredDiagnostics);
+        });
+    }
+
+    /**
+     * Remaps diagnostics from synthetic CDATA BrsFiles back to their parent XmlFile at the
+     * correct position. `<![CDATA[` is 9 characters; positions on the first line of the CDATA
+     * token need that offset added. Subsequent lines are column-accurate already.
+     */
+    private remapSyntheticFileDiagnostics(diagnostics: BsDiagnostic[]): BsDiagnostic[] {
+        return diagnostics.map(diagnostic => {
+            if (!diagnostic.file?.isSynthetic) {
+                return diagnostic;
+            }
+            const meta = this.syntheticFileMeta.get(diagnostic.file.pkgPath.toLowerCase());
+            if (!meta) {
+                return diagnostic;
+            }
+            const cdataStartLine = meta.cdataRange.start.line;
+            // content starts 9 chars after the opening '<![CDATA[' on the same line
+            const cdataContentStartChar = meta.cdataRange.start.character + '<![CDATA['.length;
+
+            const remapPos = (pos: Position) => ({
+                line: cdataStartLine + pos.line,
+                character: pos.line === 0 ? cdataContentStartChar + pos.character : pos.character
+            });
+
+            return {
+                ...diagnostic,
+                file: meta.xmlFile,
+                range: {
+                    start: remapPos(diagnostic.range.start),
+                    end: remapPos(diagnostic.range.end)
+                }
+            };
         });
     }
 
@@ -477,6 +518,10 @@ export class Program {
                         const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
                         const inlineFile = this.setFile<BrsFile>(inlinePkgPath, script.cdataText ?? '');
                         inlineFile.isSynthetic = true;
+                        this.syntheticFileMeta.set(inlinePkgPath.toLowerCase(), {
+                            xmlFile: xmlFile,
+                            cdataRange: script.cdata.range
+                        });
                     }
                 }
 
@@ -651,6 +696,11 @@ export class Program {
             }
             //remove the file from the program
             this.unassignFile(file);
+
+            //clean up synthetic file metadata if this was a synthetic CDATA file
+            if (isBrsFile(file) && file.isSynthetic) {
+                this.syntheticFileMeta.delete(file.pkgPath.toLowerCase());
+            }
 
             this.dependencyGraph.remove(file.dependencyGraphKey);
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -555,7 +555,7 @@ export class Program {
      * only used when registering synthetic inline CDATA BrsFiles so that the lexer can start its
      * position tracking at the correct XML-space offset without needing a side-channel map.
      */
-    private setFileInternal<T extends BscFile>(fileParam: FileObj | string, fileContents: string, parseOptions?: { startLine?: number; startCharacter?: number; rawSource?: string }, configure?: (file: BrsFile) => void): T {
+    private setFileInternal<T extends BscFile>(fileParam: FileObj | string, fileContents: string, parseOptions?: { startLine?: number; startCharacter?: number }, configure?: (file: BrsFile) => void): T {
         //normalize the file paths
         const { srcPath, pkgPath } = this.getPaths(fileParam, this.options.rootDir);
 
@@ -638,26 +638,17 @@ export class Program {
                 for (const script of xmlFile.ast.component?.scripts ?? []) {
                     if (script.cdata) {
                         const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
-                        // The synthetic BrsFile needs two forms of the same source:
-                        //
-                        //  • fileContents = padded content (newlines + spaces prepended so that
-                        //    XML-coordinate line numbers index correctly into the text). Tools
-                        //    like SignatureHelpUtil use fileContents for line-based text extraction.
-                        //
-                        //  • rawSource = the actual cdataText passed to the lexer together with
-                        //    startLine/startCharacter so that every token range is already in the
-                        //    parent XML coordinate space — without the spurious Newline tokens that
-                        //    the padding newlines would otherwise introduce into the token stream.
+                        // Pass the raw CDATA text directly as fileContents. startLine/startCharacter
+                        // tell the lexer to start its position counters at the correct XML-space
+                        // offset, so all token ranges are already in parent XML coordinate space.
+                        // Consumers that need line-indexed text (e.g. SignatureHelpUtil) use the
+                        // parentXmlFile's fileContents instead of the synthetic file's.
                         const cdataRange = script.cdata.range;
                         const contentStartChar = cdataRange.start.character + '<![CDATA['.length;
                         const rawSource = script.cdataText ?? '';
-                        const paddedContent = '\n'.repeat(cdataRange.start.line) +
-                            ' '.repeat(contentStartChar) +
-                            rawSource;
-                        const inlineFile = this.setFileInternal<BrsFile>(inlinePkgPath, paddedContent, {
+                        const inlineFile = this.setFileInternal<BrsFile>(inlinePkgPath, rawSource, {
                             startLine: cdataRange.start.line,
-                            startCharacter: contentStartChar,
-                            rawSource: rawSource
+                            startCharacter: contentStartChar
                         }, (file) => {
                             file.isSynthetic = true;
                         });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -181,14 +181,6 @@ export class Program {
      */
     private _cdataDiagnosticsContext: BrsFile | undefined;
 
-    /**
-     * Set of absolute srcPaths for BrsFiles that are about to be registered as synthetic (CDATA)
-     * files. Populated before `setFile` is called so that `isSynthetic` can be pre-applied inside
-     * `setFile` before `afterFileParse` fires — otherwise `emitWithSyntheticFileContext` would see
-     * `isSynthetic === false` and skip the diagnostic-context guard.
-     */
-    private _pendingSyntheticSrcPaths = new Set<string>();
-
     private scopes = {} as Record<string, Scope>;
 
     protected addScope(scope: Scope) {
@@ -563,7 +555,7 @@ export class Program {
      * only used when registering synthetic inline CDATA BrsFiles so that the lexer can start its
      * position tracking at the correct XML-space offset without needing a side-channel map.
      */
-    private setFileInternal<T extends BscFile>(fileParam: FileObj | string, fileContents: string, parseOptions?: { startLine?: number; startCharacter?: number; rawSource?: string }): T {
+    private setFileInternal<T extends BscFile>(fileParam: FileObj | string, fileContents: string, parseOptions?: { startLine?: number; startCharacter?: number; rawSource?: string }, configure?: (file: BrsFile) => void): T {
         //normalize the file paths
         const { srcPath, pkgPath } = this.getPaths(fileParam, this.options.rootDir);
 
@@ -581,12 +573,11 @@ export class Program {
                     new BrsFile(srcPath, pkgPath, this)
                 );
 
-                // Pre-mark as synthetic before parsing so that `afterFileParse` fires with
-                // `isSynthetic === true`, allowing `emitWithSyntheticFileContext` to correctly
-                // set `_cdataDiagnosticsContext` for any plugins that call `getDiagnostics()`.
-                if (this._pendingSyntheticSrcPaths.has(srcPath)) {
-                    brsFile.isSynthetic = true;
-                }
+                // Apply any caller-provided configuration (e.g. marking synthetic files) before
+                // parsing so that `afterFileParse` fires with the correct state — allowing
+                // `emitWithSyntheticFileContext` to set `_cdataDiagnosticsContext` for plugins
+                // that call `getDiagnostics()` from inside the handler.
+                configure?.(brsFile);
 
                 //add file to the `source` dependency list
                 if (brsFile.pkgPath.startsWith(startOfSourcePkgPath)) {
@@ -663,15 +654,13 @@ export class Program {
                         const paddedContent = '\n'.repeat(cdataRange.start.line) +
                             ' '.repeat(contentStartChar) +
                             rawSource;
-                        const inlineSrcPath = s`${path.resolve(this.options.rootDir, inlinePkgPath)}`;
-                        this._pendingSyntheticSrcPaths.add(inlineSrcPath);
                         const inlineFile = this.setFileInternal<BrsFile>(inlinePkgPath, paddedContent, {
                             startLine: cdataRange.start.line,
                             startCharacter: contentStartChar,
                             rawSource: rawSource
+                        }, (file) => {
+                            file.isSynthetic = true;
                         });
-                        this._pendingSyntheticSrcPaths.delete(inlineSrcPath);
-                        // isSynthetic was pre-applied inside setFile (see _pendingSyntheticSrcPaths)
                         inlineFile.excludeFromOutput = true;
                         inlineFile.parentXmlFile = xmlFile;
                         inlineFile.cdataScript = script;
@@ -1193,7 +1182,9 @@ export class Program {
         };
 
         this.plugins.emit('beforeProvideCompletions', event);
+
         this.plugins.emit('provideCompletions', event);
+
         this.plugins.emit('afterProvideCompletions', event);
 
         return event.completions;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
-import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, DocumentSymbol, CancellationToken } from 'vscode-languageserver';
+import type { CodeAction, CompletionItem, Position, Range, SignatureInformation, Location, DocumentSymbol, CancellationToken, WorkspaceEdit } from 'vscode-languageserver';
 import { CancellationTokenSource, CompletionItemKind } from 'vscode-languageserver';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
 import { Scope } from './Scope';
@@ -165,6 +165,13 @@ export class Program {
      */
     private syntheticFileMeta = new Map<string, { xmlFile: XmlFile; cdataRange: Range }>();
 
+    /**
+     * When set, `getDiagnostics()` will skip remapping diagnostics for this synthetic BrsFile,
+     * leaving them in synthetic-file coordinate space. Used during code action events for CDATA
+     * blocks so that plugins can match diagnostics by file identity (`x.file === event.file`).
+     */
+    private _cdataDiagnosticsContext: BrsFile | undefined;
+
     private scopes = {} as Record<string, Scope>;
 
     protected addScope(scope: Scope) {
@@ -306,7 +313,9 @@ export class Program {
             });
 
             this.logger.info(`diagnostic counts: total=${chalk.yellow(diagnostics.length.toString())}, after filter=${chalk.yellow(filteredDiagnostics.length.toString())}`);
-            return this.remapSyntheticFileDiagnostics(filteredDiagnostics);
+            return this._cdataDiagnosticsContext
+                ? this.partialRemapSyntheticFileDiagnostics(filteredDiagnostics, this._cdataDiagnosticsContext)
+                : this.remapSyntheticFileDiagnostics(filteredDiagnostics);
         });
     }
 
@@ -324,24 +333,127 @@ export class Program {
             if (!meta) {
                 return diagnostic;
             }
-            const cdataStartLine = meta.cdataRange.start.line;
-            // content starts 9 chars after the opening '<![CDATA[' on the same line
-            const cdataContentStartChar = meta.cdataRange.start.character + '<![CDATA['.length;
-
-            const remapPos = (pos: Position) => ({
-                line: cdataStartLine + pos.line,
-                character: pos.line === 0 ? cdataContentStartChar + pos.character : pos.character
-            });
-
             return {
                 ...diagnostic,
                 file: meta.xmlFile,
                 range: {
-                    start: remapPos(diagnostic.range.start),
-                    end: remapPos(diagnostic.range.end)
+                    start: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.start),
+                    end: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.end)
                 }
             };
         });
+    }
+
+    /**
+     * Like `remapSyntheticFileDiagnostics`, but skips remapping for `contextFile` so its
+     * diagnostics remain in synthetic-file coordinate space. Used during code action events
+     * so that plugins can match diagnostics by file identity (`x.file === event.file`).
+     */
+    private partialRemapSyntheticFileDiagnostics(diagnostics: BsDiagnostic[], contextFile: BrsFile): BsDiagnostic[] {
+        return diagnostics.map(diagnostic => {
+            if (!diagnostic.file?.isSynthetic) {
+                return diagnostic;
+            }
+            // Keep the context file's diagnostics in synthetic coordinate space
+            if (diagnostic.file === contextFile) {
+                return diagnostic;
+            }
+            // All other synthetic files remap to XML as usual
+            const meta = this.syntheticFileMeta.get(diagnostic.file.pkgPath.toLowerCase());
+            if (!meta) {
+                return diagnostic;
+            }
+            return {
+                ...diagnostic,
+                file: meta.xmlFile,
+                range: {
+                    start: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.start),
+                    end: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.end)
+                }
+            };
+        });
+    }
+
+    /**
+     * Converts a position in synthetic BrsFile coordinates to its equivalent position in the
+     * parent XML file. Line 0 of the synthetic file maps to the line containing `<![CDATA[`,
+     * offset by 9 characters (the length of `<![CDATA[`). Subsequent lines are column-accurate.
+     */
+    private remapPosFromSynthetic(cdataRange: Range, pos: Position): Position {
+        const cdataStartLine = cdataRange.start.line;
+        const cdataContentStartChar = cdataRange.start.character + '<![CDATA['.length;
+        return {
+            line: cdataStartLine + pos.line,
+            character: pos.line === 0 ? cdataContentStartChar + pos.character : pos.character
+        };
+    }
+
+    /**
+     * Converts a position in the parent XML file to the equivalent position in the synthetic
+     * BrsFile coordinate space (inverse of `remapPosFromSynthetic`).
+     */
+    private remapPosToSynthetic(cdataRange: Range, pos: Position): Position {
+        const cdataStartLine = cdataRange.start.line;
+        const cdataContentStartChar = cdataRange.start.character + '<![CDATA['.length;
+        const syntheticLine = pos.line - cdataStartLine;
+        return {
+            line: syntheticLine,
+            character: syntheticLine === 0 ? pos.character - cdataContentStartChar : pos.character
+        };
+    }
+
+    /**
+     * Returns the CDATA metadata and corresponding synthetic BrsFile for the CDATA block whose
+     * range intersects `range` within `xmlFile`, or `undefined` if no block matches.
+     */
+    private findCdataInfoForRange(xmlFile: XmlFile, range: Range): { meta: { xmlFile: XmlFile; cdataRange: Range }; brsFile: BrsFile } | undefined {
+        for (const [pkgPathKey, meta] of this.syntheticFileMeta) {
+            if (meta.xmlFile !== xmlFile) {
+                continue;
+            }
+            if (util.rangesIntersectOrTouch(meta.cdataRange, range)) {
+                const brsFile = this.getFile<BrsFile>(pkgPathKey);
+                if (brsFile) {
+                    return { meta: meta, brsFile: brsFile };
+                }
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * After code actions are generated using a synthetic BrsFile as the target, this remaps any
+     * workspace edit changes that reference the synthetic file back to the parent XML file, with
+     * positions converted from BrsFile coordinates to XML coordinates.
+     */
+    private remapCodeActionChangesToXml(
+        codeActions: CodeAction[],
+        meta: { cdataRange: Range },
+        brsFile: BrsFile,
+        xmlFile: XmlFile
+    ) {
+        const syntheticUri = URI.file(brsFile.srcPath).toString();
+        const xmlUri = URI.file(xmlFile.srcPath).toString();
+        for (const action of codeActions) {
+            const changes = (action.edit as WorkspaceEdit)?.changes;
+            if (!changes?.[syntheticUri]) {
+                continue;
+            }
+            const syntheticEdits = changes[syntheticUri];
+            delete changes[syntheticUri];
+            if (!changes[xmlUri]) {
+                changes[xmlUri] = [];
+            }
+            for (const edit of syntheticEdits) {
+                changes[xmlUri].push({
+                    ...edit,
+                    range: {
+                        start: this.remapPosFromSynthetic(meta.cdataRange, edit.range.start),
+                        end: this.remapPosFromSynthetic(meta.cdataRange, edit.range.end)
+                    }
+                });
+            }
+        }
     }
 
     public addDiagnostics(diagnostics: BsDiagnostic[]) {
@@ -1132,24 +1244,49 @@ export class Program {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(srcPath);
         if (file) {
+            let cdataInfo: { meta: { xmlFile: XmlFile; cdataRange: Range }; brsFile: BrsFile } | undefined;
+            if (isXmlFile(file)) {
+                cdataInfo = this.findCdataInfoForRange(file, range);
+            }
+
+            // When the range falls inside a CDATA block, redirect the event to the synthetic
+            // BrsFile so that BrsFile-specific code actions work correctly. Setting
+            // _cdataDiagnosticsContext causes getDiagnostics() to keep that file's diagnostics
+            // in synthetic-file coordinate space (rather than remapping to the parent XML file),
+            // so that plugins can match diagnostics by file identity (x.file === event.file)
+            // and derive correct edit positions from diagnostic.data (AST node ranges).
+            const effectiveFile = cdataInfo?.brsFile ?? file;
+            const effectiveRange = cdataInfo ? {
+                start: this.remapPosToSynthetic(cdataInfo.meta.cdataRange, range.start),
+                end: this.remapPosToSynthetic(cdataInfo.meta.cdataRange, range.end)
+            } : range;
+
+            this._cdataDiagnosticsContext = cdataInfo?.brsFile;
+
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
                 .getDiagnostics()
                 //only keep diagnostics related to this file
-                .filter(x => x.file === file)
+                .filter(x => x.file === effectiveFile)
                 //only keep diagnostics that touch this range
-                .filter(x => util.rangesIntersectOrTouch(x.range, range));
+                .filter(x => util.rangesIntersectOrTouch(x.range, effectiveRange));
 
-            const scopes = this.getScopesForFile(file);
+            const scopes = this.getScopesForFile(effectiveFile);
 
             this.plugins.emit('onGetCodeActions', {
                 program: this,
-                file: file,
-                range: range,
+                file: effectiveFile,
+                range: effectiveRange,
                 diagnostics: diagnostics,
                 scopes: scopes,
                 codeActions: codeActions
             });
+
+            this._cdataDiagnosticsContext = undefined;
+
+            if (cdataInfo) {
+                this.remapCodeActionChangesToXml(codeActions, cdataInfo.meta, cdataInfo.brsFile, file as XmlFile);
+            }
         }
         return codeActions;
     }

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -173,9 +173,11 @@ export class Program {
     private pkgMap = {} as Record<string, BscFile>;
 
     /**
-     * When set, `getDiagnostics()` will skip remapping diagnostics for this synthetic BrsFile,
-     * leaving them in synthetic-file coordinate space. Used during code action events for CDATA
-     * blocks so that plugins can match diagnostics by file identity (`x.file === event.file`).
+     * When set, `getDiagnostics()` keeps this synthetic BrsFile's diagnostics associated with
+     * the BrsFile rather than remapping them to the parent XmlFile. Set for the duration of any
+     * plugin event whose `event.file` is a synthetic BrsFile, so that plugins calling
+     * `program.getDiagnostics()` from inside the handler get results where
+     * `x.file === event.file` works correctly (e.g. a plugin implementing "fix all").
      */
     private _cdataDiagnosticsContext: BrsFile | undefined;
 
@@ -350,10 +352,7 @@ export class Program {
      */
     private partialRemapSyntheticFileDiagnostics(diagnostics: BsDiagnostic[], contextFile: BrsFile): BsDiagnostic[] {
         return diagnostics.map(diagnostic => {
-            if (!diagnostic.file?.isSynthetic) {
-                return diagnostic;
-            }
-            if (diagnostic.file === contextFile) {
+            if (!diagnostic.file?.isSynthetic || diagnostic.file === contextFile) {
                 return diagnostic;
             }
             const parentXmlFile = (diagnostic.file as BrsFile).parentXmlFile;
@@ -362,6 +361,25 @@ export class Program {
             }
             return { ...diagnostic, file: parentXmlFile };
         });
+    }
+
+    /**
+     * Emit a plugin event with `_cdataDiagnosticsContext` set for the duration if `file` is a
+     * synthetic BrsFile. This ensures plugins that call `program.getDiagnostics()` from inside
+     * the handler receive diagnostics still associated with the BrsFile, so that
+     * `x.file === event.file` identity checks work correctly.
+     */
+    private emitWithSyntheticFileContext(file: BscFile | undefined, emit: () => void) {
+        if (isBrsFile(file) && file.isSynthetic) {
+            this._cdataDiagnosticsContext = file;
+            try {
+                emit();
+            } finally {
+                this._cdataDiagnosticsContext = undefined;
+            }
+        } else {
+            emit();
+        }
     }
 
     /**
@@ -564,7 +582,7 @@ export class Program {
                 });
 
                 //notify plugins that this file has finished parsing
-                this.plugins.emit('afterFileParse', brsFile);
+                this.emitWithSyntheticFileContext(brsFile, () => this.plugins.emit('afterFileParse', brsFile));
 
                 file = brsFile;
 
@@ -886,21 +904,23 @@ export class Program {
             })
             .forEach(() => Object.values(this.files), (file) => {
                 if (!file.isValidated) {
-                    this.plugins.emit('beforeFileValidate', {
-                        program: this,
-                        file: file
-                    });
+                    this.emitWithSyntheticFileContext(file, () => {
+                        this.plugins.emit('beforeFileValidate', {
+                            program: this,
+                            file: file
+                        });
 
-                    //emit an event to allow plugins to contribute to the file validation process
-                    this.plugins.emit('onFileValidate', {
-                        program: this,
-                        file: file
-                    });
-                    //call file.validate() IF the file has that function defined
-                    file.validate?.();
-                    file.isValidated = true;
+                        //emit an event to allow plugins to contribute to the file validation process
+                        this.plugins.emit('onFileValidate', {
+                            program: this,
+                            file: file
+                        });
+                        //call file.validate() IF the file has that function defined
+                        file.validate?.();
+                        file.isValidated = true;
 
-                    this.plugins.emit('afterFileValidate', file);
+                        this.plugins.emit('afterFileValidate', file);
+                    });
                 }
             })
             .forEach(Object.values(this.scopes), (scope) => {
@@ -1237,9 +1257,11 @@ export class Program {
                     file: brsFile,
                     documentSymbols: []
                 };
-                this.plugins.emit('beforeProvideDocumentSymbols', cdataEvent);
-                this.plugins.emit('provideDocumentSymbols', cdataEvent);
-                this.plugins.emit('afterProvideDocumentSymbols', cdataEvent);
+                this.emitWithSyntheticFileContext(brsFile, () => {
+                    this.plugins.emit('beforeProvideDocumentSymbols', cdataEvent);
+                    this.plugins.emit('provideDocumentSymbols', cdataEvent);
+                    this.plugins.emit('afterProvideDocumentSymbols', cdataEvent);
+                });
                 event.documentSymbols.push(...cdataEvent.documentSymbols);
             }
         }
@@ -1259,14 +1281,8 @@ export class Program {
             const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, range.start) : undefined;
 
             // When the range falls inside a CDATA block, redirect the event to the synthetic
-            // BrsFile so that BrsFile-specific code actions work correctly. Setting
-            // _cdataDiagnosticsContext causes getDiagnostics() to keep that file's diagnostics
-            // in synthetic-file coordinate space (rather than remapping to the parent XML file),
-            // so that plugins can match diagnostics by file identity (x.file === event.file)
-            // and derive correct edit positions from diagnostic.data (AST node ranges).
+            // BrsFile so that BrsFile-specific code actions work correctly.
             const effectiveFile = cdataCtx?.brsFile ?? file;
-
-            this._cdataDiagnosticsContext = cdataCtx?.brsFile;
 
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
@@ -1278,16 +1294,16 @@ export class Program {
 
             const scopes = this.getScopesForFile(effectiveFile);
 
-            this.plugins.emit('onGetCodeActions', {
-                program: this,
-                file: effectiveFile,
-                range: range,
-                diagnostics: diagnostics,
-                scopes: scopes,
-                codeActions: codeActions
+            this.emitWithSyntheticFileContext(effectiveFile, () => {
+                this.plugins.emit('onGetCodeActions', {
+                    program: this,
+                    file: effectiveFile,
+                    range: range,
+                    diagnostics: diagnostics,
+                    scopes: scopes,
+                    codeActions: codeActions
+                });
             });
-
-            this._cdataDiagnosticsContext = undefined;
 
             if (cdataCtx) {
                 this.remapCodeActionChangesToXml(codeActions, cdataCtx.brsFile, file as XmlFile);
@@ -1321,11 +1337,13 @@ export class Program {
                     continue;
                 }
                 const cdataTokens = [] as SemanticToken[];
-                this.plugins.emit('onGetSemanticTokens', {
-                    program: this,
-                    file: brsFile,
-                    scopes: this.getScopesForFile(brsFile),
-                    semanticTokens: cdataTokens
+                this.emitWithSyntheticFileContext(brsFile, () => {
+                    this.plugins.emit('onGetSemanticTokens', {
+                        program: this,
+                        file: brsFile,
+                        scopes: this.getScopesForFile(brsFile),
+                        semanticTokens: cdataTokens
+                    });
                 });
                 result.push(...cdataTokens);
             }
@@ -1464,11 +1482,13 @@ export class Program {
     public transpileSyntheticBrsFileToSourceNode(brsFile: BrsFile, xmlSrcPath: string): SourceNode {
         const editor = new AstEditor();
 
-        this.plugins.emit('beforeFileTranspile', {
-            program: this,
-            file: brsFile,
-            outputPath: undefined,
-            editor: editor
+        this.emitWithSyntheticFileContext(brsFile, () => {
+            this.plugins.emit('beforeFileTranspile', {
+                program: this,
+                file: brsFile,
+                outputPath: undefined,
+                editor: editor
+            });
         });
         if (editor.hasChanges) {
             editor.setProperty(brsFile, 'needsTranspiled', true);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -469,6 +469,17 @@ export class Program {
 
                 file = xmlFile;
 
+                //register synthetic BrsFiles for any inline CDATA script blocks.
+                //these are treated as first-class files so all plugins (linters, validators, etc.) see them normally.
+                let cdataScriptIndex = 0;
+                for (const script of xmlFile.ast.component?.scripts ?? []) {
+                    if (script.cdata) {
+                        const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
+                        const inlineFile = this.setFile<BrsFile>(inlinePkgPath, script.cdataText ?? '');
+                        inlineFile.isSynthetic = true;
+                    }
+                }
+
                 //create a new scope for this xml file
                 let scope = new XmlScope(xmlFile, this);
                 this.addScope(scope);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -58,19 +58,15 @@ export interface SignatureInfoObj {
 }
 
 /**
- * Coordinate-space remapping context for a single CDATA block. Returned by
- * `Program.resolveCdataContext` when a position falls inside an inline script block.
- * Provides bound helpers to convert positions between the parent XML file's coordinate
- * space and the synthetic BrsFile's coordinate space.
+ * Context for a single CDATA block. Returned by `Program.resolveCdataContext` when a
+ * position falls inside an inline script block. Because synthetic BrsFiles are created
+ * with offset-padded content, their positions are already in parent XML coordinate space
+ * — no coordinate transformation is required.
  */
 export interface CdataContext {
     brsFile: BrsFile;
     xmlFile: XmlFile;
     cdataRange: Range;
-    /** Convert a position from parent XML coordinates to synthetic BrsFile coordinates. */
-    toSynthetic(pos: Position): Position;
-    /** Convert a position from synthetic BrsFile coordinates back to parent XML coordinates. */
-    fromSynthetic(pos: Position): Position;
 }
 
 export class Program {
@@ -336,9 +332,9 @@ export class Program {
     }
 
     /**
-     * Remaps diagnostics from synthetic CDATA BrsFiles back to their parent XmlFile at the
-     * correct position. `<![CDATA[` is 9 characters; positions on the first line of the CDATA
-     * token need that offset added. Subsequent lines are column-accurate already.
+     * Redirects diagnostics from synthetic CDATA BrsFiles to their parent XmlFile.
+     * Because synthetic files are created with offset-padded content, ranges are already
+     * in XML coordinate space — only the file reference needs updating.
      */
     private remapSyntheticFileDiagnostics(diagnostics: BsDiagnostic[]): BsDiagnostic[] {
         return diagnostics.map(diagnostic => {
@@ -349,73 +345,28 @@ export class Program {
             if (!meta) {
                 return diagnostic;
             }
-            return {
-                ...diagnostic,
-                file: meta.xmlFile,
-                range: {
-                    start: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.start),
-                    end: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.end)
-                }
-            };
+            return { ...diagnostic, file: meta.xmlFile };
         });
     }
 
     /**
-     * Like `remapSyntheticFileDiagnostics`, but skips remapping for `contextFile` so its
-     * diagnostics remain in synthetic-file coordinate space. Used during code action events
-     * so that plugins can match diagnostics by file identity (`x.file === event.file`).
+     * Like `remapSyntheticFileDiagnostics`, but keeps `contextFile`'s diagnostics pointing
+     * at the synthetic BrsFile so plugins can match by file identity during code action events.
      */
     private partialRemapSyntheticFileDiagnostics(diagnostics: BsDiagnostic[], contextFile: BrsFile): BsDiagnostic[] {
         return diagnostics.map(diagnostic => {
             if (!diagnostic.file?.isSynthetic) {
                 return diagnostic;
             }
-            // Keep the context file's diagnostics in synthetic coordinate space
             if (diagnostic.file === contextFile) {
                 return diagnostic;
             }
-            // All other synthetic files remap to XML as usual
             const meta = this.syntheticFileMeta.get(diagnostic.file.pkgPath.toLowerCase());
             if (!meta) {
                 return diagnostic;
             }
-            return {
-                ...diagnostic,
-                file: meta.xmlFile,
-                range: {
-                    start: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.start),
-                    end: this.remapPosFromSynthetic(meta.cdataRange, diagnostic.range.end)
-                }
-            };
+            return { ...diagnostic, file: meta.xmlFile };
         });
-    }
-
-    /**
-     * Converts a position in synthetic BrsFile coordinates to its equivalent position in the
-     * parent XML file. Line 0 of the synthetic file maps to the line containing `<![CDATA[`,
-     * offset by 9 characters (the length of `<![CDATA[`). Subsequent lines are column-accurate.
-     */
-    private remapPosFromSynthetic(cdataRange: Range, pos: Position): Position {
-        const cdataStartLine = cdataRange.start.line;
-        const cdataContentStartChar = cdataRange.start.character + '<![CDATA['.length;
-        return {
-            line: cdataStartLine + pos.line,
-            character: pos.line === 0 ? cdataContentStartChar + pos.character : pos.character
-        };
-    }
-
-    /**
-     * Converts a position in the parent XML file to the equivalent position in the synthetic
-     * BrsFile coordinate space (inverse of `remapPosFromSynthetic`).
-     */
-    private remapPosToSynthetic(cdataRange: Range, pos: Position): Position {
-        const cdataStartLine = cdataRange.start.line;
-        const cdataContentStartChar = cdataRange.start.character + '<![CDATA['.length;
-        const syntheticLine = pos.line - cdataStartLine;
-        return {
-            line: syntheticLine,
-            character: syntheticLine === 0 ? pos.character - cdataContentStartChar : pos.character
-        };
     }
 
     /**
@@ -438,16 +389,11 @@ export class Program {
     }
 
     /**
-     * After code actions are generated using a synthetic BrsFile as the target, this remaps any
-     * workspace edit changes that reference the synthetic file back to the parent XML file, with
-     * positions converted from BrsFile coordinates to XML coordinates.
+     * After code actions are generated using a synthetic BrsFile as the target, this substitutes
+     * the synthetic file URI with the parent XML file URI in any workspace edit changes.
+     * Ranges are already in XML coordinate space and need no adjustment.
      */
-    private remapCodeActionChangesToXml(
-        codeActions: CodeAction[],
-        cdataCtx: CdataContext,
-        brsFile: BrsFile,
-        xmlFile: XmlFile
-    ) {
+    private remapCodeActionChangesToXml(codeActions: CodeAction[], brsFile: BrsFile, xmlFile: XmlFile) {
         const syntheticUri = URI.file(brsFile.srcPath).toString();
         const xmlUri = URI.file(xmlFile.srcPath).toString();
         for (const action of codeActions) {
@@ -460,22 +406,15 @@ export class Program {
             if (!changes[xmlUri]) {
                 changes[xmlUri] = [];
             }
-            for (const edit of syntheticEdits) {
-                changes[xmlUri].push({
-                    ...edit,
-                    range: {
-                        start: cdataCtx.fromSynthetic(edit.range.start),
-                        end: cdataCtx.fromSynthetic(edit.range.end)
-                    }
-                });
-            }
+            changes[xmlUri].push(...syntheticEdits);
         }
     }
 
     /**
      * Given an XmlFile and a cursor position, returns a `CdataContext` if the position falls
-     * inside a `<![CDATA[...]]>` block, or `undefined` if it does not. Use the returned context
-     * to redirect LSP events to the synthetic BrsFile and remap positions in both directions.
+     * inside a `<![CDATA[...]]>` block, or `undefined` if it does not.
+     * Because synthetic files use offset-padded content, no position transformation is needed —
+     * pass the original XML-space position directly to the synthetic BrsFile's handlers.
      */
     public resolveCdataContext(xmlFile: XmlFile, position: Position): CdataContext | undefined {
         const pointRange = util.createRange(position.line, position.character, position.line, position.character);
@@ -483,55 +422,21 @@ export class Program {
         if (!info) {
             return undefined;
         }
-        const cdataRange = info.meta.cdataRange;
         return {
             brsFile: info.brsFile,
             xmlFile: xmlFile,
-            cdataRange: cdataRange,
-            toSynthetic: (pos) => this.remapPosToSynthetic(cdataRange, pos),
-            fromSynthetic: (pos) => this.remapPosFromSynthetic(cdataRange, pos)
+            cdataRange: info.meta.cdataRange
         };
     }
 
     /**
-     * Remaps any `Location` entries that reference the synthetic BrsFile back to the parent
-     * XML file with positions converted to XML coordinates. Locations in other files are
-     * returned unchanged.
+     * Substitutes the synthetic BrsFile URI with the parent XML file URI in any Location
+     * entries that reference it. Ranges are already in XML coordinate space.
      */
     private remapLocationsFromSynthetic(locations: Location[], cdataCtx: CdataContext): Location[] {
         const syntheticUri = URI.file(cdataCtx.brsFile.srcPath).toString();
         const xmlUri = URI.file(cdataCtx.xmlFile.srcPath).toString();
-        return locations.map(loc => {
-            if (loc.uri !== syntheticUri) {
-                return loc;
-            }
-            return {
-                uri: xmlUri,
-                range: {
-                    start: cdataCtx.fromSynthetic(loc.range.start),
-                    end: cdataCtx.fromSynthetic(loc.range.end)
-                }
-            };
-        });
-    }
-
-    /**
-     * Recursively remaps `range` and `selectionRange` in a `DocumentSymbol` tree from
-     * synthetic BrsFile coordinates to parent XML file coordinates.
-     */
-    private remapDocumentSymbolsFromSynthetic(symbols: DocumentSymbol[], cdataCtx: CdataContext): DocumentSymbol[] {
-        return symbols.map(sym => ({
-            ...sym,
-            range: {
-                start: cdataCtx.fromSynthetic(sym.range.start),
-                end: cdataCtx.fromSynthetic(sym.range.end)
-            },
-            selectionRange: {
-                start: cdataCtx.fromSynthetic(sym.selectionRange.start),
-                end: cdataCtx.fromSynthetic(sym.selectionRange.end)
-            },
-            children: sym.children ? this.remapDocumentSymbolsFromSynthetic(sym.children, cdataCtx) : undefined
-        }));
+        return locations.map(loc => (loc.uri === syntheticUri ? { uri: xmlUri, range: loc.range } : loc));
     }
 
     public addDiagnostics(diagnostics: BsDiagnostic[]) {
@@ -706,11 +611,20 @@ export class Program {
                 for (const script of xmlFile.ast.component?.scripts ?? []) {
                     if (script.cdata) {
                         const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
-                        const inlineFile = this.setFile<BrsFile>(inlinePkgPath, script.cdataText ?? '');
+                        // Pad the content with leading newlines and spaces so that every
+                        // position in the synthetic file naturally aligns with its position in
+                        // the parent XML file. This eliminates all coordinate remapping for LSP
+                        // events — only file URI substitution is needed in results.
+                        const cdataRange = script.cdata.range;
+                        const contentStartChar = cdataRange.start.character + '<![CDATA['.length;
+                        const paddedContent = '\n'.repeat(cdataRange.start.line) +
+                            ' '.repeat(contentStartChar) +
+                            (script.cdataText ?? '');
+                        const inlineFile = this.setFile<BrsFile>(inlinePkgPath, paddedContent);
                         inlineFile.isSynthetic = true;
                         this.syntheticFileMeta.set(s`${inlinePkgPath}`.toLowerCase(), {
                             xmlFile: xmlFile,
-                            cdataRange: script.cdata.range
+                            cdataRange: cdataRange
                         });
                     }
                 }
@@ -1211,9 +1125,7 @@ export class Program {
             return [];
         }
 
-        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
-        const effectiveFile = cdataCtx?.brsFile ?? file;
-        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+        const effectiveFile = isXmlFile(file) ? (this.resolveCdataContext(file, position)?.brsFile ?? file) : file;
 
         //find the scopes for this file
         let scopes = this.getScopesForFile(effectiveFile);
@@ -1225,28 +1137,13 @@ export class Program {
             program: this,
             file: effectiveFile,
             scopes: scopes,
-            position: effectivePosition,
+            position: position,
             completions: []
         };
 
         this.plugins.emit('beforeProvideCompletions', event);
         this.plugins.emit('provideCompletions', event);
         this.plugins.emit('afterProvideCompletions', event);
-
-        if (cdataCtx) {
-            for (const completion of event.completions) {
-                if (completion.textEdit) {
-                    if ('range' in completion.textEdit) {
-                        completion.textEdit = { ...completion.textEdit, range: { start: cdataCtx.fromSynthetic(completion.textEdit.range.start), end: cdataCtx.fromSynthetic(completion.textEdit.range.end) } };
-                    } else {
-                        completion.textEdit = { ...completion.textEdit, insert: { start: cdataCtx.fromSynthetic(completion.textEdit.insert.start), end: cdataCtx.fromSynthetic(completion.textEdit.insert.end) }, replace: { start: cdataCtx.fromSynthetic(completion.textEdit.replace.start), end: cdataCtx.fromSynthetic(completion.textEdit.replace.end) } };
-                    }
-                }
-                if (completion.additionalTextEdits) {
-                    completion.additionalTextEdits = completion.additionalTextEdits.map(e => ({ ...e, range: { start: cdataCtx.fromSynthetic(e.range.start), end: cdataCtx.fromSynthetic(e.range.end) } }));
-                }
-            }
-        }
 
         return event.completions;
     }
@@ -1277,12 +1174,11 @@ export class Program {
 
         const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
         const effectiveFile = cdataCtx?.brsFile ?? file;
-        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
 
         const event: ProvideDefinitionEvent = {
             program: this,
             file: effectiveFile,
-            position: effectivePosition,
+            position: position,
             definitions: []
         };
 
@@ -1299,14 +1195,12 @@ export class Program {
         let file = this.getFile(srcPath);
         let result: Hover[];
         if (file) {
-            const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
-            const effectiveFile = cdataCtx?.brsFile ?? file;
-            const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+            const effectiveFile = isXmlFile(file) ? (this.resolveCdataContext(file, position)?.brsFile ?? file) : file;
 
             const event = {
                 program: this,
                 file: effectiveFile,
-                position: effectivePosition,
+                position: position,
                 scopes: this.getScopesForFile(effectiveFile),
                 hovers: []
             } as ProvideHoverEvent;
@@ -1314,9 +1208,7 @@ export class Program {
             this.plugins.emit('provideHover', event);
             this.plugins.emit('afterProvideHover', event);
 
-            result = cdataCtx
-                ? event.hovers.map(h => (h.range ? { ...h, range: { start: cdataCtx.fromSynthetic(h.range.start), end: cdataCtx.fromSynthetic(h.range.end) } } : h))
-                : event.hovers;
+            result = event.hovers;
         }
 
         return result ?? [];
@@ -1340,7 +1232,8 @@ export class Program {
         this.plugins.emit('provideDocumentSymbols', event);
         this.plugins.emit('afterProvideDocumentSymbols', event);
 
-        // For XML files, also collect symbols from each inline CDATA block and remap
+        // For XML files, also collect symbols from each inline CDATA block.
+        // Ranges are already in XML coordinate space — no remapping needed.
         if (isXmlFile(file)) {
             for (const [pkgPath, meta] of this.syntheticFileMeta) {
                 if (meta.xmlFile !== file) {
@@ -1348,10 +1241,6 @@ export class Program {
                 }
                 const brsFile = this.getFile<BrsFile>(pkgPath);
                 if (!brsFile) {
-                    continue;
-                }
-                const cdataCtx = this.resolveCdataContext(file, meta.cdataRange.start);
-                if (!cdataCtx) {
                     continue;
                 }
                 const cdataEvent: ProvideDocumentSymbolsEvent = {
@@ -1362,7 +1251,7 @@ export class Program {
                 this.plugins.emit('beforeProvideDocumentSymbols', cdataEvent);
                 this.plugins.emit('provideDocumentSymbols', cdataEvent);
                 this.plugins.emit('afterProvideDocumentSymbols', cdataEvent);
-                event.documentSymbols.push(...this.remapDocumentSymbolsFromSynthetic(cdataEvent.documentSymbols, cdataCtx));
+                event.documentSymbols.push(...cdataEvent.documentSymbols);
             }
         }
 
@@ -1387,10 +1276,6 @@ export class Program {
             // so that plugins can match diagnostics by file identity (x.file === event.file)
             // and derive correct edit positions from diagnostic.data (AST node ranges).
             const effectiveFile = cdataCtx?.brsFile ?? file;
-            const effectiveRange = cdataCtx ? {
-                start: cdataCtx.toSynthetic(range.start),
-                end: cdataCtx.toSynthetic(range.end)
-            } : range;
 
             this._cdataDiagnosticsContext = cdataCtx?.brsFile;
 
@@ -1400,14 +1285,14 @@ export class Program {
                 //only keep diagnostics related to this file
                 .filter(x => x.file === effectiveFile)
                 //only keep diagnostics that touch this range
-                .filter(x => util.rangesIntersectOrTouch(x.range, effectiveRange));
+                .filter(x => util.rangesIntersectOrTouch(x.range, range));
 
             const scopes = this.getScopesForFile(effectiveFile);
 
             this.plugins.emit('onGetCodeActions', {
                 program: this,
                 file: effectiveFile,
-                range: effectiveRange,
+                range: range,
                 diagnostics: diagnostics,
                 scopes: scopes,
                 codeActions: codeActions
@@ -1416,7 +1301,7 @@ export class Program {
             this._cdataDiagnosticsContext = undefined;
 
             if (cdataCtx) {
-                this.remapCodeActionChangesToXml(codeActions, cdataCtx, cdataCtx.brsFile, file as XmlFile);
+                this.remapCodeActionChangesToXml(codeActions, cdataCtx.brsFile, file as XmlFile);
             }
         }
         return codeActions;
@@ -1438,7 +1323,8 @@ export class Program {
             semanticTokens: result
         });
 
-        // For XML files, also collect semantic tokens from each inline CDATA block and remap
+        // For XML files, also collect semantic tokens from each inline CDATA block.
+        // Ranges are already in XML coordinate space — no remapping needed.
         if (isXmlFile(file)) {
             for (const [pkgPath, meta] of this.syntheticFileMeta) {
                 if (meta.xmlFile !== file) {
@@ -1448,10 +1334,6 @@ export class Program {
                 if (!brsFile) {
                     continue;
                 }
-                const cdataCtx = this.resolveCdataContext(file, meta.cdataRange.start);
-                if (!cdataCtx) {
-                    continue;
-                }
                 const cdataTokens = [] as SemanticToken[];
                 this.plugins.emit('onGetSemanticTokens', {
                     program: this,
@@ -1459,15 +1341,7 @@ export class Program {
                     scopes: this.getScopesForFile(brsFile),
                     semanticTokens: cdataTokens
                 });
-                for (const token of cdataTokens) {
-                    result.push({
-                        ...token,
-                        range: {
-                            start: cdataCtx.fromSynthetic(token.range.start),
-                            end: cdataCtx.fromSynthetic(token.range.end)
-                        }
-                    });
-                }
+                result.push(...cdataTokens);
             }
         }
 
@@ -1479,13 +1353,11 @@ export class Program {
         if (!file) {
             return [];
         }
-        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
-        const effectiveFile = cdataCtx?.brsFile ?? file;
-        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+        const effectiveFile = isXmlFile(file) ? (this.resolveCdataContext(file, position)?.brsFile ?? file) : file;
         if (!isBrsFile(effectiveFile)) {
             return [];
         }
-        let callExpressionInfo = new CallExpressionInfo(effectiveFile, effectivePosition);
+        let callExpressionInfo = new CallExpressionInfo(effectiveFile, position);
         let signatureHelpUtil = new SignatureHelpUtil();
         return signatureHelpUtil.getSignatureHelpItems(callExpressionInfo);
     }
@@ -1499,12 +1371,11 @@ export class Program {
 
         const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
         const effectiveFile = cdataCtx?.brsFile ?? file;
-        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
 
         const event: ProvideReferencesEvent = {
             program: this,
             file: effectiveFile,
-            position: effectivePosition,
+            position: position,
             references: []
         };
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -173,13 +173,6 @@ export class Program {
     private pkgMap = {} as Record<string, BscFile>;
 
     /**
-     * Metadata for synthetic BrsFiles extracted from CDATA blocks.
-     * Keyed by the synthetic file's pkgPath (lowercase).
-     * Used to remap diagnostics back to the correct position in the parent XML file.
-     */
-    private syntheticFileMeta = new Map<string, { xmlFile: XmlFile; cdataRange: Range }>();
-
-    /**
      * When set, `getDiagnostics()` will skip remapping diagnostics for this synthetic BrsFile,
      * leaving them in synthetic-file coordinate space. Used during code action events for CDATA
      * blocks so that plugins can match diagnostics by file identity (`x.file === event.file`).
@@ -343,11 +336,11 @@ export class Program {
             if (!diagnostic.file?.isSynthetic) {
                 return diagnostic;
             }
-            const meta = this.syntheticFileMeta.get(diagnostic.file.pkgPath.toLowerCase());
-            if (!meta) {
+            const parentXmlFile = (diagnostic.file as BrsFile).parentXmlFile;
+            if (!parentXmlFile) {
                 return diagnostic;
             }
-            return { ...diagnostic, file: meta.xmlFile };
+            return { ...diagnostic, file: parentXmlFile };
         });
     }
 
@@ -363,11 +356,11 @@ export class Program {
             if (diagnostic.file === contextFile) {
                 return diagnostic;
             }
-            const meta = this.syntheticFileMeta.get(diagnostic.file.pkgPath.toLowerCase());
-            if (!meta) {
+            const parentXmlFile = (diagnostic.file as BrsFile).parentXmlFile;
+            if (!parentXmlFile) {
                 return diagnostic;
             }
-            return { ...diagnostic, file: meta.xmlFile };
+            return { ...diagnostic, file: parentXmlFile };
         });
     }
 
@@ -376,15 +369,13 @@ export class Program {
      * range intersects `range` within `xmlFile`, or `undefined` if no block matches.
      */
     private findCdataInfoForRange(xmlFile: XmlFile, range: Range): { meta: { xmlFile: XmlFile; cdataRange: Range }; brsFile: BrsFile } | undefined {
-        for (const [pkgPathKey, meta] of this.syntheticFileMeta) {
-            if (meta.xmlFile !== xmlFile) {
+        for (const pkgPath of xmlFile.inlineScriptPkgPaths) {
+            const brsFile = this.getFile<BrsFile>(pkgPath);
+            if (!brsFile?.cdataScript?.cdata) {
                 continue;
             }
-            if (util.rangesIntersectOrTouch(meta.cdataRange, range)) {
-                const brsFile = this.getFile<BrsFile>(pkgPathKey);
-                if (brsFile) {
-                    return { meta: meta, brsFile: brsFile };
-                }
+            if (util.rangesIntersectOrTouch(brsFile.cdataScript.cdata.range, range)) {
+                return { meta: { xmlFile: xmlFile, cdataRange: brsFile.cdataScript.cdata.range }, brsFile: brsFile };
             }
         }
         return undefined;
@@ -624,10 +615,8 @@ export class Program {
                             (script.cdataText ?? '');
                         const inlineFile = this.setFile<BrsFile>(inlinePkgPath, paddedContent);
                         inlineFile.isSynthetic = true;
-                        this.syntheticFileMeta.set(s`${inlinePkgPath}`.toLowerCase(), {
-                            xmlFile: xmlFile,
-                            cdataRange: cdataRange
-                        });
+                        inlineFile.parentXmlFile = xmlFile;
+                        inlineFile.cdataScript = script;
                     }
                 }
 
@@ -802,11 +791,6 @@ export class Program {
             }
             //remove the file from the program
             this.unassignFile(file);
-
-            //clean up synthetic file metadata if this was a synthetic CDATA file
-            if (isBrsFile(file) && file.isSynthetic) {
-                this.syntheticFileMeta.delete(file.pkgPath.toLowerCase());
-            }
 
             this.dependencyGraph.remove(file.dependencyGraphKey);
 
@@ -1237,10 +1221,7 @@ export class Program {
         // For XML files, also collect symbols from each inline CDATA block.
         // Ranges are already in XML coordinate space — no remapping needed.
         if (isXmlFile(file)) {
-            for (const [pkgPath, meta] of this.syntheticFileMeta) {
-                if (meta.xmlFile !== file) {
-                    continue;
-                }
+            for (const pkgPath of file.inlineScriptPkgPaths) {
                 const brsFile = this.getFile<BrsFile>(pkgPath);
                 if (!brsFile) {
                     continue;
@@ -1328,10 +1309,7 @@ export class Program {
         // For XML files, also collect semantic tokens from each inline CDATA block.
         // Ranges are already in XML coordinate space — no remapping needed.
         if (isXmlFile(file)) {
-            for (const [pkgPath, meta] of this.syntheticFileMeta) {
-                if (meta.xmlFile !== file) {
-                    continue;
-                }
+            for (const pkgPath of file.inlineScriptPkgPaths) {
                 const brsFile = this.getFile<BrsFile>(pkgPath);
                 if (!brsFile) {
                     continue;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -57,6 +57,22 @@ export interface SignatureInfoObj {
     signature: SignatureInformation;
 }
 
+/**
+ * Coordinate-space remapping context for a single CDATA block. Returned by
+ * `Program.resolveCdataContext` when a position falls inside an inline script block.
+ * Provides bound helpers to convert positions between the parent XML file's coordinate
+ * space and the synthetic BrsFile's coordinate space.
+ */
+export interface CdataContext {
+    brsFile: BrsFile;
+    xmlFile: XmlFile;
+    cdataRange: Range;
+    /** Convert a position from parent XML coordinates to synthetic BrsFile coordinates. */
+    toSynthetic(pos: Position): Position;
+    /** Convert a position from synthetic BrsFile coordinates back to parent XML coordinates. */
+    fromSynthetic(pos: Position): Position;
+}
+
 export class Program {
     constructor(
         /**
@@ -428,7 +444,7 @@ export class Program {
      */
     private remapCodeActionChangesToXml(
         codeActions: CodeAction[],
-        meta: { cdataRange: Range },
+        cdataCtx: CdataContext,
         brsFile: BrsFile,
         xmlFile: XmlFile
     ) {
@@ -448,12 +464,74 @@ export class Program {
                 changes[xmlUri].push({
                     ...edit,
                     range: {
-                        start: this.remapPosFromSynthetic(meta.cdataRange, edit.range.start),
-                        end: this.remapPosFromSynthetic(meta.cdataRange, edit.range.end)
+                        start: cdataCtx.fromSynthetic(edit.range.start),
+                        end: cdataCtx.fromSynthetic(edit.range.end)
                     }
                 });
             }
         }
+    }
+
+    /**
+     * Given an XmlFile and a cursor position, returns a `CdataContext` if the position falls
+     * inside a `<![CDATA[...]]>` block, or `undefined` if it does not. Use the returned context
+     * to redirect LSP events to the synthetic BrsFile and remap positions in both directions.
+     */
+    public resolveCdataContext(xmlFile: XmlFile, position: Position): CdataContext | undefined {
+        const pointRange = util.createRange(position.line, position.character, position.line, position.character);
+        const info = this.findCdataInfoForRange(xmlFile, pointRange);
+        if (!info) {
+            return undefined;
+        }
+        const cdataRange = info.meta.cdataRange;
+        return {
+            brsFile: info.brsFile,
+            xmlFile: xmlFile,
+            cdataRange: cdataRange,
+            toSynthetic: (pos) => this.remapPosToSynthetic(cdataRange, pos),
+            fromSynthetic: (pos) => this.remapPosFromSynthetic(cdataRange, pos)
+        };
+    }
+
+    /**
+     * Remaps any `Location` entries that reference the synthetic BrsFile back to the parent
+     * XML file with positions converted to XML coordinates. Locations in other files are
+     * returned unchanged.
+     */
+    private remapLocationsFromSynthetic(locations: Location[], cdataCtx: CdataContext): Location[] {
+        const syntheticUri = URI.file(cdataCtx.brsFile.srcPath).toString();
+        const xmlUri = URI.file(cdataCtx.xmlFile.srcPath).toString();
+        return locations.map(loc => {
+            if (loc.uri !== syntheticUri) {
+                return loc;
+            }
+            return {
+                uri: xmlUri,
+                range: {
+                    start: cdataCtx.fromSynthetic(loc.range.start),
+                    end: cdataCtx.fromSynthetic(loc.range.end)
+                }
+            };
+        });
+    }
+
+    /**
+     * Recursively remaps `range` and `selectionRange` in a `DocumentSymbol` tree from
+     * synthetic BrsFile coordinates to parent XML file coordinates.
+     */
+    private remapDocumentSymbolsFromSynthetic(symbols: DocumentSymbol[], cdataCtx: CdataContext): DocumentSymbol[] {
+        return symbols.map(sym => ({
+            ...sym,
+            range: {
+                start: cdataCtx.fromSynthetic(sym.range.start),
+                end: cdataCtx.fromSynthetic(sym.range.end)
+            },
+            selectionRange: {
+                start: cdataCtx.fromSynthetic(sym.selectionRange.start),
+                end: cdataCtx.fromSynthetic(sym.selectionRange.end)
+            },
+            children: sym.children ? this.remapDocumentSymbolsFromSynthetic(sym.children, cdataCtx) : undefined
+        }));
     }
 
     public addDiagnostics(diagnostics: BsDiagnostic[]) {
@@ -1133,25 +1211,42 @@ export class Program {
             return [];
         }
 
+        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
+        const effectiveFile = cdataCtx?.brsFile ?? file;
+        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+
         //find the scopes for this file
-        let scopes = this.getScopesForFile(file);
+        let scopes = this.getScopesForFile(effectiveFile);
 
         //if there are no scopes, include the global scope so we at least get the built-in functions
         scopes = scopes.length > 0 ? scopes : [this.globalScope];
 
         const event: ProvideCompletionsEvent = {
             program: this,
-            file: file,
+            file: effectiveFile,
             scopes: scopes,
-            position: position,
+            position: effectivePosition,
             completions: []
         };
 
         this.plugins.emit('beforeProvideCompletions', event);
-
         this.plugins.emit('provideCompletions', event);
-
         this.plugins.emit('afterProvideCompletions', event);
+
+        if (cdataCtx) {
+            for (const completion of event.completions) {
+                if (completion.textEdit) {
+                    if ('range' in completion.textEdit) {
+                        completion.textEdit = { ...completion.textEdit, range: { start: cdataCtx.fromSynthetic(completion.textEdit.range.start), end: cdataCtx.fromSynthetic(completion.textEdit.range.end) } };
+                    } else {
+                        completion.textEdit = { ...completion.textEdit, insert: { start: cdataCtx.fromSynthetic(completion.textEdit.insert.start), end: cdataCtx.fromSynthetic(completion.textEdit.insert.end) }, replace: { start: cdataCtx.fromSynthetic(completion.textEdit.replace.start), end: cdataCtx.fromSynthetic(completion.textEdit.replace.end) } };
+                    }
+                }
+                if (completion.additionalTextEdits) {
+                    completion.additionalTextEdits = completion.additionalTextEdits.map(e => ({ ...e, range: { start: cdataCtx.fromSynthetic(e.range.start), end: cdataCtx.fromSynthetic(e.range.end) } }));
+                }
+            }
+        }
 
         return event.completions;
     }
@@ -1180,17 +1275,21 @@ export class Program {
             return [];
         }
 
+        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
+        const effectiveFile = cdataCtx?.brsFile ?? file;
+        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+
         const event: ProvideDefinitionEvent = {
             program: this,
-            file: file,
-            position: position,
+            file: effectiveFile,
+            position: effectivePosition,
             definitions: []
         };
 
         this.plugins.emit('beforeProvideDefinition', event);
         this.plugins.emit('provideDefinition', event);
         this.plugins.emit('afterProvideDefinition', event);
-        return event.definitions;
+        return cdataCtx ? this.remapLocationsFromSynthetic(event.definitions, cdataCtx) : event.definitions;
     }
 
     /**
@@ -1200,17 +1299,24 @@ export class Program {
         let file = this.getFile(srcPath);
         let result: Hover[];
         if (file) {
+            const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
+            const effectiveFile = cdataCtx?.brsFile ?? file;
+            const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+
             const event = {
                 program: this,
-                file: file,
-                position: position,
-                scopes: this.getScopesForFile(file),
+                file: effectiveFile,
+                position: effectivePosition,
+                scopes: this.getScopesForFile(effectiveFile),
                 hovers: []
             } as ProvideHoverEvent;
             this.plugins.emit('beforeProvideHover', event);
             this.plugins.emit('provideHover', event);
             this.plugins.emit('afterProvideHover', event);
-            result = event.hovers;
+
+            result = cdataCtx
+                ? event.hovers.map(h => (h.range ? { ...h, range: { start: cdataCtx.fromSynthetic(h.range.start), end: cdataCtx.fromSynthetic(h.range.end) } } : h))
+                : event.hovers;
         }
 
         return result ?? [];
@@ -1222,19 +1328,45 @@ export class Program {
      */
     public getDocumentSymbols(srcPath: string): DocumentSymbol[] | undefined {
         let file = this.getFile(srcPath);
-        if (file) {
-            const event: ProvideDocumentSymbolsEvent = {
-                program: this,
-                file: file,
-                documentSymbols: []
-            };
-            this.plugins.emit('beforeProvideDocumentSymbols', event);
-            this.plugins.emit('provideDocumentSymbols', event);
-            this.plugins.emit('afterProvideDocumentSymbols', event);
-            return event.documentSymbols;
-        } else {
+        if (!file) {
             return undefined;
         }
+        const event: ProvideDocumentSymbolsEvent = {
+            program: this,
+            file: file,
+            documentSymbols: []
+        };
+        this.plugins.emit('beforeProvideDocumentSymbols', event);
+        this.plugins.emit('provideDocumentSymbols', event);
+        this.plugins.emit('afterProvideDocumentSymbols', event);
+
+        // For XML files, also collect symbols from each inline CDATA block and remap
+        if (isXmlFile(file)) {
+            for (const [pkgPath, meta] of this.syntheticFileMeta) {
+                if (meta.xmlFile !== file) {
+                    continue;
+                }
+                const brsFile = this.getFile<BrsFile>(pkgPath);
+                if (!brsFile) {
+                    continue;
+                }
+                const cdataCtx = this.resolveCdataContext(file, meta.cdataRange.start);
+                if (!cdataCtx) {
+                    continue;
+                }
+                const cdataEvent: ProvideDocumentSymbolsEvent = {
+                    program: this,
+                    file: brsFile,
+                    documentSymbols: []
+                };
+                this.plugins.emit('beforeProvideDocumentSymbols', cdataEvent);
+                this.plugins.emit('provideDocumentSymbols', cdataEvent);
+                this.plugins.emit('afterProvideDocumentSymbols', cdataEvent);
+                event.documentSymbols.push(...this.remapDocumentSymbolsFromSynthetic(cdataEvent.documentSymbols, cdataCtx));
+            }
+        }
+
+        return event.documentSymbols;
     }
 
     /**
@@ -1244,10 +1376,9 @@ export class Program {
         const codeActions = [] as CodeAction[];
         const file = this.getFile(srcPath);
         if (file) {
-            let cdataInfo: { meta: { xmlFile: XmlFile; cdataRange: Range }; brsFile: BrsFile } | undefined;
-            if (isXmlFile(file)) {
-                cdataInfo = this.findCdataInfoForRange(file, range);
-            }
+            // resolveCdataContext uses range.start as a probe point; findCdataInfoForRange
+            // is used internally to check intersection with the full range.
+            const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, range.start) : undefined;
 
             // When the range falls inside a CDATA block, redirect the event to the synthetic
             // BrsFile so that BrsFile-specific code actions work correctly. Setting
@@ -1255,13 +1386,13 @@ export class Program {
             // in synthetic-file coordinate space (rather than remapping to the parent XML file),
             // so that plugins can match diagnostics by file identity (x.file === event.file)
             // and derive correct edit positions from diagnostic.data (AST node ranges).
-            const effectiveFile = cdataInfo?.brsFile ?? file;
-            const effectiveRange = cdataInfo ? {
-                start: this.remapPosToSynthetic(cdataInfo.meta.cdataRange, range.start),
-                end: this.remapPosToSynthetic(cdataInfo.meta.cdataRange, range.end)
+            const effectiveFile = cdataCtx?.brsFile ?? file;
+            const effectiveRange = cdataCtx ? {
+                start: cdataCtx.toSynthetic(range.start),
+                end: cdataCtx.toSynthetic(range.end)
             } : range;
 
-            this._cdataDiagnosticsContext = cdataInfo?.brsFile;
+            this._cdataDiagnosticsContext = cdataCtx?.brsFile;
 
             const diagnostics = this
                 //get all current diagnostics (filtered by diagnostic filters)
@@ -1284,8 +1415,8 @@ export class Program {
 
             this._cdataDiagnosticsContext = undefined;
 
-            if (cdataInfo) {
-                this.remapCodeActionChangesToXml(codeActions, cdataInfo.meta, cdataInfo.brsFile, file as XmlFile);
+            if (cdataCtx) {
+                this.remapCodeActionChangesToXml(codeActions, cdataCtx, cdataCtx.brsFile, file as XmlFile);
             }
         }
         return codeActions;
@@ -1296,24 +1427,65 @@ export class Program {
      */
     public getSemanticTokens(srcPath: string): SemanticToken[] | undefined {
         const file = this.getFile(srcPath);
-        if (file) {
-            const result = [] as SemanticToken[];
-            this.plugins.emit('onGetSemanticTokens', {
-                program: this,
-                file: file,
-                scopes: this.getScopesForFile(file),
-                semanticTokens: result
-            });
-            return result;
+        if (!file) {
+            return undefined;
         }
+        const result = [] as SemanticToken[];
+        this.plugins.emit('onGetSemanticTokens', {
+            program: this,
+            file: file,
+            scopes: this.getScopesForFile(file),
+            semanticTokens: result
+        });
+
+        // For XML files, also collect semantic tokens from each inline CDATA block and remap
+        if (isXmlFile(file)) {
+            for (const [pkgPath, meta] of this.syntheticFileMeta) {
+                if (meta.xmlFile !== file) {
+                    continue;
+                }
+                const brsFile = this.getFile<BrsFile>(pkgPath);
+                if (!brsFile) {
+                    continue;
+                }
+                const cdataCtx = this.resolveCdataContext(file, meta.cdataRange.start);
+                if (!cdataCtx) {
+                    continue;
+                }
+                const cdataTokens = [] as SemanticToken[];
+                this.plugins.emit('onGetSemanticTokens', {
+                    program: this,
+                    file: brsFile,
+                    scopes: this.getScopesForFile(brsFile),
+                    semanticTokens: cdataTokens
+                });
+                for (const token of cdataTokens) {
+                    result.push({
+                        ...token,
+                        range: {
+                            start: cdataCtx.fromSynthetic(token.range.start),
+                            end: cdataCtx.fromSynthetic(token.range.end)
+                        }
+                    });
+                }
+            }
+        }
+
+        return result;
     }
 
     public getSignatureHelp(filePath: string, position: Position): SignatureInfoObj[] {
-        let file: BrsFile = this.getFile(filePath);
-        if (!file || !isBrsFile(file)) {
+        let file = this.getFile(filePath);
+        if (!file) {
             return [];
         }
-        let callExpressionInfo = new CallExpressionInfo(file, position);
+        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
+        const effectiveFile = cdataCtx?.brsFile ?? file;
+        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+        if (!isBrsFile(effectiveFile)) {
+            return [];
+        }
+        let callExpressionInfo = new CallExpressionInfo(effectiveFile, effectivePosition);
         let signatureHelpUtil = new SignatureHelpUtil();
         return signatureHelpUtil.getSignatureHelpItems(callExpressionInfo);
     }
@@ -1325,10 +1497,14 @@ export class Program {
             return null;
         }
 
+        const cdataCtx = isXmlFile(file) ? this.resolveCdataContext(file, position) : undefined;
+        const effectiveFile = cdataCtx?.brsFile ?? file;
+        const effectivePosition = cdataCtx ? cdataCtx.toSynthetic(position) : position;
+
         const event: ProvideReferencesEvent = {
             program: this,
-            file: file,
-            position: position,
+            file: effectiveFile,
+            position: effectivePosition,
             references: []
         };
 
@@ -1336,7 +1512,7 @@ export class Program {
         this.plugins.emit('provideReferences', event);
         this.plugins.emit('afterProvideReferences', event);
 
-        return event.references;
+        return cdataCtx ? this.remapLocationsFromSynthetic(event.references, cdataCtx) : event.references;
     }
 
     /**

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -181,6 +181,14 @@ export class Program {
      */
     private _cdataDiagnosticsContext: BrsFile | undefined;
 
+    /**
+     * Set of absolute srcPaths for BrsFiles that are about to be registered as synthetic (CDATA)
+     * files. Populated before `setFile` is called so that `isSynthetic` can be pre-applied inside
+     * `setFile` before `afterFileParse` fires — otherwise `emitWithSyntheticFileContext` would see
+     * `isSynthetic === false` and skip the diagnostic-context guard.
+     */
+    private _pendingSyntheticSrcPaths = new Set<string>();
+
     private scopes = {} as Record<string, Scope>;
 
     protected addScope(scope: Scope) {
@@ -563,6 +571,13 @@ export class Program {
                     new BrsFile(srcPath, pkgPath, this)
                 );
 
+                // Pre-mark as synthetic before parsing so that `afterFileParse` fires with
+                // `isSynthetic === true`, allowing `emitWithSyntheticFileContext` to correctly
+                // set `_cdataDiagnosticsContext` for any plugins that call `getDiagnostics()`.
+                if (this._pendingSyntheticSrcPaths.has(srcPath)) {
+                    brsFile.isSynthetic = true;
+                }
+
                 //add file to the `source` dependency list
                 if (brsFile.pkgPath.startsWith(startOfSourcePkgPath)) {
                     this.createSourceScope();
@@ -631,8 +646,11 @@ export class Program {
                         const paddedContent = '\n'.repeat(cdataRange.start.line) +
                             ' '.repeat(contentStartChar) +
                             (script.cdataText ?? '');
+                        const inlineSrcPath = s`${path.resolve(this.options.rootDir, inlinePkgPath)}`;
+                        this._pendingSyntheticSrcPaths.add(inlineSrcPath);
                         const inlineFile = this.setFile<BrsFile>(inlinePkgPath, paddedContent);
-                        inlineFile.isSynthetic = true;
+                        this._pendingSyntheticSrcPaths.delete(inlineSrcPath);
+                        // isSynthetic was pre-applied inside setFile (see _pendingSyntheticSrcPaths)
                         inlineFile.excludeFromOutput = true;
                         inlineFile.parentXmlFile = xmlFile;
                         inlineFile.cdataScript = script;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -708,7 +708,7 @@ export class Program {
                         const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
                         const inlineFile = this.setFile<BrsFile>(inlinePkgPath, script.cdataText ?? '');
                         inlineFile.isSynthetic = true;
-                        this.syntheticFileMeta.set(inlinePkgPath.toLowerCase(), {
+                        this.syntheticFileMeta.set(s`${inlinePkgPath}`.toLowerCase(), {
                             xmlFile: xmlFile,
                             cdataRange: script.cdata.range
                         });

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -554,6 +554,16 @@ export class Program {
      */
     public setFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
     public setFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
+        return this.setFileInternal<T>(fileParam, fileContents);
+    }
+
+    /**
+     * Internal implementation of setFile that accepts optional BrsFile parse options.
+     * The extra `parseOptions` parameter is intentionally not exposed on the public overloads — it is
+     * only used when registering synthetic inline CDATA BrsFiles so that the lexer can start its
+     * position tracking at the correct XML-space offset without needing a side-channel map.
+     */
+    private setFileInternal<T extends BscFile>(fileParam: FileObj | string, fileContents: string, parseOptions?: { startLine?: number; startCharacter?: number; rawSource?: string }): T {
         //normalize the file paths
         const { srcPath, pkgPath } = this.getPaths(fileParam, this.options.rootDir);
 
@@ -593,7 +603,7 @@ export class Program {
                 this.plugins.emit('beforeFileParse', sourceObj);
 
                 this.logger.time(LogLevel.debug, ['parse', chalk.green(srcPath)], () => {
-                    brsFile.parse(sourceObj.source);
+                    brsFile.parse(sourceObj.source, parseOptions);
                 });
 
                 //notify plugins that this file has finished parsing
@@ -637,18 +647,29 @@ export class Program {
                 for (const script of xmlFile.ast.component?.scripts ?? []) {
                     if (script.cdata) {
                         const inlinePkgPath = xmlFile.inlineScriptPkgPaths[cdataScriptIndex++];
-                        // Pad the content with leading newlines and spaces so that every
-                        // position in the synthetic file naturally aligns with its position in
-                        // the parent XML file. This eliminates all coordinate remapping for LSP
-                        // events — only file URI substitution is needed in results.
+                        // The synthetic BrsFile needs two forms of the same source:
+                        //
+                        //  • fileContents = padded content (newlines + spaces prepended so that
+                        //    XML-coordinate line numbers index correctly into the text). Tools
+                        //    like SignatureHelpUtil use fileContents for line-based text extraction.
+                        //
+                        //  • rawSource = the actual cdataText passed to the lexer together with
+                        //    startLine/startCharacter so that every token range is already in the
+                        //    parent XML coordinate space — without the spurious Newline tokens that
+                        //    the padding newlines would otherwise introduce into the token stream.
                         const cdataRange = script.cdata.range;
                         const contentStartChar = cdataRange.start.character + '<![CDATA['.length;
+                        const rawSource = script.cdataText ?? '';
                         const paddedContent = '\n'.repeat(cdataRange.start.line) +
                             ' '.repeat(contentStartChar) +
-                            (script.cdataText ?? '');
+                            rawSource;
                         const inlineSrcPath = s`${path.resolve(this.options.rootDir, inlinePkgPath)}`;
                         this._pendingSyntheticSrcPaths.add(inlineSrcPath);
-                        const inlineFile = this.setFile<BrsFile>(inlinePkgPath, paddedContent);
+                        const inlineFile = this.setFileInternal<BrsFile>(inlinePkgPath, paddedContent, {
+                            startLine: cdataRange.start.line,
+                            startCharacter: contentStartChar,
+                            rawSource: rawSource
+                        });
                         this._pendingSyntheticSrcPaths.delete(inlineSrcPath);
                         // isSynthetic was pre-applied inside setFile (see _pendingSyntheticSrcPaths)
                         inlineFile.excludeFromOutput = true;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -615,6 +615,7 @@ export class Program {
                             (script.cdataText ?? '');
                         const inlineFile = this.setFile<BrsFile>(inlinePkgPath, paddedContent);
                         inlineFile.isSynthetic = true;
+                        inlineFile.excludeFromOutput = true;
                         inlineFile.parentXmlFile = xmlFile;
                         inlineFile.cdataScript = script;
                         script.cdataTranspile = (state) => {
@@ -1597,8 +1598,7 @@ export class Program {
             //mark this file as processed so we don't process it more than once
             processedFiles.add(outputPath?.toLowerCase());
 
-            //synthetic CDATA BrsFiles are embedded back into their parent XML — don't write them as separate output files
-            if (isBrsFile(file) && file.isSynthetic) {
+            if (file.excludeFromOutput) {
                 return;
             }
 

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -24,7 +24,9 @@ import { isBrsFile, isXmlFile, isXmlScope, isNamespaceStatement } from './astUti
 import type { FunctionStatement, NamespaceStatement } from './parser/Statement';
 import { BscPlugin } from './bscPlugin/BscPlugin';
 import { AstEditor } from './astUtils/AstEditor';
+import type { SourceNode } from 'source-map';
 import type { SourceMapGenerator } from 'source-map';
+import { BrsTranspileState } from './parser/BrsTranspileState';
 import type { Statement } from './parser/AstNode';
 import { CallExpressionInfo } from './bscPlugin/CallExpressionInfo';
 import { SignatureHelpUtil } from './bscPlugin/SignatureHelpUtil';
@@ -1465,6 +1467,44 @@ export class Program {
     }
 
     /**
+     * Transpile a synthetic CDATA BrsFile and return a SourceNode suitable for embedding
+     * back into the parent XML file's transpile output. Plugin beforeFileTranspile events are
+     * fired so AST edits (e.g. built-in transpile transforms) are applied. afterFileTranspile
+     * is intentionally skipped — it is designed for standalone file output, not embedded content.
+     *
+     * Because synthetic BrsFiles are created with offset-padded content, their token positions
+     * already align with positions in the parent XML file. Overriding state.srcPath to the XML
+     * file's path makes the resulting SourceNode reference the XML file directly, producing a
+     * correct unified source map.
+     */
+    public transpileSyntheticBrsFileToSourceNode(brsFile: BrsFile, xmlSrcPath: string): SourceNode {
+        const editor = new AstEditor();
+
+        this.plugins.emit('beforeFileTranspile', {
+            program: this,
+            file: brsFile,
+            outputPath: undefined,
+            editor: editor
+        });
+        if (editor.hasChanges) {
+            editor.setProperty(brsFile, 'needsTranspiled', true);
+        }
+
+        // Override srcPath so every SourceNode references the XML file at the correct position
+        const state = new BrsTranspileState(brsFile);
+        state.srcPath = xmlSrcPath;
+
+        const sourceNode = util.sourceNodeFromTranspileResult(
+            null, null, state.srcPath, brsFile.ast.transpile(state)
+        );
+
+        state.editor.undoAll();
+        editor.undoAll();
+
+        return sourceNode;
+    }
+
+    /**
      * Internal function used to transpile files.
      * This does not write anything to the file system
      */
@@ -1573,6 +1613,11 @@ export class Program {
             const file = this.getFile(srcPath);
             //mark this file as processed so we don't process it more than once
             processedFiles.add(outputPath?.toLowerCase());
+
+            //synthetic CDATA BrsFiles are embedded back into their parent XML — don't write them as separate output files
+            if (isBrsFile(file) && file.isSynthetic) {
+                return;
+            }
 
             if (!this.options.pruneEmptyCodeFiles || !file.canBePruned) {
                 //skip transpiling typedef files

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -250,6 +250,11 @@ export class ProgramBuilder {
                 throw new Error('Internal invariant exception: somehow file watcher ran before `ProgramBuilder.run()`');
             }
             thePath = s`${path.resolve(this.rootDir, thePath)}`;
+            //ignore file events for synthetic files (e.g. extracted CDATA scripts) — they are managed
+            //programmatically by XmlFile and don't exist on disk in the source directory
+            if (this.program.getFile(thePath)?.isSynthetic) {
+                return;
+            }
             if (event === 'add' || event === 'change') {
                 const fileObj = {
                     src: thePath,

--- a/src/bscPlugin/SignatureHelpUtil.ts
+++ b/src/bscPlugin/SignatureHelpUtil.ts
@@ -113,7 +113,11 @@ export class SignatureHelpUtil {
 
         const documentation = functionComments.join('').trim();
 
-        const lines = util.splitIntoLines(file.fileContents);
+        // Synthetic BrsFiles (inline CDATA blocks) store only the raw CDATA text, so their
+        // fileContents cannot be indexed by XML-space line numbers. Use the parent XML file's
+        // contents instead — it has the correct text at every XML-coordinate line number.
+        const contentsForLines = file.parentXmlFile?.fileContents ?? file.fileContents;
+        const lines = util.splitIntoLines(contentsForLines);
         let key = statement.name.text + documentation;
         const params = [] as ParameterInformation[];
         for (const param of func.parameters) {

--- a/src/bscPlugin/symbols/WorkspaceSymbolProcessor.ts
+++ b/src/bscPlugin/symbols/WorkspaceSymbolProcessor.ts
@@ -1,7 +1,9 @@
-import { isBrsFile } from '../../astUtils/reflection';
+import { isBrsFile, isXmlFile } from '../../astUtils/reflection';
 import type { BrsFile } from '../../files/BrsFile';
+import type { XmlFile } from '../../files/XmlFile';
 import type { ProvideWorkspaceSymbolsEvent } from '../../interfaces';
 import { getWorkspaceSymbolsFromBrsFile } from './symbolUtils';
+import util from '../../util';
 
 export class WorkspaceSymbolProcessor {
     public constructor(
@@ -12,17 +14,30 @@ export class WorkspaceSymbolProcessor {
 
     public process() {
         const results = Object.values(this.event.program.files).map(file => {
-            if (isBrsFile(file)) {
+            if (isBrsFile(file) && !file.isSynthetic) {
                 return this.getBrsFileWorkspaceSymbols(file);
+            } else if (isXmlFile(file)) {
+                return this.getXmlFileWorkspaceSymbols(file);
             }
             return [];
         });
         return results.flat();
     }
 
-    private getBrsFileWorkspaceSymbols(file: BrsFile) {
-        const symbols = getWorkspaceSymbolsFromBrsFile(file);
+    private getBrsFileWorkspaceSymbols(file: BrsFile, uriOverride?: string) {
+        const symbols = getWorkspaceSymbolsFromBrsFile(file, uriOverride);
         this.event.workspaceSymbols.push(...symbols);
+        return this.event.workspaceSymbols;
+    }
+
+    private getXmlFileWorkspaceSymbols(file: XmlFile) {
+        const xmlUri = util.pathToUri(file.srcPath);
+        for (const pkgPath of file.inlineScriptPkgPaths) {
+            const brsFile = this.event.program.getFile<BrsFile>(pkgPath);
+            if (brsFile) {
+                this.getBrsFileWorkspaceSymbols(brsFile, xmlUri);
+            }
+        }
         return this.event.workspaceSymbols;
     }
 }

--- a/src/bscPlugin/symbols/symbolUtils.ts
+++ b/src/bscPlugin/symbols/symbolUtils.ts
@@ -28,9 +28,9 @@ export function getDocumentSymbolsFromBrsFile(file: BrsFile) {
     }
 }
 
-export function getWorkspaceSymbolsFromBrsFile(file: BrsFile) {
+export function getWorkspaceSymbolsFromBrsFile(file: BrsFile, uriOverride?: string) {
     const result: WorkspaceSymbol[] = [];
-    const uri = util.pathToUri(file.srcPath);
+    const uri = uriOverride ?? util.pathToUri(file.srcPath);
     let symbolsToProcess = getSymbolsFromAstNode(file.ast);
     while (symbolsToProcess.length > 0) {
         //get the symbol

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -80,6 +80,12 @@ export class BrsFile {
     }
 
     /**
+     * When true, this file was generated from inline CDATA content in an XML file and is not backed by a file on disk.
+     * The file watcher should ignore change events for paths that match a synthetic file.
+     */
+    public isSynthetic = false;
+
+    /**
      * Will this file result in only comment or whitespace output? If so, it can be excluded from the output if that bsconfig setting is enabled.
      */
     public get canBePruned() {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -16,6 +16,8 @@ import { Parser, ParseMode } from '../parser/Parser';
 import type { FunctionExpression, VariableExpression } from '../parser/Expression';
 import type { ClassStatement, NamespaceStatement, AssignmentStatement, MethodStatement, FieldStatement } from '../parser/Statement';
 import type { Program } from '../Program';
+import type { XmlFile } from './XmlFile';
+import type { SGScript } from '../parser/SGTypes';
 import { DynamicType } from '../types/DynamicType';
 import { FunctionType } from '../types/FunctionType';
 import { VoidType } from '../types/VoidType';
@@ -84,6 +86,17 @@ export class BrsFile {
      * The file watcher should ignore change events for paths that match a synthetic file.
      */
     public isSynthetic = false;
+
+    /**
+     * The XML file this synthetic BrsFile was extracted from. Only set when `isSynthetic` is true.
+     */
+    public parentXmlFile: XmlFile | undefined;
+
+    /**
+     * The SGScript AST node whose CDATA block this file was extracted from. Only set when `isSynthetic` is true.
+     * Provides access to the CDATA range (`cdataScript.cdata.range`), raw text, and script type.
+     */
+    public cdataScript: SGScript | undefined;
 
     /**
      * Will this file result in only comment or whitespace output? If so, it can be excluded from the output if that bsconfig setting is enabled.

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -333,17 +333,13 @@ export class BrsFile {
 
     /**
      * Calculate the AST for this file
-     * @param fileContents the source to store as fileContents (used for line-based text extraction). For
-     *   inline CDATA fragments this should be the offset-padded content so that XML-coordinate line
-     *   numbers index correctly into the text.
+     * @param fileContents the raw source to parse and store
      * @param options optional scan options forwarded to the lexer
-     * @param options.startLine the zero-indexed line to start position tracking from
+     * @param options.startLine the zero-indexed line to start position tracking from (used for
+     *   inline CDATA fragments so token ranges are in parent XML coordinate space)
      * @param options.startCharacter the zero-indexed character offset on the first line
-     * @param options.rawSource if provided, the lexer scans this string instead of `fileContents`.
-     *   Use this when `fileContents` is padded for line-index alignment but you want tokens to be
-     *   produced without the padding characters (which would otherwise become spurious Newline tokens).
      */
-    public parse(fileContents: string, options?: { startLine?: number; startCharacter?: number; rawSource?: string }) {
+    public parse(fileContents: string, options?: { startLine?: number; startCharacter?: number }) {
         try {
             this.fileContents = fileContents;
             this.diagnostics = [];
@@ -357,7 +353,7 @@ export class BrsFile {
 
             //tokenize the input file
             let lexer = this.program.logger.time('debug', ['lexer.lex', chalk.green(this.srcPath)], () => {
-                return Lexer.scan(options?.rawSource ?? fileContents, {
+                return Lexer.scan(fileContents, {
                     includeWhitespace: false,
                     startLine: options?.startLine,
                     startCharacter: options?.startCharacter

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -99,6 +99,11 @@ export class BrsFile {
     public cdataScript: SGScript | undefined;
 
     /**
+     * When true, this file will not be written as a standalone output file during transpile.
+     */
+    public excludeFromOutput = false;
+
+    /**
      * Will this file result in only comment or whitespace output? If so, it can be excluded from the output if that bsconfig setting is enabled.
      */
     public get canBePruned() {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -333,9 +333,17 @@ export class BrsFile {
 
     /**
      * Calculate the AST for this file
-     * @param fileContents the raw source code to parse
+     * @param fileContents the source to store as fileContents (used for line-based text extraction). For
+     *   inline CDATA fragments this should be the offset-padded content so that XML-coordinate line
+     *   numbers index correctly into the text.
+     * @param options optional scan options forwarded to the lexer
+     * @param options.startLine the zero-indexed line to start position tracking from
+     * @param options.startCharacter the zero-indexed character offset on the first line
+     * @param options.rawSource if provided, the lexer scans this string instead of `fileContents`.
+     *   Use this when `fileContents` is padded for line-index alignment but you want tokens to be
+     *   produced without the padding characters (which would otherwise become spurious Newline tokens).
      */
-    public parse(fileContents: string) {
+    public parse(fileContents: string, options?: { startLine?: number; startCharacter?: number; rawSource?: string }) {
         try {
             this.fileContents = fileContents;
             this.diagnostics = [];
@@ -349,8 +357,10 @@ export class BrsFile {
 
             //tokenize the input file
             let lexer = this.program.logger.time('debug', ['lexer.lex', chalk.green(this.srcPath)], () => {
-                return Lexer.scan(fileContents, {
-                    includeWhitespace: false
+                return Lexer.scan(options?.rawSource ?? fileContents, {
+                    includeWhitespace: false,
+                    startLine: options?.startLine,
+                    startCharacter: options?.startCharacter
                 });
             });
 

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1706,10 +1706,10 @@ describe('XmlFile', () => {
                 }
             });
 
-            it('uses cdataStartChar correctly for first-line synthetic positions', () => {
-                // The first line of the synthetic file (line 0) maps to the <![CDATA[ line
-                // at character offset cdataStartChar + '<![CDATA['.length.
-                // If content starts on the same line as <![CDATA[, hover should still work.
+            it('hover works when CDATA content starts on the same line as the opening marker', () => {
+                // The synthetic BrsFile is padded so its positions match XML coordinates directly.
+                // When content starts inline with <![CDATA[, the first token sits at the same
+                // line/column as in the XML file — no coordinate transformation needed.
                 const inlineFile = program.setFile<XmlFile>('components/Inline.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
                     <component name="Inline" extends="Scene">
@@ -1718,9 +1718,8 @@ describe('XmlFile', () => {
                     </component>
                 `);
                 program.validate();
-                // `sub` and `init` are on the same line as <![CDATA[, so XML line 2
-                // cdataContentStartChar = cdataStartChar + 9 = 37 + 9 = 46
-                // `init` starts at col 46 + 4 = 50 (after `sub `)
+                // `<![CDATA[` starts at col 37, so content starts at col 46.
+                // `init` is after `sub `, so at col 46 + 4 = 50 on XML line 2.
                 const hovers = program.getHover(inlineFile.srcPath, Position.create(2, 50));
                 expect(hovers).to.have.length.greaterThan(0);
                 for (const hover of hovers) {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1445,7 +1445,7 @@ describe('XmlFile', () => {
             const brsFile = program.getFile<BrsFile>(xmlFile.inlineScriptPkgPaths[0]);
             // fileContents is the raw CDATA source, not padded with leading newlines
             expect(brsFile.fileContents).to.include('sub greet');
-            expect(brsFile.fileContents.split(/\r?\n/g)[0]).to.equal('');  // first "line" is the \n right after <![CDATA[
+            expect(brsFile.fileContents.split(/\r?\n/g)[0]).to.equal(''); // first "line" is the \n right after <![CDATA[
             // parentXmlFile.fileContents is where XML-space line lookups should go
             const xmlLines = xmlFile.fileContents.split(/\r?\n/g);
             expect(xmlLines[3]).to.include('sub greet');

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1,4 +1,5 @@
 import { assert, expect } from '../chai-config.spec';
+import { SourceMapConsumer } from 'source-map';
 import * as path from 'path';
 import * as sinonImport from 'sinon';
 import type { CompletionItem } from 'vscode-languageserver';
@@ -1406,7 +1407,7 @@ describe('XmlFile', () => {
             expect(program.getFile('components/MyComp.cdata-1.script.bs')).to.exist;
         });
 
-        it('transpile replaces CDATA blocks with uri script tags', () => {
+        it('transpile preserves CDATA blocks inline in the xml output', () => {
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyComp" extends="Scene">
@@ -1418,13 +1419,16 @@ describe('XmlFile', () => {
             `, trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyComp" extends="Scene">
-                    <script type="text/brightscript" uri="pkg:/components/MyComp.cdata-0.script.brs" />
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
                     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
                 </component>
             `, 'none', 'components/MyComp.xml');
         });
 
-        it('transpile replaces mixed uri and CDATA scripts preserving order', () => {
+        it('transpile preserves mixed uri and CDATA scripts inline preserving order', () => {
             program.setFile('components/helper.brs', '');
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -1439,10 +1443,256 @@ describe('XmlFile', () => {
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyComp" extends="Scene">
                     <script type="text/brightscript" uri="./helper.brs" />
-                    <script type="text/brightscript" uri="pkg:/components/MyComp.cdata-0.script.brs" />
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
                     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
                 </component>
             `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile transforms ternary expressions in brighterscript CDATA', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        sub init()
+                            x = true ? "yes" : "no"
+                        end sub
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[sub init()
+                    if true then
+                        x = "yes"
+                    else
+                        x = "no"
+                    end if
+                end sub]]></script>
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile inlines enum values in brighterscript CDATA', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        enum Direction
+                            up = "up"
+                            down = "down"
+                        end enum
+                        sub init()
+                            d = Direction.up
+                        end sub
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+
+                sub init()
+                    d = "up"
+                end sub]]></script>
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile flattens namespaces in brighterscript CDATA', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        namespace util
+                            sub greet(name as string)
+                                print "Hello " + name
+                            end sub
+                        end namespace
+                        sub init()
+                            util.greet("world")
+                        end sub
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[sub util_greet(name as string)
+                    print "Hello " + name
+                end sub
+
+                sub init()
+                    util_greet("world")
+                end sub]]></script>
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile inlines const values in brighterscript CDATA', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        const MAX_RETRIES = 3
+                        sub init()
+                            print MAX_RETRIES
+                        end sub
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+
+                sub init()
+                    print 3
+                end sub]]></script>
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile transforms null coalescing in brighterscript CDATA', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        sub init()
+                            x = m.value ?? "default"
+                        end sub
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[sub init()
+                    x = (function(m)
+                            __bsConsequent = m.value
+                            if __bsConsequent <> invalid then
+                                return __bsConsequent
+                            else
+                                return "default"
+                            end if
+                        end function)(m)
+                end sub]]></script>
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('source map points back to original xml positions for plain brs CDATA', async () => {
+            // Generated output (1-based lines):
+            //   3: "    <script type="text/brightscript"><![CDATA["
+            //   4: "        sub init()"   ← col 0 → source line 4, col 0
+            //   5: "        end sub"      ← col 0 → source line 5, col 0
+            const xmlFile = program.setFile<XmlFile>({ src: s`${rootDir}/components/MyComp.xml`, dest: 'components/MyComp.xml' }, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        sub init()
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            program.options.sourceMap = true;
+            program.validate();
+            const result = xmlFile.transpile();
+            expect(result.map).to.exist;
+
+            await SourceMapConsumer.with(result.map.toJSON(), null, (consumer) => {
+                // raw CDATA lines map at col 0 back to the same line in the xml source
+                const subPos = consumer.originalPositionFor({ line: 4, column: 0 });
+                expect(subPos.source).to.include('MyComp.xml');
+                expect(subPos.line).to.equal(4);
+                expect(subPos.column).to.equal(0);
+
+                const endSubPos = consumer.originalPositionFor({ line: 5, column: 0 });
+                expect(endSubPos.source).to.include('MyComp.xml');
+                expect(endSubPos.line).to.equal(5);
+                expect(endSubPos.column).to.equal(0);
+            });
+        });
+
+        it('source map points back to xml positions for transpiled brighterscript CDATA', async () => {
+            // Generated output (1-based lines):
+            //   3: "    <script ...><![CDATA[sub init()"  ← 'sub' at col 46 → source (4, 8)
+            //   4: "    if true then"                     ← col 4           → source (5, 21) (ternary)
+            //   5: "        x = \"yes\""                  ← col 8           → source (5, 12)
+            const xmlFile = program.setFile<XmlFile>({ src: s`${rootDir}/components/MyComp.xml`, dest: 'components/MyComp.xml' }, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        sub init()
+                            x = true ? "yes" : "no"
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            program.options.sourceMap = true;
+            program.validate();
+            const result = xmlFile.transpile();
+            expect(result.map).to.exist;
+            // only the xml file should appear in sources — not the synthetic brs file
+            expect(result.map.toJSON().sources).to.eql([s`${rootDir}/components/MyComp.xml`]);
+
+            await SourceMapConsumer.with(result.map.toJSON(), null, (consumer) => {
+                // 'sub' is on gen line 3 right after '<![CDATA[' at col 46
+                const subPos = consumer.originalPositionFor({ line: 3, column: 46 });
+                expect(subPos.source).to.include('MyComp.xml');
+                expect(subPos.line).to.equal(4); // source line 4 (1-based) in the xml
+                expect(subPos.column).to.equal(8);
+
+                // the true branch 'x = "yes"' is on gen line 5 col 8, maps back to the ternary 'x' at source (5, 12)
+                const xPos = consumer.originalPositionFor({ line: 5, column: 8 });
+                expect(xPos.source).to.include('MyComp.xml');
+                expect(xPos.line).to.equal(5);
+                expect(xPos.column).to.equal(12);
+            });
+        });
+
+        it('source map points back to xml positions for transpiled enum values in CDATA', async () => {
+            // Generated output (1-based lines):
+            //   5: "sub init()"       ← col 0 → source (7, 8)
+            //   6: "    d = \"up\""   ← col 4 → source (8, 12)
+            //   7: "end sub]]>..."    ← col 0 → source (9, 8)
+            const xmlFile = program.setFile<XmlFile>({ src: s`${rootDir}/components/MyComp.xml`, dest: 'components/MyComp.xml' }, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        enum Direction
+                            up = "up"
+                        end enum
+                        sub init()
+                            d = Direction.up
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            program.options.sourceMap = true;
+            program.validate();
+            const result = xmlFile.transpile();
+            expect(result.map).to.exist;
+            expect(result.map.toJSON().sources).to.eql([s`${rootDir}/components/MyComp.xml`]);
+
+            await SourceMapConsumer.with(result.map.toJSON(), null, (consumer) => {
+                // 'sub' on gen line 5 col 0 → source (7, 8)
+                const subPos = consumer.originalPositionFor({ line: 5, column: 0 });
+                expect(subPos.source).to.include('MyComp.xml');
+                expect(subPos.line).to.equal(7);
+                expect(subPos.column).to.equal(8);
+
+                // 'd' on gen line 6 col 4 → source (8, 12)
+                const dPos = consumer.originalPositionFor({ line: 6, column: 4 });
+                expect(dPos.source).to.include('MyComp.xml');
+                expect(dPos.line).to.equal(8);
+                expect(dPos.column).to.equal(12);
+            });
         });
 
         it('cleans up synthetic files when the xml file is removed', () => {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -14,7 +14,7 @@ import { standardizePath as s } from '../util';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 import { ProgramBuilder } from '../ProgramBuilder';
 import { LogLevel } from '../logging';
-import { isXmlFile } from '../astUtils/reflection';
+import { isBrsFile, isXmlFile } from '../astUtils/reflection';
 import { tempDir, rootDir, stagingDir } from '../testHelpers.spec';
 
 describe('XmlFile', () => {
@@ -1979,5 +1979,130 @@ describe('XmlFile', () => {
                 }
             });
         });
+
+        describe('synthetic file plugin context', () => {
+            // Verifies that emitWithSyntheticFileContext sets _cdataDiagnosticsContext for
+            // every plugin event that fires with a synthetic BrsFile as event.file, so that
+            // plugins calling program.getDiagnostics() from inside the handler get results
+            // where x.file === event.file holds (diagnostics not yet remapped to the XmlFile).
+
+            let xmlFile: XmlFile;
+
+            beforeEach(() => {
+                xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="MyComp" extends="Scene">
+                        <script type="text/brightscript"><![CDATA[
+                            function init()
+                                undeclaredVar = unknownFunction()
+                            end function
+                        ]]></script>
+                    </component>
+                `);
+                program.validate();
+            });
+
+            // Note: afterFileParse cannot be covered here because isSynthetic is set on the
+            // BrsFile *after* setFile() returns, which is after afterFileParse fires. So the
+            // emitWithSyntheticFileContext wrapper cannot identify the file as synthetic at
+            // that point. This is a known limitation.
+
+            it('onFileValidate: _cdataDiagnosticsContext is set to the synthetic BrsFile during the event', () => {
+                // onFileValidate fires during the validation pass, before scope diagnostics are
+                // produced. We verify the context flag is set so getDiagnostics() would scope
+                // correctly if called by a plugin.
+                let contextFileInsideHandler: BrsFile | undefined;
+                program.plugins.add({
+                    name: 'test',
+                    onFileValidate: function(event) {
+                        if (isBrsFile(event.file) && event.file.isSynthetic) {
+                            contextFileInsideHandler = (program as any)._cdataDiagnosticsContext;
+                        }
+                    }
+                });
+                program.setFile('components/MyComp.xml', xmlFile.fileContents);
+                program.validate();
+                expect(contextFileInsideHandler).to.exist;
+                expect((contextFileInsideHandler as BrsFile).isSynthetic).to.be.true;
+            });
+
+            it('provideDocumentSymbols: program.getDiagnostics() inside handler associates diagnostics with the synthetic BrsFile', () => {
+                let fileIdentityWorked = false;
+                program.plugins.add({
+                    name: 'test',
+                    provideDocumentSymbols: function(event) {
+                        if (isBrsFile(event.file) && (event.file as BrsFile).isSynthetic) {
+                            const diags = program.getDiagnostics()
+                                .filter(x => x.file === event.file);
+                            if (diags.length > 0) {
+                                fileIdentityWorked = true;
+                            }
+                        }
+                    }
+                });
+                program.getDocumentSymbols(xmlFile.srcPath);
+                expect(fileIdentityWorked).to.be.true;
+            });
+
+            it('onGetSemanticTokens: program.getDiagnostics() inside handler associates diagnostics with the synthetic BrsFile', () => {
+                let fileIdentityWorked = false;
+                program.plugins.add({
+                    name: 'test',
+                    onGetSemanticTokens: function(event) {
+                        if (isBrsFile(event.file) && (event.file as BrsFile).isSynthetic) {
+                            const diags = program.getDiagnostics()
+                                .filter(x => x.file === event.file);
+                            if (diags.length > 0) {
+                                fileIdentityWorked = true;
+                            }
+                        }
+                    }
+                });
+                program.getSemanticTokens(xmlFile.srcPath);
+                expect(fileIdentityWorked).to.be.true;
+            });
+
+            it('onGetCodeActions: program.getDiagnostics() inside handler supports "fix all" pattern across multiple CDATA diagnostics', () => {
+                // Two `then` violations in one CDATA block — simulate the bslint "fix all" pattern
+                const twoThenFile = program.setFile<XmlFile>('components/TwoThen.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="TwoThen" extends="Scene">
+                        <script type="text/brightscript"><![CDATA[
+                            function a() : end function
+                            function b() : end function
+                        ]]></script>
+                    </component>
+                `);
+                program.validate();
+                const twoThenSynthetic = program.getFile<BrsFile>('components/TwoThen.cdata-0.script.brs');
+
+                // Simulate plugin calling getDiagnostics() filtered by event.file identity
+                const fixAllDiagsFoundBySyntheticIdentity: BsDiagnostic[][] = [];
+                program.plugins.add({
+                    name: 'test',
+                    onGetCodeActions: function(event) {
+                        if (event.file === twoThenSynthetic) {
+                            // This is exactly the pattern a "fix all" plugin would use
+                            const allInFile = program.getDiagnostics()
+                                .filter(x => x.file === event.file);
+                            fixAllDiagsFoundBySyntheticIdentity.push(allInFile);
+                        }
+                    }
+                });
+
+                // trigger inside first function range
+                program.getCodeActions(twoThenFile.srcPath, Range.create(3, 12, 3, 12));
+
+                // the plugin must have seen diagnostics associated with the synthetic BrsFile
+                expect(fixAllDiagsFoundBySyntheticIdentity.length).to.be.greaterThan(0);
+                // and all returned diagnostics must reference the synthetic file, not the xml file
+                for (const group of fixAllDiagsFoundBySyntheticIdentity) {
+                    for (const d of group) {
+                        expect(d.file).to.equal(twoThenSynthetic, 'expected diagnostic.file to be the synthetic BrsFile, not the XmlFile');
+                    }
+                }
+            });
+        });
     });
 });
+

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1324,4 +1324,217 @@ describe('XmlFile', () => {
             expect(program.getComponent('comp1')!.file.pkgPath).to.equal(comp2.pkgPath);
         });
     });
+
+    describe('inline CDATA scripts', () => {
+
+        it('registers a synthetic BrsFile for a brightscript CDATA block', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.inlineScriptPkgPaths).to.eql(['components/MyComp.cdata-0.script.brs']);
+            const syntheticFile = program.getFile<BrsFile>('components/MyComp.cdata-0.script.brs');
+            expect(syntheticFile).to.exist;
+            expect(syntheticFile.isSynthetic).to.be.true;
+        });
+
+        it('registers a synthetic .bs file when type is text/brighterscript', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brighterscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.inlineScriptPkgPaths).to.eql(['components/MyComp.cdata-0.script.bs']);
+            expect(program.getFile('components/MyComp.cdata-0.script.bs')).to.exist;
+        });
+
+        it('registers a synthetic .bs file when type is text/bs', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/bs"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.inlineScriptPkgPaths).to.eql(['components/MyComp.cdata-0.script.bs']);
+            expect(program.getFile('components/MyComp.cdata-0.script.bs')).to.exist;
+        });
+
+        it('does NOT treat text/brightscript as brighterscript', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.inlineScriptPkgPaths[0]).to.equal('components/MyComp.cdata-0.script.brs');
+        });
+
+        it('indexes multiple CDATA blocks independently', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function a()
+                        end function
+                    ]]></script>
+                    <script type="text/brighterscript"><![CDATA[
+                        function b()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.inlineScriptPkgPaths).to.eql([
+                'components/MyComp.cdata-0.script.brs',
+                'components/MyComp.cdata-1.script.bs'
+            ]);
+            expect(program.getFile('components/MyComp.cdata-0.script.brs')).to.exist;
+            expect(program.getFile('components/MyComp.cdata-1.script.bs')).to.exist;
+        });
+
+        it('transpile replaces CDATA blocks with uri script tags', () => {
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript" uri="pkg:/components/MyComp.cdata-0.script.brs" />
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('transpile replaces mixed uri and CDATA scripts preserving order', () => {
+            program.setFile('components/helper.brs', '');
+            testTranspile(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript" uri="./helper.brs" />
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `, trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript" uri="./helper.brs" />
+                    <script type="text/brightscript" uri="pkg:/components/MyComp.cdata-0.script.brs" />
+                    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+                </component>
+            `, 'none', 'components/MyComp.xml');
+        });
+
+        it('cleans up synthetic files when the xml file is removed', () => {
+            program.setFile('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(program.getFile('components/MyComp.cdata-0.script.brs')).to.exist;
+            program.removeFile(s`${rootDir}/components/MyComp.xml`);
+            expect(program.getFile('components/MyComp.cdata-0.script.brs')).to.not.exist;
+        });
+
+        it('replaces old synthetic files when the xml file is re-parsed', () => {
+            program.setFile('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            const firstFile = program.getFile('components/MyComp.cdata-0.script.brs');
+            expect(firstFile).to.exist;
+
+            //re-set with different cdata content
+            program.setFile('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                            print "updated"
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            const secondFile = program.getFile<BrsFile>('components/MyComp.cdata-0.script.brs');
+            expect(secondFile).to.exist;
+            //a new BrsFile object should have been created
+            expect(secondFile).to.not.equal(firstFile);
+        });
+
+        it('includes the synthetic file in scope dependencies', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            const deps = xmlFile.getOwnDependencies();
+            expect(deps.some(d => d.includes('cdata-0.script.brs'))).to.be.true;
+        });
+
+        it('validates code inside CDATA blocks', () => {
+            program.setFile('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                            undeclaredVar = unknownFunction()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            program.validate();
+            //the synthetic file should have been validated — unknown function call should produce a diagnostic
+            const syntheticFile = program.getFile<BrsFile>('components/MyComp.cdata-0.script.brs');
+            expect(syntheticFile).to.exist;
+            const allDiagnostics = program.getDiagnostics();
+            //there should be a diagnostic about the unknown function
+            expect(allDiagnostics.some(d => d.file.pkgPath === syntheticFile.pkgPath)).to.be.true;
+        });
+
+        it('sets needsTranspiled on the xml file when CDATA is present', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        function init()
+                        end function
+                    ]]></script>
+                </component>
+            `);
+            expect(xmlFile.needsTranspiled).to.be.true;
+        });
+    });
 });

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1407,6 +1407,47 @@ describe('XmlFile', () => {
             expect(program.getFile('components/MyComp.cdata-1.script.bs')).to.exist;
         });
 
+        it('synthetic BrsFile token ranges start at the CDATA position in the XML file', () => {
+            // The <![CDATA[ is on line 2 of the XML. All tokens produced by the lexer must have
+            // ranges that start at line 2 or later — there should be no spurious Newline tokens
+            // at lines 0 or 1 from the padding that was previously prepended to the source.
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        sub init()
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            const brsFile = program.getFile<BrsFile>(xmlFile.inlineScriptPkgPaths[0]);
+            // line 2 is where <![CDATA[ lives — the leading \n in cdataText lands there.
+            // No token should be at line 0 or 1 (those would be spurious padding tokens).
+            for (const token of brsFile.parser.tokens) {
+                expect(token.range.start.line).to.be.at.least(2,
+                    `token "${token.text}" (${token.kind}) should not appear before the CDATA block`
+                );
+            }
+        });
+
+        it('synthetic BrsFile fileContents has correct content at XML-space line numbers', () => {
+            // fileContents must be indexable by XML-space line numbers so that tools like
+            // SignatureHelpUtil can extract the function signature text correctly.
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[
+                        sub greet(name as string)
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            const brsFile = program.getFile<BrsFile>(xmlFile.inlineScriptPkgPaths[0]);
+            const lines = brsFile.fileContents.split(/\r?\n/g);
+            // line 3 (0-indexed) of the XML is "        sub greet(name as string)"
+            expect(lines[3]).to.include('sub greet');
+        });
+
         it('transpile preserves CDATA blocks inline in the xml output', () => {
             testTranspile(trim`
                 <?xml version="1.0" encoding="utf-8" ?>

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -10,7 +10,7 @@ import type { BsDiagnostic, FileReference } from '../interfaces';
 import { Program } from '../Program';
 import { BrsFile } from './BrsFile';
 import { XmlFile } from './XmlFile';
-import { standardizePath as s } from '../util';
+import util, { standardizePath as s } from '../util';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim, trimMap } from '../testHelpers.spec';
 import { ProgramBuilder } from '../ProgramBuilder';
 import { LogLevel } from '../logging';
@@ -1430,9 +1430,9 @@ describe('XmlFile', () => {
             }
         });
 
-        it('synthetic BrsFile fileContents has correct content at XML-space line numbers', () => {
-            // fileContents must be indexable by XML-space line numbers so that tools like
-            // SignatureHelpUtil can extract the function signature text correctly.
+        it('synthetic BrsFile fileContents is the raw CDATA text (not padded)', () => {
+            // fileContents stores only the raw CDATA text. Consumers that need line-indexed
+            // access at XML-space coordinates (e.g. SignatureHelpUtil) use parentXmlFile.fileContents.
             const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyComp" extends="Scene">
@@ -1443,9 +1443,38 @@ describe('XmlFile', () => {
                 </component>
             `);
             const brsFile = program.getFile<BrsFile>(xmlFile.inlineScriptPkgPaths[0]);
-            const lines = brsFile.fileContents.split(/\r?\n/g);
-            // line 3 (0-indexed) of the XML is "        sub greet(name as string)"
-            expect(lines[3]).to.include('sub greet');
+            // fileContents is the raw CDATA source, not padded with leading newlines
+            expect(brsFile.fileContents).to.include('sub greet');
+            expect(brsFile.fileContents.split(/\r?\n/g)[0]).to.equal('');  // first "line" is the \n right after <![CDATA[
+            // parentXmlFile.fileContents is where XML-space line lookups should go
+            const xmlLines = xmlFile.fileContents.split(/\r?\n/g);
+            expect(xmlLines[3]).to.include('sub greet');
+        });
+
+        it('getSignatureHelp returns correct label for a CDATA function called from a uri-based script', () => {
+            // Tests that SignatureHelpUtil correctly extracts the function label from the parent
+            // XML file's contents when the callee is defined in a CDATA block (synthetic BrsFile).
+            program.setFile('components/MyComp.brs', trim`
+                sub main()
+                    greet("world")
+                end sub
+            `);
+            program.setFile<XmlFile>('components/MyComp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="MyComp" extends="Scene">
+                    <script type="text/brightscript" uri="MyComp.brs" />
+                    <script type="text/brightscript"><![CDATA[
+                        sub greet(name as string)
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            // line 1 of MyComp.brs is "    greet("world")" — col 10 is inside the arg list
+            const help = program.getSignatureHelp('components/MyComp.brs', util.createPosition(1, 10));
+            expect(help).to.have.length.greaterThan(0);
+            expect(help[0].signature.label).to.equal('sub greet(name as string)');
         });
 
         it('transpile preserves CDATA blocks inline in the xml output', () => {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1504,8 +1504,8 @@ describe('XmlFile', () => {
             expect(deps.some(d => d.includes('cdata-0.script.brs'))).to.be.true;
         });
 
-        it('validates code inside CDATA blocks', () => {
-            program.setFile('components/MyComp.xml', trim`
+        it('validates code inside CDATA blocks and remaps diagnostics to the xml file', () => {
+            const xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="MyComp" extends="Scene">
                     <script type="text/brightscript"><![CDATA[
@@ -1516,12 +1516,13 @@ describe('XmlFile', () => {
                 </component>
             `);
             program.validate();
-            //the synthetic file should have been validated — unknown function call should produce a diagnostic
-            const syntheticFile = program.getFile<BrsFile>('components/MyComp.cdata-0.script.brs');
-            expect(syntheticFile).to.exist;
             const allDiagnostics = program.getDiagnostics();
-            //there should be a diagnostic about the unknown function
-            expect(allDiagnostics.some(d => d.file.pkgPath === syntheticFile.pkgPath)).to.be.true;
+            //diagnostics from the CDATA block should be remapped to the parent xml file, not the synthetic file
+            expect(allDiagnostics.some(d => d.file.pkgPath === xmlFile.pkgPath)).to.be.true;
+            expect(allDiagnostics.every(d => d.file.pkgPath !== 'components/MyComp.cdata-0.script.brs')).to.be.true;
+            //the reported position should be within the xml file's line range (not line 1 of a standalone brs file)
+            const cdataDiagnostics = allDiagnostics.filter(d => d.file.pkgPath === xmlFile.pkgPath);
+            expect(cdataDiagnostics.every(d => d.range.start.line > 2)).to.be.true;
         });
 
         it('sets needsTranspiled on the xml file when CDATA is present', () => {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -2,7 +2,7 @@ import { assert, expect } from '../chai-config.spec';
 import * as path from 'path';
 import * as sinonImport from 'sinon';
 import type { CompletionItem } from 'vscode-languageserver';
-import { CompletionItemKind, Position, Range } from 'vscode-languageserver';
+import { CompletionItemKind, Position, Range, SymbolKind } from 'vscode-languageserver';
 import * as fsExtra from 'fs-extra';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { BsDiagnostic, FileReference } from '../interfaces';
@@ -1536,6 +1536,199 @@ describe('XmlFile', () => {
                 </component>
             `);
             expect(xmlFile.needsTranspiled).to.be.true;
+        });
+
+        describe('LSP event remapping', () => {
+            // After trim, the file looks like:
+            //   line 0: <?xml version="1.0" encoding="utf-8" ?>
+            //   line 1: <component name="MyComp" extends="Scene">
+            //   line 2:     <script type="text/brightscript"><![CDATA[   <- cdataStartLine=2, cdataStartChar=37
+            //   line 3:         sub greet(name as string)
+            //   line 4:             print name
+            //   line 5:         end sub
+            //   line 6:         function getCount() as integer
+            //   line 7:             return 42
+            //   line 8:         end function
+            //   line 9:     ]]></script>
+            //   line 10: </component>
+            const cdataStartLine = 2;
+
+            let xmlFile: XmlFile;
+            beforeEach(() => {
+                xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="MyComp" extends="Scene">
+                        <script type="text/brightscript"><![CDATA[
+                            sub greet(name as string)
+                                print name
+                            end sub
+                            function getCount() as integer
+                                return 42
+                            end function
+                        ]]></script>
+                    </component>
+                `);
+                program.validate();
+            });
+
+            it('getCompletions returns BrightScript completions inside CDATA', () => {
+                // position cursor at `name` usage on line 4 col 20 (inside "name")
+                const completions = program.getCompletions(xmlFile.srcPath, Position.create(4, 20));
+                expect(completions.map(c => c.label)).to.include('name');
+            });
+
+            it('getCompletions returns empty outside CDATA', () => {
+                // position inside the <component> tag (line 1), not in CDATA
+                const completions = program.getCompletions(xmlFile.srcPath, Position.create(1, 5));
+                expect(completions).to.be.empty;
+            });
+
+            it('getHover returns hover info for a function inside CDATA', () => {
+                // hover over `greet` at line 3 col 12
+                const hovers = program.getHover(xmlFile.srcPath, Position.create(3, 12));
+                expect(hovers).to.have.length.greaterThan(0);
+            });
+
+            it('getHover remaps the hover range to XML coordinates', () => {
+                // hover over `greet` at line 3 col 12
+                const hovers = program.getHover(xmlFile.srcPath, Position.create(3, 12));
+                for (const hover of hovers) {
+                    if (hover.range) {
+                        // range must be within the CDATA block in XML coordinates, not synthetic line 0
+                        expect(hover.range.start.line).to.be.at.least(cdataStartLine);
+                    }
+                }
+            });
+
+            it('getDefinition returns a location inside the XML file for a symbol in CDATA', () => {
+                // go-to-definition on `greet` reference (line 3, col 12 is the definition site itself)
+                // use getCount call from synthetic line 0 edge case — instead hover greet on its def line
+                const locations = program.getDefinition(xmlFile.srcPath, Position.create(3, 12));
+                expect(locations).to.have.length.greaterThan(0);
+                for (const loc of locations) {
+                    // all returned locations must use the xml file URI
+                    expect(loc.uri).to.include('MyComp.xml');
+                    // and be within the CDATA block line range
+                    expect(loc.range.start.line).to.be.at.least(cdataStartLine);
+                }
+            });
+
+            it('getReferences returns locations in XML coordinates', () => {
+                // find references of the `name` parameter — position inside the word (not at the start)
+                // line 3: `        sub greet(name as string)` — `name` starts at col 18, use col 20 (inside)
+                const refs = program.getReferences(xmlFile.srcPath, Position.create(3, 20));
+                expect(refs).to.have.length.greaterThan(0);
+                for (const ref of refs) {
+                    expect(ref.uri).to.include('MyComp.xml');
+                    expect(ref.range.start.line).to.be.at.least(cdataStartLine);
+                }
+            });
+
+            it('getSemanticTokens returns tokens with XML-file coordinates', () => {
+                // Use a .bs CDATA block with namespace+class to generate semantic tokens
+                const bsXmlFile = program.setFile<XmlFile>('components/BsComp.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="BsComp" extends="Scene">
+                        <script type="text/brighterscript"><![CDATA[
+                            namespace MyNs
+                                class Greeter
+                                end class
+                            end namespace
+                            sub init()
+                                x = new MyNs.Greeter()
+                            end sub
+                        ]]></script>
+                    </component>
+                `);
+                program.validate();
+                const tokens = program.getSemanticTokens(bsXmlFile.srcPath);
+                expect(tokens).to.exist;
+                expect(tokens).to.have.length.greaterThan(0);
+                for (const token of tokens) {
+                    // all tokens must be inside the CDATA block (line 2+ in XML)
+                    expect(token.range.start.line).to.be.at.least(cdataStartLine + 1);
+                }
+            });
+
+            it('getDocumentSymbols returns function symbols with XML-file coordinates', () => {
+                const symbols = program.getDocumentSymbols(xmlFile.srcPath);
+                expect(symbols).to.exist;
+                const names = symbols.map(s => s.name);
+                expect(names).to.include('greet');
+                expect(names).to.include('getCount');
+                for (const sym of symbols) {
+                    if (sym.name === 'greet' || sym.name === 'getCount') {
+                        expect(sym.kind).to.equal(SymbolKind.Function);
+                        // symbol range must start inside the CDATA block
+                        expect(sym.range.start.line).to.be.at.least(cdataStartLine + 1);
+                    }
+                }
+            });
+
+            it('getSignatureHelp returns signature for a function call inside CDATA', () => {
+                // Add a call site so we can test signature help
+                xmlFile = program.setFile<XmlFile>('components/MyComp.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="MyComp" extends="Scene">
+                        <script type="text/brightscript"><![CDATA[
+                            sub greet(name as string)
+                            end sub
+                            sub init()
+                                greet(
+                            end sub
+                        ]]></script>
+                    </component>
+                `);
+                program.validate();
+                // line 6 is `            greet(` — `(` is at col 17, col 18 is inside the arg list
+                const sigHelp = program.getSignatureHelp(xmlFile.srcPath, Position.create(6, 18));
+                expect(sigHelp).to.have.length.greaterThan(0);
+                expect(sigHelp[0].signature.label).to.include('greet');
+            });
+
+            it('getCodeActions workspace edits reference the XML file URI', () => {
+                // use a range inside the CDATA block (line 3 = `sub greet(name as string)`)
+                const actions = program.getCodeActions(xmlFile.srcPath, Range.create(3, 8, 3, 30));
+                // if any code action has workspace edits, they must target the xml file
+                for (const action of actions) {
+                    if (action.edit?.changes) {
+                        for (const uri of Object.keys(action.edit.changes)) {
+                            expect(uri).to.include('MyComp.xml');
+                        }
+                    }
+                    if (action.edit?.documentChanges) {
+                        for (const change of action.edit.documentChanges) {
+                            if ('textDocument' in change) {
+                                expect(change.textDocument.uri).to.include('MyComp.xml');
+                            }
+                        }
+                    }
+                }
+            });
+
+            it('uses cdataStartChar correctly for first-line synthetic positions', () => {
+                // The first line of the synthetic file (line 0) maps to the <![CDATA[ line
+                // at character offset cdataStartChar + '<![CDATA['.length.
+                // If content starts on the same line as <![CDATA[, hover should still work.
+                const inlineFile = program.setFile<XmlFile>('components/Inline.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="Inline" extends="Scene">
+                        <script type="text/brightscript"><![CDATA[sub init()
+                        end sub]]></script>
+                    </component>
+                `);
+                program.validate();
+                // `sub` and `init` are on the same line as <![CDATA[, so XML line 2
+                // cdataContentStartChar = cdataStartChar + 9 = 37 + 9 = 46
+                // `init` starts at col 46 + 4 = 50 (after `sub `)
+                const hovers = program.getHover(inlineFile.srcPath, Position.create(2, 50));
+                expect(hovers).to.have.length.greaterThan(0);
+                for (const hover of hovers) {
+                    if (hover.range) {
+                        expect(hover.range.start.line).to.equal(cdataStartLine);
+                    }
+                }
+            });
         });
     });
 });

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -6,6 +6,7 @@ import { DiagnosticCodeMap, diagnosticCodes } from '../DiagnosticMessages';
 import type { FunctionScope } from '../FunctionScope';
 import type { Callable, BsDiagnostic, File, FileReference, FunctionCall, CommentFlag } from '../interfaces';
 import type { Program } from '../Program';
+import type { BrsFile } from './BrsFile';
 import util from '../util';
 import SGParser, { rangeFromTokenValue } from '../parser/SGParser';
 import chalk from 'chalk';
@@ -532,18 +533,20 @@ export class XmlFile {
 
         const originalScripts = this.ast.component?.scripts ?? [];
 
-        //replace CDATA script blocks with uri-based script tags pointing to the synthetic extracted files
+        //pre-transpile any CDATA scripts that need it, storing the SourceNode on the SGScript
+        //so that SGScript.transpileBody() can embed it directly into the XML output
         let cdataIndex = 0;
-        const scriptsWithInlineUris = originalScripts.map(script => {
+        let anySyntheticNeedsTranspiled = false;
+        for (const script of originalScripts) {
             if (script.cdata) {
                 const inlinePkgPath = this.inlineScriptPkgPaths[cdataIndex++];
-                const uriScript = new SGScript();
-                uriScript.type = 'text/brightscript';
-                uriScript.uri = util.getRokuPkgPath(inlinePkgPath.replace(/\.bs$/i, '.brs'));
-                return uriScript;
+                const brsFile = this.program.getFile<BrsFile>(inlinePkgPath);
+                if (brsFile?.needsTranspiled) {
+                    anySyntheticNeedsTranspiled = true;
+                    script.transpileSourceNode = this.program.transpileSyntheticBrsFileToSourceNode(brsFile, state.srcPath);
+                }
             }
-            return script;
-        });
+        }
 
         const extraImportScripts = this.getMissingImportsForTranspile().map(uri => {
             const script = new SGScript();
@@ -552,20 +555,24 @@ export class XmlFile {
         });
 
         const [scriptsHaveChanged, publishableScripts] = this.checkScriptsForPublishableImports([
-            ...scriptsWithInlineUris,
+            ...originalScripts,
             ...extraImportScripts
         ]);
 
         let transpileResult: SourceNode | undefined;
-        if (this.needsTranspiled || extraImportScripts.length > 0 || scriptsHaveChanged) {
+        if (this.needsTranspiled || anySyntheticNeedsTranspiled || extraImportScripts.length > 0 || scriptsHaveChanged) {
             //temporarily add the missing imports as script tags
             this.ast.component.scripts = publishableScripts;
-
 
             transpileResult = util.sourceNodeFromTranspileResult(null, null, state.srcPath, this.parser.ast.transpile(state));
 
             //restore the original scripts array
             this.ast.component.scripts = originalScripts;
+
+            //clean up transpileSourceNode — don't leave SourceNodes on AST nodes after transpile
+            for (const script of originalScripts) {
+                delete script.transpileSourceNode;
+            }
 
         } else if (this.program.options.sourceMap) {
             //emit code as-is with a simple map to the original file location

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -306,7 +306,7 @@ export class XmlFile {
 
         let dependencies = [
             ...this.scriptTagImports.map(x => x.pkgPath.toLowerCase()),
-            ...this.inlineScriptPkgPaths.map(p => p.toLowerCase())
+            ...this.inlineScriptPkgPaths.map(p => util.standardizePath(p).toLowerCase())
         ];
         //if autoImportComponentScript is enabled, add the .bs and .brs files with the same name
         if (this.program.options.autoImportComponentScript) {
@@ -476,9 +476,10 @@ export class XmlFile {
             return map;
         }, {});
         for (const pkgPath of this.inlineScriptPkgPaths) {
-            alreadyThereScriptImportMap[pkgPath.toLowerCase()] = true;
+            const normalizedPkgPath = util.standardizePath(pkgPath).toLowerCase();
+            alreadyThereScriptImportMap[normalizedPkgPath] = true;
             //also mark the .brs variant so a .bs inline script doesn't get added as an extra import
-            alreadyThereScriptImportMap[pkgPath.toLowerCase().replace(/\.bs$/, '.brs')] = true;
+            alreadyThereScriptImportMap[normalizedPkgPath.replace(/\.bs$/, '.brs')] = true;
         }
 
         let resultMap = {};

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -533,20 +533,9 @@ export class XmlFile {
 
         const originalScripts = this.ast.component?.scripts ?? [];
 
-        //pre-transpile any CDATA scripts that need it, storing the SourceNode on the SGScript
-        //so that SGScript.transpileBody() can embed it directly into the XML output
-        let cdataIndex = 0;
-        let anySyntheticNeedsTranspiled = false;
-        for (const script of originalScripts) {
-            if (script.cdata) {
-                const inlinePkgPath = this.inlineScriptPkgPaths[cdataIndex++];
-                const brsFile = this.program.getFile<BrsFile>(inlinePkgPath);
-                if (brsFile?.needsTranspiled) {
-                    anySyntheticNeedsTranspiled = true;
-                    script.transpileSourceNode = this.program.transpileSyntheticBrsFileToSourceNode(brsFile, state.srcPath);
-                }
-            }
-        }
+        const anySyntheticNeedsTranspiled = this.inlineScriptPkgPaths.some(
+            pkgPath => this.program.getFile<BrsFile>(pkgPath)?.needsTranspiled
+        );
 
         const extraImportScripts = this.getMissingImportsForTranspile().map(uri => {
             const script = new SGScript();
@@ -568,11 +557,6 @@ export class XmlFile {
 
             //restore the original scripts array
             this.ast.component.scripts = originalScripts;
-
-            //clean up transpileSourceNode — don't leave SourceNodes on AST nodes after transpile
-            for (const script of originalScripts) {
-                delete script.transpileSourceNode;
-            }
 
         } else if (this.program.options.sourceMap) {
             //emit code as-is with a simple map to the original file location

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -76,6 +76,12 @@ export class XmlFile {
     readonly canBePruned = false;
 
     /**
+     * XML files are never synthetically generated; this is always false.
+     * Exists to satisfy the BscFile union type alongside BrsFile.isSynthetic.
+     */
+    readonly isSynthetic = false;
+
+    /**
      * The list of script imports delcared in the XML of this file.
      * This excludes parent imports and auto codebehind imports
      */
@@ -168,6 +174,24 @@ export class XmlFile {
     //TODO implement the xml CDATA parsing, which would populate this list
     public functionCalls = [] as FunctionCall[];
 
+    /**
+     * The pkg paths of synthetic BrsFiles generated from inline CDATA script blocks in this file.
+     * Populated during `parse()`. Used by Program.setFile() to register the files, by
+     * attachDependencyGraph() to add them as dependencies, by transpile() to replace CDATA
+     * with uri script tags, and by dispose() to clean them up.
+     */
+    public inlineScriptPkgPaths: string[] = [];
+
+    /**
+     * Derive the pkg path for a synthetic file extracted from a CDATA block.
+     * Format: `components/MyComp.cdata-0.script.brs` (or `.bs` for brighterscript type).
+     */
+    private getInlineScriptPkgPath(cdataIndex: number, scriptType: string | undefined): string {
+        const isBrighterScript = /brighterscript|text\/bs\b/i.test(scriptType ?? '');
+        const ext = isBrighterScript ? '.bs' : '.brs';
+        return this.pkgPath.replace(/\.xml$/i, `.cdata-${cdataIndex}.script${ext}`);
+    }
+
     public functionScopes = [] as FunctionScope[];
 
     /**
@@ -209,6 +233,7 @@ export class XmlFile {
      */
     public parse(fileContents: string) {
         this.fileContents = fileContents;
+        this.inlineScriptPkgPaths = [];
 
         this.parser.parse(this.pkgPath, fileContents);
         this.diagnostics = this.parser.diagnostics.map(diagnostic => ({
@@ -222,6 +247,16 @@ export class XmlFile {
         this.needsTranspiled = this.needsTranspiled || this.ast.component?.scripts?.some(
             script => script.type?.indexOf('brighterscript') > 0 || script.uri?.endsWith('.bs')
         );
+
+        //collect inline CDATA scripts and assign them synthetic pkg paths
+        let cdataIndex = 0;
+        for (const script of this.ast.component?.scripts ?? []) {
+            if (script.cdata) {
+                this.inlineScriptPkgPaths.push(this.getInlineScriptPkgPath(cdataIndex++, script.type));
+                //any CDATA script requires the XML to be rewritten (CDATA → uri tag)
+                this.needsTranspiled = true;
+            }
+        }
     }
 
     /**
@@ -270,7 +305,8 @@ export class XmlFile {
         });
 
         let dependencies = [
-            ...this.scriptTagImports.map(x => x.pkgPath.toLowerCase())
+            ...this.scriptTagImports.map(x => x.pkgPath.toLowerCase()),
+            ...this.inlineScriptPkgPaths.map(p => p.toLowerCase())
         ];
         //if autoImportComponentScript is enabled, add the .bs and .brs files with the same name
         if (this.program.options.autoImportComponentScript) {
@@ -434,11 +470,16 @@ export class XmlFile {
             return map;
         }, {});
 
-        //if the XML already has this import, skip this one
-        let alreadyThereScriptImportMap = this.scriptTagImports.reduce((map, fileReference) => {
+        //if the XML already has this import (either a uri script tag or an inline CDATA script), skip this one
+        let alreadyThereScriptImportMap = this.scriptTagImports.reduce<Record<string, boolean>>((map, fileReference) => {
             map[fileReference.pkgPath.toLowerCase()] = true;
             return map;
         }, {});
+        for (const pkgPath of this.inlineScriptPkgPaths) {
+            alreadyThereScriptImportMap[pkgPath.toLowerCase()] = true;
+            //also mark the .brs variant so a .bs inline script doesn't get added as an extra import
+            alreadyThereScriptImportMap[pkgPath.toLowerCase().replace(/\.bs$/, '.brs')] = true;
+        }
 
         let resultMap = {};
         let result = [] as string[];
@@ -489,6 +530,20 @@ export class XmlFile {
         const state = new TranspileState(this.srcPath, this.program.options);
 
         const originalScripts = this.ast.component?.scripts ?? [];
+
+        //replace CDATA script blocks with uri-based script tags pointing to the synthetic extracted files
+        let cdataIndex = 0;
+        const scriptsWithInlineUris = originalScripts.map(script => {
+            if (script.cdata) {
+                const inlinePkgPath = this.inlineScriptPkgPaths[cdataIndex++];
+                const uriScript = new SGScript();
+                uriScript.type = 'text/brightscript';
+                uriScript.uri = util.getRokuPkgPath(inlinePkgPath.replace(/\.bs$/i, '.brs'));
+                return uriScript;
+            }
+            return script;
+        });
+
         const extraImportScripts = this.getMissingImportsForTranspile().map(uri => {
             const script = new SGScript();
             script.uri = util.getRokuPkgPath(uri.replace(/\.bs$/, '.brs'));
@@ -496,7 +551,7 @@ export class XmlFile {
         });
 
         const [scriptsHaveChanged, publishableScripts] = this.checkScriptsForPublishableImports([
-            ...originalScripts,
+            ...scriptsWithInlineUris,
             ...extraImportScripts
         ]);
 
@@ -537,5 +592,9 @@ export class XmlFile {
     public dispose() {
         //unsubscribe from any DependencyGraph subscriptions
         this.unsubscribeFromDependencyGraph?.();
+        //clean up any synthetic BrsFiles that were generated from CDATA blocks in this file
+        for (const pkgPath of this.inlineScriptPkgPaths) {
+            this.program.removeFile(pkgPath);
+        }
     }
 }

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -83,6 +83,11 @@ export class XmlFile {
     readonly isSynthetic = false;
 
     /**
+     * When true, this file will not be written as a standalone output file during transpile.
+     */
+    public excludeFromOutput = false;
+
+    /**
      * The list of script imports delcared in the XML of this file.
      * This excludes parent imports and auto codebehind imports
      */

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -189,7 +189,7 @@ export class XmlFile {
     private getInlineScriptPkgPath(cdataIndex: number, scriptType: string | undefined): string {
         const isBrighterScript = /brighterscript|text\/bs\b/i.test(scriptType ?? '');
         const ext = isBrighterScript ? '.bs' : '.brs';
-        return this.pkgPath.replace(/\.xml$/i, `.cdata-${cdataIndex}.script${ext}`);
+        return this.pkgPath.replace(/\\/g, '/').replace(/\.xml$/i, `.cdata-${cdataIndex}.script${ext}`);
     }
 
     public functionScopes = [] as FunctionScope[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -319,17 +319,27 @@ export interface Plugin {
     afterScopeValidate?: ValidateHandler;
     //file events
     beforeFileParse?: (source: SourceObj) => void;
+    /**
+     * Called after each file has been parsed. When a SceneGraph XML file contains inline
+     * `<![CDATA[...]]>` script blocks, this event is also fired once per CDATA block with a
+     * synthetic `BrsFile` as the argument (`file.isSynthetic === true`). The synthetic file's
+     * positions are already in the parent XML file's coordinate space.
+     */
     afterFileParse?: (file: BscFile) => void;
     /**
-     * Called before each file is validated
+     * Called before each file is validated. For SceneGraph XML files with inline CDATA script
+     * blocks, this is also called for each synthetic `BrsFile` (`file.isSynthetic === true`).
      */
     beforeFileValidate?: PluginHandler<BeforeFileValidateEvent>;
     /**
      * Called during the file validation process. If your plugin contributes file validations, this is a good place to contribute them.
+     * For SceneGraph XML files with inline CDATA script blocks, this is also called for each
+     * synthetic `BrsFile` (`event.file.isSynthetic === true`).
      */
     onFileValidate?: PluginHandler<OnFileValidateEvent>;
     /**
-     * Called after each file is validated
+     * Called after each file is validated. For SceneGraph XML files with inline CDATA script
+     * blocks, this is also called for each synthetic `BrsFile` (`file.isSynthetic === true`).
      */
     afterFileValidate?: (file: BscFile) => void;
     beforeFileTranspile?: PluginHandler<BeforeFileTranspileEvent>;
@@ -341,6 +351,11 @@ export type PluginHandler<T, R = void> = (event: T) => R;
 
 export interface OnGetCodeActionsEvent {
     program: Program;
+    /**
+     * The file the code action request was invoked in. When the range falls inside a
+     * `<![CDATA[...]]>` block of an XML file, this will be the synthetic `BrsFile` for that
+     * block (`file.isSynthetic === true`) rather than the `XmlFile` itself.
+     */
     file: BscFile;
     range: Range;
     scopes: Scope[];
@@ -350,6 +365,11 @@ export interface OnGetCodeActionsEvent {
 
 export interface ProvideCompletionsEvent<TFile extends BscFile = BscFile> {
     program: Program;
+    /**
+     * The file the completion request was invoked in. When the cursor position falls inside a
+     * `<![CDATA[...]]>` block of an XML file, this will be the synthetic `BrsFile` for that
+     * block (`file.isSynthetic === true`) rather than the `XmlFile` itself.
+     */
     file: TFile;
     scopes: Scope[];
     position: Position;
@@ -360,6 +380,11 @@ export type AfterProvideCompletionsEvent<TFile extends BscFile = BscFile> = Prov
 
 export interface ProvideHoverEvent {
     program: Program;
+    /**
+     * The file the hover request was invoked in. When the cursor position falls inside a
+     * `<![CDATA[...]]>` block of an XML file, this will be the synthetic `BrsFile` for that
+     * block (`file.isSynthetic === true`) rather than the `XmlFile` itself.
+     */
     file: BscFile;
     position: Position;
     scopes: Scope[];
@@ -386,7 +411,9 @@ export type AfterProvideHoverEvent = ProvideHoverEvent;
 export interface ProvideDefinitionEvent<TFile = BscFile> {
     program: Program;
     /**
-     * The file that the getDefinition request was invoked in
+     * The file that the getDefinition request was invoked in. When the cursor position falls inside
+     * a `<![CDATA[...]]>` block of an XML file, this will be the synthetic `BrsFile` for that
+     * block (`file.isSynthetic === true`) rather than the `XmlFile` itself.
      */
     file: TFile;
     /**
@@ -404,7 +431,9 @@ export type AfterProvideDefinitionEvent<TFile = BscFile> = ProvideDefinitionEven
 export interface ProvideReferencesEvent<TFile = BscFile> {
     program: Program;
     /**
-     * The file that the getDefinition request was invoked in
+     * The file that the getReferences request was invoked in. When the cursor position falls inside
+     * a `<![CDATA[...]]>` block of an XML file, this will be the synthetic `BrsFile` for that
+     * block (`file.isSynthetic === true`) rather than the `XmlFile` itself.
      */
     file: TFile;
     /**
@@ -423,7 +452,10 @@ export type AfterProvideReferencesEvent<TFile = BscFile> = ProvideReferencesEven
 export interface ProvideDocumentSymbolsEvent<TFile = BscFile> {
     program: Program;
     /**
-     * The file that the `documentSymbol` request was invoked in
+     * The file that the `documentSymbol` request was invoked in. For SceneGraph XML files with
+     * inline CDATA script blocks, this event is also emitted once per block with the synthetic
+     * `BrsFile` (`file.isSynthetic === true`). Symbol ranges are already in the parent XML
+     * coordinate space.
      */
     file: TFile;
     /**
@@ -452,7 +484,9 @@ export interface OnGetSemanticTokensEvent<T extends BscFile = BscFile> {
      */
     program: Program;
     /**
-     * The file to get semantic tokens for
+     * The file to get semantic tokens for. For SceneGraph XML files with inline CDATA script
+     * blocks, this event is also emitted once per block with the synthetic `BrsFile`
+     * (`file.isSynthetic === true`). Token ranges are already in the parent XML coordinate space.
      */
     file: T;
     /**

--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1225,6 +1225,40 @@ describe('lexer', () => {
                 Range.create(2, 7, 2, 8) // EOF
             ]);
         });
+
+        it('offsets all token ranges by startLine and startCharacter', () => {
+            // Simulates scanning an inline CDATA fragment that begins on line 5, col 10 of a parent file.
+            // The first character of the source is a newline (right after <![CDATA[]), so:
+            //   - the Newline token itself lands on (5, 10)
+            //   - subsequent lines start at their natural column (no offset after first newline)
+            const { tokens } = Lexer.scan('\nsub foo()\nend sub', {
+                includeWhitespace: false,
+                startLine: 5,
+                startCharacter: 10
+            });
+            expect(tokens.map(t => ({ kind: t.kind, range: t.range }))).to.eql([
+                { kind: TokenKind.Newline, range: Range.create(5, 10, 5, 11) },
+                { kind: TokenKind.Sub, range: Range.create(6, 0, 6, 3) },
+                { kind: TokenKind.Identifier, range: Range.create(6, 4, 6, 7) }, // foo
+                { kind: TokenKind.LeftParen, range: Range.create(6, 7, 6, 8) },
+                { kind: TokenKind.RightParen, range: Range.create(6, 8, 6, 9) },
+                { kind: TokenKind.Newline, range: Range.create(6, 9, 6, 10) },
+                { kind: TokenKind.EndSub, range: Range.create(7, 0, 7, 7) },
+                { kind: TokenKind.Eof, range: Range.create(7, 7, 7, 8) }
+            ]);
+        });
+
+        it('produces no tokens before startLine when scanning a fragment with a leading newline', () => {
+            // The leading newline is at the startLine position — no tokens at lines 0..startLine-1.
+            const { tokens } = Lexer.scan('\nsub foo()\nend sub', {
+                includeWhitespace: false,
+                startLine: 5,
+                startCharacter: 10
+            });
+            for (const token of tokens) {
+                expect(token.range.start.line).to.be.at.least(5);
+            }
+        });
     });
 
     describe('two word keywords', () => {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -93,10 +93,10 @@ export class Lexer {
         this.options = this.sanitizeOptions(options);
         this.start = 0;
         this.current = 0;
-        this.lineBegin = 0;
-        this.lineEnd = 0;
-        this.columnBegin = 0;
-        this.columnEnd = 0;
+        this.lineBegin = this.options.startLine ?? 0;
+        this.lineEnd = this.options.startLine ?? 0;
+        this.columnBegin = this.options.startCharacter ?? 0;
+        this.columnEnd = this.options.startCharacter ?? 0;
         this.tokens = [];
         this.diagnostics = [];
         while (!this.isAtEnd()) {
@@ -1102,4 +1102,17 @@ export interface ScanOptions {
      * @default true
      */
     trackLocations?: boolean;
+    /**
+     * The zero-indexed line number to start position tracking from.
+     * Useful when scanning a fragment of a larger file (e.g. an inline CDATA block)
+     * so that all token ranges are in the coordinate space of the parent file.
+     * @default 0
+     */
+    startLine?: number;
+    /**
+     * The zero-indexed character offset to start position tracking from on the first line.
+     * Only applies to the first line; subsequent lines always start at column 0.
+     * @default 0
+     */
+    startCharacter?: number;
 }

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -158,4 +158,70 @@ describe('SGParser', () => {
             range: Range.create(0, 0, 1, 12)
         });
     });
+
+    describe('SGScript.cdataText', () => {
+        function parseScript(xml: string) {
+            const parser = new SGParser();
+            parser.parse('pkg:/components/Comp.xml', xml);
+            return parser.ast.component?.scripts?.[0];
+        }
+
+        it('strips <![CDATA[ and ]]> from multiline content', () => {
+            const script = parseScript(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="C" extends="Scene">
+                    <script type="text/brightscript">
+                        <![CDATA[
+                            function init()
+                            end function
+                        ]]>
+                    </script>
+                </component>
+            `);
+            // cdataText should not contain the delimiters; whitespace inside is preserved as-is
+            expect(script?.cdataText).to.not.include('<![CDATA[');
+            expect(script?.cdataText).to.not.include(']]>');
+            expect(script?.cdataText?.trim()).to.equal('function init()\n            end function');
+        });
+
+        it('strips <![CDATA[ and ]]> from inline (single-line) content', () => {
+            const script = parseScript(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="C" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[function init() : end function]]></script>
+                </component>
+            `);
+            expect(script?.cdataText).to.equal('function init() : end function');
+        });
+
+        it('returns empty string for empty CDATA block', () => {
+            const script = parseScript(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="C" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[]]></script>
+                </component>
+            `);
+            expect(script?.cdataText).to.equal('');
+        });
+
+        it('preserves > characters inside CDATA content', () => {
+            const script = parseScript(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="C" extends="Scene">
+                    <script type="text/brightscript"><![CDATA[if x > 5 then : end if]]></script>
+                </component>
+            `);
+            expect(script?.cdataText).to.equal('if x > 5 then : end if');
+        });
+
+        it('returns undefined when there is no CDATA block', () => {
+            const script = parseScript(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="C" extends="Scene">
+                    <script type="text/brightscript" uri="./Comp.brs" />
+                </component>
+            `);
+            expect(script?.cdataText).to.be.undefined;
+        });
+    });
 });

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -63,7 +63,11 @@ describe('SGParser', () => {
                     <function name="load" />
                 </interface>
                 <script type="text/brightscript" uri="./Component1.brs" />
-                <script type="text/brightscript" uri="pkg:/components/file.cdata-0.script.brs" />
+                <script type="text/brightscript"><![CDATA[
+                        function init()
+                            print "hello"
+                        end function
+                    ]]></script>
                 <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
                 <children>
                     <Label id="loadingIndicator" text="Loading..." font="font:MediumBoldSystemFont" />

--- a/src/parser/SGParser.spec.ts
+++ b/src/parser/SGParser.spec.ts
@@ -63,11 +63,7 @@ describe('SGParser', () => {
                     <function name="load" />
                 </interface>
                 <script type="text/brightscript" uri="./Component1.brs" />
-                <script type="text/brightscript"><![CDATA[
-                        function init()
-                            print "hello"
-                        end function
-                    ]]></script>
+                <script type="text/brightscript" uri="pkg:/components/file.cdata-0.script.brs" />
                 <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
                 <children>
                     <Label id="loadingIndicator" text="Loading..." font="font:MediumBoldSystemFont" />

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -174,8 +174,24 @@ export class SGScript extends SGTag {
             .replace(/\]\]>$/, '');
     }
 
+    /**
+     * Pre-transpiled SourceNode for CDATA content. When set, transpileBody() embeds this
+     * SourceNode directly instead of the raw cdata token, producing a unified XML+BrightScript
+     * source map. Populated by XmlFile.transpile() before the AST transpile call and cleaned
+     * up immediately after.
+     */
+    public transpileSourceNode?: SourceNode;
+
     protected transpileBody(state: TranspileState): (string | SourceNode)[] {
-        if (this.cdata) {
+        if (this.transpileSourceNode) {
+            return [
+                '>',
+                '<![CDATA[',
+                this.transpileSourceNode,
+                ']]>',
+                '</', this.tag.text, '>\n'
+            ];
+        } else if (this.cdata) {
             return [
                 '>',
                 state.transpileToken(this.cdata),

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -164,6 +164,16 @@ export class SGScript extends SGTag {
         this.setAttribute('uri', value);
     }
 
+    /**
+     * The raw text content of the CDATA block, with the `<![CDATA[` and `]]>` wrappers stripped.
+     * Returns undefined if this script tag has no CDATA content.
+     */
+    get cdataText(): string | undefined {
+        return this.cdata?.text
+            .replace(/^<!\[CDATA\[/, '')
+            .replace(/\]\]>$/, '');
+    }
+
     protected transpileBody(state: TranspileState): (string | SourceNode)[] {
         if (this.cdata) {
             return [

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -172,7 +172,7 @@ export class SGScript extends SGTag {
         // Use a capture group with [\s\S]*? so multiline content and edge cases
         // (e.g. trailing whitespace after ]]>, or > characters inside the content) are handled
         // correctly without relying on ^ / $ anchors that can misbehave at string boundaries.
-        const match = this.cdata?.text.match(/^<!\[CDATA\[([\s\S]*?)\]\]>/);
+        const match = /^<!\[CDATA\[([\s\S]*?)\]\]>/.exec(this.cdata?.text);
         return match?.[1];
     }
 

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -169,9 +169,11 @@ export class SGScript extends SGTag {
      * Returns undefined if this script tag has no CDATA content.
      */
     get cdataText(): string | undefined {
-        return this.cdata?.text
-            .replace(/^<!\[CDATA\[/, '')
-            .replace(/\]\]>$/, '');
+        // Use a capture group with [\s\S]*? so multiline content and edge cases
+        // (e.g. trailing whitespace after ]]>, or > characters inside the content) are handled
+        // correctly without relying on ^ / $ anchors that can misbehave at string boundaries.
+        const match = this.cdata?.text.match(/^<!\[CDATA\[([\s\S]*?)\]\]>/);
+        return match?.[1];
     }
 
     /**

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -175,19 +175,19 @@ export class SGScript extends SGTag {
     }
 
     /**
-     * Pre-transpiled SourceNode for CDATA content. When set, transpileBody() embeds this
-     * SourceNode directly instead of the raw cdata token, producing a unified XML+BrightScript
-     * source map. Populated by XmlFile.transpile() before the AST transpile call and cleaned
-     * up immediately after.
+     * When set, called during transpile to produce a SourceNode for this CDATA block's content.
+     * Returns undefined if the BrsFile does not need transpiling (raw cdata is used as-is).
+     * Set by Program when the synthetic BrsFile is registered; lives for the lifetime of the file.
      */
-    public transpileSourceNode?: SourceNode;
+    public cdataTranspile?: (state: TranspileState) => SourceNode | undefined;
 
     protected transpileBody(state: TranspileState): (string | SourceNode)[] {
-        if (this.transpileSourceNode) {
+        const cdataSourceNode = this.cdataTranspile?.(state);
+        if (cdataSourceNode) {
             return [
                 '>',
                 '<![CDATA[',
-                this.transpileSourceNode,
+                cdataSourceNode,
                 ']]>',
                 '</', this.tag.text, '>\n'
             ];


### PR DESCRIPTION
## Summary

- Parses `<![CDATA[...]]>` script blocks in SceneGraph XML files and registers synthetic `BrsFile` objects for each block in the program
- Remaps diagnostics from synthetic BrsFile coordinates back to XML file coordinates so errors appear in the correct location
- Adds a general CDATA remapping mechanism for all LSP hooks:
  - **Code actions** (including fix-all): uses `_cdataDiagnosticsContext` to keep diagnostics in synthetic-file coordinate space during event emission so plugin file-identity comparisons work correctly
  - **Completions**: remaps cursor position into synthetic file, remaps text edits back to XML coordinates
  - **Hover**: remaps position in, remaps hover range out
  - **Go to definition / Find references**: remaps position in, remaps returned locations out
  - **Signature help**: redirects to synthetic BrsFile
  - **Semantic tokens**: iterates all CDATA blocks in the XML file, emits per-block, remaps token ranges
  - **Document symbols**: iterates all CDATA blocks, emits per-block, remaps symbol ranges recursively

## Test plan

- [ ] Existing `XmlFile.spec.ts` tests pass (`npm test`)
- [ ] Diagnostics (errors/warnings) appear on the correct line inside `<![CDATA[...]]>` blocks
- [ ] Code actions (including bslint fix-all) show up inside CDATA blocks
- [ ] Completions, hover, go-to-definition, find-references work inside CDATA blocks
- [ ] Semantic token highlighting works inside CDATA blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)