### PR TITLE
Add named argument support and duplicate parameter name warning

### DIFF
--- a/docs/named-arguments.md
+++ b/docs/named-arguments.md
@@ -1,0 +1,185 @@
+# Named Arguments
+
+BrighterScript supports calling functions with named arguments, allowing you to pass arguments by parameter name instead of by position.
+
+## Basic Usage
+
+Use `paramName: value` syntax inside a function call:
+
+```brighterscript
+sub greet(name as string, excited as boolean)
+    if excited
+        print "Hello, " + name + "!!!"
+    else
+        print "Hello, " + name
+    end if
+end sub
+
+sub main()
+    greet(name: "Bob", excited: true)
+end sub
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```brightscript
+sub greet(name as string, excited as boolean)
+    if excited
+        print "Hello, " + name + "!!!"
+    else
+        print "Hello, " + name
+    end if
+end sub
+
+sub main()
+    greet("Bob", true)
+end sub
+```
+
+</details>
+
+## Out-of-Order Arguments
+
+Named arguments can be passed in any order — BrighterScript reorders them to match the function definition at compile time:
+
+```brighterscript
+sub createUser(name as string, age as integer, admin as boolean)
+end sub
+
+sub main()
+    createUser(admin: false, name: "Alice", age: 30)
+end sub
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```brightscript
+sub createUser(name as string, age as integer, admin as boolean)
+end sub
+
+sub main()
+    createUser("Alice", 30, false)
+end sub
+```
+
+</details>
+
+## Mixed Positional and Named Arguments
+
+Positional arguments can be combined with named arguments. Positional arguments must come first:
+
+```brighterscript
+sub greet(name as string, title as string, excited as boolean)
+end sub
+
+sub main()
+    greet("Bob", excited: true, title: "Mr")
+end sub
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```brightscript
+sub greet(name as string, title as string, excited as boolean)
+end sub
+
+sub main()
+    greet("Bob", "Mr", true)
+end sub
+```
+
+</details>
+
+## Skipping Optional Parameters
+
+Named arguments let you skip optional middle parameters. BrighterScript inserts the default value for any skipped parameter:
+
+```brighterscript
+sub greet(name as string, title = "Mr", excited = false)
+end sub
+
+sub main()
+    ' Skip "title", pass "excited" by name
+    greet(name: "Bob", excited: true)
+end sub
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```brightscript
+sub greet(name as string, title = "Mr", excited = false)
+end sub
+
+sub main()
+    ' Skip "title", pass "excited" by name
+    greet("Bob", "Mr", true)
+end sub
+```
+
+</details>
+
+If a skipped optional parameter has no default value, `invalid` is inserted:
+
+```brighterscript
+sub greet(name as string, title = invalid, excited = false)
+end sub
+
+sub main()
+    greet(name: "Bob", excited: true)
+end sub
+```
+
+<details>
+  <summary>View the transpiled BrightScript code</summary>
+
+```brightscript
+sub greet(name as string, title = invalid, excited = false)
+end sub
+
+sub main()
+    greet("Bob", invalid, true)
+end sub
+```
+
+</details>
+
+## Validation
+
+BrighterScript validates named argument calls and reports the following errors:
+
+### Unknown argument name
+
+```brighterscript
+sub greet(name as string)
+end sub
+
+greet(nope: "Bob") ' error: Unknown named argument 'nope' for function 'greet'
+```
+
+### Duplicate named argument
+
+```brighterscript
+greet(name: "Bob", name: "Alice") ' error: Named argument 'name' was already provided
+```
+
+### Positional argument after named argument
+
+```brighterscript
+greet(name: "Bob", true) ' error: Positional arguments cannot follow named arguments
+```
+
+### Named arguments on an unknown function
+
+Named arguments require the function definition to be visible so BrighterScript can verify parameter names and reorder arguments at compile time:
+
+```brighterscript
+unknownFunc(param: true) ' error: Cannot use named arguments when calling 'unknownFunc' because the function definition cannot be found
+```
+
+## BrighterScript Only
+
+Named argument syntax is a BrighterScript feature and is not valid in plain BrightScript (`.brs`) files.

--- a/docs/named-arguments.md
+++ b/docs/named-arguments.md
@@ -39,32 +39,53 @@ end sub
 
 </details>
 
+## Supported Call Sites
+
+Named arguments are supported for regular functions, namespace functions, and class constructors:
+
+```brighterscript
+namespace MyNs
+    sub greet(name as string, excited as boolean)
+    end sub
+end namespace
+
+class Point
+    function new(x as integer, y as integer)
+    end function
+end class
+
+sub main()
+    MyNs.greet(name: "Bob", excited: true)
+    p = new Point(x: 1, y: 2)
+end sub
+```
+
 ## Out-of-Order Arguments
 
-Named arguments can be passed in any order — BrighterScript reorders them to match the function definition at compile time:
+Named arguments must be passed in the same order as the function declaration. Calling a function with named arguments out of declaration order is a compile-time error:
 
 ```brighterscript
 sub createUser(name as string, age as integer, admin as boolean)
 end sub
 
 sub main()
+    ' error: Named argument 'name' is out of order
     createUser(admin: false, name: "Alice", age: 30)
 end sub
 ```
 
-<details>
-  <summary>View the transpiled BrightScript code</summary>
+### Quick fix
 
-```brightscript
+In editors with BrighterScript language support, a `Reorder named arguments to match function declaration` quick fix is offered for this diagnostic. Applying it rewrites the call to match the function signature:
+
+```brighterscript
 sub createUser(name as string, age as integer, admin as boolean)
 end sub
 
 sub main()
-    createUser("Alice", 30, false)
+    createUser(name: "Alice", age: 30, admin: false)
 end sub
 ```
-
-</details>
 
 ## Mixed Positional and Named Arguments
 
@@ -174,11 +195,38 @@ greet(name: "Bob", true) ' error: Positional arguments cannot follow named argum
 
 ### Named arguments on an unknown function
 
-Named arguments require the function definition to be visible so BrighterScript can verify parameter names and reorder arguments at compile time:
+Named arguments require the function definition to be visible so BrighterScript can verify parameter names at compile time:
 
 ```brighterscript
 unknownFunc(param: true) ' error: Cannot use named arguments when calling 'unknownFunc' because the function definition cannot be found
 ```
+
+### Cross-scope parameter conflict
+
+When a `.bs` file is shared across multiple component scopes and the same function name resolves to different parameter signatures in those scopes, named arguments cannot be safely transpiled (the same call site would need different positional output per scope). BrighterScript reports this as an error:
+
+```brighterscript
+' shared.bs (included by both CompA.xml and CompB.xml)
+sub callFoo()
+    ' error: Named arguments for 'foo' are ambiguous: the function has different
+    ' parameter signatures across component scopes that share this file.
+    foo(a: 2, b: 1)
+end sub
+```
+
+```brighterscript
+' helperA.bs (included by CompA.xml)
+sub foo(a, b)
+end sub
+```
+
+```brighterscript
+' helperB.bs (included by CompB.xml)
+sub foo(b, a)
+end sub
+```
+
+To resolve, give the conflicting functions distinct names or align their parameter order across scopes.
 
 ## BrighterScript Only
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -50,6 +50,15 @@ enum RemoteButton
 end enum
 ```
 
+## [Named Arguments](named-arguments.md)
+```brighterscript
+sub greet(name as string, excited as boolean)
+end sub
+
+' pass args by name, in any order
+greet(excited: true, name: "Bob")
+```
+
 ## [Namespaces](namespaces.md)
 ```brighterscript
 namespace util

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -766,35 +766,35 @@ export let DiagnosticMessages = {
         code: 1145,
         severity: DiagnosticSeverity.Error
     }),
+    duplicateFunctionParameter: (paramName: string) => ({
+        message: `Duplicate parameter name '${paramName}'`,
+        code: 1146,
+        severity: DiagnosticSeverity.Warning
+    }),
     unknownNamedArgument: (argName: string, funcName: string) => ({
         message: `Unknown named argument '${argName}' for function '${funcName}'`,
-        code: 1146,
+        code: 1147,
         severity: DiagnosticSeverity.Error
     }),
     namedArgDuplicate: (argName: string) => ({
         message: `Named argument '${argName}' was already provided`,
-        code: 1147,
+        code: 1148,
         severity: DiagnosticSeverity.Error
     }),
     positionalArgAfterNamedArg: () => ({
         message: `Positional arguments cannot follow named arguments`,
-        code: 1148,
+        code: 1149,
         severity: DiagnosticSeverity.Error
     }),
     namedArgsNotAllowedForUnknownFunction: (funcName: string) => ({
         message: `Cannot use named arguments when calling '${funcName}' because the function definition cannot be found`,
-        code: 1149,
+        code: 1150,
         severity: DiagnosticSeverity.Error
     }),
     namedArgsCrossScopeConflict: (funcName: string) => ({
         message: `Named arguments for '${funcName}' are ambiguous: the function has different parameter signatures across component scopes that share this file. Named arguments cannot be safely transpiled.`,
         code: 1151,
         severity: DiagnosticSeverity.Error
-    }),
-    duplicateFunctionParameter: (paramName: string) => ({
-        message: `Duplicate parameter name '${paramName}'`,
-        code: 1150,
-        severity: DiagnosticSeverity.Warning
     })
 };
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -786,6 +786,11 @@ export let DiagnosticMessages = {
         code: 1149,
         severity: DiagnosticSeverity.Error
     }),
+    namedArgsCrossScopeConflict: (funcName: string) => ({
+        message: `Named arguments for '${funcName}' are ambiguous: the function has different parameter signatures across component scopes that share this file. Named arguments cannot be safely transpiled.`,
+        code: 1151,
+        severity: DiagnosticSeverity.Error
+    }),
     duplicateFunctionParameter: (paramName: string) => ({
         message: `Duplicate parameter name '${paramName}'`,
         code: 1150,

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -765,6 +765,31 @@ export let DiagnosticMessages = {
         message: `Computed associative array keys must resolve to a string value`,
         code: 1145,
         severity: DiagnosticSeverity.Error
+    }),
+    unknownNamedArgument: (argName: string, funcName: string) => ({
+        message: `Unknown named argument '${argName}' for function '${funcName}'`,
+        code: 1146,
+        severity: DiagnosticSeverity.Error
+    }),
+    namedArgDuplicate: (argName: string) => ({
+        message: `Named argument '${argName}' was already provided`,
+        code: 1147,
+        severity: DiagnosticSeverity.Error
+    }),
+    positionalArgAfterNamedArg: () => ({
+        message: `Positional arguments cannot follow named arguments`,
+        code: 1148,
+        severity: DiagnosticSeverity.Error
+    }),
+    namedArgsNotAllowedForUnknownFunction: (funcName: string) => ({
+        message: `Cannot use named arguments when calling '${funcName}' because the function definition cannot be found`,
+        code: 1149,
+        severity: DiagnosticSeverity.Error
+    }),
+    duplicateFunctionParameter: (paramName: string) => ({
+        message: `Duplicate parameter name '${paramName}'`,
+        code: 1150,
+        severity: DiagnosticSeverity.Warning
     })
 };
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -795,6 +795,11 @@ export let DiagnosticMessages = {
         message: `Named arguments for '${funcName}' are ambiguous: the function has different parameter signatures across component scopes that share this file. Named arguments cannot be safely transpiled.`,
         code: 1151,
         severity: DiagnosticSeverity.Error
+    }),
+    namedArgOutOfOrder: (argName: string) => ({
+        message: `Named argument '${argName}' is out of order`,
+        code: 1152,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -8,15 +8,17 @@ import type { CallableContainer, BsDiagnostic, FileReference, BscFile, CallableC
 import type { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
 import type { NamespaceStatement, FunctionStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement, TypeStatement } from './parser/Statement';
-import type { NewExpression } from './parser/Expression';
+import type { NewExpression, NamedArgumentExpression } from './parser/Expression';
+import type { Expression } from './parser/AstNode';
 import { ParseMode } from './parser/Parser';
+import { createInvalidLiteral } from './astUtils/creators';
 import { util } from './util';
 import { globalCallableMap } from './globalCallables';
 import { Cache } from './Cache';
 import { URI } from 'vscode-uri';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
-import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isNamespaceStatement, isEnumMemberStatement } from './astUtils/reflection';
+import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isNamespaceStatement, isEnumMemberStatement, isNamedArgumentExpression, isVariableExpression } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
 import type { Statement } from './parser/AstNode';
 import { LogLevel } from './logging';
@@ -777,6 +779,7 @@ export class Scope {
 
         //do many per-file checks
         this.enumerateBrsFiles((file) => {
+            this.validateNamedArgCalls(file, callableContainerMap);
             this.diagnosticDetectFunctionCallsWithWrongParamCount(file, callableContainerMap);
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
@@ -985,11 +988,158 @@ export class Scope {
     }
 
     /**
+     * Validate calls that use named arguments, and resolve them to positional order for transpilation.
+     * Only handles simple function calls (VariableExpression callee); method calls are not supported.
+     */
+    private validateNamedArgCalls(file: BscFile, callableContainerMap: CallableContainerMap) {
+        if (!isBrsFile(file)) {
+            return;
+        }
+        for (const func of file.parser.references.functionExpressions) {
+            for (const callExpr of func.callExpressions) {
+                if (!callExpr.args.some(isNamedArgumentExpression)) {
+                    continue;
+                }
+
+                // Named args are only supported for simple variable calls (not method/dotted calls)
+                if (!isVariableExpression(callExpr.callee)) {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as any)?.name?.text ?? '?'),
+                        range: callExpr.openingParen.range,
+                        file: file
+                    });
+                    continue;
+                }
+
+                const funcName = callExpr.callee.name.text;
+                const callableContainers = callableContainerMap.get(funcName.toLowerCase());
+                const callable = callableContainers?.[0]?.callable;
+
+                if (!callable) {
+                    this.diagnostics.push({
+                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(funcName),
+                        range: callExpr.callee.range,
+                        file: file
+                    });
+                    continue;
+                }
+
+                const params = callable.functionStatement.func.parameters;
+                // resolvedArgs[i] holds the resolved expression for the i-th positional parameter.
+                // Use assignedParams to track which slots are filled (avoids a null-union type).
+                const resolvedArgs: Expression[] = [];
+                const assignedParams = new Set<number>();
+                let seenNamedArg = false;
+                let hasError = false;
+
+                for (const arg of callExpr.args) {
+                    if (!isNamedArgumentExpression(arg)) {
+                        if (seenNamedArg) {
+                            this.diagnostics.push({
+                                ...DiagnosticMessages.positionalArgAfterNamedArg(),
+                                range: arg.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+                        const idx = assignedParams.size;
+                        if (idx < params.length) {
+                            resolvedArgs[idx] = arg;
+                            assignedParams.add(idx);
+                        }
+                    } else {
+                        seenNamedArg = true;
+                        const paramName = (arg as NamedArgumentExpression).name.text.toLowerCase();
+                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === paramName);
+
+                        if (paramIdx < 0) {
+                            this.diagnostics.push({
+                                ...DiagnosticMessages.unknownNamedArgument((arg as NamedArgumentExpression).name.text, funcName),
+                                range: (arg as NamedArgumentExpression).name.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+
+                        if (assignedParams.has(paramIdx)) {
+                            this.diagnostics.push({
+                                ...DiagnosticMessages.namedArgDuplicate((arg as NamedArgumentExpression).name.text),
+                                range: (arg as NamedArgumentExpression).name.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+
+                        resolvedArgs[paramIdx] = (arg as NamedArgumentExpression).value;
+                        assignedParams.add(paramIdx);
+                    }
+                }
+
+                if (hasError) {
+                    continue;
+                }
+
+                // Validate all required params are provided
+                for (let i = 0; i < params.length; i++) {
+                    if (!assignedParams.has(i) && !params[i].defaultValue) {
+                        const minParams = params.filter(p => !p.defaultValue).length;
+                        const maxParams = params.length;
+                        this.diagnostics.push({
+                            ...DiagnosticMessages.mismatchArgumentCount(
+                                minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
+                                callExpr.args.length
+                            ),
+                            range: callExpr.callee.range,
+                            file: file
+                        });
+                        hasError = true;
+                        break;
+                    }
+                }
+
+                if (hasError) {
+                    continue;
+                }
+
+                // Find the last provided param index so we know how many args to emit
+                let lastProvidedIdx = -1;
+                for (let i = params.length - 1; i >= 0; i--) {
+                    if (assignedParams.has(i)) {
+                        lastProvidedIdx = i;
+                        break;
+                    }
+                }
+
+                // Build the final positional arg list, filling in defaults for skipped middle optionals
+                const finalArgs: Expression[] = [];
+                for (let i = 0; i <= lastProvidedIdx; i++) {
+                    if (assignedParams.has(i)) {
+                        finalArgs.push(resolvedArgs[i]);
+                    } else {
+                        // Skipped optional param — use its default value or `invalid`
+                        finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
+                    }
+                }
+
+                callExpr.resolvedArgs = finalArgs;
+            }
+        }
+    }
+
+    /**
      * Detect calls to functions with the incorrect number of parameters
      */
     private diagnosticDetectFunctionCallsWithWrongParamCount(file: BscFile, callableContainersByLowerName: CallableContainerMap) {
         //validate all function calls
         for (let expCall of file?.functionCalls ?? []) {
+            // Skip calls that use named arguments — those are fully validated by validateNamedArgCalls()
+            if (expCall.args.some(a => isNamedArgumentExpression(a.expression))) {
+                continue;
+            }
+
             let callableContainersWithThisName = callableContainersByLowerName.get(expCall.name.toLowerCase());
 
             //use the first item from callablesByLowerName, because if there are more, that's a separate error

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -8,17 +8,15 @@ import type { CallableContainer, BsDiagnostic, FileReference, BscFile, CallableC
 import type { Program } from './Program';
 import { BsClassValidator } from './validators/ClassValidator';
 import type { NamespaceStatement, FunctionStatement, ClassStatement, EnumStatement, InterfaceStatement, EnumMemberStatement, ConstStatement, TypeStatement } from './parser/Statement';
-import type { NewExpression, NamedArgumentExpression } from './parser/Expression';
-import type { Expression } from './parser/AstNode';
+import type { NewExpression } from './parser/Expression';
 import { ParseMode } from './parser/Parser';
-import { createInvalidLiteral } from './astUtils/creators';
 import { util } from './util';
 import { globalCallableMap } from './globalCallables';
 import { Cache } from './Cache';
 import { URI } from 'vscode-uri';
 import type { BrsFile } from './files/BrsFile';
 import type { DependencyGraph, DependencyChangedEvent } from './DependencyGraph';
-import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isNamespaceStatement, isEnumMemberStatement, isNamedArgumentExpression, isVariableExpression } from './astUtils/reflection';
+import { isBrsFile, isMethodStatement, isClassStatement, isConstStatement, isCustomType, isEnumStatement, isFunctionStatement, isFunctionType, isXmlFile, isNamespaceStatement, isEnumMemberStatement, isNamedArgumentExpression } from './astUtils/reflection';
 import { SymbolTable } from './SymbolTable';
 import type { Statement } from './parser/AstNode';
 import { LogLevel } from './logging';
@@ -779,7 +777,6 @@ export class Scope {
 
         //do many per-file checks
         this.enumerateBrsFiles((file) => {
-            this.validateNamedArgCalls(file, callableContainerMap);
             this.diagnosticDetectFunctionCallsWithWrongParamCount(file, callableContainerMap);
             this.diagnosticDetectShadowedLocalVars(file, callableContainerMap);
             this.diagnosticDetectFunctionCollisions(file);
@@ -985,148 +982,6 @@ export class Scope {
         let validator = new BsClassValidator(this);
         validator.validate();
         this.diagnostics.push(...validator.diagnostics);
-    }
-
-    /**
-     * Validate calls that use named arguments, and resolve them to positional order for transpilation.
-     * Only handles simple function calls (VariableExpression callee); method calls are not supported.
-     */
-    private validateNamedArgCalls(file: BscFile, callableContainerMap: CallableContainerMap) {
-        if (!isBrsFile(file)) {
-            return;
-        }
-        for (const func of file.parser.references.functionExpressions) {
-            for (const callExpr of func.callExpressions) {
-                if (!callExpr.args.some(isNamedArgumentExpression)) {
-                    continue;
-                }
-
-                // Named args are only supported for simple variable calls (not method/dotted calls)
-                if (!isVariableExpression(callExpr.callee)) {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as any)?.name?.text ?? '?'),
-                        range: callExpr.openingParen.range,
-                        file: file
-                    });
-                    continue;
-                }
-
-                const funcName = callExpr.callee.name.text;
-                const callableContainers = callableContainerMap.get(funcName.toLowerCase());
-                const callable = callableContainers?.[0]?.callable;
-
-                if (!callable) {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(funcName),
-                        range: callExpr.callee.range,
-                        file: file
-                    });
-                    continue;
-                }
-
-                const params = callable.functionStatement.func.parameters;
-                // resolvedArgs[i] holds the resolved expression for the i-th positional parameter.
-                // Use assignedParams to track which slots are filled (avoids a null-union type).
-                const resolvedArgs: Expression[] = [];
-                const assignedParams = new Set<number>();
-                let seenNamedArg = false;
-                let hasError = false;
-
-                for (const arg of callExpr.args) {
-                    if (!isNamedArgumentExpression(arg)) {
-                        if (seenNamedArg) {
-                            this.diagnostics.push({
-                                ...DiagnosticMessages.positionalArgAfterNamedArg(),
-                                range: arg.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-                        const idx = assignedParams.size;
-                        if (idx < params.length) {
-                            resolvedArgs[idx] = arg;
-                            assignedParams.add(idx);
-                        }
-                    } else {
-                        seenNamedArg = true;
-                        const paramName = (arg as NamedArgumentExpression).name.text.toLowerCase();
-                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === paramName);
-
-                        if (paramIdx < 0) {
-                            this.diagnostics.push({
-                                ...DiagnosticMessages.unknownNamedArgument((arg as NamedArgumentExpression).name.text, funcName),
-                                range: (arg as NamedArgumentExpression).name.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-
-                        if (assignedParams.has(paramIdx)) {
-                            this.diagnostics.push({
-                                ...DiagnosticMessages.namedArgDuplicate((arg as NamedArgumentExpression).name.text),
-                                range: (arg as NamedArgumentExpression).name.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-
-                        resolvedArgs[paramIdx] = (arg as NamedArgumentExpression).value;
-                        assignedParams.add(paramIdx);
-                    }
-                }
-
-                if (hasError) {
-                    continue;
-                }
-
-                // Validate all required params are provided
-                for (let i = 0; i < params.length; i++) {
-                    if (!assignedParams.has(i) && !params[i].defaultValue) {
-                        const minParams = params.filter(p => !p.defaultValue).length;
-                        const maxParams = params.length;
-                        this.diagnostics.push({
-                            ...DiagnosticMessages.mismatchArgumentCount(
-                                minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
-                                callExpr.args.length
-                            ),
-                            range: callExpr.callee.range,
-                            file: file
-                        });
-                        hasError = true;
-                        break;
-                    }
-                }
-
-                if (hasError) {
-                    continue;
-                }
-
-                // Find the last provided param index so we know how many args to emit
-                let lastProvidedIdx = -1;
-                for (let i = params.length - 1; i >= 0; i--) {
-                    if (assignedParams.has(i)) {
-                        lastProvidedIdx = i;
-                        break;
-                    }
-                }
-
-                // Build the final positional arg list, filling in defaults for skipped middle optionals
-                const finalArgs: Expression[] = [];
-                for (let i = 0; i <= lastProvidedIdx; i++) {
-                    if (assignedParams.has(i)) {
-                        finalArgs.push(resolvedArgs[i]);
-                    } else {
-                        // Skipped optional param — use its default value or `invalid`
-                        finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
-                    }
-                }
-
-                callExpr.resolvedArgs = finalArgs;
-            }
-        }
     }
 
     /**

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,5 +1,5 @@
 import type { Body, AssignmentStatement, Block, ExpressionStatement, CommentStatement, ExitForStatement, ExitWhileStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassFieldStatement, ClassMethodStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement, TypeStatement } from '../parser/Statement';
-import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, AAIndexedMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression } from '../parser/Expression';
+import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, NamespacedVariableNameExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, AAIndexedMemberExpression, TypeCastExpression, TernaryExpression, NullCoalescingExpression, NamedArgumentExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
 import type { BscFile, File, TypedefProvider } from '../interfaces';
@@ -212,6 +212,9 @@ export function isBinaryExpression(element: AstNode | undefined): element is Bin
 }
 export function isCallExpression(element: AstNode | undefined): element is CallExpression {
     return element?.constructor.name === 'CallExpression';
+}
+export function isNamedArgumentExpression(element: AstNode | undefined): element is NamedArgumentExpression {
+    return element?.constructor.name === 'NamedArgumentExpression';
 }
 export function isFunctionExpression(element: AstNode | undefined): element is FunctionExpression {
     return element?.constructor.name === 'FunctionExpression';

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -461,6 +461,41 @@ describe('CodeActionsProcessor', () => {
         });
     });
 
+    describe('named argument ordering', () => {
+        it('offers quick fix for out-of-order named arguments', () => {
+            const file = program.setFile('source/main.bs', `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                sub main()
+                    greet(excited: true, name: "Bob")
+                end sub
+            `);
+
+            testGetCodeActions(file, util.createRange(5, 41, 5, 41), [
+                'Reorder named arguments to match function declaration'
+            ]);
+        });
+
+        it('reorders mixed positional and named args to declaration order', () => {
+            const file = program.setFile('source/main.bs', `
+                sub greet(name as string, title = "Mr" as string, excited = false as boolean)
+                end sub
+
+                sub main()
+                    greet("Bob", excited: true, title: "Dr")
+                end sub
+            `);
+
+            program.validate();
+            const actions = program.getCodeActions(file.srcPath, util.createRange(5, 50, 5, 50));
+            const action = actions.find(x => x.title === 'Reorder named arguments to match function declaration');
+            const edit = Object.values(action.edit.changes)[0][0];
+
+            expect(edit.newText).to.equal(`"Bob", title: "Dr", excited: true`);
+        });
+    });
+
     it('suggests imports at very start and very end of diagnostic', () => {
         program.setFile('source/first.bs', `
             namespace alpha

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -306,6 +306,8 @@ export class CodeActionsProcessor {
 
         for (const arg of callExpression.args) {
             if (!isNamedArgumentExpression(arg)) {
+                // Quick-fix can only reorder arguments; it cannot repair invalid syntax/shape such as
+                // positional args after named args or positional args beyond parameter count.
                 if (hasNamedArg || expectedParamIndex >= parameters.length) {
                     return;
                 }
@@ -317,6 +319,7 @@ export class CodeActionsProcessor {
             hasNamedArg = true;
             const namedArg = arg;
             const paramIndex = parameters.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
+            // Unknown names and duplicate parameter targets are invalid; do not offer a reorder fix.
             if (paramIndex < 0 || argsWithParamIndex.some(x => x.paramIndex === paramIndex)) {
                 return;
             }
@@ -383,9 +386,9 @@ export class CodeActionsProcessor {
         return callable?.functionStatement?.func?.parameters;
     }
 
-    private getNamespaceCallableBrsName(callee: CallExpression['callee']) {
+    private getNamespaceCallableBrsName(dottedGetExpression: CallExpression['callee']) {
         const scope = this.event.program.getFirstScopeForFile(this.event.file);
-        const parts = util.getAllDottedGetParts(callee);
+        const parts = util.getAllDottedGetParts(dottedGetExpression);
         if (!scope || !parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
             return undefined;
         }

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -11,8 +11,8 @@ import { ParseMode } from '../../parser/Parser';
 import type { Expression } from '../../parser/AstNode';
 import { util } from '../../util';
 import { isBrsFile, isCallExpression, isDottedGetExpression, isFunctionExpression, isMethodStatement, isNamedArgumentExpression, isNamespaceStatement, isNewExpression, isVariableExpression, isXmlFile } from '../../astUtils/reflection';
-import type { CallExpression, FunctionExpression, FunctionParameterExpression } from '../../parser/Expression';
-import type { ClassStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
+import type { CallExpression, FunctionExpression } from '../../parser/Expression';
+import type { MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import { WalkMode } from '../../astUtils/visitors';
 import { TokenKind } from '../../lexer/TokenKind';
 import { getMissingExtendsInsertPosition } from './codeActionHelpers';
@@ -570,13 +570,13 @@ export class CodeActionsProcessor {
             if (!classLink) {
                 return undefined;
             }
-            return this.getClassConstructorParams(classLink.item, containingNamespace);
+            return util.getClassConstructorParams(classLink.item, scope, containingNamespace);
         }
         if (isVariableExpression(callExpression.callee)) {
             return this.getCallableParametersByName(callExpression.callee.name.text.toLowerCase());
         }
         if (isDottedGetExpression(callExpression.callee)) {
-            const brsName = this.getNamespaceCallableBrsName(callExpression.callee);
+            const brsName = util.resolveNamespaceCallableName(callExpression.callee, scope);
             if (!brsName) {
                 return undefined;
             }
@@ -591,37 +591,6 @@ export class CodeActionsProcessor {
         }
         const callable = scope.getCallableByName(lowerName);
         return callable?.functionStatement?.func?.parameters;
-    }
-
-    private getNamespaceCallableBrsName(dottedGetExpression: CallExpression['callee']) {
-        const scope = this.event.program.getFirstScopeForFile(this.event.file);
-        const parts = util.getAllDottedGetParts(dottedGetExpression);
-        if (!scope || !parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
-            return undefined;
-        }
-        return parts.map(p => p.text).join('_');
-    }
-
-    private getClassConstructorParams(classStmt: ClassStatement, containingNamespace: string | undefined): FunctionParameterExpression[] {
-        const scope = this.event.program.getFirstScopeForFile(this.event.file);
-        if (!scope) {
-            return [];
-        }
-        let statement: ClassStatement | undefined = classStmt;
-        while (statement) {
-            const ctor = statement.body.find(
-                s => isMethodStatement(s) && s.name.text.toLowerCase() === 'new'
-            ) as MethodStatement | undefined;
-            if (ctor) {
-                return ctor.func.parameters;
-            }
-            if (!statement.parentClassName) {
-                break;
-            }
-            const parentName = statement.parentClassName.getName(ParseMode.BrighterScript);
-            statement = scope.getClassFileLink(parentName, containingNamespace)?.item;
-        }
-        return [];
     }
 
     /**

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -317,9 +317,6 @@ export class CodeActionsProcessor {
             hasNamedArg = true;
             const namedArg = arg as NamedArgumentExpression;
             const paramIndex = parameters.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
-            if (paramIndex < expectedParamIndex) {
-                // continue collecting so this action can fix all out-of-order named args in this call
-            }
             if (paramIndex < 0 || argsWithParamIndex.some(x => x.paramIndex === paramIndex)) {
                 return;
             }
@@ -366,17 +363,24 @@ export class CodeActionsProcessor {
             return this.getClassConstructorParams(classLink.item, containingNamespace);
         }
         if (isVariableExpression(callExpression.callee)) {
-            const callable = scope.getCallableByName(callExpression.callee.name.text.toLowerCase());
-            return callable?.functionStatement?.func?.parameters;
+            return this.getCallableParametersByName(callExpression.callee.name.text.toLowerCase());
         }
         if (isDottedGetExpression(callExpression.callee)) {
             const brsName = this.getNamespaceCallableBrsName(callExpression.callee);
             if (!brsName) {
                 return undefined;
             }
-            const callable = scope.getCallableByName(brsName.toLowerCase());
-            return callable?.functionStatement?.func?.parameters;
+            return this.getCallableParametersByName(brsName.toLowerCase());
         }
+    }
+
+    private getCallableParametersByName(lowerName: string) {
+        const scope = this.event.program.getFirstScopeForFile(this.event.file);
+        if (!scope) {
+            return undefined;
+        }
+        const callable = scope.getCallableByName(lowerName);
+        return callable?.functionStatement?.func?.parameters;
     }
 
     private getNamespaceCallableBrsName(callee: CallExpression['callee']) {

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -11,7 +11,7 @@ import { ParseMode } from '../../parser/Parser';
 import type { Expression } from '../../parser/AstNode';
 import { util } from '../../util';
 import { isBrsFile, isCallExpression, isDottedGetExpression, isFunctionExpression, isMethodStatement, isNamedArgumentExpression, isNamespaceStatement, isNewExpression, isVariableExpression } from '../../astUtils/reflection';
-import type { CallExpression, FunctionExpression, FunctionParameterExpression, NamedArgumentExpression } from '../../parser/Expression';
+import type { CallExpression, FunctionExpression, FunctionParameterExpression } from '../../parser/Expression';
 import type { ClassStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import { WalkMode } from '../../astUtils/visitors';
 import { TokenKind } from '../../lexer/TokenKind';
@@ -315,7 +315,7 @@ export class CodeActionsProcessor {
             }
 
             hasNamedArg = true;
-            const namedArg = arg as NamedArgumentExpression;
+            const namedArg = arg;
             const paramIndex = parameters.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
             if (paramIndex < 0 || argsWithParamIndex.some(x => x.paramIndex === paramIndex)) {
                 return;

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -8,10 +8,11 @@ import type { BrsFile } from '../../files/BrsFile';
 import type { XmlFile } from '../../files/XmlFile';
 import type { BscFile, BsDiagnostic, OnGetCodeActionsEvent } from '../../interfaces';
 import { ParseMode } from '../../parser/Parser';
+import type { Expression } from '../../parser/AstNode';
 import { util } from '../../util';
-import { isBrsFile, isFunctionExpression, isMethodStatement } from '../../astUtils/reflection';
-import type { FunctionExpression } from '../../parser/Expression';
-import type { MethodStatement } from '../../parser/Statement';
+import { isBrsFile, isCallExpression, isDottedGetExpression, isFunctionExpression, isMethodStatement, isNamedArgumentExpression, isNamespaceStatement, isNewExpression, isVariableExpression } from '../../astUtils/reflection';
+import type { CallExpression, FunctionExpression, FunctionParameterExpression, NamedArgumentExpression } from '../../parser/Expression';
+import type { ClassStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import { WalkMode } from '../../astUtils/visitors';
 import { TokenKind } from '../../lexer/TokenKind';
 
@@ -50,6 +51,8 @@ export class CodeActionsProcessor {
                 this.suggestMissingOverrideQuickFixes([diagnostic]);
             } else if (diagnostic.code === DiagnosticCodeMap.cannotUseOverrideKeywordOnConstructorFunction) {
                 this.suggestRemoveOverrideFromConstructorQuickFixes([diagnostic]);
+            } else if (diagnostic.code === DiagnosticCodeMap.namedArgOutOfOrder) {
+                this.suggestNamedArgOrderQuickFix(diagnostic as DiagnosticMessageType<'namedArgOutOfOrder'>);
             }
         }
 
@@ -273,6 +276,138 @@ export class CodeActionsProcessor {
                 })
             );
         }
+    }
+
+    /**
+     * Suggests reordering named arguments to declaration order.
+     */
+    private suggestNamedArgOrderQuickFix(diagnostic: DiagnosticMessageType<'namedArgOutOfOrder'>) {
+        if (!isBrsFile(this.event.file)) {
+            return;
+        }
+        const closestExpression = this.event.file.getClosestExpression(diagnostic.range.start);
+        const callExpression = (
+            isCallExpression(closestExpression)
+                ? closestExpression
+                : closestExpression?.findAncestor<CallExpression>(isCallExpression)
+        );
+        if (!callExpression || callExpression.args.length < 2) {
+            return;
+        }
+
+        const parameters = this.getCallExpressionParameters(callExpression);
+        if (!parameters) {
+            return;
+        }
+
+        const argsWithParamIndex = [] as Array<{ arg: Expression; paramIndex: number }>;
+        let expectedParamIndex = 0;
+        let hasNamedArg = false;
+
+        for (const arg of callExpression.args) {
+            if (!isNamedArgumentExpression(arg)) {
+                if (hasNamedArg || expectedParamIndex >= parameters.length) {
+                    return;
+                }
+                argsWithParamIndex.push({ arg: arg, paramIndex: expectedParamIndex });
+                expectedParamIndex++;
+                continue;
+            }
+
+            hasNamedArg = true;
+            const namedArg = arg as NamedArgumentExpression;
+            const paramIndex = parameters.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
+            if (paramIndex < expectedParamIndex) {
+                // continue collecting so this action can fix all out-of-order named args in this call
+            }
+            if (paramIndex < 0 || argsWithParamIndex.some(x => x.paramIndex === paramIndex)) {
+                return;
+            }
+            argsWithParamIndex.push({ arg: namedArg, paramIndex: paramIndex });
+            expectedParamIndex = paramIndex + 1;
+        }
+
+        const sortedArgs = [...argsWithParamIndex].sort((a, b) => a.paramIndex - b.paramIndex);
+        const sortedArgText = sortedArgs.map(x => util.getTextForRange(this.event.file.fileContents, x.arg.range)).join(', ');
+        const firstArg = callExpression.args[0];
+        const lastArg = callExpression.args[callExpression.args.length - 1];
+        if (!firstArg?.range || !lastArg?.range) {
+            return;
+        }
+
+        this.event.codeActions.push(
+            codeActionUtil.createCodeAction({
+                title: 'Reorder named arguments to match function declaration',
+                diagnostics: [diagnostic],
+                kind: CodeActionKind.QuickFix,
+                changes: [{
+                    type: 'replace',
+                    filePath: this.event.file.srcPath,
+                    range: util.createRangeFromPositions(firstArg.range.start, lastArg.range.end),
+                    newText: sortedArgText
+                }]
+            })
+        );
+    }
+
+    private getCallExpressionParameters(callExpression: CallExpression) {
+        const scope = this.event.program.getFirstScopeForFile(this.event.file);
+        if (!scope) {
+            return undefined;
+        }
+        if (isNewExpression(callExpression.parent)) {
+            const newExpression = callExpression.parent;
+            const className = newExpression.className.getName(ParseMode.BrighterScript);
+            const containingNamespace = newExpression.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript)?.toLowerCase();
+            const classLink = scope.getClassFileLink(className, containingNamespace);
+            if (!classLink) {
+                return undefined;
+            }
+            return this.getClassConstructorParams(classLink.item, containingNamespace);
+        }
+        if (isVariableExpression(callExpression.callee)) {
+            const callable = scope.getCallableByName(callExpression.callee.name.text.toLowerCase());
+            return callable?.functionStatement?.func?.parameters;
+        }
+        if (isDottedGetExpression(callExpression.callee)) {
+            const brsName = this.getNamespaceCallableBrsName(callExpression.callee);
+            if (!brsName) {
+                return undefined;
+            }
+            const callable = scope.getCallableByName(brsName.toLowerCase());
+            return callable?.functionStatement?.func?.parameters;
+        }
+    }
+
+    private getNamespaceCallableBrsName(callee: CallExpression['callee']) {
+        const scope = this.event.program.getFirstScopeForFile(this.event.file);
+        const parts = util.getAllDottedGetParts(callee);
+        if (!scope || !parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
+            return undefined;
+        }
+        return parts.map(p => p.text).join('_');
+    }
+
+    private getClassConstructorParams(classStmt: ClassStatement, containingNamespace: string | undefined): FunctionParameterExpression[] {
+        const scope = this.event.program.getFirstScopeForFile(this.event.file);
+        if (!scope) {
+            return [];
+        }
+        let statement: ClassStatement | undefined = classStmt;
+        while (statement) {
+            const ctor = statement.body.find(
+                s => isMethodStatement(s) && s.name.text.toLowerCase() === 'new'
+            ) as MethodStatement | undefined;
+            if (ctor) {
+                return ctor.func.parameters;
+            }
+            if (!statement.parentClassName) {
+                break;
+            }
+            const parentName = statement.parentClassName.getName(ParseMode.BrighterScript);
+            statement = scope.getClassFileLink(parentName, containingNamespace)?.item;
+        }
+        return [];
     }
 
     /**

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -1,17 +1,24 @@
-import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createToken } from '../../astUtils/creators';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
+import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createInvalidLiteral, createToken, createVariableExpression } from '../../astUtils/creators';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamedArgumentExpression, isStatement, isTernaryExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BeforeFileTranspileEvent } from '../../interfaces';
 import type { Token } from '../../lexer/Token';
 import { TokenKind } from '../../lexer/TokenKind';
 import type { Expression, Statement } from '../../parser/AstNode';
-import type { TernaryExpression } from '../../parser/Expression';
+import type { BrsTranspileState } from '../../parser/BrsTranspileState';
+import type { CallExpression, FunctionExpression, FunctionParameterExpression, NamedArgumentExpression, TernaryExpression } from '../../parser/Expression';
+import type { TranspileResult } from '../../interfaces';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import type { IfStatement } from '../../parser/Statement';
 import type { Scope } from '../../Scope';
 import util from '../../util';
+
+interface WrittenArgInfo {
+    paramIdx: number;
+    value: Expression;
+}
 
 export class BrsFilePreTranspileProcessor {
     public constructor(
@@ -21,8 +28,272 @@ export class BrsFilePreTranspileProcessor {
 
     public process() {
         if (isBrsFile(this.event.file)) {
+            this.processNamedArgumentCalls();
             this.iterateExpressions();
         }
+    }
+
+    /**
+     * Returns true if an expression needs to be hoisted into a temp variable to preserve evaluation order.
+     * Literals and simple variable references are side-effect-free and can be used directly.
+     */
+    private needsHoisting(expr: Expression) {
+        return !isLiteralExpression(expr) && !isVariableExpression(expr);
+    }
+
+    /**
+     * Rewrite calls that use named arguments into positional calls, hoisting complex argument
+     * expressions into temporary `__bsArgs*` variables to preserve written evaluation order.
+     * This follows the same beforeFileTranspile pattern as ternary expression rewriting.
+     */
+    private processNamedArgumentCalls() {
+        const scope = this.event.program.getFirstScopeForFile(this.event.file);
+        if (!scope) {
+            return;
+        }
+        const callableContainerMap = util.getCallableContainersByLowerName(scope.getAllCallables());
+        // Track a hoisting counter per function so variable names are unique within each function scope
+        const hoistCounters = new WeakMap<FunctionExpression, number>();
+
+        for (const func of this.event.file.parser.references.functionExpressions) {
+            // Iterate in reverse (outermost calls first) so that when an outer call hoists an inner
+            // call expression into a temp variable, the inner call's own hoisting inserts after the
+            // outer call's earlier hoists — preserving written evaluation order across nesting levels.
+            for (const callExpr of [...func.callExpressions].reverse()) {
+                if (!callExpr.args.some(isNamedArgumentExpression)) {
+                    continue;
+                }
+                // Only handle simple variable calls (method calls are rejected by validation)
+                if (!isVariableExpression(callExpr.callee)) {
+                    continue;
+                }
+
+                const funcName = callExpr.callee.name.text;
+                const callable = callableContainerMap.get(funcName.toLowerCase())?.[0]?.callable;
+                if (!callable) {
+                    continue;
+                }
+
+                const params = callable.functionStatement.func.parameters;
+
+                // Map each written arg to its positional param index and value.
+                // If anything is invalid (unknown param, duplicate, positional-after-named),
+                // bail out and leave the call untouched — diagnostics are already emitted by validation.
+                const writtenArgInfos: WrittenArgInfo[] = [];
+                const assignedParams = new Set<number>();
+                let seenNamedArg = false;
+                let isValid = true;
+                let positionalCount = 0;
+
+                for (const arg of callExpr.args) {
+                    if (!isNamedArgumentExpression(arg)) {
+                        if (seenNamedArg) {
+                            isValid = false;
+                            break;
+                        }
+                        const paramIdx = positionalCount++;
+                        if (paramIdx >= params.length || assignedParams.has(paramIdx)) {
+                            isValid = false;
+                            break;
+                        }
+                        assignedParams.add(paramIdx);
+                        writtenArgInfos.push({ paramIdx: paramIdx, value: arg });
+                    } else {
+                        seenNamedArg = true;
+                        const namedArg = arg as NamedArgumentExpression;
+                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
+                        if (paramIdx < 0 || assignedParams.has(paramIdx)) {
+                            isValid = false;
+                            break;
+                        }
+                        assignedParams.add(paramIdx);
+                        writtenArgInfos.push({ paramIdx: paramIdx, value: namedArg.value });
+                    }
+                }
+
+                if (!isValid) {
+                    continue;
+                }
+
+                // Find the immediate containing statement and check if it lives directly inside a
+                // Block or Body. If it does, we can safely insert hoisting assignments before it.
+                // If not (e.g. an `else if` condition whose containing IfStatement is the elseBranch
+                // of an outer IfStatement), we fall back to inline reordering without hoisting —
+                // similar to how ternary falls back to `bslib_ternary()` when it can't restructure.
+                const containingStatement = callExpr.findAncestor<Statement>(isStatement);
+                const parentBlock = containingStatement?.parent;
+                // Also prevent hoisting if the call is inside a ternary consequent or alternate —
+                // hoisting before the containing statement would run the expression unconditionally,
+                // breaking the ternary's conditional evaluation semantics.
+                let insideTernaryBranch = false;
+                {
+                    let child: typeof callExpr.parent = callExpr;
+                    let ancestor = callExpr.parent;
+                    while (ancestor && ancestor !== containingStatement) {
+                        if (isTernaryExpression(ancestor) && child !== ancestor.test) {
+                            insideTernaryBranch = true;
+                            break;
+                        }
+                        child = ancestor;
+                        ancestor = ancestor.parent;
+                    }
+                }
+                const canHoist = !!containingStatement && (isBlock(parentBlock) || isBody(parentBlock)) && !insideTernaryBranch;
+                const parentStatements = canHoist ? (parentBlock as any).statements as Statement[] : undefined;
+
+                // Find the last written index whose value is complex (needs hoisting).
+                // Args written after this point are side-effect-free and can be placed directly.
+                let lastComplexWrittenIdx = -1;
+                for (let i = writtenArgInfos.length - 1; i >= 0; i--) {
+                    if (this.needsHoisting(writtenArgInfos[i].value)) {
+                        lastComplexWrittenIdx = i;
+                        break;
+                    }
+                }
+
+                // If we can't hoist AND there are complex expressions, wrap the call in an IIFE
+                // so args are evaluated in written order but passed in positional order —
+                // the same pattern ternary uses when it can't restructure the surrounding statement.
+                if (!canHoist && lastComplexWrittenIdx >= 0) {
+                    this.event.editor.setProperty(callExpr, 'transpile', (state) => this.transpileNamedArgAsIIFE(state, callExpr, writtenArgInfos, params));
+                    continue;
+                }
+
+                // Build the positional arg map, hoisting complex expressions when safe to do so
+                const positionalArgExprs = new Map<number, Expression>();
+                for (let writtenIdx = 0; writtenIdx < writtenArgInfos.length; writtenIdx++) {
+                    const { paramIdx, value } = writtenArgInfos[writtenIdx];
+
+                    if (canHoist && writtenIdx <= lastComplexWrittenIdx && this.needsHoisting(value)) {
+                        // Hoist: emit `__bsArgs<N> = <value>` before the containing statement
+                        const counter = hoistCounters.get(func) ?? 0;
+                        hoistCounters.set(func, counter + 1);
+                        const varName = `__bsArgs${counter}`;
+
+                        const currentStmtIdx = parentStatements.indexOf(containingStatement);
+                        const hoistStatement = createAssignmentStatement({ name: varName, value: value });
+                        this.event.editor.addToArray(parentStatements, currentStmtIdx, hoistStatement);
+                        // Update the value's parent to the new hoist statement so that when a nested
+                        // named-arg call inside `value` is processed (in reversed order), its
+                        // findAncestor<Statement> walks up to the hoist statement and inserts its own
+                        // hoisting before it — preserving written evaluation order across nesting levels.
+                        this.event.editor.setProperty(value, 'parent', hoistStatement);
+                        positionalArgExprs.set(paramIdx, createVariableExpression(varName));
+                    } else {
+                        // Cannot hoist (e.g. inside an else-if condition) — place the expression
+                        // directly in positional order. Evaluation order may differ from written
+                        // order for complex expressions, but the call only runs if the branch is
+                        // reached, which is the correct semantic (unlike hoisting before the outer if).
+                        positionalArgExprs.set(paramIdx, value);
+                    }
+                }
+
+                // Find the highest assigned positional index to know how many args to emit
+                let lastProvidedIdx = -1;
+                for (const idx of positionalArgExprs.keys()) {
+                    if (idx > lastProvidedIdx) {
+                        lastProvidedIdx = idx;
+                    }
+                }
+
+                // Build the final positional arg list, filling any skipped middle optional params
+                const finalArgs: Expression[] = [];
+                for (let i = 0; i <= lastProvidedIdx; i++) {
+                    if (positionalArgExprs.has(i)) {
+                        finalArgs.push(positionalArgExprs.get(i)!);
+                    } else {
+                        // Skipped optional param — use its default value or `invalid`
+                        finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
+                    }
+                }
+
+                // Replace the call's args with the reordered positional list
+                this.event.editor.arraySplice(callExpr.args, 0, callExpr.args.length, ...finalArgs);
+            }
+        }
+    }
+
+    /**
+     * Builds the transpile output for a named-argument call that cannot be hoisted
+     * (e.g. inside an `else if` condition). Wraps the call in an IIFE so args are
+     * evaluated in written order but passed in positional order — the same pattern
+     * ternary uses for complex consequent/alternate expressions.
+     *
+     *   (function(__bsArg0, __bsArg1)
+     *       return funcName(__bsArgN, __bsArgM)
+     *   end function)(writtenVal0, writtenVal1)
+     */
+    private transpileNamedArgAsIIFE(state: BrsTranspileState, callExpr: CallExpression, writtenArgInfos: WrittenArgInfo[], params: FunctionParameterExpression[]): TranspileResult {
+        const result: TranspileResult = [];
+
+        // One IIFE param per written arg, in written order: __bsArg0, __bsArg1, ...
+        const iifeParamNames = writtenArgInfos.map((_, i) => `__bsArg${i}`);
+
+        // Find the highest positional index that was provided
+        let lastProvidedIdx = -1;
+        for (const { paramIdx } of writtenArgInfos) {
+            if (paramIdx > lastProvidedIdx) {
+                lastProvidedIdx = paramIdx;
+            }
+        }
+
+        // Map from positional param index → IIFE param name
+        const paramIdxToIIFEParam = new Map<number, string>();
+        for (let i = 0; i < writtenArgInfos.length; i++) {
+            paramIdxToIIFEParam.set(writtenArgInfos[i].paramIdx, iifeParamNames[i]);
+        }
+
+        result.push(
+            // (function(__bsArg0, __bsArg1)
+            state.sourceNode(callExpr.openingParen, `(function(${iifeParamNames.join(', ')})`),
+            state.newline,
+            // double-indent so `end function)(` sits one level deeper than the call site,
+            // matching the ternary IIFE convention
+            state.indent(2),
+            state.sourceNode(callExpr.callee, 'return '),
+            ...callExpr.callee.transpile(state),
+            '('
+        );
+
+        // Positional call args inside the IIFE body
+        for (let i = 0; i <= lastProvidedIdx; i++) {
+            if (i > 0) {
+                result.push(', ');
+            }
+            if (paramIdxToIIFEParam.has(i)) {
+                result.push(state.sourceNode(callExpr, paramIdxToIIFEParam.get(i)!));
+            } else {
+                // Skipped optional param — use its default or `invalid`
+                const defaultVal = params[i].defaultValue;
+                if (defaultVal) {
+                    result.push(...defaultVal.transpile(state));
+                } else {
+                    result.push(state.sourceNode(callExpr, 'invalid'));
+                }
+            }
+        }
+
+        result.push(
+            ')',
+            state.newline,
+            state.indent(-1),
+            // end function)(writtenVal0, writtenVal1, ...)
+            state.sourceNode(callExpr.closingParen ?? callExpr.openingParen, 'end function)(')
+        );
+
+        // Written-order values passed to the IIFE
+        for (let i = 0; i < writtenArgInfos.length; i++) {
+            if (i > 0) {
+                result.push(', ');
+            }
+            result.push(...writtenArgInfos[i].value.transpile(state));
+        }
+
+        result.push(')');
+        // compensate for the net +1 from indent(2) + indent(-1)
+        state.blockDepth--;
+
+        return result;
     }
 
     private iterateExpressions() {

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -1,5 +1,5 @@
 import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createInvalidLiteral, createToken, createVariableExpression } from '../../astUtils/creators';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamedArgumentExpression, isStatement, isTernaryExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isFunctionExpression, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamedArgumentExpression, isNamespaceStatement, isStatement, isTernaryExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BeforeFileTranspileEvent } from '../../interfaces';
@@ -11,7 +11,7 @@ import type { CallExpression, FunctionExpression, FunctionParameterExpression, N
 import type { TranspileResult } from '../../interfaces';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { IfStatement } from '../../parser/Statement';
+import type { ClassStatement, IfStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Scope } from '../../Scope';
 import util from '../../util';
 
@@ -63,154 +63,227 @@ export class BrsFilePreTranspileProcessor {
                 if (!callExpr.args.some(isNamedArgumentExpression)) {
                     continue;
                 }
-                // Only handle simple variable calls (method calls are rejected by validation)
-                if (!isVariableExpression(callExpr.callee)) {
+
+                let params: FunctionParameterExpression[] | undefined;
+
+                if (isVariableExpression(callExpr.callee)) {
+                    const funcName = callExpr.callee.name.text;
+                    params = callableContainerMap.get(funcName.toLowerCase())?.[0]?.callable?.functionStatement?.func?.parameters;
+                } else if (isDottedGetExpression(callExpr.callee)) {
+                    // Namespace function call (e.g. MyNs.myFunc(a: 1))
+                    const brsName = this.getNamespaceCallableBrsName(callExpr.callee, scope);
+                    if (brsName) {
+                        params = callableContainerMap.get(brsName.toLowerCase())?.[0]?.callable?.functionStatement?.func?.parameters;
+                    }
+                }
+
+                if (!params) {
                     continue;
                 }
 
-                const funcName = callExpr.callee.name.text;
-                const callable = callableContainerMap.get(funcName.toLowerCase())?.[0]?.callable;
-                if (!callable) {
+                this.rewriteNamedArgCall(callExpr, params, func, hoistCounters);
+            }
+
+            // Process constructor calls (new MyClass(...)) after regular calls.
+            // Constructor CallExpressions are not in func.callExpressions (the parser removes them),
+            // so they are handled here. Processing after regular calls ensures that when a constructor
+            // call is hoisted as an arg to an outer named-arg call, the parent pointer update done by
+            // the outer call's hoisting is already in place when we process the constructor's own args.
+            for (const newExpr of this.event.file.parser.references.newExpressions) {
+                const callExpr = newExpr.call;
+                if (!callExpr.args.some(isNamedArgumentExpression)) {
+                    continue;
+                }
+                // Only process constructor calls that belong to this function
+                if (newExpr.findAncestor<FunctionExpression>(isFunctionExpression) !== func) {
                     continue;
                 }
 
-                const params = callable.functionStatement.func.parameters;
-
-                // Map each written arg to its positional param index and value.
-                // If anything is invalid (unknown param, duplicate, positional-after-named),
-                // bail out and leave the call untouched — diagnostics are already emitted by validation.
-                const writtenArgInfos: WrittenArgInfo[] = [];
-                const assignedParams = new Set<number>();
-                let seenNamedArg = false;
-                let isValid = true;
-                let positionalCount = 0;
-
-                for (const arg of callExpr.args) {
-                    if (!isNamedArgumentExpression(arg)) {
-                        if (seenNamedArg) {
-                            isValid = false;
-                            break;
-                        }
-                        const paramIdx = positionalCount++;
-                        if (paramIdx >= params.length || assignedParams.has(paramIdx)) {
-                            isValid = false;
-                            break;
-                        }
-                        assignedParams.add(paramIdx);
-                        writtenArgInfos.push({ paramIdx: paramIdx, value: arg });
-                    } else {
-                        seenNamedArg = true;
-                        const namedArg = arg as NamedArgumentExpression;
-                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
-                        if (paramIdx < 0 || assignedParams.has(paramIdx)) {
-                            isValid = false;
-                            break;
-                        }
-                        assignedParams.add(paramIdx);
-                        writtenArgInfos.push({ paramIdx: paramIdx, value: namedArg.value });
-                    }
-                }
-
-                if (!isValid) {
+                const className = newExpr.className.getName(ParseMode.BrighterScript);
+                const containingNamespace = newExpr.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript)?.toLowerCase();
+                const classLink = scope.getClassFileLink(className, containingNamespace);
+                if (!classLink) {
                     continue;
                 }
 
-                // Find the immediate containing statement and check if it lives directly inside a
-                // Block or Body. If it does, we can safely insert hoisting assignments before it.
-                // If not (e.g. an `else if` condition whose containing IfStatement is the elseBranch
-                // of an outer IfStatement), we fall back to inline reordering without hoisting —
-                // similar to how ternary falls back to `bslib_ternary()` when it can't restructure.
-                const containingStatement = callExpr.findAncestor<Statement>(isStatement);
-                const parentBlock = containingStatement?.parent;
-                // Also prevent hoisting if the call is inside a ternary consequent or alternate —
-                // hoisting before the containing statement would run the expression unconditionally,
-                // breaking the ternary's conditional evaluation semantics.
-                let insideTernaryBranch = false;
-                {
-                    let child: typeof callExpr.parent = callExpr;
-                    let ancestor = callExpr.parent;
-                    while (ancestor && ancestor !== containingStatement) {
-                        if (isTernaryExpression(ancestor) && child !== ancestor.test) {
-                            insideTernaryBranch = true;
-                            break;
-                        }
-                        child = ancestor;
-                        ancestor = ancestor.parent;
-                    }
-                }
-                const canHoist = !!containingStatement && (isBlock(parentBlock) || isBody(parentBlock)) && !insideTernaryBranch;
-                const parentStatements = canHoist ? (parentBlock as any).statements as Statement[] : undefined;
-
-                // Find the last written index whose value is complex (needs hoisting).
-                // Args written after this point are side-effect-free and can be placed directly.
-                let lastComplexWrittenIdx = -1;
-                for (let i = writtenArgInfos.length - 1; i >= 0; i--) {
-                    if (this.needsHoisting(writtenArgInfos[i].value)) {
-                        lastComplexWrittenIdx = i;
-                        break;
-                    }
-                }
-
-                // If we can't hoist AND there are complex expressions, wrap the call in an IIFE
-                // so args are evaluated in written order but passed in positional order —
-                // the same pattern ternary uses when it can't restructure the surrounding statement.
-                if (!canHoist && lastComplexWrittenIdx >= 0) {
-                    this.event.editor.setProperty(callExpr, 'transpile', (state) => this.transpileNamedArgAsIIFE(state, callExpr, writtenArgInfos, params));
-                    continue;
-                }
-
-                // Build the positional arg map, hoisting complex expressions when safe to do so
-                const positionalArgExprs = new Map<number, Expression>();
-                for (let writtenIdx = 0; writtenIdx < writtenArgInfos.length; writtenIdx++) {
-                    const { paramIdx, value } = writtenArgInfos[writtenIdx];
-
-                    if (canHoist && writtenIdx <= lastComplexWrittenIdx && this.needsHoisting(value)) {
-                        // Hoist: emit `__bsArgs<N> = <value>` before the containing statement
-                        const counter = hoistCounters.get(func) ?? 0;
-                        hoistCounters.set(func, counter + 1);
-                        const varName = `__bsArgs${counter}`;
-
-                        const currentStmtIdx = parentStatements.indexOf(containingStatement);
-                        const hoistStatement = createAssignmentStatement({ name: varName, value: value });
-                        this.event.editor.addToArray(parentStatements, currentStmtIdx, hoistStatement);
-                        // Update the value's parent to the new hoist statement so that when a nested
-                        // named-arg call inside `value` is processed (in reversed order), its
-                        // findAncestor<Statement> walks up to the hoist statement and inserts its own
-                        // hoisting before it — preserving written evaluation order across nesting levels.
-                        this.event.editor.setProperty(value, 'parent', hoistStatement);
-                        positionalArgExprs.set(paramIdx, createVariableExpression(varName));
-                    } else {
-                        // Cannot hoist (e.g. inside an else-if condition) — place the expression
-                        // directly in positional order. Evaluation order may differ from written
-                        // order for complex expressions, but the call only runs if the branch is
-                        // reached, which is the correct semantic (unlike hoisting before the outer if).
-                        positionalArgExprs.set(paramIdx, value);
-                    }
-                }
-
-                // Find the highest assigned positional index to know how many args to emit
-                let lastProvidedIdx = -1;
-                for (const idx of positionalArgExprs.keys()) {
-                    if (idx > lastProvidedIdx) {
-                        lastProvidedIdx = idx;
-                    }
-                }
-
-                // Build the final positional arg list, filling any skipped middle optional params
-                const finalArgs: Expression[] = [];
-                for (let i = 0; i <= lastProvidedIdx; i++) {
-                    if (positionalArgExprs.has(i)) {
-                        finalArgs.push(positionalArgExprs.get(i)!);
-                    } else {
-                        // Skipped optional param — use its default value or `invalid`
-                        finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
-                    }
-                }
-
-                // Replace the call's args with the reordered positional list
-                this.event.editor.arraySplice(callExpr.args, 0, callExpr.args.length, ...finalArgs);
+                const params = this.getClassConstructorParams(classLink.item, scope, containingNamespace);
+                this.rewriteNamedArgCall(callExpr, params, func, hoistCounters);
             }
         }
+    }
+
+    /**
+     * Rewrite a single named-argument call expression in place, hoisting complex arg expressions
+     * into temp variables as needed to preserve written evaluation order.
+     */
+    private rewriteNamedArgCall(callExpr: CallExpression, params: FunctionParameterExpression[], func: FunctionExpression, hoistCounters: WeakMap<FunctionExpression, number>) {
+        // Map each written arg to its positional param index and value.
+        // If anything is invalid (unknown param, duplicate, positional-after-named),
+        // bail out and leave the call untouched — diagnostics are already emitted by validation.
+        const writtenArgInfos: WrittenArgInfo[] = [];
+        const assignedParams = new Set<number>();
+        let seenNamedArg = false;
+        let isValid = true;
+        let positionalCount = 0;
+
+        for (const arg of callExpr.args) {
+            if (!isNamedArgumentExpression(arg)) {
+                if (seenNamedArg) {
+                    isValid = false;
+                    break;
+                }
+                const paramIdx = positionalCount++;
+                if (paramIdx >= params.length || assignedParams.has(paramIdx)) {
+                    isValid = false;
+                    break;
+                }
+                assignedParams.add(paramIdx);
+                writtenArgInfos.push({ paramIdx: paramIdx, value: arg });
+            } else {
+                seenNamedArg = true;
+                const namedArg = arg as NamedArgumentExpression;
+                const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
+                if (paramIdx < 0 || assignedParams.has(paramIdx)) {
+                    isValid = false;
+                    break;
+                }
+                assignedParams.add(paramIdx);
+                writtenArgInfos.push({ paramIdx: paramIdx, value: namedArg.value });
+            }
+        }
+
+        if (!isValid) {
+            return;
+        }
+
+        // Find the immediate containing statement and check if it lives directly inside a
+        // Block or Body. If it does, we can safely insert hoisting assignments before it.
+        // If not (e.g. an `else if` condition whose containing IfStatement is the elseBranch
+        // of an outer IfStatement), we fall back to inline reordering without hoisting —
+        // similar to how ternary falls back to `bslib_ternary()` when it can't restructure.
+        const containingStatement = callExpr.findAncestor<Statement>(isStatement);
+        const parentBlock = containingStatement?.parent;
+        // Also prevent hoisting if the call is inside a ternary consequent or alternate —
+        // hoisting before the containing statement would run the expression unconditionally,
+        // breaking the ternary's conditional evaluation semantics.
+        let insideTernaryBranch = false;
+        {
+            let child: typeof callExpr.parent = callExpr;
+            let ancestor = callExpr.parent;
+            while (ancestor && ancestor !== containingStatement) {
+                if (isTernaryExpression(ancestor) && child !== ancestor.test) {
+                    insideTernaryBranch = true;
+                    break;
+                }
+                child = ancestor;
+                ancestor = ancestor.parent;
+            }
+        }
+        const canHoist = !!containingStatement && (isBlock(parentBlock) || isBody(parentBlock)) && !insideTernaryBranch;
+        const parentStatements = canHoist ? (parentBlock as any).statements as Statement[] : undefined;
+
+        // Find the last written index whose value is complex (needs hoisting).
+        // Args written after this point are side-effect-free and can be placed directly.
+        let lastComplexWrittenIdx = -1;
+        for (let i = writtenArgInfos.length - 1; i >= 0; i--) {
+            if (this.needsHoisting(writtenArgInfos[i].value)) {
+                lastComplexWrittenIdx = i;
+                break;
+            }
+        }
+
+        // If we can't hoist AND there are complex expressions, wrap the call in an IIFE
+        // so args are evaluated in written order but passed in positional order —
+        // the same pattern ternary uses when it can't restructure the surrounding statement.
+        if (!canHoist && lastComplexWrittenIdx >= 0) {
+            this.event.editor.setProperty(callExpr, 'transpile', (state) => this.transpileNamedArgAsIIFE(state, callExpr, writtenArgInfos, params));
+            return;
+        }
+
+        // Build the positional arg map, hoisting complex expressions when safe to do so
+        const positionalArgExprs = new Map<number, Expression>();
+        for (let writtenIdx = 0; writtenIdx < writtenArgInfos.length; writtenIdx++) {
+            const { paramIdx, value } = writtenArgInfos[writtenIdx];
+
+            if (canHoist && writtenIdx <= lastComplexWrittenIdx && this.needsHoisting(value)) {
+                // Hoist: emit `__bsArgs<N> = <value>` before the containing statement
+                const counter = hoistCounters.get(func) ?? 0;
+                hoistCounters.set(func, counter + 1);
+                const varName = `__bsArgs${counter}`;
+
+                const currentStmtIdx = parentStatements.indexOf(containingStatement);
+                const hoistStatement = createAssignmentStatement({ name: varName, value: value });
+                this.event.editor.addToArray(parentStatements, currentStmtIdx, hoistStatement);
+                // Update the value's parent to the new hoist statement so that when a nested
+                // named-arg call inside `value` is processed (in reversed order), its
+                // findAncestor<Statement> walks up to the hoist statement and inserts its own
+                // hoisting before it — preserving written evaluation order across nesting levels.
+                this.event.editor.setProperty(value, 'parent', hoistStatement);
+                positionalArgExprs.set(paramIdx, createVariableExpression(varName));
+            } else {
+                // Cannot hoist (e.g. inside an else-if condition) — place the expression
+                // directly in positional order. Evaluation order may differ from written
+                // order for complex expressions, but the call only runs if the branch is
+                // reached, which is the correct semantic (unlike hoisting before the outer if).
+                positionalArgExprs.set(paramIdx, value);
+            }
+        }
+
+        // Find the highest assigned positional index to know how many args to emit
+        let lastProvidedIdx = -1;
+        for (const idx of positionalArgExprs.keys()) {
+            if (idx > lastProvidedIdx) {
+                lastProvidedIdx = idx;
+            }
+        }
+
+        // Build the final positional arg list, filling any skipped middle optional params
+        const finalArgs: Expression[] = [];
+        for (let i = 0; i <= lastProvidedIdx; i++) {
+            if (positionalArgExprs.has(i)) {
+                finalArgs.push(positionalArgExprs.get(i)!);
+            } else {
+                // Skipped optional param — use its default value or `invalid`
+                finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
+            }
+        }
+
+        // Replace the call's args with the reordered positional list
+        this.event.editor.arraySplice(callExpr.args, 0, callExpr.args.length, ...finalArgs);
+    }
+
+    /**
+     * If the callee is a dotted-get expression whose leftmost identifier is a known namespace,
+     * returns the BrightScript-flattened name (e.g. "MyNs_myFunc"). Otherwise returns undefined.
+     */
+    private getNamespaceCallableBrsName(callee: Expression, scope: Scope): string | undefined {
+        const parts = util.getAllDottedGetParts(callee);
+        if (!parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
+            return undefined;
+        }
+        return parts.map(p => p.text).join('_');
+    }
+
+    /**
+     * Walk the class and its ancestor chain to find the first constructor's parameter list.
+     * Returns an empty array if no constructor is defined anywhere in the hierarchy.
+     */
+    private getClassConstructorParams(classStmt: ClassStatement, scope: Scope, containingNamespace: string | undefined): FunctionParameterExpression[] {
+        let stmt: ClassStatement | undefined = classStmt;
+        while (stmt) {
+            const ctor = stmt.body.find(
+                s => (s as MethodStatement)?.name?.text?.toLowerCase() === 'new'
+            ) as MethodStatement | undefined;
+            if (ctor) {
+                return ctor.func.parameters;
+            }
+            if (!stmt.parentClassName) {
+                break;
+            }
+            const parentName = stmt.parentClassName.getName(ParseMode.BrighterScript);
+            stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
+        }
+        return [];
     }
 
     /**

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -1,24 +1,17 @@
-import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createInvalidLiteral, createToken, createVariableExpression } from '../../astUtils/creators';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isFunctionExpression, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamedArgumentExpression, isNamespaceStatement, isStatement, isTernaryExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
+import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createInvalidLiteral, createToken } from '../../astUtils/creators';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isFunctionExpression, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamedArgumentExpression, isNamespaceStatement, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BeforeFileTranspileEvent } from '../../interfaces';
 import type { Token } from '../../lexer/Token';
 import { TokenKind } from '../../lexer/TokenKind';
 import type { Expression, Statement } from '../../parser/AstNode';
-import type { BrsTranspileState } from '../../parser/BrsTranspileState';
 import type { CallExpression, FunctionExpression, FunctionParameterExpression, NamedArgumentExpression, TernaryExpression } from '../../parser/Expression';
-import type { TranspileResult } from '../../interfaces';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import type { ClassStatement, IfStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Scope } from '../../Scope';
 import util from '../../util';
-
-interface WrittenArgInfo {
-    paramIdx: number;
-    value: Expression;
-}
 
 export class BrsFilePreTranspileProcessor {
     public constructor(
@@ -34,17 +27,8 @@ export class BrsFilePreTranspileProcessor {
     }
 
     /**
-     * Returns true if an expression needs to be hoisted into a temp variable to preserve evaluation order.
-     * Literals and simple variable references are side-effect-free and can be used directly.
-     */
-    private needsHoisting(expr: Expression) {
-        return !isLiteralExpression(expr) && !isVariableExpression(expr);
-    }
-
-    /**
-     * Rewrite calls that use named arguments into positional calls, hoisting complex argument
-     * expressions into temporary `__bsArgs*` variables to preserve written evaluation order.
-     * This follows the same beforeFileTranspile pattern as ternary expression rewriting.
+     * Rewrite calls that use named arguments into positional calls.
+     * Named arguments are expected to already be validated to match function parameter order.
      */
     private processNamedArgumentCalls() {
         const scope = this.event.program.getFirstScopeForFile(this.event.file);
@@ -52,14 +36,9 @@ export class BrsFilePreTranspileProcessor {
             return;
         }
         const callableContainerMap = util.getCallableContainersByLowerName(scope.getAllCallables());
-        // Track a hoisting counter per function so variable names are unique within each function scope
-        const hoistCounters = new WeakMap<FunctionExpression, number>();
 
         for (const func of this.event.file.parser.references.functionExpressions) {
-            // Iterate in reverse (outermost calls first) so that when an outer call hoists an inner
-            // call expression into a temp variable, the inner call's own hoisting inserts after the
-            // outer call's earlier hoists — preserving written evaluation order across nesting levels.
-            for (const callExpr of [...func.callExpressions].reverse()) {
+            for (const callExpr of func.callExpressions) {
                 if (!callExpr.args.some(isNamedArgumentExpression)) {
                     continue;
                 }
@@ -81,14 +60,10 @@ export class BrsFilePreTranspileProcessor {
                     continue;
                 }
 
-                this.rewriteNamedArgCall(callExpr, params, func, hoistCounters);
+                this.rewriteNamedArgCall(callExpr, params);
             }
 
-            // Process constructor calls (new MyClass(...)) after regular calls.
-            // Constructor CallExpressions are not in func.callExpressions (the parser removes them),
-            // so they are handled here. Processing after regular calls ensures that when a constructor
-            // call is hoisted as an arg to an outer named-arg call, the parent pointer update done by
-            // the outer call's hoisting is already in place when we process the constructor's own args.
+            // Constructor CallExpressions are not in func.callExpressions, so handle them separately.
             for (const newExpr of this.event.file.parser.references.newExpressions) {
                 const callExpr = newExpr.call;
                 if (!callExpr.args.some(isNamedArgumentExpression)) {
@@ -107,148 +82,44 @@ export class BrsFilePreTranspileProcessor {
                 }
 
                 const params = this.getClassConstructorParams(classLink.item, scope, containingNamespace);
-                this.rewriteNamedArgCall(callExpr, params, func, hoistCounters);
+                this.rewriteNamedArgCall(callExpr, params);
             }
         }
     }
 
     /**
-     * Rewrite a single named-argument call expression in place, hoisting complex arg expressions
-     * into temp variables as needed to preserve written evaluation order.
+     * Rewrite a single named-argument call expression in place.
+     * Leaves invalid calls unchanged (diagnostics are emitted during validation).
      */
-    private rewriteNamedArgCall(callExpr: CallExpression, params: FunctionParameterExpression[], func: FunctionExpression, hoistCounters: WeakMap<FunctionExpression, number>) {
-        // Map each written arg to its positional param index and value.
-        // If anything is invalid (unknown param, duplicate, positional-after-named),
-        // bail out and leave the call untouched — diagnostics are already emitted by validation.
-        const writtenArgInfos: WrittenArgInfo[] = [];
-        const assignedParams = new Set<number>();
+    private rewriteNamedArgCall(callExpr: CallExpression, params: FunctionParameterExpression[]) {
+        const finalArgs = [] as Expression[];
+        let expectedParamIdx = 0;
         let seenNamedArg = false;
-        let isValid = true;
-        let positionalCount = 0;
 
         for (const arg of callExpr.args) {
             if (!isNamedArgumentExpression(arg)) {
-                if (seenNamedArg) {
-                    isValid = false;
-                    break;
+                if (seenNamedArg || expectedParamIdx >= params.length) {
+                    return;
                 }
-                const paramIdx = positionalCount++;
-                if (paramIdx >= params.length || assignedParams.has(paramIdx)) {
-                    isValid = false;
-                    break;
-                }
-                assignedParams.add(paramIdx);
-                writtenArgInfos.push({ paramIdx: paramIdx, value: arg });
-            } else {
-                seenNamedArg = true;
-                const namedArg = arg as NamedArgumentExpression;
-                const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
-                if (paramIdx < 0 || assignedParams.has(paramIdx)) {
-                    isValid = false;
-                    break;
-                }
-                assignedParams.add(paramIdx);
-                writtenArgInfos.push({ paramIdx: paramIdx, value: namedArg.value });
+                finalArgs.push(arg);
+                expectedParamIdx++;
+                continue;
             }
-        }
 
-        if (!isValid) {
-            return;
-        }
-
-        // Find the immediate containing statement and check if it lives directly inside a
-        // Block or Body. If it does, we can safely insert hoisting assignments before it.
-        // If not (e.g. an `else if` condition whose containing IfStatement is the elseBranch
-        // of an outer IfStatement), we fall back to inline reordering without hoisting —
-        // similar to how ternary falls back to `bslib_ternary()` when it can't restructure.
-        const containingStatement = callExpr.findAncestor<Statement>(isStatement);
-        const parentBlock = containingStatement?.parent;
-        // Also prevent hoisting if the call is inside a ternary consequent or alternate —
-        // hoisting before the containing statement would run the expression unconditionally,
-        // breaking the ternary's conditional evaluation semantics.
-        let insideTernaryBranch = false;
-        {
-            let child: typeof callExpr.parent = callExpr;
-            let ancestor = callExpr.parent;
-            while (ancestor && ancestor !== containingStatement) {
-                if (isTernaryExpression(ancestor) && child !== ancestor.test) {
-                    insideTernaryBranch = true;
-                    break;
-                }
-                child = ancestor;
-                ancestor = ancestor.parent;
+            seenNamedArg = true;
+            const namedArg = arg as NamedArgumentExpression;
+            const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === namedArg.name.text.toLowerCase());
+            if (paramIdx < expectedParamIdx) {
+                return;
             }
-        }
-        const canHoist = !!containingStatement && (isBlock(parentBlock) || isBody(parentBlock)) && !insideTernaryBranch;
-        const parentStatements = canHoist ? (parentBlock as any).statements as Statement[] : undefined;
 
-        // Find the last written index whose value is complex (needs hoisting).
-        // Args written after this point are side-effect-free and can be placed directly.
-        let lastComplexWrittenIdx = -1;
-        for (let i = writtenArgInfos.length - 1; i >= 0; i--) {
-            if (this.needsHoisting(writtenArgInfos[i].value)) {
-                lastComplexWrittenIdx = i;
-                break;
+            for (let i = expectedParamIdx; i < paramIdx; i++) {
+                finalArgs.push(params[i]?.defaultValue?.clone() ?? createInvalidLiteral());
             }
+            finalArgs.push(namedArg.value);
+            expectedParamIdx = paramIdx + 1;
         }
 
-        // If we can't hoist AND there are complex expressions, wrap the call in an IIFE
-        // so args are evaluated in written order but passed in positional order —
-        // the same pattern ternary uses when it can't restructure the surrounding statement.
-        if (!canHoist && lastComplexWrittenIdx >= 0) {
-            this.event.editor.setProperty(callExpr, 'transpile', (state) => this.transpileNamedArgAsIIFE(state, callExpr, writtenArgInfos, params));
-            return;
-        }
-
-        // Build the positional arg map, hoisting complex expressions when safe to do so
-        const positionalArgExprs = new Map<number, Expression>();
-        for (let writtenIdx = 0; writtenIdx < writtenArgInfos.length; writtenIdx++) {
-            const { paramIdx, value } = writtenArgInfos[writtenIdx];
-
-            if (canHoist && writtenIdx <= lastComplexWrittenIdx && this.needsHoisting(value)) {
-                // Hoist: emit `__bsArgs<N> = <value>` before the containing statement
-                const counter = hoistCounters.get(func) ?? 0;
-                hoistCounters.set(func, counter + 1);
-                const varName = `__bsArgs${counter}`;
-
-                const currentStmtIdx = parentStatements.indexOf(containingStatement);
-                const hoistStatement = createAssignmentStatement({ name: varName, value: value });
-                this.event.editor.addToArray(parentStatements, currentStmtIdx, hoistStatement);
-                // Update the value's parent to the new hoist statement so that when a nested
-                // named-arg call inside `value` is processed (in reversed order), its
-                // findAncestor<Statement> walks up to the hoist statement and inserts its own
-                // hoisting before it — preserving written evaluation order across nesting levels.
-                this.event.editor.setProperty(value, 'parent', hoistStatement);
-                positionalArgExprs.set(paramIdx, createVariableExpression(varName));
-            } else {
-                // Cannot hoist (e.g. inside an else-if condition) — place the expression
-                // directly in positional order. Evaluation order may differ from written
-                // order for complex expressions, but the call only runs if the branch is
-                // reached, which is the correct semantic (unlike hoisting before the outer if).
-                positionalArgExprs.set(paramIdx, value);
-            }
-        }
-
-        // Find the highest assigned positional index to know how many args to emit
-        let lastProvidedIdx = -1;
-        for (const idx of positionalArgExprs.keys()) {
-            if (idx > lastProvidedIdx) {
-                lastProvidedIdx = idx;
-            }
-        }
-
-        // Build the final positional arg list, filling any skipped middle optional params
-        const finalArgs: Expression[] = [];
-        for (let i = 0; i <= lastProvidedIdx; i++) {
-            if (positionalArgExprs.has(i)) {
-                finalArgs.push(positionalArgExprs.get(i)!);
-            } else {
-                // Skipped optional param — use its default value or `invalid`
-                finalArgs.push(params[i].defaultValue?.clone() ?? createInvalidLiteral());
-            }
-        }
-
-        // Replace the call's args with the reordered positional list
         this.event.editor.arraySplice(callExpr.args, 0, callExpr.args.length, ...finalArgs);
     }
 
@@ -284,89 +155,6 @@ export class BrsFilePreTranspileProcessor {
             stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
         }
         return [];
-    }
-
-    /**
-     * Builds the transpile output for a named-argument call that cannot be hoisted
-     * (e.g. inside an `else if` condition). Wraps the call in an IIFE so args are
-     * evaluated in written order but passed in positional order — the same pattern
-     * ternary uses for complex consequent/alternate expressions.
-     *
-     *   (function(__bsArg0, __bsArg1)
-     *       return funcName(__bsArgN, __bsArgM)
-     *   end function)(writtenVal0, writtenVal1)
-     */
-    private transpileNamedArgAsIIFE(state: BrsTranspileState, callExpr: CallExpression, writtenArgInfos: WrittenArgInfo[], params: FunctionParameterExpression[]): TranspileResult {
-        const result: TranspileResult = [];
-
-        // One IIFE param per written arg, in written order: __bsArg0, __bsArg1, ...
-        const iifeParamNames = writtenArgInfos.map((_, i) => `__bsArg${i}`);
-
-        // Find the highest positional index that was provided
-        let lastProvidedIdx = -1;
-        for (const { paramIdx } of writtenArgInfos) {
-            if (paramIdx > lastProvidedIdx) {
-                lastProvidedIdx = paramIdx;
-            }
-        }
-
-        // Map from positional param index → IIFE param name
-        const paramIdxToIIFEParam = new Map<number, string>();
-        for (let i = 0; i < writtenArgInfos.length; i++) {
-            paramIdxToIIFEParam.set(writtenArgInfos[i].paramIdx, iifeParamNames[i]);
-        }
-
-        result.push(
-            // (function(__bsArg0, __bsArg1)
-            state.sourceNode(callExpr.openingParen, `(function(${iifeParamNames.join(', ')})`),
-            state.newline,
-            // double-indent so `end function)(` sits one level deeper than the call site,
-            // matching the ternary IIFE convention
-            state.indent(2),
-            state.sourceNode(callExpr.callee, 'return '),
-            ...callExpr.callee.transpile(state),
-            '('
-        );
-
-        // Positional call args inside the IIFE body
-        for (let i = 0; i <= lastProvidedIdx; i++) {
-            if (i > 0) {
-                result.push(', ');
-            }
-            if (paramIdxToIIFEParam.has(i)) {
-                result.push(state.sourceNode(callExpr, paramIdxToIIFEParam.get(i)!));
-            } else {
-                // Skipped optional param — use its default or `invalid`
-                const defaultVal = params[i].defaultValue;
-                if (defaultVal) {
-                    result.push(...defaultVal.transpile(state));
-                } else {
-                    result.push(state.sourceNode(callExpr, 'invalid'));
-                }
-            }
-        }
-
-        result.push(
-            ')',
-            state.newline,
-            state.indent(-1),
-            // end function)(writtenVal0, writtenVal1, ...)
-            state.sourceNode(callExpr.closingParen ?? callExpr.openingParen, 'end function)(')
-        );
-
-        // Written-order values passed to the IIFE
-        for (let i = 0; i < writtenArgInfos.length; i++) {
-            if (i > 0) {
-                result.push(', ');
-            }
-            result.push(...writtenArgInfos[i].value.transpile(state));
-        }
-
-        result.push(')');
-        // compensate for the net +1 from indent(2) + indent(-1)
-        state.blockDepth--;
-
-        return result;
     }
 
     private iterateExpressions() {

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -9,7 +9,7 @@ import type { Expression, Statement } from '../../parser/AstNode';
 import type { CallExpression, FunctionExpression, FunctionParameterExpression, NamedArgumentExpression, TernaryExpression } from '../../parser/Expression';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { ClassStatement, ConstStatement, IfStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
+import type { ConstStatement, IfStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Scope } from '../../Scope';
 import util from '../../util';
 
@@ -50,7 +50,7 @@ export class BrsFilePreTranspileProcessor {
                     params = callableContainerMap.get(funcName.toLowerCase())?.[0]?.callable?.functionStatement?.func?.parameters;
                 } else if (isDottedGetExpression(callExpr.callee)) {
                     // Namespace function call (e.g. MyNs.myFunc(a: 1))
-                    const brsName = this.getNamespaceCallableBrsName(callExpr.callee, scope);
+                    const brsName = util.resolveNamespaceCallableName(callExpr.callee, scope);
                     if (brsName) {
                         params = callableContainerMap.get(brsName.toLowerCase())?.[0]?.callable?.functionStatement?.func?.parameters;
                     }
@@ -81,7 +81,7 @@ export class BrsFilePreTranspileProcessor {
                     continue;
                 }
 
-                const params = this.getClassConstructorParams(classLink.item, scope, containingNamespace);
+                const params = util.getClassConstructorParams(classLink.item, scope, containingNamespace);
                 this.rewriteNamedArgCall(callExpr, params);
             }
         }
@@ -121,40 +121,6 @@ export class BrsFilePreTranspileProcessor {
         }
 
         this.event.editor.arraySplice(callExpr.args, 0, callExpr.args.length, ...finalArgs);
-    }
-
-    /**
-     * If the callee is a dotted-get expression whose leftmost identifier is a known namespace,
-     * returns the BrightScript-flattened name (e.g. "MyNs_myFunc"). Otherwise returns undefined.
-     */
-    private getNamespaceCallableBrsName(callee: Expression, scope: Scope): string | undefined {
-        const parts = util.getAllDottedGetParts(callee);
-        if (!parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
-            return undefined;
-        }
-        return parts.map(p => p.text).join('_');
-    }
-
-    /**
-     * Walk the class and its ancestor chain to find the first constructor's parameter list.
-     * Returns an empty array if no constructor is defined anywhere in the hierarchy.
-     */
-    private getClassConstructorParams(classStmt: ClassStatement, scope: Scope, containingNamespace: string | undefined): FunctionParameterExpression[] {
-        let stmt: ClassStatement | undefined = classStmt;
-        while (stmt) {
-            const ctor = stmt.body.find(
-                s => (s as MethodStatement)?.name?.text?.toLowerCase() === 'new'
-            ) as MethodStatement | undefined;
-            if (ctor) {
-                return ctor.func.parameters;
-            }
-            if (!stmt.parentClassName) {
-                break;
-            }
-            const parentName = stmt.parentClassName.getName(ParseMode.BrighterScript);
-            stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
-        }
-        return [];
     }
 
     private iterateExpressions() {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -123,6 +123,7 @@ export class BrsFileValidator {
                     node.symbolTable.addSymbol('m', undefined, DynamicType.instance);
                 }
                 this.validateFunctionParameterCount(node);
+                this.validateFunctionParameterNames(node);
             },
             FunctionParameterExpression: (node) => {
                 if (node.name) {
@@ -216,6 +217,24 @@ export class BrsFileValidator {
                     ...DiagnosticMessages.tooManyCallableParameters(func.parameters.length, CallExpression.MaximumArguments),
                     range: func.parameters[i].name.range
                 });
+            }
+        }
+    }
+
+    private validateFunctionParameterNames(func: FunctionExpression) {
+        const seen = new Set<string>();
+        for (const param of func.parameters) {
+            const nameLower = param.name?.text?.toLowerCase();
+            if (!nameLower) {
+                continue;
+            }
+            if (seen.has(nameLower)) {
+                this.event.file.addDiagnostic({
+                    ...DiagnosticMessages.duplicateFunctionParameter(param.name.text),
+                    range: param.name.range
+                });
+            } else {
+                seen.add(nameLower);
             }
         }
     }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,9 +1,9 @@
 import { URI } from 'vscode-uri';
-import { isBrsFile, isCallExpression, isLiteralExpression, isNamespaceStatement, isXmlScope } from '../../astUtils/reflection';
+import { isBrsFile, isCallExpression, isLiteralExpression, isNamespaceStatement, isVariableExpression, isXmlScope, isNamedArgumentExpression } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
-import type { BscFile, BsDiagnostic, OnScopeValidateEvent } from '../../interfaces';
+import type { BscFile, BsDiagnostic, OnScopeValidateEvent, CallableContainerMap } from '../../interfaces';
 import type { EnumStatement, NamespaceStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
@@ -13,7 +13,7 @@ import { TokenKind } from '../../lexer/TokenKind';
 import type { Scope } from '../../Scope';
 import type { DiagnosticRelatedInformation } from 'vscode-languageserver';
 import type { Expression } from '../../parser/AstNode';
-import type { VariableExpression, DottedGetExpression } from '../../parser/Expression';
+import type { VariableExpression, DottedGetExpression, NamedArgumentExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 
@@ -53,6 +53,7 @@ export class ScopeValidator {
                 this.iterateFileExpressions(file);
                 this.validateCreateObjectCalls(file);
                 this.validateComputedAAKeys(file);
+                this.validateNamedArgCalls(file);
             }
         });
     }
@@ -426,6 +427,116 @@ export class ScopeValidator {
             }
         }
         this.event.scope.addDiagnostics(diagnostics);
+    }
+
+    /**
+     * Validate calls that use named arguments.
+     * Only handles simple function calls (VariableExpression callee); method calls are not supported.
+     */
+    private validateNamedArgCalls(file: BrsFile) {
+        const callableContainerMap: CallableContainerMap = util.getCallableContainersByLowerName(this.event.scope.getAllCallables());
+
+        for (const func of file.parser.references.functionExpressions) {
+            for (const callExpr of func.callExpressions) {
+                if (!callExpr.args.some(isNamedArgumentExpression)) {
+                    continue;
+                }
+
+                // Named args are only supported for simple variable calls (not method/dotted calls)
+                if (!isVariableExpression(callExpr.callee)) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as any)?.name?.text ?? '?'),
+                        range: callExpr.openingParen.range,
+                        file: file
+                    });
+                    continue;
+                }
+
+                const funcName = callExpr.callee.name.text;
+                const callableContainers = callableContainerMap.get(funcName.toLowerCase());
+                const callable = callableContainers?.[0]?.callable;
+
+                if (!callable) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(funcName),
+                        range: callExpr.callee.range,
+                        file: file
+                    });
+                    continue;
+                }
+
+                const params = callable.functionStatement.func.parameters;
+                const assignedParams = new Set<number>();
+                let seenNamedArg = false;
+                let hasError = false;
+
+                for (const arg of callExpr.args) {
+                    if (!isNamedArgumentExpression(arg)) {
+                        if (seenNamedArg) {
+                            this.addDiagnostic({
+                                ...DiagnosticMessages.positionalArgAfterNamedArg(),
+                                range: arg.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+                        const idx = assignedParams.size;
+                        if (idx < params.length) {
+                            assignedParams.add(idx);
+                        }
+                    } else {
+                        seenNamedArg = true;
+                        const namedArg = arg as NamedArgumentExpression;
+                        const paramName = namedArg.name.text.toLowerCase();
+                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === paramName);
+
+                        if (paramIdx < 0) {
+                            this.addDiagnostic({
+                                ...DiagnosticMessages.unknownNamedArgument(namedArg.name.text, funcName),
+                                range: namedArg.name.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+
+                        if (assignedParams.has(paramIdx)) {
+                            this.addDiagnostic({
+                                ...DiagnosticMessages.namedArgDuplicate(namedArg.name.text),
+                                range: namedArg.name.range,
+                                file: file
+                            });
+                            hasError = true;
+                            continue;
+                        }
+
+                        assignedParams.add(paramIdx);
+                    }
+                }
+
+                if (hasError) {
+                    continue;
+                }
+
+                // Validate all required params are provided
+                for (let i = 0; i < params.length; i++) {
+                    if (!assignedParams.has(i) && !params[i].defaultValue) {
+                        const minParams = params.filter(p => !p.defaultValue).length;
+                        const maxParams = params.length;
+                        this.addDiagnostic({
+                            ...DiagnosticMessages.mismatchArgumentCount(
+                                minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
+                                callExpr.args.length
+                            ),
+                            range: callExpr.callee.range,
+                            file: file
+                        });
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,10 +1,10 @@
 import { URI } from 'vscode-uri';
-import { isBrsFile, isCallExpression, isLiteralExpression, isNamespaceStatement, isVariableExpression, isXmlScope, isNamedArgumentExpression } from '../../astUtils/reflection';
+import { isBrsFile, isCallExpression, isDottedGetExpression, isLiteralExpression, isNamespaceStatement, isVariableExpression, isXmlScope, isNamedArgumentExpression } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, BsDiagnostic, OnScopeValidateEvent, CallableContainerMap } from '../../interfaces';
-import type { EnumStatement, NamespaceStatement } from '../../parser/Statement';
+import type { ClassStatement, EnumStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
@@ -13,7 +13,7 @@ import { TokenKind } from '../../lexer/TokenKind';
 import type { Scope } from '../../Scope';
 import type { DiagnosticRelatedInformation } from 'vscode-languageserver';
 import type { Expression } from '../../parser/AstNode';
-import type { VariableExpression, DottedGetExpression, NamedArgumentExpression } from '../../parser/Expression';
+import type { FunctionParameterExpression, VariableExpression, DottedGetExpression, NamedArgumentExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 
@@ -431,19 +431,59 @@ export class ScopeValidator {
 
     /**
      * Validate calls that use named arguments.
-     * Only handles simple function calls (VariableExpression callee); method calls are not supported.
+     * Supports: simple variable calls, namespace function calls, and constructor calls (new MyClass()).
      */
     private validateNamedArgCalls(file: BrsFile) {
-        const callableContainerMap: CallableContainerMap = util.getCallableContainersByLowerName(this.event.scope.getAllCallables());
+        const { scope } = this.event;
+        const callableContainerMap: CallableContainerMap = util.getCallableContainersByLowerName(scope.getAllCallables());
 
+        // Validate regular and namespace function calls
         for (const func of file.parser.references.functionExpressions) {
             for (const callExpr of func.callExpressions) {
                 if (!callExpr.args.some(isNamedArgumentExpression)) {
                     continue;
                 }
 
-                // Named args are only supported for simple variable calls (not method/dotted calls)
-                if (!isVariableExpression(callExpr.callee)) {
+                let funcName: string;
+                let params: FunctionParameterExpression[];
+
+                if (isVariableExpression(callExpr.callee)) {
+                    funcName = callExpr.callee.name.text;
+                    const callable = callableContainerMap.get(funcName.toLowerCase())?.[0]?.callable;
+                    if (!callable) {
+                        this.addDiagnostic({
+                            ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(funcName),
+                            range: callExpr.callee.range,
+                            file: file
+                        });
+                        continue;
+                    }
+                    params = callable.functionStatement.func.parameters;
+                    this.checkNamedArgCrossScopeConflict(funcName, params, callExpr, file, scope);
+                } else if (isDottedGetExpression(callExpr.callee)) {
+                    // Namespace function call (e.g. MyNs.myFunc(a: 1))
+                    const brsName = this.getNamespaceCallableBrsName(callExpr.callee, scope);
+                    if (!brsName) {
+                        this.addDiagnostic({
+                            ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as DottedGetExpression).name.text),
+                            range: callExpr.callee.range,
+                            file: file
+                        });
+                        continue;
+                    }
+                    const callable = callableContainerMap.get(brsName.toLowerCase())?.[0]?.callable;
+                    if (!callable) {
+                        const displayName = brsName.replace(/_/g, '.');
+                        this.addDiagnostic({
+                            ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(displayName),
+                            range: callExpr.callee.range,
+                            file: file
+                        });
+                        continue;
+                    }
+                    funcName = brsName;
+                    params = callable.functionStatement.func.parameters;
+                } else {
                     this.addDiagnostic({
                         ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as any)?.name?.text ?? '?'),
                         range: callExpr.openingParen.range,
@@ -452,91 +492,184 @@ export class ScopeValidator {
                     continue;
                 }
 
-                const funcName = callExpr.callee.name.text;
-                const callableContainers = callableContainerMap.get(funcName.toLowerCase());
-                const callable = callableContainers?.[0]?.callable;
-
-                if (!callable) {
-                    this.addDiagnostic({
-                        ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(funcName),
-                        range: callExpr.callee.range,
-                        file: file
-                    });
-                    continue;
-                }
-
-                const params = callable.functionStatement.func.parameters;
-                const assignedParams = new Set<number>();
-                let seenNamedArg = false;
-                let hasError = false;
-
-                for (const arg of callExpr.args) {
-                    if (!isNamedArgumentExpression(arg)) {
-                        if (seenNamedArg) {
-                            this.addDiagnostic({
-                                ...DiagnosticMessages.positionalArgAfterNamedArg(),
-                                range: arg.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-                        const idx = assignedParams.size;
-                        if (idx < params.length) {
-                            assignedParams.add(idx);
-                        }
-                    } else {
-                        seenNamedArg = true;
-                        const namedArg = arg as NamedArgumentExpression;
-                        const paramName = namedArg.name.text.toLowerCase();
-                        const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === paramName);
-
-                        if (paramIdx < 0) {
-                            this.addDiagnostic({
-                                ...DiagnosticMessages.unknownNamedArgument(namedArg.name.text, funcName),
-                                range: namedArg.name.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-
-                        if (assignedParams.has(paramIdx)) {
-                            this.addDiagnostic({
-                                ...DiagnosticMessages.namedArgDuplicate(namedArg.name.text),
-                                range: namedArg.name.range,
-                                file: file
-                            });
-                            hasError = true;
-                            continue;
-                        }
-
-                        assignedParams.add(paramIdx);
-                    }
-                }
-
-                if (hasError) {
-                    continue;
-                }
-
-                // Validate all required params are provided
-                for (let i = 0; i < params.length; i++) {
-                    if (!assignedParams.has(i) && !params[i].defaultValue) {
-                        const minParams = params.filter(p => !p.defaultValue).length;
-                        const maxParams = params.length;
-                        this.addDiagnostic({
-                            ...DiagnosticMessages.mismatchArgumentCount(
-                                minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
-                                callExpr.args.length
-                            ),
-                            range: callExpr.callee.range,
-                            file: file
-                        });
-                        break;
-                    }
-                }
+                this.validateNamedArgCallArgs(callExpr, params, funcName, file);
             }
         }
+
+        // Validate constructor calls with named args (new MyClass(a: 1))
+        for (const newExpr of file.parser.references.newExpressions) {
+            const callExpr = newExpr.call;
+            if (!callExpr.args.some(isNamedArgumentExpression)) {
+                continue;
+            }
+
+            const className = newExpr.className.getName(ParseMode.BrighterScript);
+            const containingNamespace = callExpr.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript)?.toLowerCase();
+            const classLink = scope.getClassFileLink(className, containingNamespace);
+            if (!classLink) {
+                this.addDiagnostic({
+                    ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction(className),
+                    range: callExpr.callee.range,
+                    file: file
+                });
+                continue;
+            }
+
+            const params = this.getClassConstructorParams(classLink.item, scope, containingNamespace);
+            this.validateNamedArgCallArgs(callExpr, params, className, file);
+        }
+    }
+
+    /**
+     * Validate the named argument list for a single call expression against the resolved parameter list.
+     */
+    private validateNamedArgCallArgs(callExpr: { args: Expression[]; callee: Expression; openingParen?: { range: any } }, params: FunctionParameterExpression[], funcName: string, file: BrsFile) {
+        const assignedParams = new Set<number>();
+        let seenNamedArg = false;
+        let hasError = false;
+
+        for (const arg of callExpr.args) {
+            if (!isNamedArgumentExpression(arg)) {
+                if (seenNamedArg) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.positionalArgAfterNamedArg(),
+                        range: arg.range,
+                        file: file
+                    });
+                    hasError = true;
+                    continue;
+                }
+                const idx = assignedParams.size;
+                if (idx < params.length) {
+                    assignedParams.add(idx);
+                }
+            } else {
+                seenNamedArg = true;
+                const namedArg = arg as NamedArgumentExpression;
+                const paramName = namedArg.name.text.toLowerCase();
+                const paramIdx = params.findIndex(p => p.name.text.toLowerCase() === paramName);
+
+                if (paramIdx < 0) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.unknownNamedArgument(namedArg.name.text, funcName),
+                        range: namedArg.name.range,
+                        file: file
+                    });
+                    hasError = true;
+                    continue;
+                }
+
+                if (assignedParams.has(paramIdx)) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.namedArgDuplicate(namedArg.name.text),
+                        range: namedArg.name.range,
+                        file: file
+                    });
+                    hasError = true;
+                    continue;
+                }
+
+                assignedParams.add(paramIdx);
+            }
+        }
+
+        if (hasError) {
+            return;
+        }
+
+        // Validate all required params are provided
+        for (let i = 0; i < params.length; i++) {
+            if (!assignedParams.has(i) && !params[i].defaultValue) {
+                const minParams = params.filter(p => !p.defaultValue).length;
+                const maxParams = params.length;
+                this.addDiagnostic({
+                    ...DiagnosticMessages.mismatchArgumentCount(
+                        minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
+                        callExpr.args.length
+                    ),
+                    range: callExpr.callee.range,
+                    file: file
+                });
+                break;
+            }
+        }
+    }
+
+    /**
+     * Emit a diagnostic if the same function name resolves to different parameter signatures
+     * in other component scopes that share this file. Named arg transpilation is per-file
+     * (using the first scope), so an ambiguous signature would produce incorrect output.
+     */
+    private checkNamedArgCrossScopeConflict(funcName: string, params: FunctionParameterExpression[], callExpr: { callee: Expression }, file: BrsFile, scope: Scope) {
+        for (const otherScope of this.event.program.getScopesForFile(file)) {
+            if (otherScope === scope) {
+                continue;
+            }
+            const otherCallable = otherScope.getCallableByName(funcName);
+            if (!otherCallable) {
+                continue;
+            }
+            // Guard against namespace functions that share a short name with our target
+            if (otherCallable.getName(ParseMode.BrightScript).toLowerCase() !== funcName.toLowerCase()) {
+                continue;
+            }
+            const otherParams = otherCallable.functionStatement?.func?.parameters;
+            if (!otherParams) {
+                continue;
+            }
+            if (!this.haveSameParamSignature(params, otherParams)) {
+                this.addDiagnosticOnce({
+                    ...DiagnosticMessages.namedArgsCrossScopeConflict(funcName),
+                    range: callExpr.callee.range,
+                    file: file
+                });
+                break;
+            }
+        }
+    }
+
+    /**
+     * Returns true if both parameter lists have the same names in the same order.
+     */
+    private haveSameParamSignature(p1: FunctionParameterExpression[], p2: FunctionParameterExpression[]): boolean {
+        if (p1.length !== p2.length) {
+            return false;
+        }
+        return p1.every((p, i) => p.name.text.toLowerCase() === p2[i].name.text.toLowerCase());
+    }
+
+    /**
+     * If the callee is a dotted-get expression whose leftmost identifier is a known namespace,
+     * returns the BrightScript-flattened name (e.g. "MyNs_myFunc"). Otherwise returns undefined.
+     */
+    private getNamespaceCallableBrsName(callee: DottedGetExpression, scope: Scope): string | undefined {
+        const parts = util.getAllDottedGetParts(callee);
+        if (!parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
+            return undefined;
+        }
+        return parts.map(p => p.text).join('_');
+    }
+
+    /**
+     * Walk the class and its ancestor chain to find the first constructor's parameter list.
+     * Returns an empty array if no constructor is defined anywhere in the hierarchy.
+     */
+    private getClassConstructorParams(classStmt: ClassStatement, scope: Scope, containingNamespace: string | undefined): FunctionParameterExpression[] {
+        let stmt: ClassStatement | undefined = classStmt;
+        while (stmt) {
+            const ctor = stmt.body.find(
+                s => (s as MethodStatement)?.name?.text?.toLowerCase() === 'new'
+            ) as MethodStatement | undefined;
+            if (ctor) {
+                return ctor.func.parameters;
+            }
+            if (!stmt.parentClassName) {
+                break;
+            }
+            const parentName = stmt.parentClassName.getName(ParseMode.BrighterScript);
+            stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
+        }
+        return [];
     }
 
     /**

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -3,7 +3,7 @@ import { isBrsFile, isCallExpression, isDottedGetExpression, isLiteralExpression
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
-import type { BscFile, BsDiagnostic, OnScopeValidateEvent, CallableContainerMap } from '../../interfaces';
+import type { BscFile, BsDiagnostic, OnScopeValidateEvent, CallableContainerMap, Callable } from '../../interfaces';
 import type { ClassStatement, EnumStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
@@ -459,7 +459,7 @@ export class ScopeValidator {
                         continue;
                     }
                     params = callable.functionStatement.func.parameters;
-                    this.checkNamedArgCrossScopeConflict(funcName, params, callExpr, file, scope);
+                    this.checkNamedArgCrossScopeConflict(funcName, callable, params, callExpr, file, scope);
                 } else if (isDottedGetExpression(callExpr.callee)) {
                     // Namespace function call (e.g. MyNs.myFunc(a: 1))
                     const brsName = this.getNamespaceCallableBrsName(callExpr.callee, scope);
@@ -600,7 +600,7 @@ export class ScopeValidator {
      * in other component scopes that share this file. Named arg transpilation is per-file
      * (using the first scope), so an ambiguous signature would produce incorrect output.
      */
-    private checkNamedArgCrossScopeConflict(funcName: string, params: FunctionParameterExpression[], callExpr: { callee: Expression }, file: BrsFile, scope: Scope) {
+    private checkNamedArgCrossScopeConflict(funcName: string, callable: Callable, params: FunctionParameterExpression[], callExpr: { callee: Expression }, file: BrsFile, scope: Scope) {
         for (const otherScope of this.event.program.getScopesForFile(file)) {
             if (otherScope === scope) {
                 continue;
@@ -618,10 +618,27 @@ export class ScopeValidator {
                 continue;
             }
             if (!this.haveSameParamSignature(params, otherParams)) {
+                const relatedInformation: DiagnosticRelatedInformation[] = [
+                    {
+                        message: `'${funcName}' defined in scope '${scope.name}'`,
+                        location: util.createLocation(
+                            URI.file(callable.file.srcPath).toString(),
+                            callable.nameRange ?? callable.range
+                        )
+                    },
+                    {
+                        message: `'${funcName}' defined in scope '${otherScope.name}'`,
+                        location: util.createLocation(
+                            URI.file(otherCallable.file.srcPath).toString(),
+                            otherCallable.nameRange ?? otherCallable.range
+                        )
+                    }
+                ];
                 this.addDiagnosticOnce({
                     ...DiagnosticMessages.namedArgsCrossScopeConflict(funcName),
                     range: callExpr.callee.range,
-                    file: file
+                    file: file,
+                    relatedInformation: relatedInformation
                 });
                 break;
             }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -4,7 +4,7 @@ import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, BsDiagnostic, OnScopeValidateEvent, CallableContainerMap, Callable } from '../../interfaces';
-import type { ClassStatement, ConstStatement, EnumStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
+import type { ConstStatement, EnumStatement, NamespaceStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
@@ -544,7 +544,7 @@ export class ScopeValidator {
                     this.checkNamedArgCrossScopeConflict(funcName, callable, params, callExpr, file, scope);
                 } else if (isDottedGetExpression(callExpr.callee)) {
                     // Namespace function call (e.g. MyNs.myFunc(a: 1))
-                    const brsName = this.getNamespaceCallableBrsName(callExpr.callee, scope);
+                    const brsName = util.resolveNamespaceCallableName(callExpr.callee, scope);
                     if (!brsName) {
                         this.addDiagnostic({
                             ...DiagnosticMessages.namedArgsNotAllowedForUnknownFunction((callExpr.callee as DottedGetExpression).name.text),
@@ -597,7 +597,7 @@ export class ScopeValidator {
                 continue;
             }
 
-            const params = this.getClassConstructorParams(classLink.item, scope, containingNamespace);
+            const params = util.getClassConstructorParams(classLink.item, scope, containingNamespace);
             this.validateNamedArgCallArgs(callExpr, params, className, file);
         }
     }
@@ -760,40 +760,6 @@ export class ScopeValidator {
             return false;
         }
         return p1.every((p, i) => p.name.text.toLowerCase() === p2[i].name.text.toLowerCase());
-    }
-
-    /**
-     * If the callee is a dotted-get expression whose leftmost identifier is a known namespace,
-     * returns the BrightScript-flattened name (e.g. "MyNs_myFunc"). Otherwise returns undefined.
-     */
-    private getNamespaceCallableBrsName(callee: DottedGetExpression, scope: Scope): string | undefined {
-        const parts = util.getAllDottedGetParts(callee);
-        if (!parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
-            return undefined;
-        }
-        return parts.map(p => p.text).join('_');
-    }
-
-    /**
-     * Walk the class and its ancestor chain to find the first constructor's parameter list.
-     * Returns an empty array if no constructor is defined anywhere in the hierarchy.
-     */
-    private getClassConstructorParams(classStmt: ClassStatement, scope: Scope, containingNamespace: string | undefined): FunctionParameterExpression[] {
-        let stmt: ClassStatement | undefined = classStmt;
-        while (stmt) {
-            const ctor = stmt.body.find(
-                s => (s as MethodStatement)?.name?.text?.toLowerCase() === 'new'
-            ) as MethodStatement | undefined;
-            if (ctor) {
-                return ctor.func.parameters;
-            }
-            if (!stmt.parentClassName) {
-                break;
-            }
-            const parentName = stmt.parentClassName.getName(ParseMode.BrighterScript);
-            stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
-        }
-        return [];
     }
 
     /**

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -525,7 +525,11 @@ export class ScopeValidator {
      */
     private validateNamedArgCallArgs(callExpr: { args: Expression[]; callee: Expression; openingParen?: { range: any } }, params: FunctionParameterExpression[], funcName: string, file: BrsFile) {
         const assignedParams = new Set<number>();
+        const minParams = params.filter(p => !p.defaultValue).length;
+        const maxParams = params.length;
+        const hasTooManyArgs = callExpr.args.length > maxParams;
         let seenNamedArg = false;
+        let expectedParamIdx = 0;
         let hasError = false;
 
         for (const arg of callExpr.args) {
@@ -539,10 +543,10 @@ export class ScopeValidator {
                     hasError = true;
                     continue;
                 }
-                const idx = assignedParams.size;
-                if (idx < params.length) {
-                    assignedParams.add(idx);
+                if (expectedParamIdx < params.length) {
+                    assignedParams.add(expectedParamIdx);
                 }
+                expectedParamIdx++;
             } else {
                 seenNamedArg = true;
                 const namedArg = arg as NamedArgumentExpression;
@@ -569,7 +573,18 @@ export class ScopeValidator {
                     continue;
                 }
 
+                if (paramIdx < expectedParamIdx) {
+                    this.addDiagnostic({
+                        ...DiagnosticMessages.namedArgOutOfOrder(namedArg.name.text),
+                        range: namedArg.name.range,
+                        file: file
+                    });
+                    hasError = true;
+                    continue;
+                }
+
                 assignedParams.add(paramIdx);
+                expectedParamIdx = paramIdx + 1;
             }
         }
 
@@ -577,11 +592,21 @@ export class ScopeValidator {
             return;
         }
 
+        if (hasTooManyArgs) {
+            this.addDiagnostic({
+                ...DiagnosticMessages.mismatchArgumentCount(
+                    minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,
+                    callExpr.args.length
+                ),
+                range: callExpr.callee.range,
+                file: file
+            });
+            return;
+        }
+
         // Validate all required params are provided
         for (let i = 0; i < params.length; i++) {
             if (!assignedParams.has(i) && !params[i].defaultValue) {
-                const minParams = params.filter(p => !p.defaultValue).length;
-                const maxParams = params.length;
                 this.addDiagnostic({
                     ...DiagnosticMessages.mismatchArgumentCount(
                         minParams === maxParams ? maxParams : `${minParams}-${maxParams}`,

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -4659,6 +4659,51 @@ describe('BrsFile', () => {
         }]);
     });
 
+    it('warns on duplicate parameter names in a function', () => {
+        program.setFile('source/main.bs', `
+            function test(a, b, a)
+            end function
+        `);
+        program.validate();
+        expectDiagnostics(program, [{
+            ...DiagnosticMessages.duplicateFunctionParameter('a'),
+            range: util.createRange(1, 32, 1, 33)
+        }]);
+    });
+
+    it('warns on duplicate parameter names in a sub', () => {
+        program.setFile('source/main.bs', `
+            sub test(name as string, name as string)
+            end sub
+        `);
+        program.validate();
+        expectDiagnostics(program, [{
+            ...DiagnosticMessages.duplicateFunctionParameter('name'),
+            range: util.createRange(1, 37, 1, 41)
+        }]);
+    });
+
+    it('does not warn when all parameter names are unique', () => {
+        program.setFile('source/main.bs', `
+            function test(a, b, c)
+            end function
+        `);
+        program.validate();
+        expectZeroDiagnostics(program);
+    });
+
+    it('duplicate parameter check is case-insensitive', () => {
+        program.setFile('source/main.bs', `
+            function test(myParam, MyParam)
+            end function
+        `);
+        program.validate();
+        expectDiagnostics(program, [{
+            ...DiagnosticMessages.duplicateFunctionParameter('MyParam'),
+            range: util.createRange(1, 35, 1, 42)
+        }]);
+    });
+
     describe('getClosestExpression', () => {
         it('returns undefined for missing Position', () => {
             const file = program.setFile<BrsFile>('source/main.bs', `

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -23,7 +23,7 @@ import { standardizePath as s, util } from '../util';
 import { BrsTranspileState } from '../parser/BrsTranspileState';
 import { Preprocessor } from '../preprocessor/Preprocessor';
 import { serializeError } from 'serialize-error';
-import { isCallExpression, isMethodStatement, isClassStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isImportStatement, isFieldStatement, isEnumStatement, isConstStatement } from '../astUtils/reflection';
+import { isCallExpression, isMethodStatement, isClassStatement, isDottedGetExpression, isFunctionExpression, isFunctionStatement, isFunctionType, isLiteralExpression, isNamespaceStatement, isStringType, isVariableExpression, isImportStatement, isFieldStatement, isEnumStatement, isConstStatement, isNamedArgumentExpression } from '../astUtils/reflection';
 import type { BscType } from '../types/BscType';
 import { createVisitor, WalkMode } from '../astUtils/visitors';
 import type { DependencyGraph } from '../DependencyGraph';
@@ -658,33 +658,35 @@ export class BrsFile {
                 let args = [] as CallableArg[];
                 //TODO convert if stmts to use instanceof instead
                 for (let arg of expression.args as any) {
+                    // For named arguments, delegate to the inner value expression for type analysis
+                    const innerArg = isNamedArgumentExpression(arg) ? arg.value : arg;
 
                     //is a literal parameter value
-                    if (isLiteralExpression(arg)) {
+                    if (isLiteralExpression(innerArg)) {
                         args.push({
                             range: arg.range,
-                            type: arg.type,
-                            text: arg.token.text,
+                            type: innerArg.type,
+                            text: innerArg.token.text,
                             expression: arg,
                             typeToken: undefined
                         });
 
                         //is variable being passed into argument
-                    } else if (arg.name) {
+                    } else if (innerArg.name) {
                         args.push({
                             range: arg.range,
                             //TODO - look up the data type of the actual variable
                             type: new DynamicType(),
-                            text: arg.name.text,
+                            text: innerArg.name.text,
                             expression: arg,
                             typeToken: undefined
                         });
 
-                    } else if (arg.value) {
+                    } else if (innerArg.value) {
                         let text = '';
                         /* istanbul ignore next: TODO figure out why value is undefined sometimes */
-                        if (arg.value.value) {
-                            text = arg.value.value.toString();
+                        if (innerArg.value.value) {
+                            text = innerArg.value.value.toString();
                         }
                         let callableArg = {
                             range: arg.range,

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -90,12 +90,6 @@ export class CallExpression extends Expression {
     public readonly range: Range | undefined;
 
     /**
-     * When named arguments are used and successfully resolved during validation, this holds the
-     * positional-ordered argument list used for transpilation. If undefined, `args` is used directly.
-     */
-    public resolvedArgs?: Expression[];
-
-    /**
      * Get the name of the wrapping namespace (if it exists)
      * @deprecated use `.findAncestor(isNamespaceStatement)` instead.
      */
@@ -116,15 +110,12 @@ export class CallExpression extends Expression {
         result.push(
             state.transpileToken(this.openingParen)
         );
-        // Use resolvedArgs when named arguments have been reordered during validation,
-        // otherwise fall back to the original args list
-        const argsToTranspile = this.resolvedArgs ?? this.args;
-        for (let i = 0; i < argsToTranspile.length; i++) {
+        for (let i = 0; i < this.args.length; i++) {
             //add comma between args
             if (i > 0) {
                 result.push(', ');
             }
-            let arg = argsToTranspile[i];
+            let arg = this.args[i];
             result.push(...arg.transpile(state));
         }
         if (this.closingParen) {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -90,6 +90,12 @@ export class CallExpression extends Expression {
     public readonly range: Range | undefined;
 
     /**
+     * When named arguments are used and successfully resolved during validation, this holds the
+     * positional-ordered argument list used for transpilation. If undefined, `args` is used directly.
+     */
+    public resolvedArgs?: Expression[];
+
+    /**
      * Get the name of the wrapping namespace (if it exists)
      * @deprecated use `.findAncestor(isNamespaceStatement)` instead.
      */
@@ -110,12 +116,15 @@ export class CallExpression extends Expression {
         result.push(
             state.transpileToken(this.openingParen)
         );
-        for (let i = 0; i < this.args.length; i++) {
+        // Use resolvedArgs when named arguments have been reordered during validation,
+        // otherwise fall back to the original args list
+        const argsToTranspile = this.resolvedArgs ?? this.args;
+        for (let i = 0; i < argsToTranspile.length; i++) {
             //add comma between args
             if (i > 0) {
                 result.push(', ');
             }
-            let arg = this.args[i];
+            let arg = argsToTranspile[i];
             result.push(...arg.transpile(state));
         }
         if (this.closingParen) {
@@ -142,6 +151,43 @@ export class CallExpression extends Expression {
                 this.args?.map(e => e?.clone())
             ),
             ['callee', 'args']
+        );
+    }
+}
+
+export class NamedArgumentExpression extends Expression {
+    constructor(
+        readonly name: Identifier,
+        readonly colon: Token,
+        readonly value: Expression
+    ) {
+        super();
+        this.range = util.createBoundingRange(this.name, this.colon, this.value);
+    }
+
+    public readonly range: Range | undefined;
+
+    transpile(state: BrsTranspileState) {
+        // Named arguments are resolved to positional order during validation.
+        // If reached during transpile (e.g. for an unresolvable call), emit the value only.
+        return this.value.transpile(state);
+    }
+
+    walk(visitor: WalkVisitor, options: WalkOptions) {
+        // eslint-disable-next-line no-bitwise
+        if (options.walkMode & InternalWalkMode.walkExpressions) {
+            walk(this, 'value', visitor, options);
+        }
+    }
+
+    public clone() {
+        return this.finalizeClone(
+            new NamedArgumentExpression(
+                util.cloneToken(this.name),
+                util.cloneToken(this.colon),
+                this.value?.clone()
+            ),
+            ['value']
         );
     }
 }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -90,7 +90,8 @@ import {
     TypeCastExpression,
     UnaryExpression,
     VariableExpression,
-    XmlAttributeGetExpression
+    XmlAttributeGetExpression,
+    NamedArgumentExpression
 } from './Expression';
 import type { Diagnostic, Range } from 'vscode-languageserver';
 import type { Logger } from '../logging';
@@ -2777,7 +2778,20 @@ export class Parser {
                     throw this.lastDiagnosticAsError();
                 }
                 try {
-                    args.push(this.expression());
+                    // In BrighterScript mode, detect named argument syntax: `paramName: value`
+                    if (
+                        this.options.mode === ParseMode.BrighterScript &&
+                        this.checkAny(TokenKind.Identifier, ...this.allowedLocalIdentifiers) &&
+                        this.checkNext(TokenKind.Colon)
+                    ) {
+                        const name = this.advance() as Identifier;
+                        name.kind = TokenKind.Identifier;
+                        const colon = this.advance();
+                        const value = this.expression();
+                        args.push(new NamedArgumentExpression(name, colon, value));
+                    } else {
+                        args.push(this.expression());
+                    }
                 } catch (error) {
                     this.rethrowNonDiagnosticError(error);
                     // we were unable to get an expression, so don't continue

--- a/src/parser/tests/expression/NamedArgument.spec.ts
+++ b/src/parser/tests/expression/NamedArgument.spec.ts
@@ -1,0 +1,270 @@
+import { expect } from '../../../chai-config.spec';
+import { Program } from '../../../Program';
+import { ParseMode, Parser } from '../../Parser';
+import { DiagnosticMessages } from '../../../DiagnosticMessages';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics, getTestTranspile, rootDir } from '../../../testHelpers.spec';
+import { isNamedArgumentExpression } from '../../../astUtils/reflection';
+import type { ExpressionStatement } from '../../Statement';
+import type { CallExpression } from '../../Expression';
+
+describe('named argument expressions', () => {
+
+    describe('parsing', () => {
+        it('parses a single named argument', () => {
+            const { statements, diagnostics } = Parser.parse(
+                'myFunc(paramOne: true)',
+                { mode: ParseMode.BrighterScript }
+            );
+            expectZeroDiagnostics({ diagnostics: diagnostics });
+            const call = (statements[0] as ExpressionStatement).expression as CallExpression;
+            expect(call.args).to.be.lengthOf(1);
+            expect(isNamedArgumentExpression(call.args[0])).to.be.true;
+            expect((call.args[0] as any).name.text).to.equal('paramOne');
+        });
+
+        it('parses mixed positional and named arguments', () => {
+            const { statements, diagnostics } = Parser.parse(
+                'myFunc(first, paramThree: true)',
+                { mode: ParseMode.BrighterScript }
+            );
+            expectZeroDiagnostics({ diagnostics: diagnostics });
+            const call = (statements[0] as ExpressionStatement).expression as CallExpression;
+            expect(call.args).to.be.lengthOf(2);
+            expect(isNamedArgumentExpression(call.args[0])).to.be.false;
+            expect(isNamedArgumentExpression(call.args[1])).to.be.true;
+        });
+
+        it('parses multiple named arguments', () => {
+            const { statements, diagnostics } = Parser.parse(
+                'myFunc(paramTwo: true, paramOne: false)',
+                { mode: ParseMode.BrighterScript }
+            );
+            expectZeroDiagnostics({ diagnostics: diagnostics });
+            const call = (statements[0] as ExpressionStatement).expression as CallExpression;
+            expect(call.args).to.be.lengthOf(2);
+            expect(isNamedArgumentExpression(call.args[0])).to.be.true;
+            expect(isNamedArgumentExpression(call.args[1])).to.be.true;
+        });
+
+        it('does not treat identifier:value as named arg in BrightScript mode', () => {
+            const { diagnostics } = Parser.parse(
+                'myFunc(paramOne: true)',
+                { mode: ParseMode.BrightScript }
+            );
+            // In BrightScript mode the colon is an unexpected token
+            expect(diagnostics.length).to.be.greaterThan(0);
+        });
+
+        it('accepts complex expressions as named arg values', () => {
+            const { statements, diagnostics } = Parser.parse(
+                'myFunc(count: 1 + 2, name: "hello")',
+                { mode: ParseMode.BrighterScript }
+            );
+            expectZeroDiagnostics({ diagnostics: diagnostics });
+            const call = (statements[0] as ExpressionStatement).expression as CallExpression;
+            expect(call.args).to.be.lengthOf(2);
+        });
+    });
+
+    describe('validation', () => {
+        let program: Program;
+
+        beforeEach(() => {
+            program = new Program({ rootDir: rootDir });
+        });
+
+        afterEach(() => {
+            program.dispose();
+        });
+
+        it('validates a correctly named argument call', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(excited: true, name: "Bob")
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('gives diagnostic for unknown named argument', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string)
+                end sub
+                sub main()
+                    greet(nope: "Bob")
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.unknownNamedArgument('nope', 'greet')
+            ]);
+        });
+
+        it('gives diagnostic for duplicate named argument', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string)
+                end sub
+                sub main()
+                    greet(name: "Bob", name: "Alice")
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.namedArgDuplicate('name')
+            ]);
+        });
+
+        it('gives diagnostic for positional arg after named arg', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(name: "Bob", true)
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.positionalArgAfterNamedArg()
+            ]);
+        });
+
+        it('gives diagnostic for named arg to unknown function', () => {
+            program.setFile('source/main.bs', `
+                sub main()
+                    unknownFunc(param: true)
+                end sub
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.namedArgsNotAllowedForUnknownFunction('unknownFunc')
+            ]);
+        });
+
+        it('gives diagnostic for missing required parameter', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(excited: true)
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.mismatchArgumentCount('2', 1)
+            ]);
+        });
+
+        it('allows skipping middle optional params', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string, title = "Mr", excited = false)
+                end sub
+                sub main()
+                    greet(name: "Bob", excited: true)
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+    });
+
+    describe('transpilation', () => {
+        let program: Program;
+        let testTranspile = getTestTranspile(() => [program, rootDir]);
+
+        beforeEach(() => {
+            program = new Program({ rootDir: rootDir });
+        });
+
+        afterEach(() => {
+            program.dispose();
+        });
+
+        it('reorders named args to positional order', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(excited: true, name: "Bob")
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                sub main()
+                    greet("Bob", true)
+                end sub
+            `);
+        });
+
+        it('handles mixed positional and named args', () => {
+            testTranspile(`
+                sub greet(name as string, title as string, excited as boolean)
+                end sub
+                sub main()
+                    greet("Bob", excited: true, title: "Mr")
+                end sub
+            `, `
+                sub greet(name as string, title as string, excited as boolean)
+                end sub
+
+                sub main()
+                    greet("Bob", "Mr", true)
+                end sub
+            `);
+        });
+
+        it('fills in default value for skipped middle optional param', () => {
+            testTranspile(`
+                sub greet(name as string, title = "Mr", excited = false)
+                end sub
+                sub main()
+                    greet(name: "Bob", excited: true)
+                end sub
+            `, `
+                sub greet(name as string, title = "Mr", excited = false)
+                end sub
+
+                sub main()
+                    greet("Bob", "Mr", true)
+                end sub
+            `);
+        });
+
+        it('fills in invalid for skipped middle optional param with no default', () => {
+            testTranspile(`
+                sub greet(name as string, title = invalid, excited = false)
+                end sub
+                sub main()
+                    greet(name: "Bob", excited: true)
+                end sub
+            `, `
+                sub greet(name as string, title = invalid, excited = false)
+                end sub
+
+                sub main()
+                    greet("Bob", invalid, true)
+                end sub
+            `);
+        });
+
+        it('does not reorder when all args are positional', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet("Bob", true)
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                sub main()
+                    greet("Bob", true)
+                end sub
+            `);
+        });
+    });
+});

--- a/src/parser/tests/expression/NamedArgument.spec.ts
+++ b/src/parser/tests/expression/NamedArgument.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '../../../chai-config.spec';
 import { Program } from '../../../Program';
 import { ParseMode, Parser } from '../../Parser';
 import { DiagnosticMessages } from '../../../DiagnosticMessages';
-import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics, getTestTranspile, rootDir } from '../../../testHelpers.spec';
+import { expectDiagnostics, expectDiagnosticsIncludes, expectZeroDiagnostics, getTestTranspile, rootDir, trim } from '../../../testHelpers.spec';
 import { isNamedArgumentExpression } from '../../../astUtils/reflection';
 import type { ExpressionStatement } from '../../Statement';
 import type { CallExpression } from '../../Expression';
@@ -167,6 +167,195 @@ describe('named argument expressions', () => {
             `);
             program.validate();
             expectZeroDiagnostics(program);
+        });
+
+        describe('namespace calls', () => {
+            it('validates a correctly named argument call to a namespace function', () => {
+                program.setFile('source/main.bs', `
+                    namespace MyNs
+                        sub greet(name as string, excited as boolean)
+                        end sub
+                    end namespace
+                    sub main()
+                        MyNs.greet(excited: true, name: "Bob")
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('gives diagnostic for unknown named argument on a namespace function', () => {
+                program.setFile('source/main.bs', `
+                    namespace MyNs
+                        sub greet(name as string)
+                        end sub
+                    end namespace
+                    sub main()
+                        MyNs.greet(nope: "Bob")
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.unknownNamedArgument('nope', 'MyNs_greet')
+                ]);
+            });
+
+            it('gives diagnostic for named args on a non-namespace dotted call', () => {
+                program.setFile('source/main.bs', `
+                    sub main()
+                        obj = {}
+                        obj.method(name: "Bob")
+                    end sub
+                `);
+                program.validate();
+                expectDiagnosticsIncludes(program, [
+                    DiagnosticMessages.namedArgsNotAllowedForUnknownFunction('method')
+                ]);
+            });
+        });
+
+        describe('constructor calls', () => {
+            it('validates correctly named argument call to a class constructor', () => {
+                program.setFile('source/main.bs', `
+                    class Point
+                        x as integer
+                        y as integer
+                        function new(x as integer, y as integer)
+                            m.x = x
+                            m.y = y
+                        end function
+                    end class
+                    sub main()
+                        p = new Point(y: 2, x: 1)
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('gives diagnostic for unknown named argument on a constructor', () => {
+                program.setFile('source/main.bs', `
+                    class Point
+                        x as integer
+                        y as integer
+                        function new(x as integer, y as integer)
+                        end function
+                    end class
+                    sub main()
+                        p = new Point(z: 99)
+                    end sub
+                `);
+                program.validate();
+                expectDiagnosticsIncludes(program, [
+                    DiagnosticMessages.unknownNamedArgument('z', 'Point')
+                ]);
+            });
+
+            it('gives diagnostic for missing required constructor parameter', () => {
+                program.setFile('source/main.bs', `
+                    class Point
+                        x as integer
+                        y as integer
+                        function new(x as integer, y as integer)
+                        end function
+                    end class
+                    sub main()
+                        p = new Point(x: 1)
+                    end sub
+                `);
+                program.validate();
+                expectDiagnosticsIncludes(program, [
+                    DiagnosticMessages.mismatchArgumentCount('2', 1)
+                ]);
+            });
+
+            it('uses inherited constructor params when subclass has no constructor', () => {
+                program.setFile('source/main.bs', `
+                    class Shape
+                        color as string
+                        function new(color as string)
+                            m.color = color
+                        end function
+                    end class
+                    class Circle extends Shape
+                    end class
+                    sub main()
+                        c = new Circle(color: "red")
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+        });
+
+        describe('cross-scope conflict', () => {
+            it('gives diagnostic when same function name has different parameter signatures across component scopes', () => {
+                // shared.bs calls foo() with named args; each component imports a different
+                // definition of foo() with the same param names but in different order.
+                program.setFile('components/shared.bs', `
+                    sub callFoo()
+                        foo(b: 1, a: 2)
+                    end sub
+                `);
+                program.setFile('components/helperA.bs', `
+                    sub foo(a, b)
+                    end sub
+                `);
+                program.setFile('components/helperB.bs', `
+                    sub foo(b, a)
+                    end sub
+                `);
+                program.setFile('components/CompA.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompA" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperA.bs" />
+                    </component>
+                `);
+                program.setFile('components/CompB.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompB" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperB.bs" />
+                    </component>
+                `);
+                program.validate();
+                expectDiagnosticsIncludes(program, [
+                    DiagnosticMessages.namedArgsCrossScopeConflict('foo')
+                ]);
+            });
+
+            it('does not give cross-scope diagnostic when all scopes agree on the parameter signature', () => {
+                program.setFile('components/shared.bs', `
+                    sub callFoo()
+                        foo(b: 1, a: 2)
+                    end sub
+                `);
+                program.setFile('components/helperA.bs', `
+                    sub foo(a, b)
+                    end sub
+                `);
+                program.setFile('components/helperB.bs', `
+                    sub foo(a, b)
+                    end sub
+                `);
+                program.setFile('components/CompA.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompA" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperA.bs" />
+                    </component>
+                `);
+                program.setFile('components/CompB.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompB" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperB.bs" />
+                    </component>
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
         });
     });
 
@@ -1024,6 +1213,187 @@ describe('named argument expressions', () => {
                     greet(__bsArgs0, false)
                 end sub
             `);
+        });
+
+        describe('namespace calls', () => {
+            it('reorders named args for a namespace function call', () => {
+                testTranspile(`
+                    namespace MyNs
+                        sub greet(name as string, excited as boolean)
+                        end sub
+                    end namespace
+                    sub main()
+                        MyNs.greet(excited: true, name: "Bob")
+                    end sub
+                `, `
+                    sub MyNs_greet(name as string, excited as boolean)
+                    end sub
+
+                    sub main()
+                        MyNs_greet("Bob", true)
+                    end sub
+                `);
+            });
+
+            it('hoists complex args for a namespace function call', () => {
+                testTranspile(`
+                    namespace MyNs
+                        sub greet(name as string, excited as boolean)
+                        end sub
+                    end namespace
+                    function getName() as string
+                        return "Bob"
+                    end function
+                    sub main()
+                        MyNs.greet(excited: true, name: getName())
+                    end sub
+                `, `
+                    sub MyNs_greet(name as string, excited as boolean)
+                    end sub
+
+                    function getName() as string
+                        return "Bob"
+                    end function
+
+                    sub main()
+                        __bsArgs0 = getName()
+                        MyNs_greet(__bsArgs0, true)
+                    end sub
+                `);
+            });
+        });
+
+        describe('constructor calls', () => {
+            it('reorders named args for a constructor call', () => {
+                testTranspile(`
+                    class Point
+                        x as integer
+                        y as integer
+                        function new(x as integer, y as integer)
+                            m.x = x
+                            m.y = y
+                        end function
+                    end class
+                    sub main()
+                        p = new Point(y: 2, x: 1)
+                    end sub
+                `, `
+                    function __Point_method_new(x as integer, y as integer)
+                        m.x = invalid
+                        m.y = invalid
+                        m.x = x
+                        m.y = y
+                    end function
+                    function __Point_builder()
+                        instance = {}
+                        instance.new = __Point_method_new
+                        return instance
+                    end function
+                    function Point(x as integer, y as integer)
+                        instance = __Point_builder()
+                        instance.new(x, y)
+                        return instance
+                    end function
+
+                    sub main()
+                        p = Point(1, 2)
+                    end sub
+                `);
+            });
+
+            it('hoists complex args for a constructor call', () => {
+                testTranspile(`
+                    class Point
+                        x as integer
+                        y as integer
+                        function new(x as integer, y as integer)
+                            m.x = x
+                            m.y = y
+                        end function
+                    end class
+                    function getY() as integer
+                        return 2
+                    end function
+                    sub main()
+                        p = new Point(y: getY(), x: 1)
+                    end sub
+                `, `
+                    function __Point_method_new(x as integer, y as integer)
+                        m.x = invalid
+                        m.y = invalid
+                        m.x = x
+                        m.y = y
+                    end function
+                    function __Point_builder()
+                        instance = {}
+                        instance.new = __Point_method_new
+                        return instance
+                    end function
+                    function Point(x as integer, y as integer)
+                        instance = __Point_builder()
+                        instance.new(x, y)
+                        return instance
+                    end function
+
+                    function getY() as integer
+                        return 2
+                    end function
+
+                    sub main()
+                        __bsArgs0 = getY()
+                        p = Point(1, __bsArgs0)
+                    end sub
+                `);
+            });
+
+            it('uses inherited constructor params when subclass has no constructor', () => {
+                testTranspile(`
+                    class Shape
+                        color as string
+                        function new(color as string)
+                            m.color = color
+                        end function
+                    end class
+                    class Circle extends Shape
+                    end class
+                    sub main()
+                        c = new Circle(color: "red")
+                    end sub
+                `, `
+                    function __Shape_method_new(color as string)
+                        m.color = invalid
+                        m.color = color
+                    end function
+                    function __Shape_builder()
+                        instance = {}
+                        instance.new = __Shape_method_new
+                        return instance
+                    end function
+                    function Shape(color as string)
+                        instance = __Shape_builder()
+                        instance.new(color)
+                        return instance
+                    end function
+                    sub __Circle_method_new(color as string)
+                        m.super0_new(color)
+                    end sub
+                    function __Circle_builder()
+                        instance = __Shape_builder()
+                        instance.super0_new = instance.new
+                        instance.new = __Circle_method_new
+                        return instance
+                    end function
+                    function Circle(color as string)
+                        instance = __Circle_builder()
+                        instance.new(color)
+                        return instance
+                    end function
+
+                    sub main()
+                        c = Circle("red")
+                    end sub
+                `);
+            });
         });
     });
 });

--- a/src/parser/tests/expression/NamedArgument.spec.ts
+++ b/src/parser/tests/expression/NamedArgument.spec.ts
@@ -325,6 +325,46 @@ describe('named argument expressions', () => {
                 ]);
             });
 
+            it('includes relatedInformation pointing to each conflicting function definition', () => {
+                program.setFile('components/shared.bs', `
+                    sub callFoo()
+                        foo(b: 1, a: 2)
+                    end sub
+                `);
+                program.setFile('components/helperA.bs', `
+                    sub foo(a, b)
+                    end sub
+                `);
+                program.setFile('components/helperB.bs', `
+                    sub foo(b, a)
+                    end sub
+                `);
+                program.setFile('components/CompA.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompA" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperA.bs" />
+                    </component>
+                `);
+                program.setFile('components/CompB.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="CompB" extends="Scene">
+                        <script type="text/brightscript" uri="shared.bs" />
+                        <script type="text/brightscript" uri="helperB.bs" />
+                    </component>
+                `);
+                program.validate();
+                expectDiagnosticsIncludes(program, [
+                    {
+                        ...DiagnosticMessages.namedArgsCrossScopeConflict('foo'),
+                        relatedInformation: [
+                            { message: `'foo' defined in scope 'components/CompA.xml'` },
+                            { message: `'foo' defined in scope 'components/CompB.xml'` }
+                        ]
+                    }
+                ]);
+            });
+
             it('does not give cross-scope diagnostic when all scopes agree on the parameter signature', () => {
                 program.setFile('components/shared.bs', `
                     sub callFoo()

--- a/src/parser/tests/expression/NamedArgument.spec.ts
+++ b/src/parser/tests/expression/NamedArgument.spec.ts
@@ -266,5 +266,764 @@ describe('named argument expressions', () => {
                 end sub
             `);
         });
+
+        it('does not hoist variable or literal named args — just reorders them', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    myName = "Bob"
+                    greet(excited: true, name: myName)
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                sub main()
+                    myName = "Bob"
+                    greet(myName, true)
+                end sub
+            `);
+        });
+
+        it('hoists a complex named arg expression to preserve evaluation order', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    greet(excited: true, name: getName())
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    __bsArgs0 = getName()
+                    greet(__bsArgs0, true)
+                end sub
+            `);
+        });
+
+        it('hoists multiple complex named args in written order', () => {
+            testTranspile(`
+                sub greet(name as string, greeting as string)
+                end sub
+                function getName() as string
+                    return "Bob"
+                end function
+                function getGreeting() as string
+                    return "Hello"
+                end function
+                sub main()
+                    greet(greeting: getGreeting(), name: getName())
+                end sub
+            `, `
+                sub greet(name as string, greeting as string)
+                end sub
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                function getGreeting() as string
+                    return "Hello"
+                end function
+
+                sub main()
+                    __bsArgs0 = getGreeting()
+                    __bsArgs1 = getName()
+                    greet(__bsArgs1, __bsArgs0)
+                end sub
+            `);
+        });
+
+        it('hoists before an if-statement when the call is in the condition', () => {
+            testTranspile(`
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    if shouldGreet(excited: true, name: getName()) then
+                        print "greeting"
+                    end if
+                end sub
+            `, `
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    __bsArgs0 = getName()
+                    if shouldGreet(__bsArgs0, true) then
+                        print "greeting"
+                    end if
+                end sub
+            `);
+        });
+
+        it('wraps in an IIFE for an else-if condition to preserve evaluation order', () => {
+            // Hoisting before the outer `if` would be wrong — `getName()` should only be
+            // called if the else-if branch is actually reached. An IIFE (same pattern as
+            // ternary for complex consequents) evaluates args in written order and passes
+            // them to the function in positional order, all inline.
+            testTranspile(`
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    if false then
+                        print "no"
+                    else if shouldGreet(excited: true, name: getName()) then
+                        print "greeting"
+                    end if
+                end sub
+            `, `
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    if false then
+                        print "no"
+                    else if (function(__bsArg0, __bsArg1)
+                            return shouldGreet(__bsArg1, __bsArg0)
+                        end function)(true, getName()) then
+                        print "greeting"
+                    end if
+                end sub
+            `);
+        });
+
+        it('hoists before the for-statement when the call is in the to-expression', () => {
+            testTranspile(`
+                function getEnd(fromVal as integer, toVal as integer) as integer
+                    return fromVal + toVal
+                end function
+                function getLimit() as integer
+                    return 10
+                end function
+                sub main()
+                    for i = 0 to getEnd(toVal: getLimit(), fromVal: 0)
+                        print i
+                    end for
+                end sub
+            `, `
+                function getEnd(fromVal as integer, toVal as integer) as integer
+                    return fromVal + toVal
+                end function
+
+                function getLimit() as integer
+                    return 10
+                end function
+
+                sub main()
+                    __bsArgs0 = getLimit()
+                    for i = 0 to getEnd(0, __bsArgs0)
+                        print i
+                    end for
+                end sub
+            `);
+        });
+
+        it('hoists inside the loop body when the call is inside a for loop', () => {
+            testTranspile(`
+                sub process(value as integer, factor as integer)
+                end sub
+                function getFactor() as integer
+                    return 2
+                end function
+                sub main()
+                    for i = 0 to 5
+                        process(factor: getFactor(), value: i)
+                    end for
+                end sub
+            `, `
+                sub process(value as integer, factor as integer)
+                end sub
+
+                function getFactor() as integer
+                    return 2
+                end function
+
+                sub main()
+                    for i = 0 to 5
+                        __bsArgs0 = getFactor()
+                        process(i, __bsArgs0)
+                    end for
+                end sub
+            `);
+        });
+
+        it('hoists before the outer call when named-arg call is nested inside another call', () => {
+            testTranspile(`
+                sub outer(value as string)
+                end sub
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    outer(inner(name: getName(), greeting: "Hello"))
+                end sub
+            `, `
+                sub outer(value as string)
+                end sub
+
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    __bsArgs0 = getName()
+                    outer(inner("Hello", __bsArgs0))
+                end sub
+            `);
+        });
+
+        it('ternary as named arg value is hoisted then rewritten to if-statement', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(name: "Bob", excited: condition ? true : false)
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                sub main()
+                    if condition then
+                        __bsArgs0 = true
+                    else
+                        __bsArgs0 = false
+                    end if
+                    greet("Bob", __bsArgs0)
+                end sub
+            `);
+        });
+
+        it('named arg call with only literals used as ternary condition becomes an if-statement', () => {
+            testTranspile(`
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+                sub main()
+                    result = shouldGreet(excited: true, name: "Bob") ? "yes" : "no"
+                end sub
+            `, `
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+
+                sub main()
+                    if shouldGreet("Bob", true) then
+                        result = "yes"
+                    else
+                        result = "no"
+                    end if
+                end sub
+            `);
+        });
+
+        it('complex named arg call in ternary consequent wraps in IIFE to avoid unconditional evaluation', () => {
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    result = condition ? inner(name: getName(), greeting: "Hello") : "fallback"
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    if condition then
+                        result = (function(__bsArg0, __bsArg1)
+                                return inner(__bsArg1, __bsArg0)
+                            end function)(getName(), "Hello")
+                    else
+                        result = "fallback"
+                    end if
+                end sub
+            `);
+        });
+
+        it('complex named arg call in ternary alternate wraps in IIFE to avoid unconditional evaluation', () => {
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    result = condition ? "fallback" : inner(name: getName(), greeting: "Hello")
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    if condition then
+                        result = "fallback"
+                    else
+                        result = (function(__bsArg0, __bsArg1)
+                                return inner(__bsArg1, __bsArg0)
+                            end function)(getName(), "Hello")
+                    end if
+                end sub
+            `);
+        });
+
+        it('named arg call (simple) used as value inside another named arg call', () => {
+            // inner has only literals — just reordered; outer hoists the inner call result
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                sub outer(value as string, flag as boolean)
+                end sub
+                sub main()
+                    outer(flag: true, value: inner(name: "Bob", greeting: "Hello"))
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                sub outer(value as string, flag as boolean)
+                end sub
+
+                sub main()
+                    __bsArgs0 = inner("Hello", "Bob")
+                    outer(__bsArgs0, true)
+                end sub
+            `);
+        });
+
+        it('named arg call (complex inner) used as value inside another named arg call wraps inner in IIFE', () => {
+            // inner has a complex arg — because the hoist statement for outer has no parent yet when
+            // inner is processed, canHoist is false and inner falls back to IIFE, which is correct:
+            // getGreeting() is evaluated inside the IIFE call, after outer's literal arg.
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                sub outer(value as string, flag as boolean)
+                end sub
+                function getGreeting() as string
+                    return "Hello"
+                end function
+                sub main()
+                    outer(flag: true, value: inner(name: "Bob", greeting: getGreeting()))
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                sub outer(value as string, flag as boolean)
+                end sub
+
+                function getGreeting() as string
+                    return "Hello"
+                end function
+
+                sub main()
+                    __bsArgs0 = (function(__bsArg0, __bsArg1)
+                            return inner(__bsArg1, __bsArg0)
+                        end function)("Bob", getGreeting())
+                    outer(__bsArgs0, true)
+                end sub
+            `);
+        });
+
+        it('both outer and inner named arg calls have complex args — outer written order is preserved', () => {
+            // outer written order: flag: getFlag() first, then value: inner(...)
+            // getFlag() is hoisted first, then the IIFE for inner (which calls getGreeting() lazily),
+            // ensuring getFlag() evaluates before getGreeting() as written.
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                sub outer(value as string, flag as boolean)
+                end sub
+                function getGreeting() as string
+                    return "Hello"
+                end function
+                function getFlag() as boolean
+                    return true
+                end function
+                sub main()
+                    outer(flag: getFlag(), value: inner(name: "Bob", greeting: getGreeting()))
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                sub outer(value as string, flag as boolean)
+                end sub
+
+                function getGreeting() as string
+                    return "Hello"
+                end function
+
+                function getFlag() as boolean
+                    return true
+                end function
+
+                sub main()
+                    __bsArgs0 = getFlag()
+                    __bsArgs1 = (function(__bsArg0, __bsArg1)
+                            return inner(__bsArg1, __bsArg0)
+                        end function)("Bob", getGreeting())
+                    outer(__bsArgs1, __bsArgs0)
+                end sub
+            `);
+        });
+
+        it('doubly-nested ternary with complex named arg in innermost branch uses IIFE', () => {
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                function getName() as string
+                    return "Bob"
+                end function
+                sub main()
+                    result = cond1 ? (cond2 ? inner(name: getName(), greeting: "Hello") : "alt1") : "alt2"
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub main()
+                    if cond1 then
+                        if cond2 then
+                            result = (function(__bsArg0, __bsArg1)
+                                    return inner(__bsArg1, __bsArg0)
+                                end function)(getName(), "Hello")
+                        else
+                            result = "alt1"
+                        end if
+                    else
+                        result = "alt2"
+                    end if
+                end sub
+            `);
+        });
+
+        it('three-level nested ternary with complex named arg in deepest branch', () => {
+            testTranspile(`
+                function inner(a as string, b as string) as string
+                    return a + b
+                end function
+                function getB() as string
+                    return "B"
+                end function
+                sub main()
+                    result = c1 ? (c2 ? (c3 ? inner(b: getB(), a: "A") : "d3") : "d2") : "d1"
+                end sub
+            `, `
+                function inner(a as string, b as string) as string
+                    return a + b
+                end function
+
+                function getB() as string
+                    return "B"
+                end function
+
+                sub main()
+                    if c1 then
+                        if c2 then
+                            if c3 then
+                                result = (function(__bsArg0, __bsArg1)
+                                        return inner(__bsArg1, __bsArg0)
+                                    end function)(getB(), "A")
+                            else
+                                result = "d3"
+                            end if
+                        else
+                            result = "d2"
+                        end if
+                    else
+                        result = "d1"
+                    end if
+                end sub
+            `);
+        });
+
+        it('named arg call in ternary branch inside else-if', () => {
+            testTranspile(`
+                function pick(a as string, b as string) as string
+                    return a
+                end function
+                function getA() as string
+                    return "A"
+                end function
+                sub main()
+                    if false then
+                        print "no"
+                    else if true then
+                        result = condition ? pick(b: getA(), a: "X") : "fallback"
+                    end if
+                end sub
+            `, `
+                function pick(a as string, b as string) as string
+                    return a
+                end function
+
+                function getA() as string
+                    return "A"
+                end function
+
+                sub main()
+                    if false then
+                        print "no"
+                    else if true then
+                        if condition then
+                            result = (function(__bsArg0, __bsArg1)
+                                    return pick(__bsArg1, __bsArg0)
+                                end function)(getA(), "X")
+                        else
+                            result = "fallback"
+                        end if
+                    end if
+                end sub
+            `);
+        });
+
+        it('outer variable used as named arg value in else-if is passed as IIFE arg, not a closure', () => {
+            // BrightScript has no closures. When an IIFE is needed (else-if context), outer
+            // variables must be passed as IIFE parameters — not referenced inside the body.
+            // Here myName becomes __bsArg1, passed in the invocation: (getExcited(), myName)
+            testTranspile(`
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+                function getExcited() as boolean
+                    return true
+                end function
+                sub main()
+                    myName = "Bob"
+                    if false then
+                        print "no"
+                    else if shouldGreet(excited: getExcited(), name: myName) then
+                        print "greeting"
+                    end if
+                end sub
+            `, `
+                function shouldGreet(name as string, excited as boolean) as boolean
+                    return true
+                end function
+
+                function getExcited() as boolean
+                    return true
+                end function
+
+                sub main()
+                    myName = "Bob"
+                    if false then
+                        print "no"
+                    else if (function(__bsArg0, __bsArg1)
+                            return shouldGreet(__bsArg1, __bsArg0)
+                        end function)(getExcited(), myName) then
+                        print "greeting"
+                    end if
+                end sub
+            `);
+        });
+
+        it('outer variable as named arg in ternary branch is passed as IIFE arg, not a closure', () => {
+            // myName is in the IIFE invocation list, not referenced inside the IIFE body directly.
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                function getGreeting() as string
+                    return "Hello"
+                end function
+                sub main()
+                    myName = "Bob"
+                    result = condition ? inner(name: myName, greeting: getGreeting()) : "fallback"
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                function getGreeting() as string
+                    return "Hello"
+                end function
+
+                sub main()
+                    myName = "Bob"
+                    if condition then
+                        result = (function(__bsArg0, __bsArg1)
+                                return inner(__bsArg1, __bsArg0)
+                            end function)(myName, getGreeting())
+                    else
+                        result = "fallback"
+                    end if
+                end sub
+            `);
+        });
+
+        it('outer variable in nested named arg call is passed as IIFE arg, not a closure', () => {
+            // myName flows into the inner IIFE invocation — never referenced inside any IIFE body.
+            testTranspile(`
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+                sub outer(value as string, flag as boolean)
+                end sub
+                function getGreeting() as string
+                    return "Hello"
+                end function
+                sub main()
+                    myName = "Bob"
+                    outer(flag: true, value: inner(name: myName, greeting: getGreeting()))
+                end sub
+            `, `
+                function inner(greeting as string, name as string) as string
+                    return greeting + " " + name
+                end function
+
+                sub outer(value as string, flag as boolean)
+                end sub
+
+                function getGreeting() as string
+                    return "Hello"
+                end function
+
+                sub main()
+                    myName = "Bob"
+                    __bsArgs0 = (function(__bsArg0, __bsArg1)
+                            return inner(__bsArg1, __bsArg0)
+                        end function)(myName, getGreeting())
+                    outer(__bsArgs0, true)
+                end sub
+            `);
+        });
+
+        it('outer variable mixed with positional arg in else-if IIFE — all passed as IIFE args', () => {
+            // Positional "Hello" and named greeting: myName are both IIFE args in written order,
+            // with getExcited() in between. No outer variable is referenced inside the IIFE body.
+            testTranspile(`
+                function greet(name as string, greeting as string, excited as boolean) as boolean
+                    return true
+                end function
+                function getExcited() as boolean
+                    return true
+                end function
+                sub main()
+                    myName = "Bob"
+                    if false then
+                        print "no"
+                    else if greet("Hello", excited: getExcited(), greeting: myName) then
+                        print "greeting"
+                    end if
+                end sub
+            `, `
+                function greet(name as string, greeting as string, excited as boolean) as boolean
+                    return true
+                end function
+
+                function getExcited() as boolean
+                    return true
+                end function
+
+                sub main()
+                    myName = "Bob"
+                    if false then
+                        print "no"
+                    else if (function(__bsArg0, __bsArg1, __bsArg2)
+                            return greet(__bsArg0, __bsArg2, __bsArg1)
+                        end function)("Hello", getExcited(), myName) then
+                        print "greeting"
+                    end if
+                end sub
+            `);
+        });
+
+        it('hoisting counter is scoped per function', () => {
+            testTranspile(`
+                sub greet(name as string, excited as boolean)
+                end sub
+                function getName() as string
+                    return "Bob"
+                end function
+                sub first()
+                    greet(excited: true, name: getName())
+                end sub
+                sub second()
+                    greet(excited: false, name: getName())
+                end sub
+            `, `
+                sub greet(name as string, excited as boolean)
+                end sub
+
+                function getName() as string
+                    return "Bob"
+                end function
+
+                sub first()
+                    __bsArgs0 = getName()
+                    greet(__bsArgs0, true)
+                end sub
+
+                sub second()
+                    __bsArgs0 = getName()
+                    greet(__bsArgs0, false)
+                end sub
+            `);
+        });
     });
 });

--- a/src/parser/tests/expression/NamedArgument.spec.ts
+++ b/src/parser/tests/expression/NamedArgument.spec.ts
@@ -82,7 +82,7 @@ describe('named argument expressions', () => {
                 sub greet(name as string, excited as boolean)
                 end sub
                 sub main()
-                    greet(excited: true, name: "Bob")
+                    greet(name: "Bob", excited: true)
                 end sub
             `);
             program.validate();
@@ -128,6 +128,20 @@ describe('named argument expressions', () => {
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.positionalArgAfterNamedArg()
+            ]);
+        });
+
+        it('gives diagnostic when named args are out of declaration order', () => {
+            program.setFile('source/main.bs', `
+                sub greet(name as string, excited as boolean)
+                end sub
+                sub main()
+                    greet(excited: true, name: "Bob")
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.namedArgOutOfOrder('name')
             ]);
         });
 
@@ -177,7 +191,7 @@ describe('named argument expressions', () => {
                         end sub
                     end namespace
                     sub main()
-                        MyNs.greet(excited: true, name: "Bob")
+                        MyNs.greet(name: "Bob", excited: true)
                     end sub
                 `);
                 program.validate();
@@ -226,7 +240,7 @@ describe('named argument expressions', () => {
                         end function
                     end class
                     sub main()
-                        p = new Point(y: 2, x: 1)
+                        p = new Point(x: 1, y: 2)
                     end sub
                 `);
                 program.validate();
@@ -294,7 +308,7 @@ describe('named argument expressions', () => {
                 // definition of foo() with the same param names but in different order.
                 program.setFile('components/shared.bs', `
                     sub callFoo()
-                        foo(b: 1, a: 2)
+                        foo(a: 2, b: 1)
                     end sub
                 `);
                 program.setFile('components/helperA.bs', `
@@ -328,7 +342,7 @@ describe('named argument expressions', () => {
             it('includes relatedInformation pointing to each conflicting function definition', () => {
                 program.setFile('components/shared.bs', `
                     sub callFoo()
-                        foo(b: 1, a: 2)
+                        foo(a: 2, b: 1)
                     end sub
                 `);
                 program.setFile('components/helperA.bs', `
@@ -368,7 +382,7 @@ describe('named argument expressions', () => {
             it('does not give cross-scope diagnostic when all scopes agree on the parameter signature', () => {
                 program.setFile('components/shared.bs', `
                     sub callFoo()
-                        foo(b: 1, a: 2)
+                        foo(a: 2, b: 1)
                     end sub
                 `);
                 program.setFile('components/helperA.bs', `
@@ -411,12 +425,12 @@ describe('named argument expressions', () => {
             program.dispose();
         });
 
-        it('reorders named args to positional order', () => {
+        it('transpiles in-order named args to positional args', () => {
             testTranspile(`
                 sub greet(name as string, excited as boolean)
                 end sub
                 sub main()
-                    greet(excited: true, name: "Bob")
+                    greet(name: "Bob", excited: true)
                 end sub
             `, `
                 sub greet(name as string, excited as boolean)
@@ -428,1012 +442,38 @@ describe('named argument expressions', () => {
             `);
         });
 
-        it('handles mixed positional and named args', () => {
+        it('fills skipped leading optional params', () => {
             testTranspile(`
-                sub greet(name as string, title as string, excited as boolean)
+                sub greet(name = "Unknown" as string, excited = false as boolean)
                 end sub
                 sub main()
-                    greet("Bob", excited: true, title: "Mr")
+                    greet(excited: true)
                 end sub
             `, `
-                sub greet(name as string, title as string, excited as boolean)
+                sub greet(name = "Unknown" as string, excited = false as boolean)
+                end sub
+
+                sub main()
+                    greet("Unknown", true)
+                end sub
+            `);
+        });
+
+        it('handles mixed positional and named args in declaration order', () => {
+            testTranspile(`
+                sub greet(name as string, title = "Mr" as string, excited = false as boolean)
+                end sub
+                sub main()
+                    greet("Bob", excited: true)
+                end sub
+            `, `
+                sub greet(name as string, title = "Mr" as string, excited = false as boolean)
                 end sub
 
                 sub main()
                     greet("Bob", "Mr", true)
                 end sub
             `);
-        });
-
-        it('fills in default value for skipped middle optional param', () => {
-            testTranspile(`
-                sub greet(name as string, title = "Mr", excited = false)
-                end sub
-                sub main()
-                    greet(name: "Bob", excited: true)
-                end sub
-            `, `
-                sub greet(name as string, title = "Mr", excited = false)
-                end sub
-
-                sub main()
-                    greet("Bob", "Mr", true)
-                end sub
-            `);
-        });
-
-        it('fills in invalid for skipped middle optional param with no default', () => {
-            testTranspile(`
-                sub greet(name as string, title = invalid, excited = false)
-                end sub
-                sub main()
-                    greet(name: "Bob", excited: true)
-                end sub
-            `, `
-                sub greet(name as string, title = invalid, excited = false)
-                end sub
-
-                sub main()
-                    greet("Bob", invalid, true)
-                end sub
-            `);
-        });
-
-        it('does not reorder when all args are positional', () => {
-            testTranspile(`
-                sub greet(name as string, excited as boolean)
-                end sub
-                sub main()
-                    greet("Bob", true)
-                end sub
-            `, `
-                sub greet(name as string, excited as boolean)
-                end sub
-
-                sub main()
-                    greet("Bob", true)
-                end sub
-            `);
-        });
-
-        it('does not hoist variable or literal named args — just reorders them', () => {
-            testTranspile(`
-                sub greet(name as string, excited as boolean)
-                end sub
-                sub main()
-                    myName = "Bob"
-                    greet(excited: true, name: myName)
-                end sub
-            `, `
-                sub greet(name as string, excited as boolean)
-                end sub
-
-                sub main()
-                    myName = "Bob"
-                    greet(myName, true)
-                end sub
-            `);
-        });
-
-        it('hoists a complex named arg expression to preserve evaluation order', () => {
-            testTranspile(`
-                sub greet(name as string, excited as boolean)
-                end sub
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    greet(excited: true, name: getName())
-                end sub
-            `, `
-                sub greet(name as string, excited as boolean)
-                end sub
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    __bsArgs0 = getName()
-                    greet(__bsArgs0, true)
-                end sub
-            `);
-        });
-
-        it('hoists multiple complex named args in written order', () => {
-            testTranspile(`
-                sub greet(name as string, greeting as string)
-                end sub
-                function getName() as string
-                    return "Bob"
-                end function
-                function getGreeting() as string
-                    return "Hello"
-                end function
-                sub main()
-                    greet(greeting: getGreeting(), name: getName())
-                end sub
-            `, `
-                sub greet(name as string, greeting as string)
-                end sub
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                function getGreeting() as string
-                    return "Hello"
-                end function
-
-                sub main()
-                    __bsArgs0 = getGreeting()
-                    __bsArgs1 = getName()
-                    greet(__bsArgs1, __bsArgs0)
-                end sub
-            `);
-        });
-
-        it('hoists before an if-statement when the call is in the condition', () => {
-            testTranspile(`
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    if shouldGreet(excited: true, name: getName()) then
-                        print "greeting"
-                    end if
-                end sub
-            `, `
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    __bsArgs0 = getName()
-                    if shouldGreet(__bsArgs0, true) then
-                        print "greeting"
-                    end if
-                end sub
-            `);
-        });
-
-        it('wraps in an IIFE for an else-if condition to preserve evaluation order', () => {
-            // Hoisting before the outer `if` would be wrong — `getName()` should only be
-            // called if the else-if branch is actually reached. An IIFE (same pattern as
-            // ternary for complex consequents) evaluates args in written order and passes
-            // them to the function in positional order, all inline.
-            testTranspile(`
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    if false then
-                        print "no"
-                    else if shouldGreet(excited: true, name: getName()) then
-                        print "greeting"
-                    end if
-                end sub
-            `, `
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    if false then
-                        print "no"
-                    else if (function(__bsArg0, __bsArg1)
-                            return shouldGreet(__bsArg1, __bsArg0)
-                        end function)(true, getName()) then
-                        print "greeting"
-                    end if
-                end sub
-            `);
-        });
-
-        it('hoists before the for-statement when the call is in the to-expression', () => {
-            testTranspile(`
-                function getEnd(fromVal as integer, toVal as integer) as integer
-                    return fromVal + toVal
-                end function
-                function getLimit() as integer
-                    return 10
-                end function
-                sub main()
-                    for i = 0 to getEnd(toVal: getLimit(), fromVal: 0)
-                        print i
-                    end for
-                end sub
-            `, `
-                function getEnd(fromVal as integer, toVal as integer) as integer
-                    return fromVal + toVal
-                end function
-
-                function getLimit() as integer
-                    return 10
-                end function
-
-                sub main()
-                    __bsArgs0 = getLimit()
-                    for i = 0 to getEnd(0, __bsArgs0)
-                        print i
-                    end for
-                end sub
-            `);
-        });
-
-        it('hoists inside the loop body when the call is inside a for loop', () => {
-            testTranspile(`
-                sub process(value as integer, factor as integer)
-                end sub
-                function getFactor() as integer
-                    return 2
-                end function
-                sub main()
-                    for i = 0 to 5
-                        process(factor: getFactor(), value: i)
-                    end for
-                end sub
-            `, `
-                sub process(value as integer, factor as integer)
-                end sub
-
-                function getFactor() as integer
-                    return 2
-                end function
-
-                sub main()
-                    for i = 0 to 5
-                        __bsArgs0 = getFactor()
-                        process(i, __bsArgs0)
-                    end for
-                end sub
-            `);
-        });
-
-        it('hoists before the outer call when named-arg call is nested inside another call', () => {
-            testTranspile(`
-                sub outer(value as string)
-                end sub
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    outer(inner(name: getName(), greeting: "Hello"))
-                end sub
-            `, `
-                sub outer(value as string)
-                end sub
-
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    __bsArgs0 = getName()
-                    outer(inner("Hello", __bsArgs0))
-                end sub
-            `);
-        });
-
-        it('ternary as named arg value is hoisted then rewritten to if-statement', () => {
-            testTranspile(`
-                sub greet(name as string, excited as boolean)
-                end sub
-                sub main()
-                    greet(name: "Bob", excited: condition ? true : false)
-                end sub
-            `, `
-                sub greet(name as string, excited as boolean)
-                end sub
-
-                sub main()
-                    if condition then
-                        __bsArgs0 = true
-                    else
-                        __bsArgs0 = false
-                    end if
-                    greet("Bob", __bsArgs0)
-                end sub
-            `);
-        });
-
-        it('named arg call with only literals used as ternary condition becomes an if-statement', () => {
-            testTranspile(`
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-                sub main()
-                    result = shouldGreet(excited: true, name: "Bob") ? "yes" : "no"
-                end sub
-            `, `
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-
-                sub main()
-                    if shouldGreet("Bob", true) then
-                        result = "yes"
-                    else
-                        result = "no"
-                    end if
-                end sub
-            `);
-        });
-
-        it('complex named arg call in ternary consequent wraps in IIFE to avoid unconditional evaluation', () => {
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    result = condition ? inner(name: getName(), greeting: "Hello") : "fallback"
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    if condition then
-                        result = (function(__bsArg0, __bsArg1)
-                                return inner(__bsArg1, __bsArg0)
-                            end function)(getName(), "Hello")
-                    else
-                        result = "fallback"
-                    end if
-                end sub
-            `);
-        });
-
-        it('complex named arg call in ternary alternate wraps in IIFE to avoid unconditional evaluation', () => {
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    result = condition ? "fallback" : inner(name: getName(), greeting: "Hello")
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    if condition then
-                        result = "fallback"
-                    else
-                        result = (function(__bsArg0, __bsArg1)
-                                return inner(__bsArg1, __bsArg0)
-                            end function)(getName(), "Hello")
-                    end if
-                end sub
-            `);
-        });
-
-        it('named arg call (simple) used as value inside another named arg call', () => {
-            // inner has only literals — just reordered; outer hoists the inner call result
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                sub outer(value as string, flag as boolean)
-                end sub
-                sub main()
-                    outer(flag: true, value: inner(name: "Bob", greeting: "Hello"))
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                sub outer(value as string, flag as boolean)
-                end sub
-
-                sub main()
-                    __bsArgs0 = inner("Hello", "Bob")
-                    outer(__bsArgs0, true)
-                end sub
-            `);
-        });
-
-        it('named arg call (complex inner) used as value inside another named arg call wraps inner in IIFE', () => {
-            // inner has a complex arg — because the hoist statement for outer has no parent yet when
-            // inner is processed, canHoist is false and inner falls back to IIFE, which is correct:
-            // getGreeting() is evaluated inside the IIFE call, after outer's literal arg.
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                sub outer(value as string, flag as boolean)
-                end sub
-                function getGreeting() as string
-                    return "Hello"
-                end function
-                sub main()
-                    outer(flag: true, value: inner(name: "Bob", greeting: getGreeting()))
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                sub outer(value as string, flag as boolean)
-                end sub
-
-                function getGreeting() as string
-                    return "Hello"
-                end function
-
-                sub main()
-                    __bsArgs0 = (function(__bsArg0, __bsArg1)
-                            return inner(__bsArg1, __bsArg0)
-                        end function)("Bob", getGreeting())
-                    outer(__bsArgs0, true)
-                end sub
-            `);
-        });
-
-        it('both outer and inner named arg calls have complex args — outer written order is preserved', () => {
-            // outer written order: flag: getFlag() first, then value: inner(...)
-            // getFlag() is hoisted first, then the IIFE for inner (which calls getGreeting() lazily),
-            // ensuring getFlag() evaluates before getGreeting() as written.
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                sub outer(value as string, flag as boolean)
-                end sub
-                function getGreeting() as string
-                    return "Hello"
-                end function
-                function getFlag() as boolean
-                    return true
-                end function
-                sub main()
-                    outer(flag: getFlag(), value: inner(name: "Bob", greeting: getGreeting()))
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                sub outer(value as string, flag as boolean)
-                end sub
-
-                function getGreeting() as string
-                    return "Hello"
-                end function
-
-                function getFlag() as boolean
-                    return true
-                end function
-
-                sub main()
-                    __bsArgs0 = getFlag()
-                    __bsArgs1 = (function(__bsArg0, __bsArg1)
-                            return inner(__bsArg1, __bsArg0)
-                        end function)("Bob", getGreeting())
-                    outer(__bsArgs1, __bsArgs0)
-                end sub
-            `);
-        });
-
-        it('doubly-nested ternary with complex named arg in innermost branch uses IIFE', () => {
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                function getName() as string
-                    return "Bob"
-                end function
-                sub main()
-                    result = cond1 ? (cond2 ? inner(name: getName(), greeting: "Hello") : "alt1") : "alt2"
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub main()
-                    if cond1 then
-                        if cond2 then
-                            result = (function(__bsArg0, __bsArg1)
-                                    return inner(__bsArg1, __bsArg0)
-                                end function)(getName(), "Hello")
-                        else
-                            result = "alt1"
-                        end if
-                    else
-                        result = "alt2"
-                    end if
-                end sub
-            `);
-        });
-
-        it('three-level nested ternary with complex named arg in deepest branch', () => {
-            testTranspile(`
-                function inner(a as string, b as string) as string
-                    return a + b
-                end function
-                function getB() as string
-                    return "B"
-                end function
-                sub main()
-                    result = c1 ? (c2 ? (c3 ? inner(b: getB(), a: "A") : "d3") : "d2") : "d1"
-                end sub
-            `, `
-                function inner(a as string, b as string) as string
-                    return a + b
-                end function
-
-                function getB() as string
-                    return "B"
-                end function
-
-                sub main()
-                    if c1 then
-                        if c2 then
-                            if c3 then
-                                result = (function(__bsArg0, __bsArg1)
-                                        return inner(__bsArg1, __bsArg0)
-                                    end function)(getB(), "A")
-                            else
-                                result = "d3"
-                            end if
-                        else
-                            result = "d2"
-                        end if
-                    else
-                        result = "d1"
-                    end if
-                end sub
-            `);
-        });
-
-        it('named arg call in ternary branch inside else-if', () => {
-            testTranspile(`
-                function pick(a as string, b as string) as string
-                    return a
-                end function
-                function getA() as string
-                    return "A"
-                end function
-                sub main()
-                    if false then
-                        print "no"
-                    else if true then
-                        result = condition ? pick(b: getA(), a: "X") : "fallback"
-                    end if
-                end sub
-            `, `
-                function pick(a as string, b as string) as string
-                    return a
-                end function
-
-                function getA() as string
-                    return "A"
-                end function
-
-                sub main()
-                    if false then
-                        print "no"
-                    else if true then
-                        if condition then
-                            result = (function(__bsArg0, __bsArg1)
-                                    return pick(__bsArg1, __bsArg0)
-                                end function)(getA(), "X")
-                        else
-                            result = "fallback"
-                        end if
-                    end if
-                end sub
-            `);
-        });
-
-        it('outer variable used as named arg value in else-if is passed as IIFE arg, not a closure', () => {
-            // BrightScript has no closures. When an IIFE is needed (else-if context), outer
-            // variables must be passed as IIFE parameters — not referenced inside the body.
-            // Here myName becomes __bsArg1, passed in the invocation: (getExcited(), myName)
-            testTranspile(`
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-                function getExcited() as boolean
-                    return true
-                end function
-                sub main()
-                    myName = "Bob"
-                    if false then
-                        print "no"
-                    else if shouldGreet(excited: getExcited(), name: myName) then
-                        print "greeting"
-                    end if
-                end sub
-            `, `
-                function shouldGreet(name as string, excited as boolean) as boolean
-                    return true
-                end function
-
-                function getExcited() as boolean
-                    return true
-                end function
-
-                sub main()
-                    myName = "Bob"
-                    if false then
-                        print "no"
-                    else if (function(__bsArg0, __bsArg1)
-                            return shouldGreet(__bsArg1, __bsArg0)
-                        end function)(getExcited(), myName) then
-                        print "greeting"
-                    end if
-                end sub
-            `);
-        });
-
-        it('outer variable as named arg in ternary branch is passed as IIFE arg, not a closure', () => {
-            // myName is in the IIFE invocation list, not referenced inside the IIFE body directly.
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                function getGreeting() as string
-                    return "Hello"
-                end function
-                sub main()
-                    myName = "Bob"
-                    result = condition ? inner(name: myName, greeting: getGreeting()) : "fallback"
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                function getGreeting() as string
-                    return "Hello"
-                end function
-
-                sub main()
-                    myName = "Bob"
-                    if condition then
-                        result = (function(__bsArg0, __bsArg1)
-                                return inner(__bsArg1, __bsArg0)
-                            end function)(myName, getGreeting())
-                    else
-                        result = "fallback"
-                    end if
-                end sub
-            `);
-        });
-
-        it('outer variable in nested named arg call is passed as IIFE arg, not a closure', () => {
-            // myName flows into the inner IIFE invocation — never referenced inside any IIFE body.
-            testTranspile(`
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-                sub outer(value as string, flag as boolean)
-                end sub
-                function getGreeting() as string
-                    return "Hello"
-                end function
-                sub main()
-                    myName = "Bob"
-                    outer(flag: true, value: inner(name: myName, greeting: getGreeting()))
-                end sub
-            `, `
-                function inner(greeting as string, name as string) as string
-                    return greeting + " " + name
-                end function
-
-                sub outer(value as string, flag as boolean)
-                end sub
-
-                function getGreeting() as string
-                    return "Hello"
-                end function
-
-                sub main()
-                    myName = "Bob"
-                    __bsArgs0 = (function(__bsArg0, __bsArg1)
-                            return inner(__bsArg1, __bsArg0)
-                        end function)(myName, getGreeting())
-                    outer(__bsArgs0, true)
-                end sub
-            `);
-        });
-
-        it('outer variable mixed with positional arg in else-if IIFE — all passed as IIFE args', () => {
-            // Positional "Hello" and named greeting: myName are both IIFE args in written order,
-            // with getExcited() in between. No outer variable is referenced inside the IIFE body.
-            testTranspile(`
-                function greet(name as string, greeting as string, excited as boolean) as boolean
-                    return true
-                end function
-                function getExcited() as boolean
-                    return true
-                end function
-                sub main()
-                    myName = "Bob"
-                    if false then
-                        print "no"
-                    else if greet("Hello", excited: getExcited(), greeting: myName) then
-                        print "greeting"
-                    end if
-                end sub
-            `, `
-                function greet(name as string, greeting as string, excited as boolean) as boolean
-                    return true
-                end function
-
-                function getExcited() as boolean
-                    return true
-                end function
-
-                sub main()
-                    myName = "Bob"
-                    if false then
-                        print "no"
-                    else if (function(__bsArg0, __bsArg1, __bsArg2)
-                            return greet(__bsArg0, __bsArg2, __bsArg1)
-                        end function)("Hello", getExcited(), myName) then
-                        print "greeting"
-                    end if
-                end sub
-            `);
-        });
-
-        it('hoisting counter is scoped per function', () => {
-            testTranspile(`
-                sub greet(name as string, excited as boolean)
-                end sub
-                function getName() as string
-                    return "Bob"
-                end function
-                sub first()
-                    greet(excited: true, name: getName())
-                end sub
-                sub second()
-                    greet(excited: false, name: getName())
-                end sub
-            `, `
-                sub greet(name as string, excited as boolean)
-                end sub
-
-                function getName() as string
-                    return "Bob"
-                end function
-
-                sub first()
-                    __bsArgs0 = getName()
-                    greet(__bsArgs0, true)
-                end sub
-
-                sub second()
-                    __bsArgs0 = getName()
-                    greet(__bsArgs0, false)
-                end sub
-            `);
-        });
-
-        describe('namespace calls', () => {
-            it('reorders named args for a namespace function call', () => {
-                testTranspile(`
-                    namespace MyNs
-                        sub greet(name as string, excited as boolean)
-                        end sub
-                    end namespace
-                    sub main()
-                        MyNs.greet(excited: true, name: "Bob")
-                    end sub
-                `, `
-                    sub MyNs_greet(name as string, excited as boolean)
-                    end sub
-
-                    sub main()
-                        MyNs_greet("Bob", true)
-                    end sub
-                `);
-            });
-
-            it('hoists complex args for a namespace function call', () => {
-                testTranspile(`
-                    namespace MyNs
-                        sub greet(name as string, excited as boolean)
-                        end sub
-                    end namespace
-                    function getName() as string
-                        return "Bob"
-                    end function
-                    sub main()
-                        MyNs.greet(excited: true, name: getName())
-                    end sub
-                `, `
-                    sub MyNs_greet(name as string, excited as boolean)
-                    end sub
-
-                    function getName() as string
-                        return "Bob"
-                    end function
-
-                    sub main()
-                        __bsArgs0 = getName()
-                        MyNs_greet(__bsArgs0, true)
-                    end sub
-                `);
-            });
-        });
-
-        describe('constructor calls', () => {
-            it('reorders named args for a constructor call', () => {
-                testTranspile(`
-                    class Point
-                        x as integer
-                        y as integer
-                        function new(x as integer, y as integer)
-                            m.x = x
-                            m.y = y
-                        end function
-                    end class
-                    sub main()
-                        p = new Point(y: 2, x: 1)
-                    end sub
-                `, `
-                    function __Point_method_new(x as integer, y as integer)
-                        m.x = invalid
-                        m.y = invalid
-                        m.x = x
-                        m.y = y
-                    end function
-                    function __Point_builder()
-                        instance = {}
-                        instance.new = __Point_method_new
-                        return instance
-                    end function
-                    function Point(x as integer, y as integer)
-                        instance = __Point_builder()
-                        instance.new(x, y)
-                        return instance
-                    end function
-
-                    sub main()
-                        p = Point(1, 2)
-                    end sub
-                `);
-            });
-
-            it('hoists complex args for a constructor call', () => {
-                testTranspile(`
-                    class Point
-                        x as integer
-                        y as integer
-                        function new(x as integer, y as integer)
-                            m.x = x
-                            m.y = y
-                        end function
-                    end class
-                    function getY() as integer
-                        return 2
-                    end function
-                    sub main()
-                        p = new Point(y: getY(), x: 1)
-                    end sub
-                `, `
-                    function __Point_method_new(x as integer, y as integer)
-                        m.x = invalid
-                        m.y = invalid
-                        m.x = x
-                        m.y = y
-                    end function
-                    function __Point_builder()
-                        instance = {}
-                        instance.new = __Point_method_new
-                        return instance
-                    end function
-                    function Point(x as integer, y as integer)
-                        instance = __Point_builder()
-                        instance.new(x, y)
-                        return instance
-                    end function
-
-                    function getY() as integer
-                        return 2
-                    end function
-
-                    sub main()
-                        __bsArgs0 = getY()
-                        p = Point(1, __bsArgs0)
-                    end sub
-                `);
-            });
-
-            it('uses inherited constructor params when subclass has no constructor', () => {
-                testTranspile(`
-                    class Shape
-                        color as string
-                        function new(color as string)
-                            m.color = color
-                        end function
-                    end class
-                    class Circle extends Shape
-                    end class
-                    sub main()
-                        c = new Circle(color: "red")
-                    end sub
-                `, `
-                    function __Shape_method_new(color as string)
-                        m.color = invalid
-                        m.color = color
-                    end function
-                    function __Shape_builder()
-                        instance = {}
-                        instance.new = __Shape_method_new
-                        return instance
-                    end function
-                    function Shape(color as string)
-                        instance = __Shape_builder()
-                        instance.new(color)
-                        return instance
-                    end function
-                    sub __Circle_method_new(color as string)
-                        m.super0_new(color)
-                    end sub
-                    function __Circle_builder()
-                        instance = __Shape_builder()
-                        instance.super0_new = instance.new
-                        instance.new = __Circle_method_new
-                        return instance
-                    end function
-                    function Circle(color as string)
-                        instance = __Circle_builder()
-                        instance.new(color)
-                        return instance
-                    end function
-
-                    sub main()
-                        c = Circle("red")
-                    end sub
-                `);
-            });
         });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,9 @@ import { ObjectType } from './types/ObjectType';
 import { StringType } from './types/StringType';
 import { VoidType } from './types/VoidType';
 import { ParseMode } from './parser/Parser';
-import type { DottedGetExpression, VariableExpression } from './parser/Expression';
+import type { DottedGetExpression, FunctionParameterExpression, VariableExpression } from './parser/Expression';
+import type { ClassStatement, MethodStatement } from './parser/Statement';
+import type { Scope } from './Scope';
 import { LogLevel, createLogger } from './logging';
 import type { Identifier, Locatable, Token } from './lexer/Token';
 import { TokenKind } from './lexer/TokenKind';
@@ -1597,6 +1599,40 @@ export class Util {
             }
         }
         return parts.reverse();
+    }
+
+    /**
+     * If the callee is a dotted-get expression whose leftmost identifier is a known namespace in the
+     * given scope, returns the BrightScript-flattened name (e.g. "MyNs_myFunc"). Otherwise returns undefined.
+     */
+    public resolveNamespaceCallableName(callee: Expression, scope: Scope): string | undefined {
+        const parts = this.getAllDottedGetParts(callee);
+        if (!parts || !scope.namespaceLookup.has(parts[0].text.toLowerCase())) {
+            return undefined;
+        }
+        return parts.map(p => p.text).join('_');
+    }
+
+    /**
+     * Walk the class and its ancestor chain to find the first constructor's parameter list.
+     * Returns an empty array if no constructor is defined anywhere in the hierarchy.
+     */
+    public getClassConstructorParams(classStmt: ClassStatement, scope: Scope, containingNamespace: string | undefined): FunctionParameterExpression[] {
+        let stmt: ClassStatement | undefined = classStmt;
+        while (stmt) {
+            const ctor = stmt.body.find(
+                s => (s as MethodStatement)?.name?.text?.toLowerCase() === 'new'
+            ) as MethodStatement | undefined;
+            if (ctor) {
+                return ctor.func.parameters;
+            }
+            if (!stmt.parentClassName) {
+                break;
+            }
+            const parentName = stmt.parentClassName.getName(ParseMode.BrighterScript);
+            stmt = scope.getClassFileLink(parentName, containingNamespace)?.item;
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Named arguments**: allows calling functions using named parameter syntax (e.g. `greet(name: "Bob")`)
  - Validates unknown named arguments against the function definition
  - Errors on duplicate named arguments in the same call
  - Errors on positional arguments following named arguments
  - Errors when named args are used on an unknown function (can't verify param names)
- **Duplicate parameter warning**: emits a warning (code 1150) when a `function`/`sub` definition has two or more parameters with the same name (case-insensitive)
- Fixes `Expression` import in `Scope.ts` to pull from `parser/AstNode` where it is declared

## New diagnostic codes

| Code | Severity | Message |
|------|----------|---------|
| 1146 | Error | Unknown named argument `'{name}'` for function `'{func}'` |
| 1147 | Error | Named argument `'{name}'` was already provided |
| 1148 | Error | Positional arguments cannot follow named arguments |
| 1149 | Error | Cannot use named arguments when calling `'{func}'` because the function definition cannot be found |
| 1150 | Warning | Duplicate parameter name `'{name}'` |

## Test plan

- [ ] Named argument tests in `src/parser/tests/expression/NamedArgument.spec.ts`
- [ ] Duplicate parameter tests in `src/files/BrsFile.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)