### PR TITLE
Fix cross-file const inlining and flag const cycles

### DIFF
--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -1,5 +1,5 @@
 import { createAssignmentStatement, createBlock, createDottedSetStatement, createIfStatement, createIndexedSetStatement, createToken } from '../../astUtils/creators';
-import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
+import { isAssignmentStatement, isBinaryExpression, isBlock, isBody, isBrsFile, isDottedGetExpression, isDottedSetStatement, isGroupingExpression, isIndexedGetExpression, isIndexedSetStatement, isLiteralExpression, isNamespaceStatement, isUnaryExpression, isVariableExpression } from '../../astUtils/reflection';
 import { createVisitor, WalkMode } from '../../astUtils/visitors';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BeforeFileTranspileEvent } from '../../interfaces';
@@ -9,7 +9,7 @@ import type { Expression, Statement } from '../../parser/AstNode';
 import type { TernaryExpression } from '../../parser/Expression';
 import { LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { IfStatement } from '../../parser/Statement';
+import type { ConstStatement, IfStatement, NamespaceStatement } from '../../parser/Statement';
 import type { Scope } from '../../Scope';
 import util from '../../util';
 
@@ -286,8 +286,11 @@ export class BrsFilePreTranspileProcessor {
 
     private processExpression(ternaryExpression: Expression, scope: Scope | undefined) {
         let containingNamespace = this.event.file.getNamespaceStatementForPosition(ternaryExpression.range.start)?.getName(ParseMode.BrighterScript);
+        this.processExpressionInNamespace(ternaryExpression, scope, containingNamespace);
+    }
 
-        const parts = util.splitExpression(ternaryExpression);
+    private processExpressionInNamespace(expression: Expression, scope: Scope | undefined, containingNamespace: string | undefined) {
+        const parts = util.splitExpression(expression);
 
         const processedNames: string[] = [];
         for (let part of parts) {
@@ -318,6 +321,15 @@ export class BrsFilePreTranspileProcessor {
             }
 
             if (value && !isCircular) {
+                //If the const's value is a complex expression (e.g. an aa literal containing
+                //enum refs), recursively process inner refs so they're inlined too. Without
+                //this step, cross-file const usage leaves nested enum/const refs unresolved
+                //because the consumer file's pre-transpile pass never visits the inlined
+                //value's children (they live in the const's defining file).
+                if (constStatement && !isLiteralExpression(value)) {
+                    this.processInlinedConstValue(value, scope, constStatement);
+                }
+
                 //override the transpile for this item.
                 this.event.editor.setProperty(part, 'transpile', (state) => {
                     if (isLiteralExpression(value)) {
@@ -331,5 +343,23 @@ export class BrsFilePreTranspileProcessor {
                 return;
             }
         }
+    }
+
+    private processInlinedConstValue(value: Expression, scope: Scope | undefined, constStatement: ConstStatement) {
+        const innerNamespace = constStatement.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
+        value.walk(createVisitor({
+            VariableExpression: (varExpr) => {
+                if (isDottedGetExpression(varExpr.parent)) {
+                    return;
+                }
+                this.processExpressionInNamespace(varExpr, scope, innerNamespace);
+            },
+            DottedGetExpression: (dottedExpr) => {
+                if (isDottedGetExpression(dottedExpr.parent)) {
+                    return;
+                }
+                this.processExpressionInNamespace(dottedExpr, scope, innerNamespace);
+            }
+        }), { walkMode: WalkMode.visitExpressionsRecursive });
     }
 }

--- a/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
+++ b/src/bscPlugin/transpile/BrsFilePreTranspileProcessor.ts
@@ -286,10 +286,10 @@ export class BrsFilePreTranspileProcessor {
 
     private processExpression(ternaryExpression: Expression, scope: Scope | undefined) {
         let containingNamespace = this.event.file.getNamespaceStatementForPosition(ternaryExpression.range.start)?.getName(ParseMode.BrighterScript);
-        this.processExpressionInNamespace(ternaryExpression, scope, containingNamespace);
+        this.processExpressionInNamespace(ternaryExpression, scope, containingNamespace, new Set<ConstStatement>());
     }
 
-    private processExpressionInNamespace(expression: Expression, scope: Scope | undefined, containingNamespace: string | undefined) {
+    private processExpressionInNamespace(expression: Expression, scope: Scope | undefined, containingNamespace: string | undefined, visitedConsts: Set<ConstStatement>) {
         const parts = util.splitExpression(expression);
 
         const processedNames: string[] = [];
@@ -327,7 +327,14 @@ export class BrsFilePreTranspileProcessor {
                 //because the consumer file's pre-transpile pass never visits the inlined
                 //value's children (they live in the const's defining file).
                 if (constStatement && !isLiteralExpression(value)) {
-                    this.processInlinedConstValue(value, scope, constStatement);
+                    //if we're already inlining this const upstream, skip both the recursive
+                    //walk AND the transpile override. Setting the override here would still
+                    //create a transpile-time cycle (the value contains a ref back to a const
+                    //that has been overridden to re-inline this same value).
+                    if (visitedConsts.has(constStatement)) {
+                        return;
+                    }
+                    this.processInlinedConstValue(value, scope, constStatement, visitedConsts);
                 }
 
                 //override the transpile for this item.
@@ -345,20 +352,28 @@ export class BrsFilePreTranspileProcessor {
         }
     }
 
-    private processInlinedConstValue(value: Expression, scope: Scope | undefined, constStatement: ConstStatement) {
+    private processInlinedConstValue(value: Expression, scope: Scope | undefined, constStatement: ConstStatement, visitedConsts: Set<ConstStatement>) {
+        //skip if we've already walked this const's value during the current outer
+        //inline. This guards against unbounded recursion when consts have circular
+        //aggregate references (const A = { x: B }; const B = { y: A }) and avoids
+        //redundant work for diamond reference graphs.
+        if (visitedConsts.has(constStatement)) {
+            return;
+        }
+        visitedConsts.add(constStatement);
         const innerNamespace = constStatement.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
         value.walk(createVisitor({
             VariableExpression: (varExpr) => {
                 if (isDottedGetExpression(varExpr.parent)) {
                     return;
                 }
-                this.processExpressionInNamespace(varExpr, scope, innerNamespace);
+                this.processExpressionInNamespace(varExpr, scope, innerNamespace, visitedConsts);
             },
             DottedGetExpression: (dottedExpr) => {
                 if (isDottedGetExpression(dottedExpr.parent)) {
                     return;
                 }
-                this.processExpressionInNamespace(dottedExpr, scope, innerNamespace);
+                this.processExpressionInNamespace(dottedExpr, scope, innerNamespace, visitedConsts);
             }
         }), { walkMode: WalkMode.visitExpressionsRecursive });
     }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1,10 +1,10 @@
 import { URI } from 'vscode-uri';
-import { isBrsFile, isCallExpression, isLiteralExpression, isNamespaceStatement, isXmlScope } from '../../astUtils/reflection';
+import { isBrsFile, isCallExpression, isDottedGetExpression, isLiteralExpression, isNamespaceStatement, isVariableExpression, isXmlScope } from '../../astUtils/reflection';
 import { Cache } from '../../Cache';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { BrsFile } from '../../files/BrsFile';
 import type { BscFile, BsDiagnostic, OnScopeValidateEvent } from '../../interfaces';
-import type { EnumStatement, NamespaceStatement } from '../../parser/Statement';
+import type { ConstStatement, EnumStatement, NamespaceStatement } from '../../parser/Statement';
 import util from '../../util';
 import { nodes, components } from '../../roku-types';
 import type { BRSComponentData } from '../../roku-types';
@@ -39,6 +39,7 @@ export class ScopeValidator {
         this.event = event;
         this.walkFiles();
         this.detectDuplicateEnums();
+        this.detectCircularConstReferences();
     }
 
     public reset() {
@@ -349,6 +350,99 @@ export class ScopeValidator {
             }
         }
         this.event.scope.addDiagnostics(diagnostics);
+    }
+
+    /**
+     * Flag circular references between consts (e.g. const A = B; const B = A, or
+     * aggregate cycles like const A = { x: B }; const B = { y: A }). Without this
+     * check, the transpile pass silently emits unresolved refs at the cycle break
+     * point, producing code that fails at runtime.
+     */
+    private detectCircularConstReferences() {
+        const scope = this.event.scope;
+        const diagnostics: BsDiagnostic[] = [];
+        const fullyValidated = new Set<ConstStatement>();
+        const reportedCycleStarts = new Set<ConstStatement>();
+
+        const followConstRef = (
+            expression: Expression,
+            namespace: string | undefined,
+            chain: ConstStatement[]
+        ) => {
+            const parts = util.splitExpression(expression);
+            const processedNames: string[] = [];
+            for (const part of parts) {
+                if (!isVariableExpression(part) && !isDottedGetExpression(part)) {
+                    return;
+                }
+                processedNames.push(part.name?.text?.toLowerCase());
+                const link = scope.getConstFileLink(processedNames.join('.'), namespace);
+                if (link) {
+                    walkConst(link.item, link.file, chain);
+                    return;
+                }
+            }
+        };
+
+        const walkConst = (
+            constStatement: ConstStatement,
+            file: BrsFile,
+            chain: ConstStatement[]
+        ) => {
+            const cycleStart = chain.indexOf(constStatement);
+            if (cycleStart >= 0) {
+                //emit one diagnostic per distinct cycle (keyed on the first const in the cycle).
+                //A 3-cycle A->B->C->A is otherwise reported 3 times (once per starting node).
+                const cycleNodes = chain.slice(cycleStart);
+                const canonicalStart = cycleNodes.reduce((min, c) => {
+                    return (c.fullName ?? '') < (min.fullName ?? '') ? c : min;
+                }, cycleNodes[0]);
+                if (reportedCycleStarts.has(canonicalStart)) {
+                    return;
+                }
+                reportedCycleStarts.add(canonicalStart);
+                const items = cycleNodes.map(c => c.fullName).concat(constStatement.fullName);
+                diagnostics.push({
+                    ...DiagnosticMessages.circularReferenceDetected(items, scope.name),
+                    file: file,
+                    range: constStatement.tokens.name.range
+                });
+                return;
+            }
+            if (fullyValidated.has(constStatement)) {
+                return;
+            }
+            chain.push(constStatement);
+            const innerNamespace = constStatement.findAncestor<NamespaceStatement>(isNamespaceStatement)?.getName(ParseMode.BrighterScript);
+            const value = constStatement.value;
+            if (value) {
+                if (isVariableExpression(value) || isDottedGetExpression(value)) {
+                    followConstRef(value, innerNamespace, chain);
+                } else {
+                    value.walk(createVisitor({
+                        VariableExpression: (varExpr) => {
+                            if (isDottedGetExpression(varExpr.parent)) {
+                                return;
+                            }
+                            followConstRef(varExpr, innerNamespace, chain);
+                        },
+                        DottedGetExpression: (dottedExpr) => {
+                            if (isDottedGetExpression(dottedExpr.parent)) {
+                                return;
+                            }
+                            followConstRef(dottedExpr, innerNamespace, chain);
+                        }
+                    }), { walkMode: WalkMode.visitExpressionsRecursive });
+                }
+            }
+            chain.pop();
+            fullyValidated.add(constStatement);
+        };
+
+        for (const [, link] of scope.getConstMap()) {
+            walkConst(link.item, link.file, []);
+        }
+        scope.addDiagnostics(diagnostics);
     }
 
     /**

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -1,4 +1,4 @@
-import { expectCompletionsIncludes, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
+import { expectCompletionsIncludes, expectDiagnostics, expectZeroDiagnostics, getTestGetTypedef, getTestTranspile } from '../../../testHelpers.spec';
 import { util } from '../../../util';
 import { Program } from '../../../Program';
 import { createSandbox } from 'sinon';
@@ -8,6 +8,7 @@ import type { ConstStatement } from '../../Statement';
 import { TokenKind } from '../../../lexer/TokenKind';
 import { LiteralExpression } from '../../Expression';
 import { CompletionItemKind } from 'vscode-languageserver-protocol';
+import { DiagnosticMessages } from '../../../DiagnosticMessages';
 import { rootDir } from '../../../testHelpers.spec';
 
 const sinon = createSandbox();
@@ -308,6 +309,8 @@ describe('ConstStatement', () => {
         });
 
         it('handles cyclical const references without infinite loop', () => {
+            //the cycle is also reported via a diagnostic; this test only verifies
+            //the transpile output doesn't recurse forever.
             testTranspile(`
                 const A = B
                 const B = C
@@ -319,7 +322,7 @@ describe('ConstStatement', () => {
                 sub main()
                     print A
                 end sub
-            `);
+            `, 'trim', 'source/main.bs', false);
         });
 
         it('resolves consts inside array literals', () => {
@@ -568,6 +571,7 @@ describe('ConstStatement', () => {
             //the inner-most cyclic ref is left as the original namespace path so
             //transpile completes without recursing forever. The runtime semantics
             //of the cyclic ref are inherently broken, but the compile must not hang.
+            //(A diagnostic is also emitted; see the dedicated cycle-diagnostic tests.)
             testTranspile(`
                 sub main()
                     print ns.A
@@ -580,7 +584,61 @@ describe('ConstStatement', () => {
                         })
                     })
                 end sub
+            `, 'trim', 'source/main.bs', false);
+        });
+
+        it('flags scalar circular const reference', () => {
+            program.setFile('source/main.bs', `
+                const A = B
+                const B = A
             `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.circularReferenceDetected(['A', 'B', 'A'], 'source').message
+            ]);
+        });
+
+        it('flags aggregate circular const reference', () => {
+            program.setFile('source/main.bs', `
+                namespace ns
+                    const A = { "x": ns.B }
+                    const B = { "y": ns.A }
+                end namespace
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.A'], 'source').message
+            ]);
+        });
+
+        it('flags three-cycle const reference and reports it once', () => {
+            program.setFile('source/main.bs', `
+                namespace ns
+                    const A = { "x": ns.B }
+                    const B = { "y": ns.C }
+                    const C = { "z": ns.A }
+                end namespace
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.C', 'ns.A'], 'source').message
+            ]);
+        });
+
+        it('does not flag diamond const reference graph', () => {
+            program.setFile('source/main.bs', `
+                namespace ns
+                    enum E
+                        X = "X"
+                    end enum
+                    const Base = { "c": ns.E.X }
+                    const A = { "a": ns.Base }
+                    const B = { "b": ns.Base }
+                    const Root = { "left": ns.A, "right": ns.B }
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
         });
 
         it('resolves complex multi-file const-enum chain', () => {

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -421,6 +421,54 @@ describe('ConstStatement', () => {
             `);
         });
 
+        it('resolves enum refs inside an aa-literal const used cross-file (issue #1618)', () => {
+            program.setFile('source/map.bs', `
+                namespace name.space
+                    enum someEnum
+                        one = "val1"
+                        two = "val2"
+                        three = "val3"
+                    end enum
+
+                    const myMap = {
+                        "key1": someEnum.one
+                        "key2": someEnum.two
+                        "key3": someEnum.three
+                    }
+                end namespace
+            `);
+            testTranspile(`
+                namespace name.space
+                    class someClass
+                        public function someFunc(key as dynamic) as object
+                            return name.space.myMap[key]
+                        end function
+                    end class
+                end namespace
+            `, `
+                sub __name_space_someClass_method_new()
+                end sub
+                function __name_space_someClass_method_someFunc(key as dynamic) as object
+                    return ({
+                        "key1": "val1"
+                        "key2": "val2"
+                        "key3": "val3"
+                    })[key]
+                end function
+                function __name_space_someClass_builder()
+                    instance = {}
+                    instance.new = __name_space_someClass_method_new
+                    instance.someFunc = __name_space_someClass_method_someFunc
+                    return instance
+                end function
+                function name_space_someClass()
+                    instance = __name_space_someClass_builder()
+                    instance.new()
+                    return instance
+                end function
+            `);
+        });
+
         it('resolves complex multi-file const-enum chain', () => {
             program.setFile('source/colors.bs', `
                 namespace Theme

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -469,6 +469,36 @@ describe('ConstStatement', () => {
             `);
         });
 
+        it('resolves enum refs in computed keys of an aa-literal const used cross-file', () => {
+            program.setFile('source/map.bs', `
+                namespace name.space
+                    enum someEnum
+                        one = "key1"
+                        two = "key2"
+                    end enum
+
+                    const myMap = {
+                        [someEnum.one]: "val1"
+                        [someEnum.two]: "val2"
+                    }
+                end namespace
+            `);
+            testTranspile(`
+                namespace name.space
+                    sub useMap(key as dynamic) as object
+                        return name.space.myMap[key]
+                    end sub
+                end namespace
+            `, `
+                sub name_space_useMap(key as dynamic) as object
+                    return ({
+                        "key1": "val1"
+                        "key2": "val2"
+                    })[key]
+                end sub
+            `);
+        });
+
         it('resolves complex multi-file const-enum chain', () => {
             program.setFile('source/colors.bs', `
                 namespace Theme

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -499,6 +499,90 @@ describe('ConstStatement', () => {
             `);
         });
 
+        it('inlines a const aa-literal at multiple consumer call sites in the same file', () => {
+            program.setFile('source/consts.bs', `
+                namespace ns
+                    enum E
+                        X = "X"
+                    end enum
+                    const M = { "x": ns.E.X }
+                end namespace
+            `);
+            testTranspile(`
+                sub main()
+                    a = ns.M
+                    b = ns.M
+                end sub
+            `, `
+                sub main()
+                    a = ({
+                        "x": "X"
+                    })
+                    b = ({
+                        "x": "X"
+                    })
+                end sub
+            `);
+        });
+
+        it('handles diamond const reference graph (one base const reached via two paths)', () => {
+            program.setFile('source/consts.bs', `
+                namespace ns
+                    enum E
+                        X = "X"
+                    end enum
+                    const C = { "c": ns.E.X }
+                    const A = { "a": ns.C }
+                    const B = { "b": ns.C }
+                end namespace
+            `);
+            testTranspile(`
+                sub main()
+                    print ns.A
+                    print ns.B
+                end sub
+            `, `
+                sub main()
+                    print ({
+                        "a": ({
+                            "c": "X"
+                        })
+                    })
+                    print ({
+                        "b": ({
+                            "c": "X"
+                        })
+                    })
+                end sub
+            `);
+        });
+
+        it('does not infinite-loop on circular const-of-aa references', function() {
+            this.timeout(2000);
+            program.setFile('source/consts.bs', `
+                namespace ns
+                    const A = { "x": ns.B }
+                    const B = { "y": ns.A }
+                end namespace
+            `);
+            //the inner-most cyclic ref is left as the original namespace path so
+            //transpile completes without recursing forever. The runtime semantics
+            //of the cyclic ref are inherently broken, but the compile must not hang.
+            testTranspile(`
+                sub main()
+                    print ns.A
+                end sub
+            `, `
+                sub main()
+                    print ({
+                        "x": ({
+                            "y": ns_A
+                        })
+                    })
+                end sub
+            `);
+        });
+
         it('resolves complex multi-file const-enum chain', () => {
             program.setFile('source/colors.bs', `
                 namespace Theme

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -1336,6 +1336,7 @@ describe('EnumStatement', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
+                DiagnosticMessages.circularReferenceDetected(['A', 'B', 'A'], 'source').message,
                 DiagnosticMessages.computedAAKeyMustBeStringExpression()
             ]);
         });


### PR DESCRIPTION
## Summary

Fixes #1618.

When a `const`'s value is an aa-literal (or other complex expression) containing enum or const references, and the const is consumed from a *different file* than where it was defined, the inner refs were left unresolved in the transpiled output. For example:

```bs
' map.bs
namespace name.space
    enum someEnum
        one = "val1"
    end enum
    const myMap = { "key1": someEnum.one }
end namespace

' helper.bs — different file
namespace name.space
    class someClass
        public function someFunc(key as dynamic) as object
            return name.space.myMap[key]
        end function
    end class
end namespace
```

Transpiled output (before this fix):

```brs
return ({
    "key1": someEnum.one  ' ← never replaced; crashes at runtime
})[key]
```

## Why same-file worked but cross-file didn't

`BrsFilePreTranspileProcessor.iterateExpressions` walks the consumer file's `parser.references.expressions` and overrides each VariableExpression / DottedGetExpression's `transpile` to inline the resolved const/enum literal. When the const and consumer are in the same file, that pass coincidentally also visits the inner enum refs nested inside the const's aa-literal value. Cross-file, those AST nodes live in the *defining* file and the consumer's pass never visits them, so they emit their default `someEnum.one` text.

## Fix

In `processExpressionInNamespace`, after resolving a const reference, if the resolved value is non-literal, walk it and apply the same const/enum substitution to every inner `VariableExpression` / `DottedGetExpression` (skipping inner parts of dotted chains, which are handled at the chain level). The walk is scoped to the **const statement's** containing namespace, since that's where the inner refs were authored, not the consumer's namespace.

The substitution uses the existing `editor.setProperty('transpile', ...)` mechanism; the editor undoes those overrides after the consumer file's transpile finishes, so the const's defining file isn't affected on subsequent transpile passes.

## Tests

Two new tests in `ConstStatement.spec.ts`:
- `resolves enum refs inside an aa-literal const used cross-file (issue #1618)` — direct repro from the issue
- `resolves enum refs in computed keys of an aa-literal const used cross-file` — covers `[someEnum.X]: value` form