### PR TITLE
Report const cycle diagnostic per node to match class convention

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -357,12 +357,14 @@ export class ScopeValidator {
      * aggregate cycles like const A = { x: B }; const B = { y: A }). Without this
      * check, the transpile pass silently emits unresolved refs at the cycle break
      * point, producing code that fails at runtime.
+     *
+     * Mirrors the existing class-hierarchy circular-reference detection: each const
+     * starts its own walk, and an N-cycle produces N diagnostics (one rooted at
+     * each member of the cycle).
      */
     private detectCircularConstReferences() {
         const scope = this.event.scope;
         const diagnostics: BsDiagnostic[] = [];
-        const fullyValidated = new Set<ConstStatement>();
-        const reportedCycleStarts = new Set<ConstStatement>();
 
         const followConstRef = (
             expression: Expression,
@@ -391,25 +393,12 @@ export class ScopeValidator {
         ) => {
             const cycleStart = chain.indexOf(constStatement);
             if (cycleStart >= 0) {
-                //emit one diagnostic per distinct cycle (keyed on the first const in the cycle).
-                //A 3-cycle A->B->C->A is otherwise reported 3 times (once per starting node).
-                const cycleNodes = chain.slice(cycleStart);
-                const canonicalStart = cycleNodes.reduce((min, c) => {
-                    return (c.fullName ?? '') < (min.fullName ?? '') ? c : min;
-                }, cycleNodes[0]);
-                if (reportedCycleStarts.has(canonicalStart)) {
-                    return;
-                }
-                reportedCycleStarts.add(canonicalStart);
-                const items = cycleNodes.map(c => c.fullName).concat(constStatement.fullName);
+                const items = chain.slice(cycleStart).map(c => c.fullName).concat(constStatement.fullName);
                 diagnostics.push({
                     ...DiagnosticMessages.circularReferenceDetected(items, scope.name),
                     file: file,
                     range: constStatement.tokens.name.range
                 });
-                return;
-            }
-            if (fullyValidated.has(constStatement)) {
                 return;
             }
             chain.push(constStatement);
@@ -436,7 +425,6 @@ export class ScopeValidator {
                 }
             }
             chain.pop();
-            fullyValidated.add(constStatement);
         };
 
         for (const [, link] of scope.getConstMap()) {

--- a/src/parser/tests/statement/ConstStatement.spec.ts
+++ b/src/parser/tests/statement/ConstStatement.spec.ts
@@ -593,8 +593,11 @@ describe('ConstStatement', () => {
                 const B = A
             `);
             program.validate();
+            //matches the class-hierarchy convention: one diagnostic per const in the cycle,
+            //each rotated so the diagnostic's const is at the head of the chain
             expectDiagnostics(program, [
-                DiagnosticMessages.circularReferenceDetected(['A', 'B', 'A'], 'source').message
+                DiagnosticMessages.circularReferenceDetected(['A', 'B', 'A'], 'source').message,
+                DiagnosticMessages.circularReferenceDetected(['B', 'A', 'B'], 'source').message
             ]);
         });
 
@@ -607,11 +610,12 @@ describe('ConstStatement', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.A'], 'source').message
+                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.A'], 'source').message,
+                DiagnosticMessages.circularReferenceDetected(['ns.B', 'ns.A', 'ns.B'], 'source').message
             ]);
         });
 
-        it('flags three-cycle const reference and reports it once', () => {
+        it('flags three-cycle const reference once per node', () => {
             program.setFile('source/main.bs', `
                 namespace ns
                     const A = { "x": ns.B }
@@ -621,7 +625,9 @@ describe('ConstStatement', () => {
             `);
             program.validate();
             expectDiagnostics(program, [
-                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.C', 'ns.A'], 'source').message
+                DiagnosticMessages.circularReferenceDetected(['ns.A', 'ns.B', 'ns.C', 'ns.A'], 'source').message,
+                DiagnosticMessages.circularReferenceDetected(['ns.B', 'ns.C', 'ns.A', 'ns.B'], 'source').message,
+                DiagnosticMessages.circularReferenceDetected(['ns.C', 'ns.A', 'ns.B', 'ns.C'], 'source').message
             ]);
         });
 

--- a/src/parser/tests/statement/Enum.spec.ts
+++ b/src/parser/tests/statement/Enum.spec.ts
@@ -1337,6 +1337,7 @@ describe('EnumStatement', () => {
             program.validate();
             expectDiagnostics(program, [
                 DiagnosticMessages.circularReferenceDetected(['A', 'B', 'A'], 'source').message,
+                DiagnosticMessages.circularReferenceDetected(['B', 'A', 'B'], 'source').message,
                 DiagnosticMessages.computedAAKeyMustBeStringExpression()
             ]);
         });


### PR DESCRIPTION
## Summary

Follow-up to #1680. The const cycle diagnostic added there reported each cycle once (deduped via the lexicographically-smallest fullName). The class hierarchy diagnostic in [ClassValidator.detectCircularReferences](src/validators/ClassValidator.ts) reports an N-cycle as N diagnostics — one rooted at each member, with the chain rotated so the diagnostic's class is at the head. See [BrsFile.Class.spec.ts:1215-1217](src/files/BrsFile.Class.spec.ts#L1215-L1217) for the existing 3-cycle assertion.

This PR drops the dedup so consts emit the same shape, giving users a consistent diagnostic experience across the two cycle types.

## Changes

- `ScopeValidator.detectCircularConstReferences`: removed the `reportedCycleStarts` and `fullyValidated` sets. Each const starts a fresh DFS; cycles are reported on every member with the chain rotated.
- Updated three const cycle tests + one Enum test that incidentally uses a circular const setup.

## Test plan

- [x] `npx mocha` — 2633/2633 pass, 0 regressions
- [x] `npx eslint` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)