### PR TITLE
Share BscSymbol references in SymbolTable.mergeSymbolTable

### DIFF
--- a/src/SymbolTable.spec.ts
+++ b/src/SymbolTable.spec.ts
@@ -60,6 +60,43 @@ describe('SymbolTable', () => {
             otherTable.addSymbol('foo', null as any, new IntegerType());
             st.mergeSymbolTable(otherTable);
         });
+
+        it('shares symbol object references with the source rather than cloning', () => {
+            const source = new SymbolTable('Source');
+            source.addSymbol('foo', null as any, new StringType());
+            const destination = new SymbolTable('Destination');
+            destination.mergeSymbolTable(source);
+
+            expect(destination.getSymbol('foo')![0]).to.equal(source.getSymbol('foo')![0]);
+        });
+
+        it('keeps destination isolated from later mutations to source', () => {
+            const source = new SymbolTable('Source');
+            source.addSymbol('foo', null as any, new StringType());
+            const destination = new SymbolTable('Destination');
+            destination.mergeSymbolTable(source);
+
+            //adding to source after the merge must not leak into destination
+            source.addSymbol('foo', null as any, new IntegerType());
+
+            expect(destination.getSymbol('foo')!.length).to.eq(1);
+            expect(destination.getSymbol('foo')![0].type.toString()).to.eq('string');
+        });
+
+        it('accumulates symbols when merging multiple sources sharing a key', () => {
+            const sourceA = new SymbolTable('SourceA');
+            sourceA.addSymbol('foo', null as any, new StringType());
+            const sourceB = new SymbolTable('SourceB');
+            sourceB.addSymbol('foo', null as any, new IntegerType());
+
+            const destination = new SymbolTable('Destination');
+            destination.mergeSymbolTable(sourceA);
+            destination.mergeSymbolTable(sourceB);
+
+            expect(
+                destination.getSymbol('foo')!.map(symbol => symbol.type.toString())
+            ).to.eql(['string', 'integer']);
+        });
     });
 
     it('searches siblings before parents', () => {

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -115,18 +115,21 @@ export class SymbolTable {
     }
 
     /**
-     * Adds all the symbols from another table to this one
-     * It will overwrite any existing symbols in this table
+     * Adds all the symbols from another table to this one.
+     * Source symbols are shared by reference (not cloned) since BscSymbol is treated as immutable.
+     * The destination still owns its own array per key, so subsequent addSymbol calls on either
+     * table do not leak across.
      */
     mergeSymbolTable(symbolTable: SymbolTable) {
-        for (let [, value] of symbolTable.symbolMap) {
-            for (const symbol of value) {
-                this.addSymbol(
-                    symbol.name,
-                    symbol.range,
-                    symbol.type
-                );
+        for (const [key, sourceSymbols] of symbolTable.symbolMap) {
+            let destSymbols = this.symbolMap.get(key);
+            if (!destSymbols) {
+                destSymbols = [];
+                this.symbolMap.set(key, destSymbols);
             }
+            // for (const symbol of sourceSymbols) {
+            destSymbols.push(...sourceSymbols);
+            // }
         }
     }
 
@@ -148,6 +151,11 @@ export class SymbolTable {
     }
 }
 
+/**
+ * A symbol entry stored in a SymbolTable.
+ * Treated as immutable once added: range and type must not be reassigned, and the object
+ * may be shared by reference across multiple symbol tables (e.g. via mergeSymbolTable).
+ */
 export interface BscSymbol {
     name: string;
     range: Range;

--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -127,9 +127,7 @@ export class SymbolTable {
                 destSymbols = [];
                 this.symbolMap.set(key, destSymbols);
             }
-            // for (const symbol of sourceSymbols) {
             destSymbols.push(...sourceSymbols);
-            // }
         }
     }
 


### PR DESCRIPTION
## Summary

Reduce memory pressure during validation by sharing `BscSymbol` references when merging symbol tables, rather than allocating a fresh `{name, range, type}` wrapper per merged symbol.

## Why

`SymbolTable.mergeSymbolTable` was allocating a large amount of `BscSymbol` wrapper objects during validation of large projects, contributing to OOM crashes on brighterscript builds of ~1300+ source-file codebases. Investigation showed:

- `BscSymbol` is a 3-field interface (`name`, `range`, `type`) and is never mutated post-creation in production code (grepped `\.range\s*=` / `\.type\s*=` against symbol-typed values: zero hits).
- `addSymbol` already shared `range` and `type` by reference. Only the wrapper object was being duplicated.
- The only public reader, `hasSymbol` (called from `ScopeValidator` and `BrsFileValidator`), only checks existence and never reads symbol contents.

Removing the redundant wrapper allocation costs nothing semantically and saves significant GC pressure during validation of large codebases.

## Heap profile delta

Measured on a large real-world project (~1300 source files), sampled allocations:

|                            | before    | after     | delta     |
|----------------------------|-----------|-----------|-----------|
| total sampled allocations  | 1933 MB   | 1854 MB   | -80 MB    |
| `mergeSymbolTable` self    | 270 MB    | 226 MB    | -44 MB    |

The win is modest because the wrapper objects are only one part of the merge cost (Map node growth and array slot growth remain). A follow-up PR addresses the larger cost in `buildNamespaceLookup`.

## Changes

- `SymbolTable.mergeSymbolTable` rewritten to push source symbol refs into the destination array directly, instead of calling `addSymbol` per entry.
- Doc-comment on `BscSymbol` declaring it immutable.
- Three new specs in `SymbolTable.spec.ts`:
  - reference identity preservation across merge
  - destination isolation against later source mutations
  - accumulation across multiple sources sharing a key

## Test plan

- [x] `npm run test:nocover` passes (2660 -> 2663 specs; the deltas are the new specs)
- [x] `npx eslint src/SymbolTable.ts src/SymbolTable.spec.ts` clean
- [x] Heap profile re-run on the real-world project shows the documented delta

## Notes

This is the first of several PRs targeting brighterscript memory growth on large codebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)