### PR TITLE
Add bs:disable / bs:enable block directives and diagnostic suppression quick fixes

### DIFF
--- a/docs/suppressing-compiler-messages.md
+++ b/docs/suppressing-compiler-messages.md
@@ -43,3 +43,36 @@ end sub
 ```
 
 The primary motivation for this feature was to provide a stopgap measure to hide incorrectly-thrown errors on legitimate BrightScript code due to parser bugs. It is recommended that you only use these comments when absolutely necessary.
+
+## Ignoring errors and warnings for an entire file
+
+To suppress diagnostics across an entire file, place a `bs:disable-file` comment in the file's header. The directive only takes effect when it appears before any executable code (comment-only lines and blank lines above it are fine). For XML files, place the comment between the `<?xml ?>` declaration and the root component element.
+
+ - `bs:disable-file`
+ - `bs:disable-file: code1 code2 code3`
+
+```BrightScript
+' bs:disable-file: 1001 1002
+
+sub Main()
+    DoSomething()
+end sub
+```
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- bs:disable-file: 1006 -->
+<component name="Foo">
+</component>
+```
+
+A `bs:disable-file` comment placed below the first line of code (or below the root XML element) is ignored.
+
+## Quick fixes
+
+The BrighterScript language server offers two quick-fix actions on every diagnostic so you can suppress the message without leaving your editor:
+
+ - **Disable {code} for this line: {message}** &mdash; if a `bs:disable-line` or `bs:disable-next-line` directive already exists on/above the diagnostic line, the code is appended to it. Otherwise a new `bs:disable-next-line: {code}` comment is inserted above the diagnostic.
+ - **Disable {code} for this file: {message}** &mdash; if a `bs:disable-file` directive already exists in the file's header, the code is appended to it. Otherwise a new `bs:disable-file: {code}` comment is inserted at the top of the file.
+
+These actions appear after the standard quick fixes for a diagnostic.

--- a/docs/suppressing-compiler-messages.md
+++ b/docs/suppressing-compiler-messages.md
@@ -46,12 +46,12 @@ The primary motivation for this feature was to provide a stopgap measure to hide
 
 ## Ignoring errors and warnings for a block of code or whole file
 
-Use ESLint-style `bs:disable` / `bs:enable` directives to suppress diagnostics for a span of code. A `bs:disable` opens a suppression block; a matching `bs:enable` closes it. If no `bs:enable` follows, the block runs to the end of the file &mdash; so a bare `bs:disable` at the top of a file suppresses the whole file.
+Use `bs:disable` and `bs:enable` to suppress diagnostics for a span of code. A `bs:disable` opens a suppression block, and a matching `bs:enable` closes it. If no `bs:enable` follows, the block runs to the end of the file, so a bare `bs:disable` at the top of a file suppresses the whole file.
 
- - `bs:disable` &mdash; suppress all diagnostics from this line until the next `bs:enable`
- - `bs:disable: code1 code2 code3` &mdash; suppress only the listed codes
- - `bs:enable` &mdash; close any open `bs:disable` block
- - `bs:enable: code1 code2 code3` &mdash; carve out specific codes from an open `bs:disable`
+ - `bs:disable`: suppress all diagnostics from this line until the next `bs:enable`
+ - `bs:disable: code1 code2 code3`: suppress only the listed codes
+ - `bs:enable`: close any open `bs:disable` block
+ - `bs:enable: code1 code2 code3`: re-enable specific codes from an open `bs:disable`
 
 ```BrightScript
 ' bs:disable: 1001 1002
@@ -68,7 +68,7 @@ end sub
 </component>
 ```
 
-`bs:enable: <code>` after a bare `bs:disable` selectively re-enables one diagnostic while keeping the rest suppressed:
+`bs:enable: <code>` after a bare `bs:disable` re-enables one diagnostic while keeping the rest suppressed:
 
 ```BrightScript
 ' bs:disable
@@ -84,7 +84,7 @@ end sub
 
 The BrighterScript language server offers two quick-fix actions on every diagnostic so you can suppress the message without leaving your editor:
 
- - **Disable {code} for this line: {message}** &mdash; if a `bs:disable-line` or `bs:disable-next-line` directive already exists on/above the diagnostic line, the code is appended to it. Otherwise a new `bs:disable-next-line: {code}` comment is inserted above the diagnostic.
- - **Disable {code} for this file: {message}** &mdash; if a header-level `bs:disable` directive already exists, the code is appended to it. Otherwise a new `bs:disable: {code}` comment is inserted at the top of the file.
+ - **Disable {code} for this line: {message}**: if a `bs:disable-line` or `bs:disable-next-line` directive already exists on or above the diagnostic line, the code is appended to it. Otherwise a new `bs:disable-next-line: {code}` comment is inserted above the diagnostic.
+ - **Disable {code} for this file: {message}**: if a header-level `bs:disable` directive already exists, the code is appended to it. Otherwise a new `bs:disable: {code}` comment is inserted at the top of the file.
 
 These actions appear after the standard quick fixes for a diagnostic.

--- a/docs/suppressing-compiler-messages.md
+++ b/docs/suppressing-compiler-messages.md
@@ -44,15 +44,17 @@ end sub
 
 The primary motivation for this feature was to provide a stopgap measure to hide incorrectly-thrown errors on legitimate BrightScript code due to parser bugs. It is recommended that you only use these comments when absolutely necessary.
 
-## Ignoring errors and warnings for an entire file
+## Ignoring errors and warnings for a block of code or whole file
 
-To suppress diagnostics across an entire file, place a `bs:disable-file` comment in the file's header. The directive only takes effect when it appears before any executable code (comment-only lines and blank lines above it are fine). For XML files, place the comment between the `<?xml ?>` declaration and the root component element.
+Use ESLint-style `bs:disable` / `bs:enable` directives to suppress diagnostics for a span of code. A `bs:disable` opens a suppression block; a matching `bs:enable` closes it. If no `bs:enable` follows, the block runs to the end of the file &mdash; so a bare `bs:disable` at the top of a file suppresses the whole file.
 
- - `bs:disable-file`
- - `bs:disable-file: code1 code2 code3`
+ - `bs:disable` &mdash; suppress all diagnostics from this line until the next `bs:enable`
+ - `bs:disable: code1 code2 code3` &mdash; suppress only the listed codes
+ - `bs:enable` &mdash; close any open `bs:disable` block
+ - `bs:enable: code1 code2 code3` &mdash; carve out specific codes from an open `bs:disable`
 
 ```BrightScript
-' bs:disable-file: 1001 1002
+' bs:disable: 1001 1002
 
 sub Main()
     DoSomething()
@@ -61,18 +63,28 @@ end sub
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- bs:disable-file: 1006 -->
+<!-- bs:disable: 1006 -->
 <component name="Foo">
 </component>
 ```
 
-A `bs:disable-file` comment placed below the first line of code (or below the root XML element) is ignored.
+`bs:enable: <code>` after a bare `bs:disable` selectively re-enables one diagnostic while keeping the rest suppressed:
+
+```BrightScript
+' bs:disable
+'   1006 is still suppressed below, but 1001 reports normally
+' bs:enable: 1001
+
+sub Main()
+    DoSomething()
+end sub
+```
 
 ## Quick fixes
 
 The BrighterScript language server offers two quick-fix actions on every diagnostic so you can suppress the message without leaving your editor:
 
  - **Disable {code} for this line: {message}** &mdash; if a `bs:disable-line` or `bs:disable-next-line` directive already exists on/above the diagnostic line, the code is appended to it. Otherwise a new `bs:disable-next-line: {code}` comment is inserted above the diagnostic.
- - **Disable {code} for this file: {message}** &mdash; if a `bs:disable-file` directive already exists in the file's header, the code is appended to it. Otherwise a new `bs:disable-file: {code}` comment is inserted at the top of the file.
+ - **Disable {code} for this file: {message}** &mdash; if a header-level `bs:disable` directive already exists, the code is appended to it. Otherwise a new `bs:disable: {code}` comment is inserted at the top of the file.
 
 These actions appear after the standard quick fixes for a diagnostic.

--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -84,37 +84,57 @@ describe('CommentFlagProcessor', () => {
                 processor['tokenize'](`'bs:disable-line`, null as any as Range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'line',
+                directive: 'line',
                 codes: []
             });
         });
 
-        it('tokenizes bs:disable-file comment', () => {
+        it('tokenizes bs:disable comment as a block directive', () => {
             expect(
-                processor['tokenize'](`'bs:disable-file`, Range.create(0, 0, 0, 16))
+                processor['tokenize'](`'bs:disable`, Range.create(0, 0, 0, 11))
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'file',
+                directive: 'disable',
                 codes: []
             });
         });
 
-        it('tokenizes bs:disable-file comment with codes', () => {
-            const token = Lexer.scan(`'bs:disable-file:1 2 3`).tokens[0];
+        it('tokenizes bs:enable comment as a block directive', () => {
+            expect(
+                processor['tokenize'](`'bs:enable`, Range.create(0, 0, 0, 10))
+            ).to.eql({
+                commentTokenText: `'`,
+                directive: 'enable',
+                codes: []
+            });
+        });
+
+        it('prefers the longer prefix so bs:disable-line is not parsed as bs:disable', () => {
+            expect(
+                processor['tokenize'](`'bs:disable-line`, Range.create(0, 0, 0, 16))
+            ).to.eql({
+                commentTokenText: `'`,
+                directive: 'line',
+                codes: []
+            });
+        });
+
+        it('tokenizes bs:disable comment with codes', () => {
+            const token = Lexer.scan(`'bs:disable:1 2 3`).tokens[0];
             expect(
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'file',
+                directive: 'disable',
                 codes: [{
                     code: '1',
-                    range: Range.create(0, 17, 0, 18)
+                    range: Range.create(0, 12, 0, 13)
                 }, {
                     code: '2',
-                    range: Range.create(0, 19, 0, 20)
+                    range: Range.create(0, 14, 0, 15)
                 }, {
                     code: '3',
-                    range: Range.create(0, 21, 0, 22)
+                    range: Range.create(0, 16, 0, 17)
                 }]
             });
         });
@@ -125,7 +145,7 @@ describe('CommentFlagProcessor', () => {
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'line',
+                directive: 'line',
                 codes: [{
                     code: '123456',
                     range: Range.create(0, 29, 0, 35)
@@ -145,7 +165,7 @@ describe('CommentFlagProcessor', () => {
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'line',
+                directive: 'line',
                 codes: [{
                     code: '1',
                     range: Range.create(0, 17, 0, 18)
@@ -165,7 +185,7 @@ describe('CommentFlagProcessor', () => {
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'line',
+                directive: 'line',
                 codes: [{
                     code: '1',
                     range: Range.create(0, 18, 0, 19)
@@ -179,7 +199,7 @@ describe('CommentFlagProcessor', () => {
                 processor['tokenize'](token.text, token.range)
             ).to.eql({
                 commentTokenText: `'`,
-                disableType: 'line',
+                directive: 'line',
                 codes: [{
                     code: '1',
                     range: Range.create(0, 18, 0, 19)
@@ -188,11 +208,18 @@ describe('CommentFlagProcessor', () => {
         });
     });
 
-    describe('tryAdd', () => {
-        it('supports non-numeric codes', () => {
-            processor.tryAdd(`'bs:disable-line lint123 LINT2 some-textual-diagnostic`, Range.create(0, 0, 0, 54));
+    describe('tryAdd + finalize', () => {
+        beforeEach(() => {
+            //seed the known-codes list so numeric codes used in the tests are accepted
+            processor = new CommentFlagProcessor(mockBscFile, [`'`], [1001, 1002]);
+        });
+
+        it('supports non-numeric codes on line directives', () => {
+            const fresh = new CommentFlagProcessor(mockBscFile, [`'`]);
+            fresh.tryAdd(`'bs:disable-line lint123 LINT2 some-textual-diagnostic`, Range.create(0, 0, 0, 54));
+            fresh.finalize();
             expect(
-                processor.commentFlags.flatMap(x => x.codes)
+                fresh.commentFlags.flatMap(flag => flag.codes)
             ).to.eql([
                 'lint123',
                 'lint2',
@@ -200,34 +227,83 @@ describe('CommentFlagProcessor', () => {
             ]);
         });
 
-        it('produces a whole-file affectedRange for bs:disable-file', () => {
-            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
-            processor.tryAdd(`'bs:disable-file`, Range.create(0, 0, 0, 16));
-            expect(processor.commentFlags[0]).to.deep.include({
-                codes: null,
-                affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
-            });
+        it('a bare bs:disable with no closing bs:enable suppresses the rest of the file', () => {
+            processor.tryAdd(`'bs:disable`, Range.create(0, 0, 0, 11));
+            processor.finalize();
+
+            const blockFlag = processor.commentFlags.find(flag => flag.codes === null && flag.affectedRange.end.line === Number.MAX_SAFE_INTEGER);
+            expect(blockFlag).to.exist;
+            expect(blockFlag.enableCodes).to.be.undefined;
+            expect(blockFlag.affectedRange).to.deep.equal(util.createRange(1, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER));
         });
 
-        it('produces a whole-file affectedRange for bs:disable-file with codes', () => {
-            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
-            processor.tryAdd(`'bs:disable-file: lint1 lint2`, Range.create(0, 0, 0, 29));
-            expect(processor.commentFlags[0]).to.deep.include({
-                codes: ['lint1', 'lint2'],
-                affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
-            });
+        it('a bs:disable / bs:enable pair only suppresses lines between the two', () => {
+            processor.tryAdd(`'bs:disable`, Range.create(2, 0, 2, 11));
+            processor.tryAdd(`'bs:enable`, Range.create(5, 0, 5, 10));
+            processor.finalize();
+
+            const blockFlag = processor.commentFlags.find(flag => flag.codes === null && flag.affectedRange.end.line < Number.MAX_SAFE_INTEGER);
+            expect(blockFlag).to.exist;
+            expect(blockFlag.affectedRange).to.deep.equal(util.createRange(3, 0, 4, Number.MAX_SAFE_INTEGER));
+            expect(blockFlag.enableCodes).to.be.undefined;
         });
 
-        it('skips bs:disable-file when allowFileLevel is false', () => {
-            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
-            processor.tryAdd(`'bs:disable-file`, Range.create(5, 0, 5, 16), { allowFileLevel: false });
-            expect(processor.commentFlags).to.be.empty;
+        it('bs:enable: <code> after a bare bs:disable carves out an exception via enableCodes', () => {
+            //         line 0: bs:disable
+            //         line 5: bs:enable: 1001
+            processor.tryAdd(`'bs:disable`, Range.create(0, 0, 0, 11));
+            processor.tryAdd(`'bs:enable: 1001`, Range.create(5, 0, 5, 16));
+            processor.finalize();
+
+            //first block flag (lines 1-4): all disabled, no carveouts
+            const firstBlock = processor.commentFlags.find(flag => flag.codes === null &&
+                flag.affectedRange.start.line === 1 &&
+                flag.affectedRange.end.line === 4
+            );
+            expect(firstBlock, 'first block flag').to.exist;
+            expect(firstBlock.enableCodes).to.be.undefined;
+
+            //second block flag (lines 6-EOF): all disabled except 1001
+            const secondBlock = processor.commentFlags.find(flag => flag.codes === null &&
+                flag.affectedRange.start.line === 6
+            );
+            expect(secondBlock, 'second block flag').to.exist;
+            expect(secondBlock.enableCodes).to.eql([1001]);
         });
 
-        it('still allows bs:disable-line when allowFileLevel is false', () => {
-            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
-            processor.tryAdd(`'bs:disable-line`, Range.create(5, 8, 5, 24), { allowFileLevel: false });
-            expect(processor.commentFlags).not.to.be.empty;
+        it('bs:disable: <code> after a bare bs:enable starts suppressing only that code', () => {
+            //         line 0: bs:enable   (no-op state-wise; nothing to suppress yet)
+            //         line 3: bs:disable: 1001
+            processor.tryAdd(`'bs:enable`, Range.create(0, 0, 0, 10));
+            processor.tryAdd(`'bs:disable: 1001`, Range.create(3, 0, 3, 17));
+            processor.finalize();
+
+            //the bare bs:enable produces no flag (nothing is suppressed in lines 1-2)
+            const beforeDisable = processor.commentFlags.find(flag => flag.affectedRange.start.line === 1 && flag.affectedRange.end.line === 2
+            );
+            expect(beforeDisable, 'no flag emitted while nothing is suppressed').to.be.undefined;
+
+            //the disable: 1001 produces a flag covering lines 4-EOF
+            const afterDisable = processor.commentFlags.find(flag => Array.isArray(flag.codes) && flag.codes.length === 1 && flag.codes[0] === 1001
+            );
+            expect(afterDisable, 'disable: 1001 flag').to.exist;
+            expect(afterDisable.affectedRange.start.line).to.equal(4);
+            expect(afterDisable.enableCodes).to.be.undefined;
+        });
+
+        it('bs:disable: <code> while in disable-all mode subtracts the code from the carveouts', () => {
+            //         line 0: bs:disable               (disable everything)
+            //         line 3: bs:enable: 1001 1002    (carve out 1001, 1002)
+            //         line 6: bs:disable: 1001        (re-suppress 1001 by removing it from carveouts)
+            processor.tryAdd(`'bs:disable`, Range.create(0, 0, 0, 11));
+            processor.tryAdd(`'bs:enable: 1001 1002`, Range.create(3, 0, 3, 21));
+            processor.tryAdd(`'bs:disable: 1001`, Range.create(6, 0, 6, 17));
+            processor.finalize();
+
+            const finalBlock = processor.commentFlags.find(flag => flag.codes === null && flag.affectedRange.start.line === 7
+            );
+            expect(finalBlock, 'final block flag').to.exist;
+            expect(finalBlock.enableCodes).to.eql([1002]);
         });
     });
 });

--- a/src/CommentFlagProcessor.spec.ts
+++ b/src/CommentFlagProcessor.spec.ts
@@ -3,6 +3,7 @@ import { Range } from 'vscode-languageserver';
 import { CommentFlagProcessor } from './CommentFlagProcessor';
 import { Lexer } from './lexer/Lexer';
 import type { BscFile } from '.';
+import util from './util';
 
 describe('CommentFlagProcessor', () => {
     let processor: CommentFlagProcessor;
@@ -88,6 +89,36 @@ describe('CommentFlagProcessor', () => {
             });
         });
 
+        it('tokenizes bs:disable-file comment', () => {
+            expect(
+                processor['tokenize'](`'bs:disable-file`, Range.create(0, 0, 0, 16))
+            ).to.eql({
+                commentTokenText: `'`,
+                disableType: 'file',
+                codes: []
+            });
+        });
+
+        it('tokenizes bs:disable-file comment with codes', () => {
+            const token = Lexer.scan(`'bs:disable-file:1 2 3`).tokens[0];
+            expect(
+                processor['tokenize'](token.text, token.range)
+            ).to.eql({
+                commentTokenText: `'`,
+                disableType: 'file',
+                codes: [{
+                    code: '1',
+                    range: Range.create(0, 17, 0, 18)
+                }, {
+                    code: '2',
+                    range: Range.create(0, 19, 0, 20)
+                }, {
+                    code: '3',
+                    range: Range.create(0, 21, 0, 22)
+                }]
+            });
+        });
+
         it('works for special case', () => {
             const token = Lexer.scan(`print "hi" 'bs:disable-line: 123456 999999   aaaab`).tokens[2];
             expect(
@@ -167,6 +198,36 @@ describe('CommentFlagProcessor', () => {
                 'lint2',
                 'some-textual-diagnostic'
             ]);
+        });
+
+        it('produces a whole-file affectedRange for bs:disable-file', () => {
+            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
+            processor.tryAdd(`'bs:disable-file`, Range.create(0, 0, 0, 16));
+            expect(processor.commentFlags[0]).to.deep.include({
+                codes: null,
+                affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+            });
+        });
+
+        it('produces a whole-file affectedRange for bs:disable-file with codes', () => {
+            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
+            processor.tryAdd(`'bs:disable-file: lint1 lint2`, Range.create(0, 0, 0, 29));
+            expect(processor.commentFlags[0]).to.deep.include({
+                codes: ['lint1', 'lint2'],
+                affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+            });
+        });
+
+        it('skips bs:disable-file when allowFileLevel is false', () => {
+            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
+            processor.tryAdd(`'bs:disable-file`, Range.create(5, 0, 5, 16), { allowFileLevel: false });
+            expect(processor.commentFlags).to.be.empty;
+        });
+
+        it('still allows bs:disable-line when allowFileLevel is false', () => {
+            processor = new CommentFlagProcessor(mockBscFile, [`'`]);
+            processor.tryAdd(`'bs:disable-line`, Range.create(5, 8, 5, 24), { allowFileLevel: false });
+            expect(processor.commentFlags).not.to.be.empty;
         });
     });
 });

--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -16,15 +16,8 @@ export class CommentFlagProcessor {
         /**
          * Valid diagnostic codes. Codes NOT in this list will be flagged
          */
-        public diagnosticCodes = [] as DiagnosticCode[],
-        /**
-         * Diagnostic codes to never filter (these codes will always be flagged)
-         */
-        public ignoreDiagnosticCodes = [] as DiagnosticCode[]
+        public diagnosticCodes = [] as DiagnosticCode[]
     ) {
-
-        this.allCodesExceptIgnores = this.diagnosticCodes.filter(x => !this.ignoreDiagnosticCodes.includes(x));
-
     }
 
     /**
@@ -38,90 +31,156 @@ export class CommentFlagProcessor {
     public diagnostics = [] as BsDiagnostic[];
 
     /**
-     * A list of all codes EXCEPT the ones in `ignoreDiagnosticCodes`
+     * Block-level `bs:disable` / `bs:enable` directives, recorded in source order
+     * by `tryAdd` and resolved into `CommentFlag`s by `finalize()`.
      */
-    public allCodesExceptIgnores: DiagnosticCode[];
+    private blockDirectives = [] as BlockDirective[];
 
-    public tryAdd(text: string, range: Range, options?: { allowFileLevel?: boolean }) {
+    public tryAdd(text: string, range: Range) {
         const tokenized = this.tokenize(text, range);
         if (!tokenized) {
             return;
         }
 
-        //file-level directives are gated by the caller (typically only honored at the top of the file)
-        if (tokenized.disableType === 'file' && options?.allowFileLevel === false) {
+        //block directives — queue them with their raw code tokens; finalize() validates and resolves them
+        if (tokenized.directive === 'disable' || tokenized.directive === 'enable') {
+            this.blockDirectives.push({
+                kind: tokenized.directive,
+                rawCodes: tokenized.codes,
+                range: range
+            });
             return;
         }
 
-        let affectedRange: Range;
-        if (tokenized.disableType === 'line') {
-            affectedRange = util.createRange(range.start.line, 0, range.start.line, range.start.character);
-        } else if (tokenized.disableType === 'next-line') {
-            affectedRange = util.createRange(range.start.line + 1, 0, range.start.line + 1, Number.MAX_SAFE_INTEGER);
-        } else {
-            // tokenized.disableType must be 'file'
-            affectedRange = util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
-        }
+        //line-level directives — emit a flag inline
+        const affectedRange = tokenized.directive === 'line'
+            ? util.createRange(range.start.line, 0, range.start.line, range.start.character)
+            : util.createRange(range.start.line + 1, 0, range.start.line + 1, Number.MAX_SAFE_INTEGER);
 
-        let commentFlag: CommentFlag | null = null;
-
-        //statement to disable EVERYTHING
         if (tokenized.codes.length === 0) {
-            commentFlag = {
+            //bare `bs:disable-line` / `bs:disable-next-line` — suppress everything
+            this.commentFlags.push({
                 file: this.file,
-                //null means all codes
                 codes: null,
                 range: range,
                 affectedRange: affectedRange
-            };
-
-            //disable specific diagnostic codes
-        } else {
-            let codes = [] as DiagnosticCode[];
-            for (let codeToken of tokenized.codes) {
-                let codeInt = parseInt(codeToken.code);
-                //is a plugin-contributed or non-numeric code
-                if (isNaN(codeInt)) {
-                    codes.push(codeToken.code?.toString()?.toLowerCase());
-
-                    //validate numeric codes against the list of known bsc codes
-                } else if (this.diagnosticCodes.includes(codeInt)) {
-                    codes.push(codeInt);
-
-                    //add a warning for unknown codes
-                } else {
-                    this.diagnostics.push({
-                        ...DiagnosticMessages.unknownDiagnosticCode(codeInt),
-                        file: this.file,
-                        range: codeToken.range
-                    });
-                }
-            }
-            if (codes.length > 0) {
-                commentFlag = {
-                    file: this.file,
-                    codes: codes,
-                    range: range,
-                    affectedRange: affectedRange
-                };
-            }
+            });
+            return;
         }
 
-        if (commentFlag) {
-            this.commentFlags.push(commentFlag);
-
-            //add an ignore for everything in this comment except for Unknown_diagnostic_code_1014
+        const codes = this.collectCodes(tokenized.codes);
+        if (codes && codes.length > 0) {
             this.commentFlags.push({
-                affectedRange: commentFlag.range,
-                range: commentFlag.range,
-                codes: this.allCodesExceptIgnores,
-                file: this.file
+                file: this.file,
+                codes: codes,
+                range: range,
+                affectedRange: affectedRange
             });
         }
     }
 
     /**
-     * Small tokenizer for bs:disable comments
+     * Resolve any pending `bs:disable` / `bs:enable` block directives into `CommentFlag`s.
+     * Must be called after the file's comment tokens have been fed through `tryAdd`.
+     */
+    public finalize() {
+        if (this.blockDirectives.length === 0) {
+            return;
+        }
+
+        //state across the file: which codes are suppressed within the current block
+        let allSuppressed = false;
+        const carveOuts = new Set<DiagnosticCode>();
+
+        for (let i = 0; i < this.blockDirectives.length; i++) {
+            const directive = this.blockDirectives[i];
+            const codes = this.collectCodes(directive.rawCodes);
+
+            //apply this directive to the running state
+            if (codes === null) {
+                //bare `bs:disable` / `bs:enable` resets state
+                allSuppressed = directive.kind === 'disable';
+                carveOuts.clear();
+            } else if (directive.kind === 'disable') {
+                //in disable-all mode, "disable: X" cancels a prior carve-out for X
+                //in enable-all mode, "disable: X" adds X to the suppressed set
+                for (const code of codes) {
+                    if (allSuppressed) {
+                        carveOuts.delete(code);
+                    } else {
+                        carveOuts.add(code);
+                    }
+                }
+            } else {
+                //'enable' with specific codes — symmetric inverse of the above
+                for (const code of codes) {
+                    if (allSuppressed) {
+                        carveOuts.add(code);
+                    } else {
+                        carveOuts.delete(code);
+                    }
+                }
+            }
+
+            //affectedRange runs from the line after this directive to just before the next block directive (or EOF)
+            const next = this.blockDirectives[i + 1];
+            const startLine = directive.range.start.line + 1;
+            const endLine = next ? next.range.start.line - 1 : Number.MAX_SAFE_INTEGER;
+            if (endLine < startLine) {
+                continue;
+            }
+            const affectedRange = util.createRange(startLine, 0, endLine, Number.MAX_SAFE_INTEGER);
+
+            //emit a flag only when the current state actually suppresses something
+            if (allSuppressed) {
+                this.commentFlags.push({
+                    file: this.file,
+                    codes: null,
+                    enableCodes: carveOuts.size > 0 ? [...carveOuts] : undefined,
+                    range: directive.range,
+                    affectedRange: affectedRange
+                });
+            } else if (carveOuts.size > 0) {
+                this.commentFlags.push({
+                    file: this.file,
+                    codes: [...carveOuts],
+                    range: directive.range,
+                    affectedRange: affectedRange
+                });
+            }
+        }
+    }
+
+    /**
+     * Resolve a list of `{ code, range }` tokens into validated diagnostic codes.
+     * Pushes diagnostics for any unknown numeric codes. Returns `null` when no codes were specified
+     * (i.e. a bare `bs:disable` / `bs:enable`), and an array otherwise.
+     */
+    private collectCodes(rawCodes: Array<{ code: string; range: Range }>): DiagnosticCode[] | null {
+        if (rawCodes.length === 0) {
+            return null;
+        }
+        const codes = [] as DiagnosticCode[];
+        for (const codeToken of rawCodes) {
+            const codeInt = parseInt(codeToken.code);
+            if (isNaN(codeInt)) {
+                //plugin-contributed or non-numeric code
+                codes.push(codeToken.code?.toString()?.toLowerCase());
+            } else if (this.diagnosticCodes.includes(codeInt)) {
+                codes.push(codeInt);
+            } else {
+                this.diagnostics.push({
+                    ...DiagnosticMessages.unknownDiagnosticCode(codeInt),
+                    file: this.file,
+                    range: codeToken.range
+                });
+            }
+        }
+        return codes;
+    }
+
+    /**
+     * Small tokenizer for `bs:` directive comments.
      */
     private tokenize(text: string, range: Range): DisableToken | null {
         let lowerText = text.toLowerCase();
@@ -137,23 +196,29 @@ export class CommentFlagProcessor {
             }
         }
 
-        let disableType: 'line' | 'next-line' | 'file';
-        //trim leading/trailing whitespace
-        let len = lowerText.length;
+        //trim leading whitespace
+        const len = lowerText.length;
         lowerText = lowerText.trimLeft();
         offset += len - lowerText.length;
+
+        //match longest-prefix first so `bs:disable-line` doesn't get parsed as `bs:disable`
+        let directive: 'line' | 'next-line' | 'disable' | 'enable';
         if (lowerText.startsWith('bs:disable-line')) {
             lowerText = lowerText.substring('bs:disable-line'.length);
             offset += 'bs:disable-line'.length;
-            disableType = 'line';
+            directive = 'line';
         } else if (lowerText.startsWith('bs:disable-next-line')) {
             lowerText = lowerText.substring('bs:disable-next-line'.length);
             offset += 'bs:disable-next-line'.length;
-            disableType = 'next-line';
-        } else if (lowerText.startsWith('bs:disable-file')) {
-            lowerText = lowerText.substring('bs:disable-file'.length);
-            offset += 'bs:disable-file'.length;
-            disableType = 'file';
+            directive = 'next-line';
+        } else if (lowerText.startsWith('bs:disable')) {
+            lowerText = lowerText.substring('bs:disable'.length);
+            offset += 'bs:disable'.length;
+            directive = 'disable';
+        } else if (lowerText.startsWith('bs:enable')) {
+            lowerText = lowerText.substring('bs:enable'.length);
+            offset += 'bs:enable'.length;
+            directive = 'enable';
         } else {
             return null;
         }
@@ -164,9 +229,9 @@ export class CommentFlagProcessor {
             offset += 1;
         }
 
-        let items = this.tokenizeByWhitespace(lowerText);
-        let codes = [] as Array<{ code: string; range: Range }>;
-        for (let item of items) {
+        const items = this.tokenizeByWhitespace(lowerText);
+        const codes = [] as Array<{ code: string; range: Range }>;
+        for (const item of items) {
             codes.push({
                 code: item.text,
                 range: util.createRange(
@@ -180,7 +245,7 @@ export class CommentFlagProcessor {
 
         return {
             commentTokenText: commentTokenText,
-            disableType: disableType,
+            directive: directive,
             codes: codes
         };
     }
@@ -227,9 +292,19 @@ interface Token {
 
 interface DisableToken {
     commentTokenText: string | null;
-    disableType: 'line' | 'next-line' | 'file';
+    directive: 'line' | 'next-line' | 'disable' | 'enable';
     codes: {
         code: string;
         range: Range;
     }[];
+}
+
+interface BlockDirective {
+    kind: 'disable' | 'enable';
+    /**
+     * The raw code tokens parsed from the directive comment. `finalize()` runs `collectCodes` over
+     * these to validate them and emit any unknown-code diagnostics. An empty array means a bare directive.
+     */
+    rawCodes: Array<{ code: string; range: Range }>;
+    range: Range;
 }

--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -42,18 +42,25 @@ export class CommentFlagProcessor {
      */
     public allCodesExceptIgnores: DiagnosticCode[];
 
-    public tryAdd(text: string, range: Range) {
+    public tryAdd(text: string, range: Range, options?: { allowFileLevel?: boolean }) {
         const tokenized = this.tokenize(text, range);
         if (!tokenized) {
+            return;
+        }
+
+        //file-level directives are gated by the caller (typically only honored at the top of the file)
+        if (tokenized.disableType === 'file' && options?.allowFileLevel === false) {
             return;
         }
 
         let affectedRange: Range;
         if (tokenized.disableType === 'line') {
             affectedRange = util.createRange(range.start.line, 0, range.start.line, range.start.character);
-        } else {
-            // tokenized.disableType must be 'next-line'
+        } else if (tokenized.disableType === 'next-line') {
             affectedRange = util.createRange(range.start.line + 1, 0, range.start.line + 1, Number.MAX_SAFE_INTEGER);
+        } else {
+            // tokenized.disableType must be 'file'
+            affectedRange = util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
         }
 
         let commentFlag: CommentFlag | null = null;
@@ -130,7 +137,7 @@ export class CommentFlagProcessor {
             }
         }
 
-        let disableType: 'line' | 'next-line';
+        let disableType: 'line' | 'next-line' | 'file';
         //trim leading/trailing whitespace
         let len = lowerText.length;
         lowerText = lowerText.trimLeft();
@@ -143,6 +150,10 @@ export class CommentFlagProcessor {
             lowerText = lowerText.substring('bs:disable-next-line'.length);
             offset += 'bs:disable-next-line'.length;
             disableType = 'next-line';
+        } else if (lowerText.startsWith('bs:disable-file')) {
+            lowerText = lowerText.substring('bs:disable-file'.length);
+            offset += 'bs:disable-file'.length;
+            disableType = 'file';
         } else {
             return null;
         }
@@ -216,7 +227,7 @@ interface Token {
 
 interface DisableToken {
     commentTokenText: string | null;
-    disableType: 'line' | 'next-line';
+    disableType: 'line' | 'next-line' | 'file';
     codes: {
         code: string;
         range: Range;

--- a/src/CommentFlagProcessor.ts
+++ b/src/CommentFlagProcessor.ts
@@ -42,7 +42,7 @@ export class CommentFlagProcessor {
             return;
         }
 
-        //block directives — queue them with their raw code tokens; finalize() validates and resolves them
+        //queue block directives with their raw code tokens; finalize() validates and resolves them
         if (tokenized.directive === 'disable' || tokenized.directive === 'enable') {
             this.blockDirectives.push({
                 kind: tokenized.directive,
@@ -52,13 +52,13 @@ export class CommentFlagProcessor {
             return;
         }
 
-        //line-level directives — emit a flag inline
+        //line-level directives emit a flag inline
         const affectedRange = tokenized.directive === 'line'
             ? util.createRange(range.start.line, 0, range.start.line, range.start.character)
             : util.createRange(range.start.line + 1, 0, range.start.line + 1, Number.MAX_SAFE_INTEGER);
 
         if (tokenized.codes.length === 0) {
-            //bare `bs:disable-line` / `bs:disable-next-line` — suppress everything
+            //bare `bs:disable-line` / `bs:disable-next-line` suppresses everything
             this.commentFlags.push({
                 file: this.file,
                 codes: null,
@@ -112,7 +112,7 @@ export class CommentFlagProcessor {
                     }
                 }
             } else {
-                //'enable' with specific codes — symmetric inverse of the above
+                //'enable' with specific codes does the opposite of the disable branch above
                 for (const code of codes) {
                     if (allSuppressed) {
                         carveOuts.add(code);

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '../../chai-config.spec';
 import { URI } from 'vscode-uri';
-import type { Range } from 'vscode-languageserver';
+import type { CodeAction, Range } from 'vscode-languageserver';
 import type { BscFile, OnGetCodeActionsEvent } from '../../interfaces';
 import { Program } from '../../Program';
 import { expectCodeActions, trim } from '../../testHelpers.spec';
@@ -21,16 +21,28 @@ describe('CodeActionsProcessor', () => {
     });
 
     /**
-     * Helper function for testing code actions
+     * Helper function for testing code actions. By default it filters out the generic
+     * `Disable {code} for this line/file` quick fixes because every diagnostic gets them
+     * and the per-feature tests below only care about feature-specific actions.
      */
-    function testGetCodeActions(file: BscFile | string, range: Range, expected: string[]) {
+    function testGetCodeActions(file: BscFile | string, range: Range, expected: string[], options?: { includeDisableDirectives?: boolean }) {
         program.validate();
-        expect(
-            program.getCodeActions(
-                typeof file === 'string' ? file : file.srcPath,
-                range
-            ).map(x => x.title).sort()
-        ).to.eql(expected);
+        const titles = program.getCodeActions(
+            typeof file === 'string' ? file : file.srcPath,
+            range
+        ).map(x => x.title);
+        expect(filterDisableActions(titles, options).sort()).to.eql(expected);
+    }
+
+    /**
+     * Drops the generic `Disable {code} for this line/file` titles from a list so feature-level
+     * assertions can stay focused on their own actions.
+     */
+    function filterDisableActions(titles: string[], options?: { includeDisableDirectives?: boolean }) {
+        if (options?.includeDisableDirectives) {
+            return titles;
+        }
+        return titles.filter(t => !/^Disable .+ for this (line|file)/.test(t));
     }
 
     describe('getCodeActions', () => {
@@ -140,7 +152,7 @@ describe('CodeActionsProcessor', () => {
                 // doSome|thing()
                 util.createRange(2, 22, 2, 22)
             );
-            expect(codeActions.map(x => x.title).sort()).to.eql([
+            expect(filterDisableActions(codeActions.map(x => x.title)).sort()).to.eql([
                 `import "pkg:/components/lib1.brs"`,
                 `import "pkg:/components/lib2.brs"`
             ]);
@@ -169,13 +181,13 @@ describe('CodeActionsProcessor', () => {
 
             program.validate();
 
-            //there should be no code actions since this is a brs file
+            //there should be no import code actions since this is a brs file (disable directives still appear for any diagnostic)
             const codeActions = program.getCodeActions(
                 file.srcPath,
                 // DoSometh|ing()
                 util.createRange(2, 28, 2, 28)
             );
-            expect(codeActions).to.be.empty;
+            expect(filterDisableActions(codeActions.map(x => x.title))).to.be.empty;
         });
 
         it('suggests class imports', () => {
@@ -200,11 +212,11 @@ describe('CodeActionsProcessor', () => {
             program.validate();
 
             expect(
-                program.getCodeActions(
+                filterDisableActions(program.getCodeActions(
                     file.srcPath,
                     // new Per|son()
                     util.createRange(2, 34, 2, 34)
-                ).map(x => x.title).sort()
+                ).map(x => x.title)).sort()
             ).to.eql([
                 `import "pkg:/source/Person.bs"`
             ]);
@@ -234,11 +246,11 @@ describe('CodeActionsProcessor', () => {
             program.validate();
 
             expect(
-                program.getCodeActions(
+                filterDisableActions(program.getCodeActions(
                     file.srcPath,
                     // new Anim|als.Cat()
                     util.createRange(2, 36, 2, 36)
-                ).map(x => x.title).sort()
+                ).map(x => x.title)).sort()
             ).to.eql([
                 `import "pkg:/source/Animals.bs"`
             ]);
@@ -998,6 +1010,209 @@ describe('CodeActionsProcessor', () => {
             const changes = Object.values(fix!.edit!.changes!)[0];
             // range covers "override " (8 chars + 1 space)
             expect(changes[0].range.start.character).to.equal(changes[0].range.end.character - 9);
+        });
+    });
+
+    describe('disable diagnostic actions', () => {
+        const findLineAction = (actions: CodeAction[], code: string | number) => actions.find(a => a.title.startsWith(`Disable ${code} for this line`));
+        const findFileAction = (actions: CodeAction[], code: string | number) => actions.find(a => a.title.startsWith(`Disable ${code} for this file`));
+
+        it('emits disable-line and disable-file actions for any diagnostic with a code', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            const actions = program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22));
+            //the diagnostic for an undefined function — code is `cannotFindFunction` (1140)
+            expect(findLineAction(actions, 1140), 'expected a "Disable 1140 for this line: ..." action').to.exist;
+            expect(findFileAction(actions, 1140), 'expected a "Disable 1140 for this file: ..." action').to.exist;
+        });
+
+        it('includes the diagnostic message in the action title', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            const actions = program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22));
+            const action = findLineAction(actions, 1140);
+            expect(action!.title).to.match(/^Disable 1140 for this line: .+/);
+            //the message portion is the diagnostic's message, so it should mention the missing function name
+            expect(action!.title).to.include('doSomething');
+        });
+
+        it('inserts a bs:disable-next-line directive above the diagnostic, preserving indent', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            const action = findLineAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            expect(edits).to.have.lengthOf(1);
+            //"                    doSomething()" — 20 spaces of indent on line 2
+            expect(edits[0].newText).to.equal(`                    ' bs:disable-next-line: 1140\n`);
+            expect(edits[0].range).to.eql(util.createRange(2, 0, 2, 0));
+        });
+
+        it('inserts a bs:disable-file directive at line 0 in a brs/bs file', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            const action = findFileAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            expect(edits[0].newText).to.equal(`' bs:disable-file: 1140\n`);
+            expect(edits[0].range).to.eql(util.createRange(0, 0, 0, 0));
+        });
+
+        it('inserts an XML-style disable-file directive after the XML declaration', () => {
+            const file = program.setFile('components/comp1.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="comp1">
+                </component>
+            `);
+            program.validate();
+            const action = program.getCodeActions(file.srcPath, util.createRange(1, 5, 1, 5))
+                .find(a => /^Disable .+ for this file/.test(a.title));
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            //inserted right after `?>` on line 0 with a leading newline so the directive sits on its own line
+            expect(edits[0].newText.startsWith('\n<!-- bs:disable-file: ')).to.be.true;
+            expect(edits[0].newText.endsWith(' -->')).to.be.true;
+            expect(edits[0].range.start.line).to.equal(0);
+        });
+
+        it('does not emit disable actions for diagnostics without a code', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                end sub
+            `);
+            program.validate();
+            //inject a diagnostic with no code into the event
+            const range = util.createRange(1, 16, 1, 16);
+            const event: OnGetCodeActionsEvent = {
+                program: program,
+                file: file as BscFile,
+                range: range,
+                scopes: program.getScopesForFile(file),
+                diagnostics: [{ code: undefined, message: 'no code', range: range, file: file } as any],
+                codeActions: []
+            };
+            new CodeActionsProcessor(event).process();
+            expect(event.codeActions.filter(a => /^Disable .+ for this/.test(a.title))).to.be.empty;
+        });
+
+        it('extends an existing bs:disable-next-line directive instead of inserting a new one', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    ' bs:disable-next-line: 9999
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            //the diagnostic is on line 3 (the doSomething call). The existing directive sits on line 2.
+            const action = findLineAction(program.getCodeActions(file.srcPath, util.createRange(3, 22, 3, 22)), 1140);
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            expect(edits).to.have.lengthOf(1);
+            //replaces the existing comment with a merged version
+            expect(edits[0].newText).to.equal(`' bs:disable-next-line: 9999 1140`);
+        });
+
+        it('extends an existing trailing bs:disable-line directive', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    doSomething() ' bs:disable-line: 9999
+                end sub
+            `);
+            program.validate();
+            const action = findLineAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            expect(edits[0].newText).to.equal(`' bs:disable-line: 9999 1140`);
+        });
+
+        it('extends an existing bs:disable-file directive instead of inserting a new one', () => {
+            const file = program.setFile('source/main.bs', `' bs:disable-file: 9999
+                sub init()
+                    doSomething()
+                end sub
+            `);
+            program.validate();
+            const action = findFileAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            expect(edits[0].newText).to.equal(`' bs:disable-file: 9999 1140`);
+        });
+
+        it('extends an existing XML bs:disable-file directive', () => {
+            const file = program.setFile('components/comp1.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <!-- bs:disable-file: 9999 -->
+                <component name="comp1">
+                </component>
+            `);
+            program.validate();
+            const action = program.getCodeActions(file.srcPath, util.createRange(2, 5, 2, 5))
+                .find(a => /^Disable .+ for this file/.test(a.title));
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            //the new code is appended to the existing space-separated list
+            expect(/^<!-- bs:disable-file: 9999 \d+ -->$/.test(edits[0].newText)).to.be.true;
+        });
+
+        it('does not duplicate the code when it is already in an existing directive', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    ' bs:disable-next-line: 9001
+                    print "hello"
+                end sub
+            `);
+            program.validate();
+            //inject a synthetic diagnostic so we can exercise the no-op path with a code that's already listed in the existing directive
+            const range = util.createRange(3, 22, 3, 22);
+            const event: OnGetCodeActionsEvent = {
+                program: program,
+                file: file as BscFile,
+                range: range,
+                scopes: program.getScopesForFile(file),
+                diagnostics: [{ code: 9001, message: 'fake diagnostic', range: range, file: file } as any],
+                codeActions: []
+            };
+            new CodeActionsProcessor(event).process();
+            //the line action should be skipped (already in directive); the file action should still be available
+            expect(findLineAction(event.codeActions, 9001)).to.be.undefined;
+            expect(findFileAction(event.codeActions, 9001)).to.exist;
+        });
+
+        it('skips the line action when an existing directive suppresses all codes', () => {
+            const file = program.setFile('source/main.bs', `
+                sub init()
+                    ' bs:disable-next-line
+                    print "hello"
+                end sub
+            `);
+            program.validate();
+            const range = util.createRange(3, 22, 3, 22);
+            const event: OnGetCodeActionsEvent = {
+                program: program,
+                file: file as BscFile,
+                range: range,
+                scopes: program.getScopesForFile(file),
+                diagnostics: [{ code: 9001, message: 'fake diagnostic', range: range, file: file } as any],
+                codeActions: []
+            };
+            new CodeActionsProcessor(event).process();
+            expect(findLineAction(event.codeActions, 9001)).to.be.undefined;
         });
     });
 });

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -1091,6 +1091,23 @@ describe('CodeActionsProcessor', () => {
             expect(edits[0].range.start.line).to.equal(0);
         });
 
+        it('inserts an XML-style bs:disable directive at line 0 when the <?xml ?> declaration is missing', () => {
+            //Roku permits XML component files without the optional `<?xml ?>` declaration
+            const file = program.setFile('components/comp1.xml', trim`
+                <component name="comp1">
+                </component>
+            `);
+            program.validate();
+            const action = program.getCodeActions(file.srcPath, util.createRange(0, 5, 0, 5))
+                .find(a => /^Disable .+ for this file/.test(a.title));
+            expect(action).to.exist;
+            const edits = Object.values(action!.edit!.changes!)[0];
+            //no declaration to anchor to, so insert at the very top with a trailing newline
+            expect(edits[0].newText.startsWith('<!-- bs:disable: ')).to.be.true;
+            expect(edits[0].newText.endsWith(' -->\n')).to.be.true;
+            expect(edits[0].range).to.eql(util.createRange(0, 0, 0, 0));
+        });
+
         it('does not emit disable actions for diagnostics without a code', () => {
             const file = program.setFile('source/main.bs', `
                 sub init()

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.spec.ts
@@ -1017,7 +1017,7 @@ describe('CodeActionsProcessor', () => {
         const findLineAction = (actions: CodeAction[], code: string | number) => actions.find(a => a.title.startsWith(`Disable ${code} for this line`));
         const findFileAction = (actions: CodeAction[], code: string | number) => actions.find(a => a.title.startsWith(`Disable ${code} for this file`));
 
-        it('emits disable-line and disable-file actions for any diagnostic with a code', () => {
+        it('emits "Disable for this line" and "Disable for this file" actions for any diagnostic with a code', () => {
             const file = program.setFile('source/main.bs', `
                 sub init()
                     doSomething()
@@ -1060,7 +1060,7 @@ describe('CodeActionsProcessor', () => {
             expect(edits[0].range).to.eql(util.createRange(2, 0, 2, 0));
         });
 
-        it('inserts a bs:disable-file directive at line 0 in a brs/bs file', () => {
+        it('inserts a bs:disable directive at line 0 in a brs/bs file', () => {
             const file = program.setFile('source/main.bs', `
                 sub init()
                     doSomething()
@@ -1070,11 +1070,11 @@ describe('CodeActionsProcessor', () => {
             const action = findFileAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
             expect(action).to.exist;
             const edits = Object.values(action!.edit!.changes!)[0];
-            expect(edits[0].newText).to.equal(`' bs:disable-file: 1140\n`);
+            expect(edits[0].newText).to.equal(`' bs:disable: 1140\n`);
             expect(edits[0].range).to.eql(util.createRange(0, 0, 0, 0));
         });
 
-        it('inserts an XML-style disable-file directive after the XML declaration', () => {
+        it('inserts an XML-style bs:disable directive after the XML declaration', () => {
             const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
                 <component name="comp1">
@@ -1086,7 +1086,7 @@ describe('CodeActionsProcessor', () => {
             expect(action).to.exist;
             const edits = Object.values(action!.edit!.changes!)[0];
             //inserted right after `?>` on line 0 with a leading newline so the directive sits on its own line
-            expect(edits[0].newText.startsWith('\n<!-- bs:disable-file: ')).to.be.true;
+            expect(edits[0].newText.startsWith('\n<!-- bs:disable: ')).to.be.true;
             expect(edits[0].newText.endsWith(' -->')).to.be.true;
             expect(edits[0].range.start.line).to.equal(0);
         });
@@ -1141,8 +1141,8 @@ describe('CodeActionsProcessor', () => {
             expect(edits[0].newText).to.equal(`' bs:disable-line: 9999 1140`);
         });
 
-        it('extends an existing bs:disable-file directive instead of inserting a new one', () => {
-            const file = program.setFile('source/main.bs', `' bs:disable-file: 9999
+        it('extends an existing header-level bs:disable directive instead of inserting a new one', () => {
+            const file = program.setFile('source/main.bs', `' bs:disable: 9999
                 sub init()
                     doSomething()
                 end sub
@@ -1151,13 +1151,13 @@ describe('CodeActionsProcessor', () => {
             const action = findFileAction(program.getCodeActions(file.srcPath, util.createRange(2, 22, 2, 22)), 1140);
             expect(action).to.exist;
             const edits = Object.values(action!.edit!.changes!)[0];
-            expect(edits[0].newText).to.equal(`' bs:disable-file: 9999 1140`);
+            expect(edits[0].newText).to.equal(`' bs:disable: 9999 1140`);
         });
 
-        it('extends an existing XML bs:disable-file directive', () => {
+        it('extends an existing XML header-level bs:disable directive', () => {
             const file = program.setFile('components/comp1.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>
-                <!-- bs:disable-file: 9999 -->
+                <!-- bs:disable: 9999 -->
                 <component name="comp1">
                 </component>
             `);
@@ -1167,7 +1167,7 @@ describe('CodeActionsProcessor', () => {
             expect(action).to.exist;
             const edits = Object.values(action!.edit!.changes!)[0];
             //the new code is appended to the existing space-separated list
-            expect(/^<!-- bs:disable-file: 9999 \d+ -->$/.test(edits[0].newText)).to.be.true;
+            expect(/^<!-- bs:disable: 9999 \d+ -->$/.test(edits[0].newText)).to.be.true;
         });
 
         it('does not duplicate the code when it is already in an existing directive', () => {

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -123,8 +123,11 @@ export class CodeActionsProcessor {
         }
         const codeStr = String(code);
         const isXml = isXmlFile(file);
+        //existing.forLine: any line/next-line directive on or above the diagnostic line that the line action could extend
+        //existing.forFile: any header-level bs:disable that the file action could extend
         const existing = this.findExistingDisableDirectives(file, diagnostic.range.start.line);
 
+        //format helpers wrap the directive body in the right comment syntax (`'` for brs, `<!-- -->` for xml)
         const formatLineDirective = (token: 'line' | 'next-line', codes: string[]) => {
             const body = `bs:disable-${token}: ${codes.join(' ')}`;
             return isXml ? `<!-- ${body} -->` : `' ${body}`;
@@ -135,9 +138,11 @@ export class CodeActionsProcessor {
         };
 
         // ---- "disable for this line" ----
-        //if extending an existing directive, preserve its type (line vs next-line); otherwise we always insert a new next-line directive
+        //the two lambdas passed to getDiagnosticSuppressionChange are the "extend existing" and "insert fresh" branches:
+        //  1) rebuild the existing directive comment with the new code merged into its code list (preserving line vs next-line)
+        //  2) insert a fresh `bs:disable-next-line: {code}` on the line above the diagnostic, matching its indent
         const indent = ' '.repeat(diagnostic.range.start.character);
-        const lineAction = this.buildAppendOrInsertAction(
+        const lineAction = this.getDiagnosticSuppressionChange(
             existing.forLine,
             codeStr,
             () => formatLineDirective(existing.forLine!.type as 'line' | 'next-line', this.mergeCodes(existing.forLine?.codes, codeStr)),
@@ -158,7 +163,10 @@ export class CodeActionsProcessor {
         }
 
         // ---- "disable for this file" ----
-        const fileAction = this.buildAppendOrInsertAction(
+        //same pattern as above, but operating on the header-level bs:disable directive:
+        //  1) rebuild the existing header directive with the new code appended
+        //  2) insert a fresh `bs:disable: {code}` at the file header (top of brs, or after `<?xml ?>` for xml)
+        const fileAction = this.getDiagnosticSuppressionChange(
             existing.forFile,
             codeStr,
             () => formatBlockDirective(this.mergeCodes(existing.forFile?.codes, codeStr)),
@@ -183,12 +191,13 @@ export class CodeActionsProcessor {
     }
 
     /**
-     * If `existing` is set, returns a replace edit that swaps the existing directive comment for a
-     * rebuilt version (with the new code merged in). Otherwise returns an insert edit using
-     * `buildInsert`. Returns null when the existing directive already covers the code (so nothing
-     * needs to change).
+     * Returns the file change that suppresses `codeStr` via a directive comment, or `null` when no
+     * change is needed (the existing directive already covers the code, or already suppresses
+     * everything). When `existing` is set, the result is a replace that swaps the directive comment
+     * for the text from `buildReplacementText`. When `existing` is null, the result is an insert
+     * built from `buildInsert`.
      */
-    private buildAppendOrInsertAction(
+    private getDiagnosticSuppressionChange(
         existing: ExistingDirective | null,
         codeStr: string,
         buildReplacementText: () => string,

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -106,8 +106,8 @@ export class CodeActionsProcessor {
      *   - "Disable {code} for this line" — adds the code to an existing `bs:disable-line` /
      *     `bs:disable-next-line` directive on/above the diagnostic if present, otherwise inserts
      *     a new `bs:disable-next-line: {code}` comment on the line above.
-     *   - "Disable {code} for this file" — adds the code to an existing `bs:disable-file`
-     *     directive in the file's header if present, otherwise inserts a new one at the top.
+     *   - "Disable {code} for this file" — adds the code to an existing header-level `bs:disable`
+     *     directive if present, otherwise inserts a new `bs:disable: {code}` at the top of the file.
      *
      * Comment placement and the line-vs-next-line preference are centralized here so they can be
      * revisited without touching the directive parser.
@@ -125,8 +125,12 @@ export class CodeActionsProcessor {
         const isXml = isXmlFile(file);
         const existing = this.findExistingDisableDirectives(file, diagnostic.range.start.line);
 
-        const formatDirective = (token: 'line' | 'next-line' | 'file', codes: string[]) => {
+        const formatLineDirective = (token: 'line' | 'next-line', codes: string[]) => {
             const body = `bs:disable-${token}: ${codes.join(' ')}`;
+            return isXml ? `<!-- ${body} -->` : `' ${body}`;
+        };
+        const formatBlockDirective = (codes: string[]) => {
+            const body = `bs:disable: ${codes.join(' ')}`;
             return isXml ? `<!-- ${body} -->` : `' ${body}`;
         };
 
@@ -136,10 +140,10 @@ export class CodeActionsProcessor {
         const lineAction = this.buildAppendOrInsertAction(
             existing.forLine,
             codeStr,
-            () => formatDirective(existing.forLine!.type as 'line' | 'next-line', this.mergeCodes(existing.forLine?.codes, codeStr)),
+            () => formatLineDirective(existing.forLine!.type as 'line' | 'next-line', this.mergeCodes(existing.forLine?.codes, codeStr)),
             () => ({
                 position: util.createPosition(diagnostic.range.start.line, 0),
-                newText: `${indent}${formatDirective('next-line', [codeStr])}\n`
+                newText: `${indent}${formatLineDirective('next-line', [codeStr])}\n`
             })
         );
         if (lineAction) {
@@ -157,12 +161,12 @@ export class CodeActionsProcessor {
         const fileAction = this.buildAppendOrInsertAction(
             existing.forFile,
             codeStr,
-            () => formatDirective('file', this.mergeCodes(existing.forFile?.codes, codeStr)),
+            () => formatBlockDirective(this.mergeCodes(existing.forFile?.codes, codeStr)),
             () => {
                 const headerInsert = this.getDisableFileInsertion(file);
                 return {
                     position: headerInsert.position,
-                    newText: headerInsert.prefix + formatDirective('file', [codeStr]) + headerInsert.suffix
+                    newText: headerInsert.prefix + formatBlockDirective([codeStr]) + headerInsert.suffix
                 };
             }
         );
@@ -220,9 +224,9 @@ export class CodeActionsProcessor {
     }
 
     /**
-     * Walks the file's tokens and returns existing `bs:disable-{line,next-line}` and
-     * `bs:disable-file` directives that would cover the diagnostic on `diagLine`. Used so
-     * the suppression quick fixes can extend an existing directive instead of stacking new ones.
+     * Walks the file's tokens and returns existing `bs:disable-{line,next-line}` and header-level
+     * `bs:disable` directives that would cover the diagnostic on `diagLine`. Used so the suppression
+     * quick fixes can extend an existing directive instead of stacking new ones.
      */
     private findExistingDisableDirectives(file: BscFile, diagLine: number): { forLine: ExistingDirective | null; forFile: ExistingDirective | null } {
         const isXml = isXmlFile(file);
@@ -248,12 +252,13 @@ export class CodeActionsProcessor {
             if (!parsed) {
                 continue;
             }
-            const directive: ExistingDirective = { type: parsed.disableType, codes: parsed.codes, range: tokenRange };
-            if (!forLine && parsed.disableType === 'line' && tokenRange.start.line === diagLine) {
+            const directive: ExistingDirective = { type: parsed.directiveType, codes: parsed.codes, range: tokenRange };
+            if (!forLine && parsed.directiveType === 'line' && tokenRange.start.line === diagLine) {
                 forLine = directive;
-            } else if (!forLine && parsed.disableType === 'next-line' && tokenRange.start.line === diagLine - 1) {
+            } else if (!forLine && parsed.directiveType === 'next-line' && tokenRange.start.line === diagLine - 1) {
                 forLine = directive;
-            } else if (!forFile && parsed.disableType === 'file' && inHeader) {
+            } else if (!forFile && parsed.directiveType === 'block' && inHeader) {
+                //only header-level `bs:disable` directives are extended for the file-level quick fix
                 forFile = directive;
             }
         }
@@ -261,7 +266,7 @@ export class CodeActionsProcessor {
     }
 
     /**
-     * Decides where in the file a `bs:disable-file` directive should be inserted, returning
+     * Decides where in the file a header-level `bs:disable` directive should be inserted, returning
      * the position plus any prefix/suffix needed so the directive lands on its own line in
      * the header (before the first executable statement / root XML element).
      */
@@ -848,16 +853,18 @@ export class CodeActionsProcessor {
 }
 
 interface ExistingDirective {
-    type: 'line' | 'next-line' | 'file';
+    type: 'line' | 'next-line' | 'block';
     codes: string[];
     range: Range;
 }
 
 /**
- * Parses a comment's text and returns the disable directive details if it is one. Recognizes
+ * Parses a comment's text and returns the directive details if it is one. Recognizes
  * `'`, `rem`, and `<!-- -->` comment styles. Returns `null` for comments that aren't directives.
+ * `block` covers the ESLint-style `bs:disable` (the `bs:enable` partner is parsed but treated
+ * as not-a-quick-fix-target — only `bs:disable` directives are returned).
  */
-function parseDisableComment(text: string): { disableType: 'line' | 'next-line' | 'file'; codes: string[] } | null {
+function parseDisableComment(text: string): { directiveType: 'line' | 'next-line' | 'block'; codes: string[] } | null {
     let inner = text;
     if (inner.startsWith('<!--')) {
         inner = inner.slice('<!--'.length);
@@ -871,17 +878,18 @@ function parseDisableComment(text: string): { disableType: 'line' | 'next-line' 
     }
     inner = inner.trimStart();
     const lower = inner.toLowerCase();
-    let disableType: 'line' | 'next-line' | 'file';
+    //match longest-prefix first so `bs:disable-line` doesn't get parsed as `bs:disable`
+    let directiveType: 'line' | 'next-line' | 'block';
     let prefixLength: number;
-    if (lower.startsWith('bs:disable-line')) {
-        disableType = 'line';
-        prefixLength = 'bs:disable-line'.length;
-    } else if (lower.startsWith('bs:disable-next-line')) {
-        disableType = 'next-line';
+    if (lower.startsWith('bs:disable-next-line')) {
+        directiveType = 'next-line';
         prefixLength = 'bs:disable-next-line'.length;
-    } else if (lower.startsWith('bs:disable-file')) {
-        disableType = 'file';
-        prefixLength = 'bs:disable-file'.length;
+    } else if (lower.startsWith('bs:disable-line')) {
+        directiveType = 'line';
+        prefixLength = 'bs:disable-line'.length;
+    } else if (lower.startsWith('bs:disable')) {
+        directiveType = 'block';
+        prefixLength = 'bs:disable'.length;
     } else {
         return null;
     }
@@ -890,5 +898,5 @@ function parseDisableComment(text: string): { disableType: 'line' | 'next-line' 
         inner = inner.slice(1);
     }
     const codes = inner.trim().length === 0 ? [] : inner.trim().split(/\s+/);
-    return { disableType: disableType, codes: codes };
+    return { directiveType: directiveType, codes: codes };
 }

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -9,12 +9,14 @@ import type { XmlFile } from '../../files/XmlFile';
 import type { BscFile, BsDiagnostic, OnGetCodeActionsEvent } from '../../interfaces';
 import { ParseMode } from '../../parser/Parser';
 import { util } from '../../util';
-import { isBrsFile, isFunctionExpression, isMethodStatement } from '../../astUtils/reflection';
+import { isBrsFile, isFunctionExpression, isMethodStatement, isXmlFile } from '../../astUtils/reflection';
 import type { FunctionExpression } from '../../parser/Expression';
 import type { MethodStatement } from '../../parser/Statement';
 import { WalkMode } from '../../astUtils/visitors';
 import { TokenKind } from '../../lexer/TokenKind';
 import { getMissingExtendsInsertPosition } from './codeActionHelpers';
+import { rangeFromTokenValue } from '../../parser/SGParser';
+import type { Range } from 'vscode-languageserver';
 
 export class CodeActionsProcessor {
     public constructor(
@@ -91,7 +93,197 @@ export class CodeActionsProcessor {
             this.suggestMissingImportsFixAllQuickFix();
         }
 
+        // Suppression actions appear last so real fixes are surfaced first
+        for (const diagnostic of this.event.diagnostics) {
+            this.suggestDisableDiagnosticQuickFixes(diagnostic);
+        }
+
         this.suggestedImports.clear();
+    }
+
+    /**
+     * For any diagnostic with a code, offers two quick-fix actions:
+     *   - "Disable {code} for this line" — adds the code to an existing `bs:disable-line` /
+     *     `bs:disable-next-line` directive on/above the diagnostic if present, otherwise inserts
+     *     a new `bs:disable-next-line: {code}` comment on the line above.
+     *   - "Disable {code} for this file" — adds the code to an existing `bs:disable-file`
+     *     directive in the file's header if present, otherwise inserts a new one at the top.
+     *
+     * Comment placement and the line-vs-next-line preference are centralized here so they can be
+     * revisited without touching the directive parser.
+     */
+    private suggestDisableDiagnosticQuickFixes(diagnostic: BsDiagnostic) {
+        const code = diagnostic.code;
+        if (code === undefined || code === null) {
+            return;
+        }
+        const file = this.event.file;
+        if (!isBrsFile(file) && !isXmlFile(file)) {
+            return;
+        }
+        const codeStr = String(code);
+        const isXml = isXmlFile(file);
+        const existing = this.findExistingDisableDirectives(file, diagnostic.range.start.line);
+
+        const formatDirective = (token: 'line' | 'next-line' | 'file', codes: string[]) => {
+            const body = `bs:disable-${token}: ${codes.join(' ')}`;
+            return isXml ? `<!-- ${body} -->` : `' ${body}`;
+        };
+
+        // ---- "disable for this line" ----
+        //if extending an existing directive, preserve its type (line vs next-line); otherwise we always insert a new next-line directive
+        const indent = ' '.repeat(diagnostic.range.start.character);
+        const lineAction = this.buildAppendOrInsertAction(
+            existing.forLine,
+            codeStr,
+            () => formatDirective(existing.forLine!.type as 'line' | 'next-line', this.mergeCodes(existing.forLine?.codes, codeStr)),
+            () => ({
+                position: util.createPosition(diagnostic.range.start.line, 0),
+                newText: `${indent}${formatDirective('next-line', [codeStr])}\n`
+            })
+        );
+        if (lineAction) {
+            this.event.codeActions.push(
+                codeActionUtil.createCodeAction({
+                    title: `Disable ${code} for this line: ${diagnostic.message}`,
+                    diagnostics: [diagnostic],
+                    kind: CodeActionKind.QuickFix,
+                    changes: [lineAction]
+                })
+            );
+        }
+
+        // ---- "disable for this file" ----
+        const fileAction = this.buildAppendOrInsertAction(
+            existing.forFile,
+            codeStr,
+            () => formatDirective('file', this.mergeCodes(existing.forFile?.codes, codeStr)),
+            () => {
+                const headerInsert = this.getDisableFileInsertion(file);
+                return {
+                    position: headerInsert.position,
+                    newText: headerInsert.prefix + formatDirective('file', [codeStr]) + headerInsert.suffix
+                };
+            }
+        );
+        if (fileAction) {
+            this.event.codeActions.push(
+                codeActionUtil.createCodeAction({
+                    title: `Disable ${code} for this file: ${diagnostic.message}`,
+                    diagnostics: [diagnostic],
+                    kind: CodeActionKind.QuickFix,
+                    changes: [fileAction]
+                })
+            );
+        }
+    }
+
+    /**
+     * If `existing` is set, returns a replace edit that swaps the existing directive comment for a
+     * rebuilt version (with the new code merged in). Otherwise returns an insert edit using
+     * `buildInsert`. Returns null when the existing directive already covers the code (so nothing
+     * needs to change).
+     */
+    private buildAppendOrInsertAction(
+        existing: ExistingDirective | null,
+        codeStr: string,
+        buildReplacementText: () => string,
+        buildInsert: () => { position: ReturnType<typeof util.createPosition>; newText: string }
+    ): InsertChange | ReplaceChange | null {
+        if (existing) {
+            //existing directive without specific codes already suppresses everything — no-op
+            if (existing.codes.length === 0) {
+                return null;
+            }
+            //the new code is already in the directive — no-op
+            if (existing.codes.some(c => c.toLowerCase() === codeStr.toLowerCase())) {
+                return null;
+            }
+            return {
+                type: 'replace',
+                filePath: this.event.file.srcPath,
+                range: existing.range,
+                newText: buildReplacementText()
+            };
+        }
+        const insert = buildInsert();
+        return {
+            type: 'insert',
+            filePath: this.event.file.srcPath,
+            position: insert.position,
+            newText: insert.newText
+        };
+    }
+
+    private mergeCodes(existingCodes: string[] | undefined, newCode: string): string[] {
+        return [...(existingCodes ?? []), newCode];
+    }
+
+    /**
+     * Walks the file's tokens and returns existing `bs:disable-{line,next-line}` and
+     * `bs:disable-file` directives that would cover the diagnostic on `diagLine`. Used so
+     * the suppression quick fixes can extend an existing directive instead of stacking new ones.
+     */
+    private findExistingDisableDirectives(file: BscFile, diagLine: number): { forLine: ExistingDirective | null; forFile: ExistingDirective | null } {
+        const isXml = isXmlFile(file);
+        const tokens: any[] = (file as any).parser?.tokens ?? [];
+        let inHeader = true;
+        let forLine: ExistingDirective | null = null;
+        let forFile: ExistingDirective | null = null;
+        for (const token of tokens) {
+            const isComment = isXml ? token.tokenType?.name === 'Comment' : token.kind === TokenKind.Comment;
+            if (!isComment) {
+                if (isXml) {
+                    if (token.tokenType?.name === 'OPEN') {
+                        inHeader = false;
+                    }
+                } else if (token.kind !== TokenKind.Newline && token.kind !== TokenKind.Whitespace && token.kind !== TokenKind.Eof) {
+                    inHeader = false;
+                }
+                continue;
+            }
+            const tokenRange: Range = isXml ? rangeFromTokenValue(token) : token.range;
+            const tokenText: string = isXml ? token.image : token.text;
+            const parsed = parseDisableComment(tokenText);
+            if (!parsed) {
+                continue;
+            }
+            const directive: ExistingDirective = { type: parsed.disableType, codes: parsed.codes, range: tokenRange };
+            if (!forLine && parsed.disableType === 'line' && tokenRange.start.line === diagLine) {
+                forLine = directive;
+            } else if (!forLine && parsed.disableType === 'next-line' && tokenRange.start.line === diagLine - 1) {
+                forLine = directive;
+            } else if (!forFile && parsed.disableType === 'file' && inHeader) {
+                forFile = directive;
+            }
+        }
+        return { forLine: forLine, forFile: forFile };
+    }
+
+    /**
+     * Decides where in the file a `bs:disable-file` directive should be inserted, returning
+     * the position plus any prefix/suffix needed so the directive lands on its own line in
+     * the header (before the first executable statement / root XML element).
+     */
+    private getDisableFileInsertion(file: BscFile): { position: ReturnType<typeof util.createPosition>; prefix: string; suffix: string } {
+        if (isXmlFile(file)) {
+            //insert after the `<?xml ?>` declaration if present, otherwise at the very top
+            const declCloseToken = file.parser.tokens?.find(t => (t as any).tokenType?.name === 'SPECIAL_CLOSE');
+            if (declCloseToken) {
+                const endLine = (declCloseToken as any).endLine - 1;
+                const endColumn = (declCloseToken as any).endColumn;
+                return {
+                    position: util.createPosition(endLine, endColumn),
+                    prefix: '\n',
+                    suffix: ''
+                };
+            }
+        }
+        return {
+            position: util.createPosition(0, 0),
+            prefix: '',
+            suffix: '\n'
+        };
     }
 
     /**
@@ -653,4 +845,50 @@ export class CodeActionsProcessor {
             );
         }
     }
+}
+
+interface ExistingDirective {
+    type: 'line' | 'next-line' | 'file';
+    codes: string[];
+    range: Range;
+}
+
+/**
+ * Parses a comment's text and returns the disable directive details if it is one. Recognizes
+ * `'`, `rem`, and `<!-- -->` comment styles. Returns `null` for comments that aren't directives.
+ */
+function parseDisableComment(text: string): { disableType: 'line' | 'next-line' | 'file'; codes: string[] } | null {
+    let inner = text;
+    if (inner.startsWith('<!--')) {
+        inner = inner.slice('<!--'.length);
+        if (inner.endsWith('-->')) {
+            inner = inner.slice(0, -('-->'.length));
+        }
+    } else if (inner.startsWith(`'`)) {
+        inner = inner.slice(1);
+    } else if (/^rem\b/i.test(inner)) {
+        inner = inner.slice('rem'.length);
+    }
+    inner = inner.trimStart();
+    const lower = inner.toLowerCase();
+    let disableType: 'line' | 'next-line' | 'file';
+    let prefixLength: number;
+    if (lower.startsWith('bs:disable-line')) {
+        disableType = 'line';
+        prefixLength = 'bs:disable-line'.length;
+    } else if (lower.startsWith('bs:disable-next-line')) {
+        disableType = 'next-line';
+        prefixLength = 'bs:disable-next-line'.length;
+    } else if (lower.startsWith('bs:disable-file')) {
+        disableType = 'file';
+        prefixLength = 'bs:disable-file'.length;
+    } else {
+        return null;
+    }
+    inner = inner.slice(prefixLength);
+    if (inner.startsWith(':')) {
+        inner = inner.slice(1);
+    }
+    const codes = inner.trim().length === 0 ? [] : inner.trim().split(/\s+/);
+    return { disableType: disableType, codes: codes };
 }

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -103,10 +103,10 @@ export class CodeActionsProcessor {
 
     /**
      * For any diagnostic with a code, offers two quick-fix actions:
-     *   - "Disable {code} for this line" — adds the code to an existing `bs:disable-line` /
+     *   - "Disable {code} for this line": adds the code to an existing `bs:disable-line` or
      *     `bs:disable-next-line` directive on/above the diagnostic if present, otherwise inserts
      *     a new `bs:disable-next-line: {code}` comment on the line above.
-     *   - "Disable {code} for this file" — adds the code to an existing header-level `bs:disable`
+     *   - "Disable {code} for this file": adds the code to an existing header-level `bs:disable`
      *     directive if present, otherwise inserts a new `bs:disable: {code}` at the top of the file.
      *
      * Comment placement and the line-vs-next-line preference are centralized here so they can be
@@ -195,11 +195,11 @@ export class CodeActionsProcessor {
         buildInsert: () => { position: ReturnType<typeof util.createPosition>; newText: string }
     ): InsertChange | ReplaceChange | null {
         if (existing) {
-            //existing directive without specific codes already suppresses everything — no-op
+            //existing directive without specific codes already suppresses everything; no-op
             if (existing.codes.length === 0) {
                 return null;
             }
-            //the new code is already in the directive — no-op
+            //the new code is already in the directive; no-op
             if (existing.codes.some(c => c.toLowerCase() === codeStr.toLowerCase())) {
                 return null;
             }
@@ -445,7 +445,7 @@ export class CodeActionsProcessor {
                 }
             }
 
-            //skip ambiguous names — we can't choose a file automatically
+            //skip ambiguous names; we can't choose a file automatically
             if (files.length !== 1) {
                 continue;
             }
@@ -764,7 +764,7 @@ export class CodeActionsProcessor {
         const changes: DeleteChange[] = diagnostics.map(d => ({
             type: 'delete' as const,
             filePath: this.event.file.srcPath,
-            // delete "override " — the keyword token plus the trailing space before function/sub
+            // delete "override " (the keyword token plus the trailing space before function/sub)
             range: util.createRange(
                 d.range.start.line,
                 d.range.start.character,
@@ -861,8 +861,8 @@ interface ExistingDirective {
 /**
  * Parses a comment's text and returns the directive details if it is one. Recognizes
  * `'`, `rem`, and `<!-- -->` comment styles. Returns `null` for comments that aren't directives.
- * `block` covers the ESLint-style `bs:disable` (the `bs:enable` partner is parsed but treated
- * as not-a-quick-fix-target — only `bs:disable` directives are returned).
+ * `block` covers `bs:disable`. The `bs:enable` partner isn't surfaced since the quick fix only
+ * extends `bs:disable` directives.
  */
 function parseDisableComment(text: string): { directiveType: 'line' | 'next-line' | 'block'; codes: string[] } | null {
     let inner = text;

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -932,26 +932,23 @@ describe('BrsFile', () => {
             });
         });
 
-        describe('bs:disable-file', () => {
-            it('suppresses every diagnostic in the file when no codes are specified', () => {
+        describe('bs:disable / bs:enable block directives', () => {
+            it('a bare bs:disable with no closing bs:enable suppresses every diagnostic in the file', () => {
                 let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
-                    'bs:disable-file
+                    'bs:disable
                     sub Main()
                         name = "bob
                     end sub
                 `);
-                expect(file.commentFlags[0]).to.exist;
-                expect(file.commentFlags[0]).to.deep.include({
-                    codes: null,
-                    affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
-                } as CommentFlag);
+                const blockFlag = file.commentFlags.find(flag => flag.codes === null && flag.affectedRange.end.line === Number.MAX_SAFE_INTEGER);
+                expect(blockFlag, 'a bs:disable flag should be emitted').to.exist;
                 program.validate();
                 expectZeroDiagnostics(program);
             });
 
             it('suppresses only the listed codes', () => {
                 program.setFile('source/main.brs', `
-                    'bs:disable-file: 1083
+                    'bs:disable: 1083
                     sub Main()
                         name = "bob
                     end sub
@@ -962,7 +959,7 @@ describe('BrsFile', () => {
 
             it('does not suppress unlisted codes', () => {
                 program.setFile('source/main.brs', `
-                    'bs:disable-file: 9999
+                    'bs:disable: 9999
                     sub Main()
                         name = "bob
                     end sub
@@ -974,7 +971,7 @@ describe('BrsFile', () => {
             it('honors a directive that follows other comment-only lines and blank lines', () => {
                 program.setFile('source/main.brs', `
                     'leading comment
-                    'bs:disable-file
+                    'bs:disable
                     sub Main()
                         name = "bob
                     end sub
@@ -983,15 +980,83 @@ describe('BrsFile', () => {
                 expectZeroDiagnostics(program);
             });
 
-            it('ignores the directive when it appears below code', () => {
+            it('a bs:enable closes the bs:disable block, leaving later code un-suppressed', () => {
                 program.setFile('source/main.brs', `
+                    'bs:disable
+                    'bs:enable
                     sub Main()
                         name = "bob
                     end sub
-                    'bs:disable-file
                 `);
                 program.validate();
                 expectHasDiagnostics(program);
+            });
+
+            it('bs:enable: <code> after a bare bs:disable carves out an exception for that code', () => {
+                program.setFile('source/main.brs', `
+                    'bs:disable
+                    'bs:enable: 1083
+                    sub Main()
+                        name = "bob
+                    end sub
+                `);
+                //code 1083 is now re-enabled, so the diagnostic surfaces
+                program.validate();
+                expectHasDiagnostics(program);
+            });
+        });
+
+        describe('unknown diagnostic codes', () => {
+            it('reports an unknown-code warning for bs:disable-next-line: <unknown>', () => {
+                program.setFile('source/main.brs', `
+                    sub main()
+                        'bs:disable-next-line: 999999
+                        print "hi"
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownDiagnosticCode(999999)
+                }]);
+            });
+
+            it('reports an unknown-code warning for bs:disable: <unknown> (block directive)', () => {
+                program.setFile('source/main.brs', `
+                    'bs:disable: 999999
+                    sub main()
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownDiagnosticCode(999999)
+                }]);
+            });
+
+            it('reports an unknown-code warning for bs:enable: <unknown>', () => {
+                program.setFile('source/main.brs', `
+                    'bs:disable
+                    'bs:enable: 999999
+                    sub main()
+                    end sub
+                `);
+                program.validate();
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownDiagnosticCode(999999)
+                }]);
+            });
+
+            it('still suppresses the valid code when an unknown code is mixed in', () => {
+                program.setFile('source/main.brs', `
+                    sub Main()
+                        'bs:disable-next-line: 1083 999999
+                        name = "bob
+                    end sub
+                `);
+                program.validate();
+                //the unterminated string (1083) is suppressed; 999999 is still reported as unknown
+                expectDiagnostics(program, [{
+                    ...DiagnosticMessages.unknownDiagnosticCode(999999)
+                }]);
             });
         });
     });

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -931,6 +931,69 @@ describe('BrsFile', () => {
                 expectZeroDiagnostics(program);
             });
         });
+
+        describe('bs:disable-file', () => {
+            it('suppresses every diagnostic in the file when no codes are specified', () => {
+                let file = program.setFile<BrsFile>({ src: `${rootDir}/source/main.brs`, dest: 'source/main.brs' }, `
+                    'bs:disable-file
+                    sub Main()
+                        name = "bob
+                    end sub
+                `);
+                expect(file.commentFlags[0]).to.exist;
+                expect(file.commentFlags[0]).to.deep.include({
+                    codes: null,
+                    affectedRange: util.createRange(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+                } as CommentFlag);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('suppresses only the listed codes', () => {
+                program.setFile('source/main.brs', `
+                    'bs:disable-file: 1083
+                    sub Main()
+                        name = "bob
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('does not suppress unlisted codes', () => {
+                program.setFile('source/main.brs', `
+                    'bs:disable-file: 9999
+                    sub Main()
+                        name = "bob
+                    end sub
+                `);
+                program.validate();
+                expectHasDiagnostics(program);
+            });
+
+            it('honors a directive that follows other comment-only lines and blank lines', () => {
+                program.setFile('source/main.brs', `
+                    'leading comment
+                    'bs:disable-file
+                    sub Main()
+                        name = "bob
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('ignores the directive when it appears below code', () => {
+                program.setFile('source/main.brs', `
+                    sub Main()
+                        name = "bob
+                    end sub
+                    'bs:disable-file
+                `);
+                program.validate();
+                expectHasDiagnostics(program);
+            });
+        });
     });
 
     describe('parse', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { Scope } from '../Scope';
 import type { NamespaceFileContribution } from '../Scope';
 import { SymbolTable } from '../SymbolTable';
-import { DiagnosticCodeMap, diagnosticCodes, DiagnosticMessages } from '../DiagnosticMessages';
+import { diagnosticCodes, DiagnosticMessages } from '../DiagnosticMessages';
 import { FunctionScope } from '../FunctionScope';
 import type { Callable, CallableArg, CallableParam, CommentFlag, FunctionCall, BsDiagnostic, FileReference, FileLink, BscFile } from '../interfaces';
 import type { Token } from '../lexer/Token';
@@ -522,17 +522,15 @@ export class BrsFile {
      * @param tokens - an array of tokens of which to find `TokenKind.Comment` from
      */
     public getCommentFlags(tokens: Token[]) {
-        const processor = new CommentFlagProcessor(this, ['rem', `'`], diagnosticCodes, [DiagnosticCodeMap.unknownDiagnosticCode]);
+        const processor = new CommentFlagProcessor(this, ['rem', `'`], diagnosticCodes);
 
         this.commentFlags = [];
-        let inHeader = true;
         for (let token of tokens) {
             if (token.kind === TokenKind.Comment) {
-                processor.tryAdd(token.text, token.range, { allowFileLevel: inHeader });
-            } else if (token.kind !== TokenKind.Newline && token.kind !== TokenKind.Whitespace && token.kind !== TokenKind.Eof) {
-                inHeader = false;
+                processor.tryAdd(token.text, token.range);
             }
         }
+        processor.finalize();
         this.commentFlags.push(...processor.commentFlags);
         this.diagnostics.push(...processor.diagnostics);
     }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -525,9 +525,12 @@ export class BrsFile {
         const processor = new CommentFlagProcessor(this, ['rem', `'`], diagnosticCodes, [DiagnosticCodeMap.unknownDiagnosticCode]);
 
         this.commentFlags = [];
+        let inHeader = true;
         for (let token of tokens) {
             if (token.kind === TokenKind.Comment) {
-                processor.tryAdd(token.text, token.range);
+                processor.tryAdd(token.text, token.range, { allowFileLevel: inHeader });
+            } else if (token.kind !== TokenKind.Newline && token.kind !== TokenKind.Whitespace && token.kind !== TokenKind.Eof) {
+                inHeader = false;
             }
         }
         this.commentFlags.push(...processor.commentFlags);

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1268,11 +1268,11 @@ describe('XmlFile', () => {
             ]);
         });
 
-        describe('bs:disable-file', () => {
-            it('suppresses every diagnostic in the file when no codes are specified', () => {
+        describe('bs:disable / bs:enable block directives', () => {
+            it('a bare bs:disable suppresses every diagnostic in the file', () => {
                 program.setFile<XmlFile>('components/file.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
-                    <!--bs:disable-file-->
+                    <!--bs:disable-->
                     <component>
                     </component>
                 `);
@@ -1283,7 +1283,7 @@ describe('XmlFile', () => {
             it('suppresses only the listed codes', () => {
                 program.setFile<XmlFile>('components/file.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
-                    <!--bs:disable-file 1007-->
+                    <!--bs:disable 1007-->
                     <component>
                     </component>
                 `);
@@ -1296,7 +1296,7 @@ describe('XmlFile', () => {
             it('does not suppress unlisted codes', () => {
                 program.setFile<XmlFile>('components/file.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
-                    <!--bs:disable-file 1006-->
+                    <!--bs:disable 1006-->
                     <component name="Foo">
                     </component>
                 `);
@@ -1306,11 +1306,12 @@ describe('XmlFile', () => {
                 ]);
             });
 
-            it('ignores the directive when it appears below the root element', () => {
+            it('a bs:enable closes the disable block', () => {
                 program.setFile<XmlFile>('components/file.xml', trim`
                     <?xml version="1.0" encoding="utf-8" ?>
+                    <!--bs:disable-->
+                    <!--bs:enable-->
                     <component>
-                        <!--bs:disable-file-->
                     </component>
                 `);
                 program.validate();

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1267,6 +1267,59 @@ describe('XmlFile', () => {
                 DiagnosticMessages.xmlComponentMissingExtendsAttribute()
             ]);
         });
+
+        describe('bs:disable-file', () => {
+            it('suppresses every diagnostic in the file when no codes are specified', () => {
+                program.setFile<XmlFile>('components/file.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <!--bs:disable-file-->
+                    <component>
+                    </component>
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+
+            it('suppresses only the listed codes', () => {
+                program.setFile<XmlFile>('components/file.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <!--bs:disable-file 1007-->
+                    <component>
+                    </component>
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.xmlComponentMissingNameAttribute()
+                ]);
+            });
+
+            it('does not suppress unlisted codes', () => {
+                program.setFile<XmlFile>('components/file.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <!--bs:disable-file 1006-->
+                    <component name="Foo">
+                    </component>
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.xmlComponentMissingExtendsAttribute()
+                ]);
+            });
+
+            it('ignores the directive when it appears below the root element', () => {
+                program.setFile<XmlFile>('components/file.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component>
+                        <!--bs:disable-file-->
+                    </component>
+                `);
+                program.validate();
+                expectDiagnostics(program, [
+                    DiagnosticMessages.xmlComponentMissingNameAttribute(),
+                    DiagnosticMessages.xmlComponentMissingExtendsAttribute()
+                ]);
+            });
+        });
     });
 
     describe('duplicate components', () => {

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import type { CodeWithSourceMap } from 'source-map';
 import { SourceNode } from 'source-map';
 import type { CompletionItem, Location, Position, Range } from 'vscode-languageserver';
-import { DiagnosticCodeMap, diagnosticCodes } from '../DiagnosticMessages';
+import { diagnosticCodes } from '../DiagnosticMessages';
 import type { FunctionScope } from '../FunctionScope';
 import type { Callable, BsDiagnostic, File, FileReference, FunctionCall, CommentFlag } from '../interfaces';
 import type { Program } from '../Program';
@@ -235,23 +235,19 @@ export class XmlFile {
      * Collect all bs: comment flags
      */
     public getCommentFlags(tokens: Array<IToken & { tokenType: TokenType }>) {
-        const processor = new CommentFlagProcessor(this, ['<!--'], diagnosticCodes, [DiagnosticCodeMap.unknownDiagnosticCode]);
+        const processor = new CommentFlagProcessor(this, ['<!--'], diagnosticCodes);
 
         this.commentFlags = [];
-        let inHeader = true;
         for (let token of tokens) {
             if (token.tokenType.name === 'Comment') {
                 processor.tryAdd(
                     //remove the close comment symbol
                     token.image.replace(/\-\-\>$/, ''),
-                    rangeFromTokenValue(token),
-                    { allowFileLevel: inHeader }
+                    rangeFromTokenValue(token)
                 );
-            } else if (token.tokenType.name === 'OPEN') {
-                //first element open ends the header — anything past it is inside the document body
-                inHeader = false;
             }
         }
+        processor.finalize();
         this.commentFlags.push(...processor.commentFlags);
         this.diagnostics.push(...processor.diagnostics);
     }

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -238,13 +238,18 @@ export class XmlFile {
         const processor = new CommentFlagProcessor(this, ['<!--'], diagnosticCodes, [DiagnosticCodeMap.unknownDiagnosticCode]);
 
         this.commentFlags = [];
+        let inHeader = true;
         for (let token of tokens) {
             if (token.tokenType.name === 'Comment') {
                 processor.tryAdd(
                     //remove the close comment symbol
                     token.image.replace(/\-\-\>$/, ''),
-                    rangeFromTokenValue(token)
+                    rangeFromTokenValue(token),
+                    { allowFileLevel: inHeader }
                 );
+            } else if (token.tokenType.name === 'OPEN') {
+                //first element open ends the header — anything past it is inside the document body
+                inHeader = false;
             }
         }
         this.commentFlags.push(...processor.commentFlags);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -183,13 +183,18 @@ export interface CommentFlag {
      */
     affectedRange: Range;
     /**
-     * Codes this flag suppresses. `null` means "all codes". An array means just those codes.
+     * Codes this flag suppresses.
+     * - `null`: every code (the flag suppresses everything in its `affectedRange`)
+     * - array: only those specific codes
+     * - `undefined` (or omitted): no codes (the flag suppresses nothing on its own; useful when the suppression decision is fully delegated to `enableCodes`)
      */
-    codes: DiagnosticCode[] | null;
+    codes?: DiagnosticCode[] | null;
     /**
-     * Codes that are explicitly re-enabled (carved out) within this flag's affected range.
+     * Codes explicitly re-enabled (carved out) within this flag's `affectedRange`.
      * A diagnostic matched by `codes` is NOT suppressed if it is also matched by `enableCodes`.
-     * `null` means "all codes" (i.e. nothing is suppressed). Omitted/`undefined` means no carve-outs.
+     * - `null`: every code is re-enabled (nothing in the range is suppressed)
+     * - array: only those specific codes are carved out
+     * - `undefined` (or omitted): no carve-outs; suppression is governed entirely by `codes`
      */
     enableCodes?: DiagnosticCode[] | null;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -182,7 +182,16 @@ export interface CommentFlag {
      * The range that this flag applies to (i.e. the lines that should be suppressed/re-enabled)
      */
     affectedRange: Range;
+    /**
+     * Codes this flag suppresses. `null` means "all codes". An array means just those codes.
+     */
     codes: DiagnosticCode[] | null;
+    /**
+     * Codes that are explicitly re-enabled (carved out) within this flag's affected range.
+     * A diagnostic matched by `codes` is NOT suppressed if it is also matched by `enableCodes`.
+     * `null` means "all codes" (i.e. nothing is suppressed). Omitted/`undefined` means no carve-outs.
+     */
+    enableCodes?: DiagnosticCode[] | null;
 }
 
 type ValidateHandler = (scope: Scope, files: BscFile[], callables: CallableContainerMap) => void;

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -244,7 +244,7 @@ export function trimMap(source: string) {
     return source.replace(/('|<!--)\/\/# sourceMappingURL=.*$/m, '').trimEnd();
 }
 
-export function expectCodeActions(test: () => any, expected: CodeActionShorthand[]) {
+export function expectCodeActions(test: () => any, expected: CodeActionShorthand[], options?: { includeDisableDirectives?: boolean }) {
     const sinon = createSandbox();
     const stub = sinon.stub(codeActionUtil, 'createCodeAction');
     try {
@@ -253,7 +253,12 @@ export function expectCodeActions(test: () => any, expected: CodeActionShorthand
         sinon.restore();
     }
 
-    const args = stub.getCalls().map(x => x.args[0]);
+    let args = stub.getCalls().map(x => x.args[0]);
+    //the generic `Disable X for this line/file` actions show up for every diagnostic. Existing tests
+    //assert on specific fixes, so filter them out unless the caller opts in.
+    if (!options?.includeDisableDirectives) {
+        args = args.filter(arg => !/^Disable .+ for this (line|file)/.test(arg.title));
+    }
     //delete any `diagnostics` arrays to help with testing performance (since it's circular...causes all sorts of issues)
     for (let arg of args) {
         delete arg.diagnostics;

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import type { Diagnostic, Position, Range, Location, DiagnosticRelatedInformatio
 import { URI } from 'vscode-uri';
 import * as xml2js from 'xml2js';
 import type { BsConfig, FinalizedBsConfig } from './BsConfig';
-import { DiagnosticMessages } from './DiagnosticMessages';
+import { DiagnosticCodeMap, DiagnosticMessages } from './DiagnosticMessages';
 import type { CallableContainer, BsDiagnostic, FileReference, CallableContainerMap, Plugin, ExpressionInfo, TranspileResult, MaybePromise, DisposableLike, PluginFactory } from './interfaces';
 import { BooleanType } from './types/BooleanType';
 import { DoubleType } from './types/DoubleType';
@@ -827,13 +827,21 @@ export class Util {
      */
     public diagnosticIsSuppressed(diagnostic: BsDiagnostic) {
         const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
+        //the "unknown diagnostic code" warning is always surfaced — otherwise typo'd codes in directive comments could silence themselves
+        if (diagnosticCode === DiagnosticCodeMap.unknownDiagnosticCode) {
+            return false;
+        }
         for (let flag of diagnostic.file?.commentFlags ?? []) {
-            //this diagnostic is affected by this flag
-            if (diagnostic.range && this.rangeContains(flag.affectedRange, diagnostic.range.start)) {
-                //if the flag acts upon this diagnostic's code
-                if (flag.codes === null || (diagnosticCode !== undefined && flag.codes.includes(diagnosticCode))) {
-                    return true;
-                }
+            if (!diagnostic.range || !this.rangeContains(flag.affectedRange, diagnostic.range.start)) {
+                continue;
+            }
+            const inDisable = flag.codes === null || (diagnosticCode !== undefined && flag.codes?.includes(diagnosticCode));
+            if (!inDisable) {
+                continue;
+            }
+            const inEnable = flag.enableCodes === null || (diagnosticCode !== undefined && flag.enableCodes?.includes(diagnosticCode));
+            if (!inEnable) {
+                return true;
             }
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -835,12 +835,14 @@ export class Util {
             if (!diagnostic.range || !this.rangeContains(flag.affectedRange, diagnostic.range.start)) {
                 continue;
             }
-            const inDisable = flag.codes === null || (diagnosticCode !== undefined && flag.codes?.includes(diagnosticCode));
-            if (!inDisable) {
+            //if this flag explicitly re-enables the code, it's not suppressed here, keep looking
+            const isEnabled = flag.enableCodes === null || (diagnosticCode !== undefined && flag.enableCodes?.includes(diagnosticCode));
+            if (isEnabled) {
                 continue;
             }
-            const inEnable = flag.enableCodes === null || (diagnosticCode !== undefined && flag.enableCodes?.includes(diagnosticCode));
-            if (!inEnable) {
+            //if this flag disables the code, it's suppressed
+            const isDisabled = flag.codes === null || (diagnosticCode !== undefined && flag.codes?.includes(diagnosticCode));
+            if (isDisabled) {
                 return true;
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -827,7 +827,7 @@ export class Util {
      */
     public diagnosticIsSuppressed(diagnostic: BsDiagnostic) {
         const diagnosticCode = typeof diagnostic.code === 'string' ? diagnostic.code.toLowerCase() : diagnostic.code;
-        //the "unknown diagnostic code" warning is always surfaced — otherwise typo'd codes in directive comments could silence themselves
+        //the "unknown diagnostic code" warning is always surfaced. Otherwise typo'd codes in directive comments could silence themselves.
         if (diagnosticCode === DiagnosticCodeMap.unknownDiagnosticCode) {
             return false;
         }
@@ -1813,7 +1813,7 @@ export class Util {
             }
         }
 
-        // no usable sourceMappingURL — try co-located <srcPath>.map
+        // no usable sourceMappingURL; try co-located <srcPath>.map
         const colocated = `${srcPath}.map`;
         if (await fsExtra.pathExists(colocated)) {
             return JSON.parse(await fsExtra.readFile(colocated, 'utf8')) as RawSourceMap;


### PR DESCRIPTION
## Summary

- Add `bs:disable` and `bs:enable` block-style comment directives. `bs:disable` opens a suppression block, and a matching `bs:enable` closes it. If no `bs:enable` follows, the block runs to the end of the file, so a bare `bs:disable` at the top of a file suppresses the whole file (the original `bs:disable-file` use case). Specific codes can be passed (`bs:disable: 1001 1002`), and `bs:enable: <code>` carves out an exception inside an open `bs:disable`.
- Add an optional `enableCodes` field on the `CommentFlag` interface, so a single flag can model "all suppressed, except codes X". Both `codes` and `enableCodes` follow the same tri-state model: `null` for "every code", an array for "these codes", `undefined` for "no codes".
- Refactor `CommentFlagProcessor` to a small state machine. `tryAdd` queues block directives; a new `finalize()` walks them in order, threading `{ allSuppressed, carveOuts }` and emitting one flag per directive whose `affectedRange` runs to the next block directive or EOF. Line-level directives still emit inline.
- Update `diagnosticIsSuppressed` to honor the new `enableCodes` field, and hard-code `unknownDiagnosticCode` as never-suppressed so typo'd codes in directives still surface.
- Add two quick-fix code actions on every diagnostic with a code:
  - **Disable {code} for this line: {message}** extends an existing `bs:disable-line` / `bs:disable-next-line` if one is on or above the diagnostic, otherwise inserts a fresh `bs:disable-next-line: {code}` above it (preserving indent).
  - **Disable {code} for this file: {message}** extends an existing header-level `bs:disable` if present, otherwise inserts a new `bs:disable: {code}` at the top of the file (after `<?xml ?>` for XML, or at line 0 if the declaration is omitted).
- Update `docs/suppressing-compiler-messages.md` with the new directive pair and quick fixes.

## Test plan
- [x] `CommentFlagProcessor` unit tests cover tokenization (line / next-line / disable / enable variants, longest-prefix priority), the state machine in `finalize()` (bare disable, paired enable, carve-outs, subtractive disable while in disable-all mode), and `unknownDiagnosticCode` emission for unrecognized codes.
- [x] `BrsFile` and `XmlFile` integration tests cover bare `bs:disable`, code-list disable, `bs:enable` closing the block, and the `bs:enable: <code>` carve-out path.
- [x] `CodeActionsProcessor` tests cover both quick fixes, indent preservation, message-in-title, merge-into-existing for line / next-line / file / XML, no-duplicate handling, the suppress-all skip, and the file action when the optional `<?xml ?>` declaration is absent.
- [x] Full brighterscript suite passes (2801 tests).
- [x] ESLint clean on changed files.
- [ ] Manual smoke test in the VS Code extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
