### PR TITLE
First Validation performance improvements 

### DIFF
--- a/src/BsConfig.ts
+++ b/src/BsConfig.ts
@@ -51,6 +51,21 @@ export interface BsConfig {
     noEmit?: boolean;
 
     /**
+     * @deprecated packaging is handled outside of `BsConfig`
+     */
+    createPackage?: boolean;
+
+    /**
+     * @deprecated deployment is handled outside of `BsConfig`
+     */
+    deploy?: boolean;
+
+    /**
+     * @deprecated staging copy behavior is handled outside of `BsConfig`
+     */
+    copyToStaging?: boolean;
+
+    /**
      * If true, the server will keep running and will watch and recompile on every file change
      * @default false
      */
@@ -281,6 +296,9 @@ type OptionalBsConfigFields =
     | 'extends'
     | 'require'
     | 'outDir'
+    | 'createPackage'
+    | 'deploy'
+    | 'copyToStaging'
     | 'diagnosticLevel'
     | 'rootDir'
     | 'stagingDir'

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1366,12 +1366,7 @@ export class Program {
                 this.logger.time(LogLevel.info, ['addDiagnosticsForScopes'], () => {
                     this.crossScopeValidation.addDiagnosticsForScopes(scopesToCheck);
                 });
-                if (this.isFirstValidation) {
-                    //on the first validation, we want to validate all scopes, so we add all files to the set of files to be validated in scope context
-                    for (const file of Object.values(this.files)) {
-                        filesToBeValidatedInScopeContext.add(file);
-                    }
-                } else {
+                if (!this.isFirstValidation) {
                     const filesToRevalidate = this.crossScopeValidation.getFilesRequiringChangedSymbol(scopesToCheck, changedSymbols);
                     for (const file of filesToRevalidate) {
                         filesToBeValidatedInScopeContext.add(file);

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -761,6 +761,7 @@ export class Program {
             file: file,
             program: this
         };
+        this.scopesPerFile.clear();
 
         this.plugins.emit('beforeAddFile', fileAddEvent);
 
@@ -778,6 +779,7 @@ export class Program {
     private unassignFile<T extends BscFile = BscFile>(file: T) {
         delete this.files[file.srcPath.toLowerCase()];
         this.destMap.delete(file.destPath.toLowerCase());
+        this.scopesPerFile.clear();
         return file;
     }
 
@@ -1101,6 +1103,7 @@ export class Program {
         xmlFilesValidated: XmlFile[];
         changedSymbols: Map<SymbolTypeFlag, Set<string>>;
         changedComponentTypes: string[];
+        scopesToInvalidate: Scope[];
         scopesToValidate: Scope[];
         filesToBeValidatedInScopeContext: Set<BscFile>;
 
@@ -1109,6 +1112,7 @@ export class Program {
             xmlFilesValidated: [],
             changedSymbols: new Map<SymbolTypeFlag, Set<string>>(),
             changedComponentTypes: [],
+            scopesToInvalidate: [],
             scopesToValidate: [],
             filesToBeValidatedInScopeContext: new Set<BscFile>()
         };
@@ -1166,6 +1170,7 @@ export class Program {
         const xmlFilesValidated: XmlFile[] = this.validationDetails.xmlFilesValidated;
         const changedSymbols = this.validationDetails.changedSymbols;
         const changedComponentTypes = this.validationDetails.changedComponentTypes;
+        const scopesToInvalidate = this.validationDetails.scopesToInvalidate;
         const scopesToValidate = this.validationDetails.scopesToValidate;
         const filesToBeValidatedInScopeContext = this.validationDetails.filesToBeValidatedInScopeContext;
 
@@ -1173,7 +1178,7 @@ export class Program {
 
         let logValidateEnd = (status?: string) => { };
 
-        //will be populated later on during the correspnding sequencer event
+        //will be populated later on during the corresponding sequencer event
         let filesToProcess: BscFile[];
 
         const sequencer = new Sequencer({
@@ -1246,7 +1251,7 @@ export class Program {
             .forEach('do deferred component creation', () => [...brsFilesValidated, ...xmlFilesValidated], (file) => {
                 if (isXmlFile(file)) {
                     this.addDeferredComponentTypeSymbolCreation(file);
-                } else if (isBrsFile(file)) {
+                } else if (isBrsFile(file) && !this.isFirstValidation) {
                     const fileHasChanges = file.providedSymbols.changes.get(SymbolTypeFlag.runtime).size > 0 || file.providedSymbols.changes.get(SymbolTypeFlag.typetime).size > 0;
                     if (fileHasChanges) {
                         for (const scope of this.getScopesForFile(file)) {
@@ -1361,9 +1366,16 @@ export class Program {
                 this.logger.time(LogLevel.info, ['addDiagnosticsForScopes'], () => {
                     this.crossScopeValidation.addDiagnosticsForScopes(scopesToCheck);
                 });
-                const filesToRevalidate = this.crossScopeValidation.getFilesRequiringChangedSymbol(scopesToCheck, changedSymbols);
-                for (const file of filesToRevalidate) {
-                    filesToBeValidatedInScopeContext.add(file);
+                if (this.isFirstValidation) {
+                    //on the first validation, we want to validate all scopes, so we add all files to the set of files to be validated in scope context
+                    for (const file of Object.values(this.files)) {
+                        filesToBeValidatedInScopeContext.add(file);
+                    }
+                } else {
+                    const filesToRevalidate = this.crossScopeValidation.getFilesRequiringChangedSymbol(scopesToCheck, changedSymbols);
+                    for (const file of filesToRevalidate) {
+                        filesToBeValidatedInScopeContext.add(file);
+                    }
                 }
 
                 this.currentScopeValidationOptions = {
@@ -1376,18 +1388,28 @@ export class Program {
                 //can reset changedComponent types
                 this.validationDetails.changedComponentTypes = [];
             })
-            .forEach('invalidate affected scopes', () => filesToBeValidatedInScopeContext, (file) => {
+            .forEach('invalidating file segments', () => filesToBeValidatedInScopeContext, (file) => {
                 if (isBrsFile(file)) {
                     file.validationSegmenter.unValidateAllSegments();
-                    for (const scope of this.getScopesForFile(file)) {
+                    if (!this.isFirstValidation) {
+                        scopesToInvalidate.push(...this.getScopesForFile(file));
+                    }
+                }
+            })
+            .once('invalidate affected scopes', () => {
+                if (this.isFirstValidation) {
+                    for (const scope of this.getAllUserScopes()) {
+                        scope.invalidate();
+                    }
+                } else {
+                    for (const scope of scopesToInvalidate) {
                         scope.invalidate();
                     }
                 }
             })
             .once('checking scopes to validate', () => {
                 //sort the scope names so we get consistent results
-                for (const scopeName of this.getSortedScopeNames()) {
-                    let scope = this.scopes[scopeName];
+                for (const scope of this.getAllUserScopes()) {
                     if (scope.shouldValidate(this.currentScopeValidationOptions)) {
                         scopesToValidate.push(scope);
                     }
@@ -1411,12 +1433,7 @@ export class Program {
             })
             .once('detect duplicate component names', () => {
                 this.detectDuplicateComponentNames();
-                this.isFirstValidation = false;
 
-                // can reset other validation details
-                this.validationDetails.changedSymbols = new Map<SymbolTypeFlag, Set<string>>();
-                this.validationDetails.scopesToValidate = [];
-                this.validationDetails.filesToBeValidatedInScopeContext = new Set<BscFile>();
 
             })
             .onCancel(() => {
@@ -1424,6 +1441,13 @@ export class Program {
             })
             .onSuccess(() => {
                 logValidateEnd();
+                this.isFirstValidation = false;
+
+                // can reset other validation details
+                this.validationDetails.changedSymbols = new Map<SymbolTypeFlag, Set<string>>();
+                this.validationDetails.scopesToInvalidate = [];
+                this.validationDetails.scopesToValidate = [];
+                this.validationDetails.filesToBeValidatedInScopeContext = new Set<BscFile>();
             })
             .onComplete(() => {
                 //if we emitted the beforeValidateProgram hook, emit the afterValidateProgram hook as well
@@ -1462,8 +1486,7 @@ export class Program {
 
     private getScopesForCrossScopeValidation(someComponentTypeChanged: boolean, didProvidedSymbolChange: boolean) {
         const scopesForCrossScopeValidation: Scope[] = [];
-        for (let scopeName of this.getSortedScopeNames()) {
-            let scope = this.scopes[scopeName];
+        for (let scope of this.getAllUserScopes()) {
             if (this.globalScope === scope) {
                 continue;
             }
@@ -1612,12 +1635,25 @@ export class Program {
         return this.sortedScopeNames;
     }
 
+    public getAllUserScopes() {
+        return Object.values(this.scopes).filter(s => s.name !== 'global');
+    }
+
+
+    private scopesPerFile: Map<BscFile, Scope[]> = new Map();
+
+
     /**
      * Get a list of all scopes the file is loaded into
      * @param file the file
      */
     public getScopesForFile(file: BscFile | string) {
         const resolvedFile = typeof file === 'string' ? this.getFile(file) : file;
+
+        const cachedResult = this.scopesPerFile.get(resolvedFile);
+        if (cachedResult) {
+            return cachedResult;
+        }
 
         let result = [] as Scope[];
         if (resolvedFile) {
@@ -1630,6 +1666,7 @@ export class Program {
                 }
             }
         }
+        this.scopesPerFile.set(resolvedFile, result);
         return result;
     }
 

--- a/src/Scope.spec.ts
+++ b/src/Scope.spec.ts
@@ -2486,6 +2486,80 @@ describe('Scope', () => {
             });
         });
 
+        describe('types from XML components', () => {
+            it('allows using an assocArray from an XML component in a callfunc parameter', () => {
+                program.setFile('components/Parent.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="Parent" extends="Group">
+                        <script uri="Parent.bs"/>
+                        <interface>
+                            <field id="myAA" type="assocArray" />
+                        </interface>
+                    </component>
+                `);
+                program.setFile('components/ParentTypes.bs', `
+                    interface iParent
+                        top as roSGNodeParent
+                        comp2 as roSGNodeComp2
+                    end interface
+                `);
+
+                program.setFile('components/Parent.bs', `
+                    import "pkg:/components/ParentTypes.bs"
+
+                    typecast m as iParent
+
+                    sub init()
+                        m.comp2 = createObject("roSGNode", "Comp2")
+                    end sub
+                `);
+
+                program.setFile('components/Comp.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="Comp" extends="Parent">
+                        <script uri="Comp.bs"/>
+                    </component>
+                `);
+                program.setFile(s`components/Comp.bs`, `
+                    import "pkg:/components/CompTypes.bs"
+
+                    typecast m as iComp
+
+                    sub doSomething()
+                        m.comp2@.takesInterface({name: "example", data: m.top.myAA})
+                    end sub
+                `);
+                program.setFile(s`components/CompTypes.bs`, `
+                    import "pkg:/components/ParentTypes.bs"
+                    interface iComp extends iParent
+                        top as roSGNodeComp
+                    end interface
+                `);
+
+                program.setFile('components/Comp2.xml', trim`
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <component name="Comp2" extends="Group">
+                        <script uri="Comp2.bs"/>
+                        <interface>
+                            <function name="takesInterface" />
+                        </interface>
+                    </component>
+                `);
+                program.setFile(s`components/Comp2.bs`, `
+                    interface IfaceOptions
+                        name as string
+                        optional data as roAssociativeArray
+                    end interface
+
+                    sub takesInterface(aa as IfaceOptions)
+                        print aa
+                    end sub
+                `);
+                program.validate();
+                expectZeroDiagnostics(program);
+            });
+        });
+
         describe('revalidations', () => {
             it('revalidates dependent files when a file is changed', () => {
                 program.setFile('source/common.bs', `

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -1,4 +1,4 @@
-import type { Body, AssignmentStatement, Block, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement, AugmentedAssignmentStatement, ConditionalCompileConstStatement, ConditionalCompileErrorStatement, ConditionalCompileStatement, ExitStatement, TypeStatement } from '../parser/Statement';
+import type { Body, AssignmentStatement, Block, EmptyStatement, ExpressionStatement, FunctionStatement, IfStatement, IncrementStatement, PrintStatement, GotoStatement, LabelStatement, ReturnStatement, EndStatement, StopStatement, ForStatement, ForEachStatement, WhileStatement, DottedSetStatement, IndexedSetStatement, LibraryStatement, NamespaceStatement, ImportStatement, ClassStatement, InterfaceFieldStatement, InterfaceMethodStatement, InterfaceStatement, EnumStatement, EnumMemberStatement, TryCatchStatement, CatchStatement, ThrowStatement, MethodStatement, FieldStatement, ConstStatement, ContinueStatement, DimStatement, TypecastStatement, AliasStatement, AugmentedAssignmentStatement, ConditionalCompileConstStatement, ConditionalCompileErrorStatement, ConditionalCompileStatement, ExitStatement, TypeStatement } from '../parser/Statement';
 import type { LiteralExpression, BinaryExpression, CallExpression, FunctionExpression, DottedGetExpression, XmlAttributeGetExpression, IndexedGetExpression, GroupingExpression, EscapedCharCodeLiteralExpression, ArrayLiteralExpression, AALiteralExpression, UnaryExpression, VariableExpression, SourceLiteralExpression, NewExpression, CallfuncExpression, TemplateStringQuasiExpression, TemplateStringExpression, TaggedTemplateStringExpression, AnnotationExpression, FunctionParameterExpression, AAMemberExpression, AAIndexedMemberExpression, TernaryExpression, NullCoalescingExpression, PrintSeparatorExpression, TypecastExpression, TypedArrayExpression, TypeExpression, InlineInterfaceMemberExpression, InlineInterfaceExpression, TypedFunctionTypeExpression } from '../parser/Expression';
 import type { BrsFile } from '../files/BrsFile';
 import type { XmlFile } from '../files/XmlFile';
@@ -101,6 +101,15 @@ export function isBlock(element: AstNode | undefined): element is Block {
 }
 export function isExpressionStatement(element: AstNode | undefined): element is ExpressionStatement {
     return element?.kind === AstNodeKind.ExpressionStatement;
+}
+export function isEmptyStatement(element: AstNode | undefined): element is EmptyStatement {
+    return element?.kind === AstNodeKind.EmptyStatement;
+}
+/**
+ * @deprecated use `isEmptyStatement` instead
+ */
+export function isCommentStatement(element: AstNode | undefined): element is EmptyStatement {
+    return isEmptyStatement(element);
 }
 export function isExitStatement(element: AstNode | undefined): element is ExitStatement {
     return element?.kind === AstNodeKind.ExitStatement;

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -830,15 +830,13 @@ export class ScopeValidator {
         }
         let paramIndex = 0;
         for (let arg of argsForCall) {
-            const data = {} as ExtraSymbolData;
-            let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
-
             const paramType = funcType.params[paramIndex]?.type;
             if (!paramType) {
                 // unable to find a paramType -- maybe there are more args than params
                 break;
             }
-
+            const data = {} as ExtraSymbolData;
+            let argType = this.getNodeTypeWrapper(file, arg, { flags: SymbolTypeFlag.runtime, data: data });
             if (isCallableType(paramType) && isClassType(argType) && isClassStatement(data.definingNode)) {
                 argType = data.definingNode.getConstructorType();
             }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -738,13 +738,21 @@ export class ScopeValidator {
         while (isTypeStatementType(funcType)) {
             funcType = funcType.wrappedType;
         }
+        let _funcName: string;
+        // Only get the function name if we need it for a diagnostic, since it can be expensive to calculate for complex expressions
+        function getFuncName() {
+            if (_funcName) {
+                return _funcName;
+            }
+            _funcName = util.getAllDottedGetPartsAsString(callee, ParseMode.BrighterScript, isCallfuncExpression(callee) ? '@.' : '.');
+            return _funcName;
+        }
         if (!funcType?.isResolvable() || !isCallableType(funcType) || isCompoundType(funcType)) {
-            const funcName = util.getAllDottedGetPartsAsString(callee, ParseMode.BrighterScript, isCallfuncExpression(callee) ? '@.' : '.');
             if (isUnionType(funcType)) {
                 if (!util.isUnionOfFunctions(funcType) && !isCallfuncExpression(callee)) {
                     // union of func and non func. not callable
                     this.addMultiScopeDiagnostic({
-                        ...DiagnosticMessages.notCallable(funcName),
+                        ...DiagnosticMessages.notCallable(getFuncName()),
                         location: callErrorLocation
                     });
                     return;
@@ -764,7 +772,7 @@ export class ScopeValidator {
                             // param differences!
                             this.addMultiScopeDiagnostic({
                                 ...DiagnosticMessages.incompatibleSymbolDefinition(
-                                    funcName,
+                                    getFuncName(),
                                     { isUnion: true, data: compatibilityData }),
                                 location: callErrorLocation
                             });
@@ -777,17 +785,16 @@ export class ScopeValidator {
 
             }
             if (funcType && !isCallableType(funcType) && !isReferenceType(funcType)) {
-                const globalFuncWithVarName = globalCallableMap.get(funcName.toLowerCase());
+                const globalFuncWithVarName = globalCallableMap.get(getFuncName().toLowerCase());
                 if (globalFuncWithVarName) {
                     funcType = globalFuncWithVarName.type;
                 } else {
                     this.addMultiScopeDiagnostic({
-                        ...DiagnosticMessages.notCallable(funcName),
+                        ...DiagnosticMessages.notCallable(getFuncName()),
                         location: callErrorLocation
                     });
                     return;
                 }
-
             }
         }
 

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -583,7 +583,10 @@ export class ScopeValidator {
     protected validateCreateObjectCall(file: BrsFile, call: CallExpression) {
 
         //skip non CreateObject function calls
-        const callName = util.getAllDottedGetPartsAsString(call.callee)?.toLowerCase();
+        if (!isVariableExpression(call.callee)) {
+            return;
+        }
+        const callName = call.callee.tokens.name?.text?.toLowerCase();
         if (callName !== 'createobject' || !isLiteralExpression(call?.args[0])) {
             return;
         }

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -905,7 +905,6 @@ export class ScopeValidator {
         const expectedLHSType = this.getNodeTypeWrapper(file, dottedSetStmt, { ...getTypeOpts, data: {}, typeChain: typeChainExpectedLHS });
         const actualRHSType = this.getNodeTypeWrapper(file, dottedSetStmt?.value, getTypeOpts);
         const compatibilityData: TypeCompatibilityData = {};
-        const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
         // check if anything in typeChain is an AA - if so, just allow it
         if (typeChainExpectedLHS.find(typeChainItem => isAssociativeArrayType(typeChainItem.type))) {
             // something in the chain is an AA
@@ -913,6 +912,7 @@ export class ScopeValidator {
             return;
         }
         if (!expectedLHSType || !expectedLHSType?.isResolvable()) {
+            const typeChainScan = util.processTypeChain(typeChainExpectedLHS);
             this.addMultiScopeDiagnostic({
                 ...DiagnosticMessages.cannotFindName(typeChainScan.itemName, typeChainScan.fullNameOfItem, typeChainScan.itemParentTypeName, this.getParentTypeDescriptor(typeChainScan)),
                 location: typeChainScan?.location
@@ -1228,9 +1228,9 @@ export class ScopeValidator {
             }
         } else if (isDynamicType(exprType) && isEnumType(parentTypeInfo?.type) && isDottedGetExpression(expression)) {
             const enumFileLink = this.event.scope.getEnumFileLink(util.getAllDottedGetPartsAsString(expression.obj));
-            const typeChainScanForItem = util.processTypeChain(typeChain);
-            const typeChainScanForParent = util.processTypeChain(typeChain.slice(0, -1));
             if (enumFileLink) {
+                const typeChainScanForItem = util.processTypeChain(typeChain);
+                const typeChainScanForParent = util.processTypeChain(typeChain.slice(0, -1));
                 this.addMultiScopeDiagnostic({
                     ...DiagnosticMessages.cannotFindName(lastTypeInfo?.name, typeChainScanForItem.fullChainName, typeChainScanForParent.fullNameOfItem, 'enum'),
                     location: lastTypeInfo?.location,

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -1,6 +1,6 @@
 import type { WalkVisitor, WalkOptions } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
-import type { Location, Position } from 'vscode-languageserver';
+import type { Location, Position, Range } from 'vscode-languageserver';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { InternalWalkMode } from '../astUtils/visitors';
 import type { SymbolTable } from '../SymbolTable';
@@ -22,6 +22,13 @@ export abstract class AstNode {
      *  The starting and ending location of the node.
      */
     public abstract location?: Location | undefined;
+
+    /**
+     * @deprecated use `location.range` instead
+     */
+    public get range(): Range | undefined {
+        return this.location?.range;
+    }
 
     public abstract transpile(state: BrsTranspileState): TranspileResult;
 

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -669,6 +669,20 @@ export class DottedGetExpression extends Expression {
     };
     readonly obj: Expression;
 
+    /**
+     * @deprecated use `tokens.name` instead
+     */
+    public get name(): Identifier {
+        return this.tokens.name;
+    }
+
+    /**
+     * @deprecated use `tokens.dot` instead
+     */
+    public get dot(): Token | undefined {
+        return this.tokens.dot;
+    }
+
     public readonly kind = AstNodeKind.DottedGetExpression;
 
     public readonly location: Location | undefined;
@@ -848,6 +862,27 @@ export class IndexedGetExpression extends Expression {
         readonly closingSquare?: Token;
         readonly questionDot?: Token; //  ? or ?.
     };
+
+    /**
+     * @deprecated use `tokens.questionDot` instead
+     */
+    public get questionDotToken(): Token | undefined {
+        return this.tokens.questionDot;
+    }
+
+    /**
+     * @deprecated use `tokens.openingSquare` instead
+     */
+    public get openingSquare(): Token | undefined {
+        return this.tokens.openingSquare;
+    }
+
+    /**
+     * @deprecated use `indexes[0]` instead
+     */
+    public get index(): Expression | undefined {
+        return this.indexes?.[0];
+    }
 
     public readonly location: Location | undefined;
 
@@ -1535,6 +1570,13 @@ export class VariableExpression extends Expression {
     public readonly kind = AstNodeKind.VariableExpression;
 
     public readonly location: Location;
+
+    /**
+     * @deprecated use `tokens.name` instead
+     */
+    public get name(): Identifier {
+        return this.tokens.name;
+    }
 
     public getName(parseMode?: ParseMode) {
         return this.tokens.name.text;

--- a/src/types/InterfaceType.ts
+++ b/src/types/InterfaceType.ts
@@ -1,6 +1,6 @@
 import type { TypeCompatibilityData } from '../interfaces';
 import { SymbolTypeFlag } from '../SymbolTypeFlag';
-import { isCallFuncableTypeLike, isDynamicType, isInterfaceType, isInvalidType, isObjectType } from '../astUtils/reflection';
+import { isArrayTypeLike, isAssociativeArrayTypeLike, isCallFuncableTypeLike, isDynamicType, isInterfaceType, isInvalidType, isObjectType } from '../astUtils/reflection';
 import type { BscType } from './BscType';
 import { BscTypeKind } from './BscTypeKind';
 import { isUnionTypeCompatible } from './helpers';
@@ -22,6 +22,12 @@ export class InterfaceType extends CallFuncableType {
             isDynamicType(targetType) ||
             isObjectType(targetType) ||
             isUnionTypeCompatible(this, targetType, data)) {
+            return true;
+        }
+        if (isAssociativeArrayTypeLike(this) && isAssociativeArrayTypeLike(targetType)) {
+            return true;
+        }
+        if (isArrayTypeLike(this) && isArrayTypeLike(targetType)) {
             return true;
         }
         if (isCallFuncableTypeLike(targetType)) {


### PR DESCRIPTION
In v1, the first run still went through incremental-style dependency analysis (figuring out changed symbols, affected files, and impacted scopes).  
In this branch, first validation explicitly assumes everything should be validated, which removes a lot of expensive bookkeeping on cold start.

## What is different from v1 for first validation

### Before (v1)
- First validation used changed-symbol and cross-scope dependency flows similar to revalidation.
- Scope invalidation and file selection were driven by dependency discovery.
- Deferred component symbol work for Brs files could run during the initial pass.
- Some validation state reset happened earlier in the pipeline.

### Now (this branch)
- First validation directly includes all files in scope-context validation.
- First validation invalidates all user scopes in one shot, instead of deriving/invalidation-by-affected-file.
- Deferred component creation for Brsfiles is skipped on first validation (still done for XML and subsequent validations).
- First-validation completion now resets validation bookkeeping in the success path (after a successful run).
- Scope iteration/invalidation paths were simplified to use all user scopes directly.
- Scope lookup results per file are cached and cache is cleared when files are added/removed, reducing repeated scope-resolution cost.

## Why this improves performance
The first validation run has no meaningful incremental baseline, so trying to compute precise impact sets is mostly overhead.  
By switching initial validation to a full-pass strategy, we avoid dependency graph churn and repeated scope/file impact calculations, while preserving incremental behavior for subsequent validations.

## Additional branch changes (non-first-validation)
- Lazy function-name computation in call validation to avoid expensive name building unless a diagnostic actually needs it.
- Type compatibility fix allowing associative-array/array-like compatibility in interface checks where appropriate.
- Added test coverage for XML component assocArray usage passed into callfunc interface parameters.

## Behavior and risk notes
- Intended semantic behavior remains the same; this is primarily a performance-path change for cold validation.
- Main risk area is any workflow depending on first-pass ordering/diagnostic timing rather than final diagnostic set.
- Revalidation logic remains incremental after first successful validation.

## Metrics (Example App)

### Before
```
[04:25:25:781 PM] Validating project finished. (6s524.620ms)
[04:25:25:789 PM] Program.validate metrics:
    wait for previous run------------------------------------------------------- 000.005ms,   1 calls
    before and on programValidate----------------------------------------------- 000.145ms,   1 calls
    get files to be validated--------------------------------------------------- 001.275ms,   1 calls
    add component reference types----------------------------------------------- 000.669ms,   1 calls
    validateFile------------------------------------------------------------- 02s027.987ms, 839 calls
    do deferred component creation---------------------------------------------- 057.636ms, 839 calls
    build component types for any component that changes------------------------ 056.637ms,   1 calls
    track and update type-time and runtime symbol dependencies and changes------ 008.704ms,   1 calls
    tracks changed symbols and prepares files and scopes for validation--------- 317.518ms,   1 calls
    invalidate affected scopes-------------------------------------------------- 026.028ms, 839 calls
    checking scopes to validate------------------------------------------------- 000.214ms,   1 calls
    beforeScopeValidate--------------------------------------------------------- 000.105ms, 294 calls
    validate scope----------------------------------------------------------- 03s955.053ms, 294 calls
    afterValidateScope---------------------------------------------------------- 068.071ms, 294 calls
    detect duplicate component names-------------------------------------------- 001.095ms,   1 calls
    Total-------------------------------------------------------------------- 06s521.140ms,
```

### After

```
[08:43:54:358 PM] Validating project finished. (5s44.717ms)
[08:43:54:367 PM] Program.validate metrics:
    wait for previous run------------------------------------------------------- 000.005ms,   1 calls
    before and on programValidate----------------------------------------------- 000.128ms,   1 calls
    get files to be validated--------------------------------------------------- 001.148ms,   1 calls
    add component reference types----------------------------------------------- 000.552ms,   1 calls
    validateFile------------------------------------------------------------- 01s618.443ms, 839 calls
    do deferred component creation---------------------------------------------- 000.630ms, 839 calls
    build component types for any component that changes------------------------ 078.657ms,   1 calls
    track and update type-time and runtime symbol dependencies and changes------ 008.971ms,   1 calls
    tracks changed symbols and prepares files and scopes for validation--------- 249.544ms,   1 calls
    invalidating file segments-------------------------------------------------- 001.417ms, 839 calls
    invalidate affected scopes-------------------------------------------------- 000.143ms,   1 calls
    checking scopes to validate------------------------------------------------- 000.177ms,   1 calls
    beforeScopeValidate--------------------------------------------------------- 000.089ms, 294 calls
    validate scope----------------------------------------------------------- 03s028.436ms, 294 calls
    afterValidateScope---------------------------------------------------------- 053.363ms, 294 calls
    detect duplicate component names-------------------------------------------- 000.795ms,   1 calls
    Total-------------------------------------------------------------------- 05s042.497ms,
```

Roughly, a 20% improvement on first validation time.