### PR TITLE
Do not scope validate files that are marked in the diagnosticFilters

### DIFF
--- a/src/DiagnosticManager.spec.ts
+++ b/src/DiagnosticManager.spec.ts
@@ -253,4 +253,17 @@ describe('DiagnosticManager', () => {
         });
     });
 
+    describe('shouldFilterFile', () => {
+        it('returns true if the DiagnosticFilterer says to filter the file', () => {
+            const file = program.setFile('source/main.brs', '') as BrsFile;
+            program.diagnostics['diagnosticFilterer'].isFileFiltered = () => true;
+            expect(program.diagnostics.shouldFilterFile(file)).to.be.true;
+        });
+
+        it('returns false if the DiagnosticFilterer says not to filter the file', () => {
+            const file = program.setFile('source/main.brs', '') as BrsFile;
+            program.diagnostics['diagnosticFilterer'].isFileFiltered = () => false;
+            expect(program.diagnostics.shouldFilterFile(file)).to.be.false;
+        });
+    });
 });

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -482,8 +482,7 @@ export class DiagnosticManager {
         if (this.diagnosticFilterer.options !== this.options) {
             this.diagnosticFilterer.options = this.options;
         }
-        this.diagnosticFilterer.isFileFiltered(file);
-        return false;
+        return this.diagnosticFilterer.isFileFiltered(file);
     }
 
 }

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -13,10 +13,11 @@ import { AssociativeArrayType } from '../../types/AssociativeArrayType';
 import undent from 'undent';
 import * as fsExtra from 'fs-extra';
 import { tempDir, rootDir } from '../../testHelpers.spec';
-import { isReturnStatement } from '../../astUtils/reflection';
+import { isFunctionStatement, isReturnStatement } from '../../astUtils/reflection';
 import { ScopeValidator } from './ScopeValidator';
-import type { ReturnStatement } from '../../parser/Statement';
+import type { FunctionStatement, ReturnStatement } from '../../parser/Statement';
 import { Logger } from '@rokucommunity/logger';
+import { ParseMode } from '../..';
 
 describe('ScopeValidator', () => {
 
@@ -7046,6 +7047,35 @@ describe('ScopeValidator', () => {
             `);
             program.validate();
             expectZeroDiagnostics(program);
+        });
+    });
+
+
+    describe('file filter', () => {
+        it('should not walk files if the DiagnosticFilterer says not to', () => {
+            const program = new Program({
+                rootDir: rootDir + '/src',
+                files: [
+                    `/source/**/*.*`,
+                    `/components/**/*.*`
+                ],
+                diagnosticFilters: [
+                    { files: `source/doNotValidate.brs` }
+                ]
+            });
+
+            const fileNotValidated = program.setFile<BrsFile>('source/doNotValidate.brs', `
+                sub doStuff()
+                    a = 1 + "hello" ' obviously wrong, but should not be reported because of the filter
+                end sub
+            `);
+
+            program.validate();
+            expectZeroDiagnostics(program);
+            const unvalidatedSegments = fileNotValidated.validationSegmenter.getAllUnvalidatedSegments();
+            expect(unvalidatedSegments).to.lengthOf(1);
+            expect(isFunctionStatement(unvalidatedSegments[0])).to.be.true;
+            expect((unvalidatedSegments[0] as FunctionStatement).getName(ParseMode.BrighterScript)).to.equal('doStuff');
         });
     });
 });


### PR DESCRIPTION
Fixed a typo that ignored the *actual* result of `DiagnosticFilter.isFileFiltered` in `DiagnosticsManager`