### PR TITLE
Add SceneGraph XML element and attribute completions

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -219,8 +219,8 @@ export class LanguageServer {
                 // Tell the client that the server supports code completion
                 completionProvider: {
                     resolveProvider: false,
-                    //anytime the user types a period, auto-show the completion results
-                    triggerCharacters: ['.'],
+                    //`.` auto-shows brightscript completions; `<` auto-shows xml element completions
+                    triggerCharacters: ['.', '<'],
                     allCommitCharacters: ['.', '@']
                 },
                 documentSymbolProvider: true,

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -50,6 +50,52 @@ describe('Program', () => {
         program.dispose();
     });
 
+    describe('scenegraph node metadata', () => {
+        it('getSceneGraphNodeNames includes built-in nodes and project components', () => {
+            program.setFile('components/widget.xml', trim`
+                <component name="Widget" extends="Group">
+                </component>
+            `);
+            const names = program.getSceneGraphNodeNames();
+            expect(names).to.include('Label');
+            expect(names).to.include('Widget');
+        });
+
+        it('hasSceneGraphNode recognizes built-in nodes and project components (case-insensitive)', () => {
+            program.setFile('components/widget.xml', trim`
+                <component name="Widget" extends="Group">
+                </component>
+            `);
+            expect(program.hasSceneGraphNode('label')).to.be.true;
+            expect(program.hasSceneGraphNode('widget')).to.be.true;
+            expect(program.hasSceneGraphNode('NotARealNode')).to.be.false;
+        });
+
+        it('getSceneGraphNodeFields walks the extends chain of a built-in node', () => {
+            //Label extends LabelBase extends ... eventually Node; `id` comes from Node
+            const fieldNames = program.getSceneGraphNodeFields('Label').map(x => x.name);
+            expect(fieldNames).to.include('text');
+            expect(fieldNames).to.include('id');
+        });
+
+        it('getSceneGraphNodeFields walks from a project component into its built-in parent', () => {
+            program.setFile('components/widget.xml', trim`
+                <component name="Widget" extends="Group">
+                    <interface>
+                        <field id="caption" type="string" />
+                    </interface>
+                </component>
+            `);
+            const fields = program.getSceneGraphNodeFields('Widget');
+            const own = fields.find(x => x.name === 'caption');
+            const inherited = fields.find(x => x.name === 'visible');
+            //own field from the component's interface
+            expect(own?.origin).to.equal('own');
+            //inherited field from the built-in Group (via Node)
+            expect(inherited?.origin).to.equal('inherited');
+        });
+    });
+
     it('does not throw exception after calling validate() after dispose()', () => {
         program.setFile('source/themes/alpha.bs', `
             sub main()

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -38,10 +38,17 @@ import { SignatureHelpUtil } from './bscPlugin/SignatureHelpUtil';
 import { DiagnosticSeverityAdjuster } from './DiagnosticSeverityAdjuster';
 import { Sequencer } from './common/Sequencer';
 import { Deferred } from './deferred';
+import { nodes as builtInSceneGraphNodeData } from './roku-types';
+import type { SGNodeData } from './roku-types';
 
 const startOfSourcePkgPath = `source${path.sep}`;
 const bslibNonAliasedRokuModulesPkgPath = s`source/roku_modules/rokucommunity_bslib/bslib.brs`;
 const bslibAliasedRokuModulesPkgPath = s`source/roku_modules/bslib/bslib.brs`;
+
+/**
+ * The built-in Roku SceneGraph nodes, keyed by their lower-case name
+ */
+const builtInSceneGraphNodes = builtInSceneGraphNodeData as unknown as Record<string, SGNodeData>;
 
 export interface SourceObj {
     /**
@@ -488,6 +495,113 @@ export class Program {
      */
     public getComponentScope(componentName: string) {
         return this.getComponent(componentName)?.scope;
+    }
+
+    /**
+     * Get the names of all known SceneGraph nodes: the built-in Roku nodes plus every component
+     * defined in this program. Names keep their original casing and are deduplicated by lower-case name.
+     */
+    public getSceneGraphNodeNames(): string[] {
+        const namesByLowerName = new Map<string, string>();
+        for (const node of Object.values(builtInSceneGraphNodes)) {
+            namesByLowerName.set(node.name.toLowerCase(), node.name);
+        }
+        for (const componentName in this.components) {
+            const displayName = this.components[componentName][0]?.file.componentName?.text;
+            if (displayName) {
+                namesByLowerName.set(displayName.toLowerCase(), displayName);
+            }
+        }
+        return [...namesByLowerName.values()];
+    }
+
+    /**
+     * Determine whether a SceneGraph node with the given name exists, either as a built-in Roku node
+     * or as a component defined in this program.
+     */
+    public hasSceneGraphNode(nodeName: string): boolean {
+        if (!nodeName) {
+            return false;
+        }
+        return !!builtInSceneGraphNodes[nodeName.toLowerCase()] || !!this.getComponent(nodeName);
+    }
+
+    /**
+     * Get the built-in Roku node data and/or the project component file backing a SceneGraph node name.
+     * Returns `undefined` when no node or component matches.
+     */
+    public getSceneGraphNode(nodeName: string): SceneGraphNodeLookup | undefined {
+        if (!nodeName) {
+            return undefined;
+        }
+        const builtInNode = builtInSceneGraphNodes[nodeName.toLowerCase()];
+        const componentFile = this.getComponent(nodeName)?.file;
+        if (!builtInNode && !componentFile) {
+            return undefined;
+        }
+        return { builtInNode: builtInNode, componentFile: componentFile };
+    }
+
+    /**
+     * Get every field available on a SceneGraph node, walking the full `extends` chain across both
+     * built-in Roku nodes and project components. Fields declared closer to the node take precedence
+     * over inherited fields with the same name.
+     */
+    public getSceneGraphNodeFields(nodeName: string): ResolvedSceneGraphField[] {
+        const fieldsByLowerName = new Map<string, ResolvedSceneGraphField>();
+        const visitedNodeNames = new Set<string>();
+
+        const addField = (field: ResolvedSceneGraphField) => {
+            if (!field.name) {
+                return;
+            }
+            const lowerName = field.name.toLowerCase();
+            //the first definition we encounter is the closest one, so it wins
+            if (!fieldsByLowerName.has(lowerName)) {
+                fieldsByLowerName.set(lowerName, field);
+            }
+        };
+
+        const walk = (currentNodeName: string, origin: SceneGraphFieldOrigin) => {
+            const lowerName = currentNodeName?.toLowerCase();
+            if (!lowerName || visitedNodeNames.has(lowerName)) {
+                return;
+            }
+            visitedNodeNames.add(lowerName);
+
+            //prefer a project component (a project component can shadow a built-in of the same name)
+            const component = this.getComponent(currentNodeName);
+            if (component) {
+                for (const field of component.file.ast.component?.api?.fields ?? []) {
+                    addField({ name: field.id, type: field.type, default: field.value, origin: origin });
+                }
+                const parentName = component.file.ast.component?.extends;
+                if (parentName) {
+                    walk(parentName, 'inherited');
+                }
+                return;
+            }
+
+            const builtInNode = builtInSceneGraphNodes[lowerName];
+            if (builtInNode) {
+                for (const field of builtInNode.fields ?? []) {
+                    addField({
+                        name: field.name,
+                        type: field.type,
+                        default: field.default,
+                        description: field.description,
+                        accessPermission: field.accessPermission,
+                        origin: origin
+                    });
+                }
+                if (builtInNode.extends?.name) {
+                    walk(builtInNode.extends.name, 'inherited');
+                }
+            }
+        };
+
+        walk(nodeName, 'own');
+        return [...fieldsByLowerName.values()];
     }
 
     /**
@@ -1929,4 +2043,30 @@ export interface FileTranspileResult {
     code: string;
     map: SourceMapGenerator;
     typedef: string;
+}
+
+/**
+ * Where a resolved SceneGraph field was declared, relative to the node it was resolved for:
+ * `own` = declared on the node itself, `inherited` = declared on an ancestor in the `extends` chain
+ */
+export type SceneGraphFieldOrigin = 'own' | 'inherited';
+
+/**
+ * A field available on a SceneGraph node, resolved across the node's full `extends` chain
+ */
+export interface ResolvedSceneGraphField {
+    name: string;
+    type?: string;
+    default?: string;
+    description?: string;
+    accessPermission?: string;
+    origin: SceneGraphFieldOrigin;
+}
+
+/**
+ * The built-in Roku node data and/or project component file backing a SceneGraph node name
+ */
+export interface SceneGraphNodeLookup {
+    builtInNode?: SGNodeData;
+    componentFile?: XmlFile;
 }

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -396,7 +396,7 @@ describe('XmlFile', () => {
         });
 
         //TODO - refine this test once cdata scripts are supported
-        it('provides xml element completions, never brightscript scope completions', () => {
+        it('does not provide node completions outside of <children>', () => {
             program.setFile('components/component1.brs', ``);
 
             let xmlFile = program.setFile('components/component1.xml', trim`
@@ -406,10 +406,8 @@ describe('XmlFile', () => {
                 </component>
             `);
 
-            const completions = program.getCompletions(xmlFile.srcPath, Position.create(1, 1));
-            //every completion is an xml element (node) completion, not a brightscript scope symbol
-            expect(completions).not.to.be.empty;
-            expect(completions.every(x => x.kind === CompletionItemKind.Class)).to.be.true;
+            //at the component root (not inside <children>) we should not spew node/scope completions
+            expect(program.getCompletions(xmlFile.srcPath, Position.create(1, 1))).to.be.empty;
         });
 
         /**
@@ -446,6 +444,21 @@ describe('XmlFile', () => {
             //a component can't contain itself
             expect(labels).not.to.include('Main');
             expect(completions.every(x => x.kind === CompletionItemKind.Class)).to.be.true;
+        });
+
+        it('does not provide node completions inside <interface>', () => {
+            const xmlFile = program.setFile<XmlFile>('components/main.xml', trim`
+                <component name="Main" extends="Group">
+                    <interface>
+                        <
+                    </interface>
+                </component>
+            `);
+            const lines = xmlFile.fileContents.split('\n');
+            const lineIndex = lines.findIndex(line => line.trim() === '<');
+            const completions = xmlFile.getCompletions(Position.create(lineIndex, lines[lineIndex].indexOf('<') + 1));
+            //nodes/components are only valid inside <children>, not inside <interface>
+            expect(completions).to.be.empty;
         });
 
         it('provides field completions inside an open element tag', () => {

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -36,6 +36,18 @@ describe('XmlFile', () => {
     });
 
     describe('parse', () => {
+        it('does not crash on malformed child elements (e.g. a lone `<` while typing)', () => {
+            //this used to throw in SGParser.mapNode because the element had no tag name
+            file = program.setFile('components/malformed.xml', trim`
+                <component name="Main" extends="Group">
+                    <children>
+                        <
+                    </children>
+                </component>
+            `);
+            expect(isXmlFile(file)).to.be.true;
+        });
+
         it('allows modifying the parsed XML model', () => {
             const expected = 'OtherName';
             program.plugins.add({
@@ -384,7 +396,7 @@ describe('XmlFile', () => {
         });
 
         //TODO - refine this test once cdata scripts are supported
-        it('prevents scope completions entirely', () => {
+        it('provides xml element completions, never brightscript scope completions', () => {
             program.setFile('components/component1.brs', ``);
 
             let xmlFile = program.setFile('components/component1.xml', trim`
@@ -394,7 +406,72 @@ describe('XmlFile', () => {
                 </component>
             `);
 
-            expect(program.getCompletions(xmlFile.srcPath, Position.create(1, 1))).to.be.empty;
+            const completions = program.getCompletions(xmlFile.srcPath, Position.create(1, 1));
+            //every completion is an xml element (node) completion, not a brightscript scope symbol
+            expect(completions).not.to.be.empty;
+            expect(completions.every(x => x.kind === CompletionItemKind.Class)).to.be.true;
+        });
+
+        /**
+         * Find the (line, character) position immediately after the first occurrence of `marker` in the file
+         */
+        function positionAfter(fileContents: string, marker: string): Position {
+            const index = fileContents.indexOf(marker);
+            const before = fileContents.substring(0, index + marker.length);
+            const lines = before.split('\n');
+            return Position.create(lines.length - 1, lines[lines.length - 1].length);
+        }
+
+        it('provides element completions for scenegraph nodes and project components after `<`', () => {
+            program.setFile('components/widget.xml', trim`
+                <component name="Widget" extends="Group">
+                </component>
+            `);
+            const xmlFile = program.setFile<XmlFile>('components/main.xml', trim`
+                <component name="Main" extends="Group">
+                    <children>
+                        <
+                    </children>
+                </component>
+            `);
+            //position the caret right after the lone `<` inside <children>
+            const lines = xmlFile.fileContents.split('\n');
+            const lineIndex = lines.findIndex(line => line.trim() === '<');
+            const completions = xmlFile.getCompletions(Position.create(lineIndex, lines[lineIndex].indexOf('<') + 1));
+            const labels = completions.map(x => x.label);
+            //built-in node
+            expect(labels).to.include('Label');
+            //project component
+            expect(labels).to.include('Widget');
+            //a component can't contain itself
+            expect(labels).not.to.include('Main');
+            expect(completions.every(x => x.kind === CompletionItemKind.Class)).to.be.true;
+        });
+
+        it('provides field completions inside an open element tag', () => {
+            const xmlFile = program.setFile<XmlFile>('components/main.xml', trim`
+                <component name="Main" extends="Group">
+                    <children>
+                        <Label text="hi" >
+                    </children>
+                </component>
+            `);
+            const completions = xmlFile.getCompletions(positionAfter(xmlFile.fileContents, '<Label text="hi" '));
+            const labels = completions.map(x => x.label);
+            //Label has a `color` field
+            expect(labels).to.include('color');
+            //`text` is already present on the tag, so it should not be suggested again
+            expect(labels).not.to.include('text');
+            expect(completions.every(x => x.kind === CompletionItemKind.Field)).to.be.true;
+        });
+
+        it('getTokenAt returns the token whose range contains the position', () => {
+            const xmlFile = program.setFile<XmlFile>('components/main.xml', trim`
+                <component name="Main" extends="Group">
+                </component>
+            `);
+            const token = xmlFile.getTokenAt(positionAfter(xmlFile.fileContents, '<compon'));
+            expect(token?.image).to.equal('component');
         });
     });
 

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import type { CodeWithSourceMap } from 'source-map';
 import { SourceNode } from 'source-map';
 import type { CompletionItem, Location, Position, Range } from 'vscode-languageserver';
+import { CompletionItemKind, InsertTextFormat } from 'vscode-languageserver';
 import { diagnosticCodes } from '../DiagnosticMessages';
 import type { FunctionScope } from '../FunctionScope';
 import type { Callable, BsDiagnostic, File, FileReference, FunctionCall, CommentFlag } from '../interfaces';
@@ -16,6 +17,19 @@ import { SGScript } from '../parser/SGTypes';
 import { CommentFlagProcessor } from '../CommentFlagProcessor';
 import type { IToken, TokenType } from 'chevrotain';
 import { TranspileState } from '../parser/TranspileState';
+
+/**
+ * Names of the `@xml-tools` lexer token types we inspect for completions and hover
+ */
+const XmlTokenName = {
+    open: 'OPEN',
+    slashOpen: 'SLASH_OPEN',
+    close: 'CLOSE',
+    slashClose: 'SLASH_CLOSE',
+    name: 'Name',
+    equals: 'EQUALS',
+    string: 'STRING'
+} as const;
 
 export class XmlFile {
     constructor(
@@ -368,12 +382,140 @@ export class XmlFile {
      * Get all available completions for the specified position
      */
     public getCompletions(position: Position): CompletionItem[] {
-        let scriptImport = util.getScriptImportAtPosition(this.scriptTagImports, position);
+        //handle script import path completions (e.g. `<script uri="|" />`)
+        const scriptImport = util.getScriptImportAtPosition(this.scriptTagImports, position);
         if (scriptImport) {
             return this.program.getScriptImportCompletions(this.pkgPath, scriptImport);
-        } else {
+        }
+
+        //don't provide completions inside an attribute value string (e.g. `text="|"`); reserved for future work
+        if (this.getTokenAt(position)?.tokenType.name === XmlTokenName.string) {
             return [];
         }
+
+        const tokens = (this.parser.tokens ?? []) as unknown as IToken[];
+        //find the most recent tag boundary (`<`, `</`, `>`, `/>`) the cursor has moved past. A boundary the
+        //cursor merely sits at the start of (e.g. the `>` the caret is right before) doesn't count, so a
+        //caret inside `<Label |>` still resolves to the opening `<Label` rather than the trailing `>`.
+        let boundaryIndex = -1;
+        for (let i = 0; i < tokens.length; i++) {
+            const startLine = (tokens[i].startLine ?? 1) - 1;
+            const startCharacter = (tokens[i].startColumn ?? 1) - 1;
+            //tokens are ordered, so stop once one starts at or after the cursor
+            if (position.line < startLine || (position.line === startLine && position.character <= startCharacter)) {
+                break;
+            }
+            const tokenName = tokens[i].tokenType.name;
+            if (tokenName === XmlTokenName.open || tokenName === XmlTokenName.slashOpen || tokenName === XmlTokenName.close || tokenName === XmlTokenName.slashClose) {
+                boundaryIndex = i;
+            }
+        }
+        const boundary = boundaryIndex >= 0 ? tokens[boundaryIndex] : undefined;
+
+        //cursor is inside an open start tag: `<` tagName [attributes...]
+        if (boundary?.tokenType.name === XmlTokenName.open) {
+            const tagNameToken = tokens[boundaryIndex + 1];
+            //no tag name yet, or the cursor is still on/within the tag name -> complete element names
+            if (tagNameToken?.tokenType.name !== XmlTokenName.name || util.comparePositionToRange(position, this.getTokenRange(tagNameToken)) <= 0) {
+                return this.getElementCompletions(false);
+            }
+            //otherwise complete attribute (field) names for the enclosing node
+            return this.getAttributeCompletions(tagNameToken.image, this.getExistingAttributeNames(boundaryIndex + 2));
+        }
+
+        //cursor is in element content (right after a `>` / `/>`) -> complete child element names
+        if (boundary?.tokenType.name === XmlTokenName.close || boundary?.tokenType.name === XmlTokenName.slashClose) {
+            return this.getElementCompletions(true);
+        }
+
+        //inside a closing tag (`</...`), before any tag, or any other position -> no completions
+        return [];
+    }
+
+    /**
+     * Get element (tag name) completions for every known SceneGraph node and project component.
+     * @param includeOpenBracket whether to prefix the inserted snippet with `<` (true when the cursor is
+     * not already immediately after an `<`)
+     */
+    private getElementCompletions(includeOpenBracket: boolean): CompletionItem[] {
+        const ownComponentName = this.componentName?.text?.toLowerCase();
+        const openBracket = includeOpenBracket ? '<' : '';
+        return this.program.getSceneGraphNodeNames()
+            //a component can't contain itself
+            .filter(name => !ownComponentName || name.toLowerCase() !== ownComponentName)
+            .map(name => ({
+                label: name,
+                kind: CompletionItemKind.Class,
+                insertTextFormat: InsertTextFormat.Snippet,
+                insertText: `${openBracket}${name} $0></${name}>`,
+                //sort project components ahead of built-in nodes
+                sortText: (this.program.getComponent(name) ? '0' : '1') + name
+            }));
+    }
+
+    /**
+     * Get attribute (field) name completions for the node with the given name, excluding attributes
+     * already present on the tag.
+     */
+    private getAttributeCompletions(nodeName: string, existingAttributeNames: string[]): CompletionItem[] {
+        const existing = new Set(existingAttributeNames.map(name => name.toLowerCase()));
+        return this.program.getSceneGraphNodeFields(nodeName)
+            .filter(field => !existing.has(field.name.toLowerCase()))
+            //built-in read-only fields can't be set in xml; project fields (no accessPermission) are always writable
+            .filter(field => !field.accessPermission || /write/i.test(field.accessPermission))
+            .map(field => ({
+                label: field.name,
+                kind: CompletionItemKind.Field,
+                insertTextFormat: InsertTextFormat.Snippet,
+                insertText: `${field.name}="$1"`,
+                detail: field.type,
+                documentation: field.description,
+                //sort a node's own fields ahead of inherited ones
+                sortText: (field.origin === 'own' ? '0' : '1') + field.name
+            }));
+    }
+
+    /**
+     * Collect the names of attributes already written on a start tag, scanning forward from the given
+     * token index until the tag closes. Used to avoid suggesting attributes that are already present.
+     */
+    private getExistingAttributeNames(startIndex: number): string[] {
+        const names: string[] = [];
+        const tokens = (this.parser.tokens ?? []) as unknown as IToken[];
+        for (let i = startIndex; i < tokens.length; i++) {
+            const tokenName = tokens[i].tokenType.name;
+            //inside a start tag the only token kinds are attribute names, `=`, and values; anything else ends the tag
+            if (tokenName !== XmlTokenName.name && tokenName !== XmlTokenName.equals && tokenName !== XmlTokenName.string) {
+                break;
+            }
+            if (tokenName === XmlTokenName.name && tokens[i + 1]?.tokenType.name === XmlTokenName.equals) {
+                names.push(tokens[i].image);
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Get the xml token whose range contains the given position (used by completions and hover)
+     */
+    public getTokenAt(position: Position): IToken | undefined {
+        for (const token of (this.parser.tokens ?? []) as unknown as IToken[]) {
+            if (util.rangeContains(this.getTokenRange(token), position)) {
+                return token;
+            }
+        }
+    }
+
+    /**
+     * Build a brighterscript (0-based) range from an `@xml-tools` (1-based) token
+     */
+    private getTokenRange(token: IToken): Range {
+        return util.createRange(
+            token.startLine - 1,
+            token.startColumn - 1,
+            token.endLine - 1,
+            token.endColumn
+        );
     }
 
     /**

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -417,7 +417,7 @@ export class XmlFile {
             const tagNameToken = tokens[boundaryIndex + 1];
             //no tag name yet, or the cursor is still on/within the tag name -> complete element names
             if (tagNameToken?.tokenType.name !== XmlTokenName.name || util.comparePositionToRange(position, this.getTokenRange(tagNameToken)) <= 0) {
-                return this.getElementCompletions(false);
+                return this.getElementCompletions(position, false);
             }
             //otherwise complete attribute (field) names for the enclosing node
             return this.getAttributeCompletions(tagNameToken.image, this.getExistingAttributeNames(boundaryIndex + 2));
@@ -425,7 +425,7 @@ export class XmlFile {
 
         //cursor is in element content (right after a `>` / `/>`) -> complete child element names
         if (boundary?.tokenType.name === XmlTokenName.close || boundary?.tokenType.name === XmlTokenName.slashClose) {
-            return this.getElementCompletions(true);
+            return this.getElementCompletions(position, true);
         }
 
         //inside a closing tag (`</...`), before any tag, or any other position -> no completions
@@ -433,11 +433,19 @@ export class XmlFile {
     }
 
     /**
-     * Get element (tag name) completions for every known SceneGraph node and project component.
+     * Get element (tag name) completions for the node/component types valid at this position. Nodes and
+     * components are only valid inside a `<children>` block (or nested inside another node), so this returns
+     * nothing at the component root, inside `<interface>`, etc. (those elements are handled by snippets).
+     * @param position the cursor position, used to determine the enclosing element
      * @param includeOpenBracket whether to prefix the inserted snippet with `<` (true when the cursor is
      * not already immediately after an `<`)
      */
-    private getElementCompletions(includeOpenBracket: boolean): CompletionItem[] {
+    private getElementCompletions(position: Position, includeOpenBracket: boolean): CompletionItem[] {
+        const container = this.getEnclosingElementName(position)?.toLowerCase();
+        //only offer node/component completions inside <children> or nested inside another node
+        if (container !== 'children' && !(container && this.program.hasSceneGraphNode(container))) {
+            return [];
+        }
         const ownComponentName = this.componentName?.text?.toLowerCase();
         const openBracket = includeOpenBracket ? '<' : '';
         return this.program.getSceneGraphNodeNames()
@@ -493,6 +501,64 @@ export class XmlFile {
             }
         }
         return names;
+    }
+
+    /**
+     * Determine the name of the element that directly encloses the given position, by walking the tokens
+     * and tracking a stack of open (content-bearing) elements. Self-closing tags and closed tags are not
+     * on the stack, so the result is the nearest ancestor whose start tag closed before the cursor.
+     * Returns undefined at the top level of the document.
+     */
+    private getEnclosingElementName(position: Position): string | undefined {
+        const tokens = (this.parser.tokens ?? []) as unknown as IToken[];
+        const stack: string[] = [];
+        let expectingTagName = false;
+        let isCloseTag = false;
+        let currentTag: string | undefined;
+        for (const token of tokens) {
+            const startLine = (token.startLine ?? 1) - 1;
+            const startCharacter = (token.startColumn ?? 1) - 1;
+            //tokens are ordered, so stop once one starts at or after the cursor
+            if (position.line < startLine || (position.line === startLine && position.character <= startCharacter)) {
+                break;
+            }
+            switch (token.tokenType.name) {
+                case XmlTokenName.open:
+                    expectingTagName = true;
+                    isCloseTag = false;
+                    currentTag = undefined;
+                    break;
+                case XmlTokenName.slashOpen:
+                    expectingTagName = true;
+                    isCloseTag = true;
+                    currentTag = undefined;
+                    break;
+                case XmlTokenName.name:
+                    //the first Name after an opener is the tag name; later Names are attributes
+                    if (expectingTagName) {
+                        currentTag = token.image;
+                        expectingTagName = false;
+                    }
+                    break;
+                case XmlTokenName.close:
+                    if (isCloseTag) {
+                        stack.pop();
+                    } else if (currentTag) {
+                        stack.push(currentTag);
+                    }
+                    currentTag = undefined;
+                    isCloseTag = false;
+                    expectingTagName = false;
+                    break;
+                case XmlTokenName.slashClose:
+                    //self-closing start tag; nothing is pushed
+                    currentTag = undefined;
+                    isCloseTag = false;
+                    expectingTagName = false;
+                    break;
+            }
+        }
+        return stack[stack.length - 1];
     }
 
     /**

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -171,6 +171,10 @@ interface IToken {
     endOffset?: number;
     endLine?: number;
     endColumn?: number;
+    /**
+     * The lexer token type. Present on tokens produced by `@xml-tools`; used to classify cursor context.
+     */
+    tokenType?: { name: string };
 }
 
 function mapElement({ children }: ElementCstNode, diagnostics: Diagnostic[]): SGTag {
@@ -226,8 +230,12 @@ function reportUnexpectedChildren(name: SGToken, diagnostics: Diagnostic[]) {
     });
 }
 
-function mapNode({ children }: ElementCstNode): SGNode {
-    const nameToken = children.Name[0];
+function mapNode({ children }: ElementCstNode): SGNode | undefined {
+    const nameToken = children.Name?.[0];
+    //skip malformed elements that have no tag name (e.g. a lone `<` while the user is still typing)
+    if (!nameToken) {
+        return undefined;
+    }
     let range: Range;
     const selfClosing = !!children.SLASH_CLOSE;
     if (selfClosing) {
@@ -276,7 +284,9 @@ function mapNodes(content: ContentCstNode): SGNode[] {
         return [];
     }
     const { element } = content.children;
-    return element?.map(element => mapNode(element));
+    return element
+        ?.map(element => mapNode(element))
+        .filter((node): node is SGNode => !!node);
 }
 
 function hasElements(content: ContentCstNode): boolean {

--- a/src/roku-types/index.ts
+++ b/src/roku-types/index.ts
@@ -57,6 +57,10 @@ export interface SGNodeData extends BrightScriptDocLookup {
     fields: BRSFieldData[];
     events: BrightScriptDocLookup[];
     interfaces: BrightScriptDocLookup[];
+    /**
+     * The node this node extends. Absent on the root `Node` type.
+     */
+    extends?: BrightScriptDocLookup;
 }
 
 export interface BRSComponentData extends BrightScriptDocLookup, PossiblyDeprecated {


### PR DESCRIPTION
Bring first-class SceneGraph XML completions into brighterscript so `.xml` component files get completions out of the box (previously only `<script uri>` paths completed). Driven by the built-in `roku-types` node metadata plus the project's own components; no scraped data is bundled.

- Element (tag name) completions after `<` and in element content: built-in nodes and project components.
- Field (attribute name) completions inside an open start tag, resolved across the node's full `extends` chain; attributes already present are excluded and read-only built-in fields are omitted.
- New `Program` methods `getSceneGraphNodeNames`, `getSceneGraphNodeFields`, `hasSceneGraphNode`, `getSceneGraphNode`.
- `<` added as a completion trigger character.
- `SGParser` no longer throws on a malformed child element (e.g. a lone `<` while typing).

First of three stacked PRs: completions, then validation, then hover.