### PR TITLE
Honor deprecated staging options loaded from bsconfig files

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -472,14 +472,14 @@ describe('util', () => {
             );
         });
 
-        it('does not leak deprecated staging options from project files onto the final options', () => {
+        it('passes deprecated staging options from project files through to the final options', () => {
             fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
                 stagingFolderPath: './staging',
                 stagingDir: './staging'
             });
             const result = util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` });
-            expect(result.stagingFolderPath).to.be.undefined;
-            expect(result.stagingDir).to.be.undefined;
+            expect(result.stagingFolderPath).to.eql('./staging');
+            expect(result.stagingDir).to.eql('./staging');
         });
 
         it('honors copyToStaging from a loaded project file', () => {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -394,6 +394,102 @@ describe('util', () => {
                 outDir: './out'
             });
         });
+
+        it('honors stagingFolderPath from a loaded project file', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                stagingFolderPath: './staging'
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).outDir
+            ).to.eql(
+                s`${rootDir}/staging`
+            );
+        });
+
+        it('honors stagingDir from a loaded project file', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                stagingDir: './staging'
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).outDir
+            ).to.eql(
+                s`${rootDir}/staging`
+            );
+        });
+
+        it('prefers outDir over stagingFolderPath when both are in the project file', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                outDir: './modern',
+                stagingFolderPath: './legacy'
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).outDir
+            ).to.eql(
+                s`${rootDir}/modern`
+            );
+        });
+
+        it('prefers a provided outDir option over the project file stagingFolderPath', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                stagingFolderPath: './legacy'
+            });
+            expect(
+                util.normalizeAndResolveConfig({
+                    project: s`${rootDir}/bsconfig.json`,
+                    outDir: './cli-out'
+                }).outDir
+            ).to.eql(
+                './cli-out'
+            );
+        });
+
+        it('resolves stagingFolderPath relative to the bsconfig file that declared it', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/folder1/parent.json`, {
+                stagingFolderPath: './staging'
+            });
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                extends: 'folder1/parent.json'
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).outDir
+            ).to.eql(
+                s`${rootDir}/folder1/staging`
+            );
+        });
+
+        it('lets a child config stagingFolderPath override the parent outDir', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/parent.json`, {
+                outDir: './parent-out'
+            });
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                extends: 'parent.json',
+                stagingFolderPath: './child-staging'
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).outDir
+            ).to.eql(
+                s`${rootDir}/child-staging`
+            );
+        });
+
+        it('does not leak deprecated staging options from project files onto the final options', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                stagingFolderPath: './staging',
+                stagingDir: './staging'
+            });
+            const result = util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` });
+            expect(result.stagingFolderPath).to.be.undefined;
+            expect(result.stagingDir).to.be.undefined;
+        });
+
+        it('honors copyToStaging from a loaded project file', () => {
+            fsExtra.outputJsonSync(s`${rootDir}/bsconfig.json`, {
+                copyToStaging: false
+            });
+            expect(
+                util.normalizeAndResolveConfig({ project: s`${rootDir}/bsconfig.json` }).noEmit
+            ).to.be.true;
+        });
     });
 
     describe('normalizeConfig', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -247,6 +247,17 @@ export class Util {
             if (result.outDir) {
                 result.outDir = path.resolve(projectFileCwd, result.outDir);
             }
+            //map the deprecated staging options to `outDir` (relative to THIS config file), then discard them
+            //so they don't flow through to the final program options
+            if (!('outDir' in projectConfig)) {
+                if (projectConfig.stagingFolderPath) {
+                    result.outDir = path.resolve(projectFileCwd, projectConfig.stagingFolderPath);
+                } else if (projectConfig.stagingDir) {
+                    result.outDir = path.resolve(projectFileCwd, projectConfig.stagingDir);
+                }
+            }
+            delete result.stagingFolderPath;
+            delete result.stagingDir;
             if (result.cwd) {
                 result.cwd = path.resolve(projectFileCwd, result.cwd);
             }
@@ -284,27 +295,32 @@ export class Util {
      * @param config a bsconfig object to use as the baseline for the resulting config
      */
     public normalizeAndResolveConfig(config: BsConfig | undefined): FinalizedBsConfig {
-        let result = this.normalizeConfig({
-            ...config
-        });
-
         if (config?.noProject) {
-            return result;
+            return this.normalizeConfig({
+                ...config
+            });
         }
 
+        let project: string | undefined;
         //if no options were provided, try to find a bsconfig.json file
         if (!config || !config.project) {
-            result.project = this.getConfigFilePath(config?.cwd);
+            project = this.getConfigFilePath(config?.cwd);
         } else {
             //use the config's project link
-            result.project = config.project;
+            project = config.project;
         }
-        if (result.project) {
-            let configFile = this.loadConfigFile(result.project, undefined, config?.cwd);
-            result = Object.assign(result, configFile);
+
+        let mergedConfig = { ...config };
+        if (project) {
+            let configFile = this.loadConfigFile(project, undefined, config?.cwd);
+            //the project file values are the defaults; the provided options override them
+            mergedConfig = { ...configFile, ...config };
         }
-        //override the defaults with the specified options
-        result = Object.assign(result, config);
+
+        //set defaults and map deprecated options AFTER merging the project file, so that
+        //deprecated options (i.e. `stagingFolderPath`, `copyToStaging`) from the project file are properly honored
+        let result = this.normalizeConfig(mergedConfig);
+        result.project = project;
         return result;
     }
 
@@ -321,6 +337,8 @@ export class Util {
 
         if (typeof config.logLevel === 'string') {
             logLevel = LogLevel[(config.logLevel as string).toLowerCase()] ?? LogLevel.log;
+        } else if (typeof config.logLevel === 'number') {
+            logLevel = config.logLevel;
         }
 
         let bslibDestinationDir = config.bslibDestinationDir ?? 'source';

--- a/src/util.ts
+++ b/src/util.ts
@@ -247,8 +247,8 @@ export class Util {
             if (result.outDir) {
                 result.outDir = path.resolve(projectFileCwd, result.outDir);
             }
-            //map the deprecated staging options to `outDir` (relative to THIS config file), then discard them
-            //so they don't flow through to the final program options
+            //map the deprecated staging options to `outDir` (relative to THIS config file).
+            //the deprecated options themselves are left as-is so consumers that still read them keep working
             if (!('outDir' in projectConfig)) {
                 if (projectConfig.stagingFolderPath) {
                     result.outDir = path.resolve(projectFileCwd, projectConfig.stagingFolderPath);
@@ -256,8 +256,6 @@ export class Util {
                     result.outDir = path.resolve(projectFileCwd, projectConfig.stagingDir);
                 }
             }
-            delete result.stagingFolderPath;
-            delete result.stagingDir;
             if (result.cwd) {
                 result.cwd = path.resolve(projectFileCwd, result.cwd);
             }


### PR DESCRIPTION
## Problem

`stagingFolderPath` / `stagingDir` (the deprecated aliases for `outDir`) are silently ignored when they come from a bsconfig.json loaded via `--project` (or auto-discovery). Output goes to the default `./out` instead of the configured staging directory:

```jsonc
// bsconfig.json
{
    "stagingFolderPath": "../dist/launcher"  // ignored — output lands in ./out
}
```

```
npx bsc --project bsconfig.json
```

The deprecated-alias mapping lives in `normalizeConfig`, but `normalizeAndResolveConfig` ran it **before** loading the project file:

1. `normalizeConfig({...config})` runs on the CLI options only → no staging key present → `outDir` is baked to the `'./out'` default
2. the project file is then `Object.assign`ed on top → `stagingFolderPath` lands as an inert unrecognized key; `outDir` keeps the already-computed default — the alias mapping never re-runs

Configs passed programmatically (e.g. `ProgramBuilder.run(util.loadConfigFile(...))`) were unaffected because the legacy keys are present when `normalizeConfig` runs — which made this easy to miss: the same project builds correctly through a build script and breaks through the CLI. The `copyToStaging` → `noEmit` alias had the same file-sourced blind spot.

## Changes

- **`normalizeAndResolveConfig`**: merge the project file **first** (file values as defaults, provided options overriding), then normalize once at the end — so every deprecated-option mapping sees file-sourced values.
- **`loadConfigFile`**: map the deprecated staging options to `outDir` — resolved relative to the bsconfig file that declared them, matching the existing `outDir` handling. The deprecated options themselves pass through as authored, so consumers that still read `options.stagingFolderPath`/`options.stagingDir` keep working; `outDir` is the normalized source of truth. In `extends` chains, a child's `stagingFolderPath` overrides a parent's `outDir` (per-key child-wins semantics).
- **`normalizeConfig`**: accept numeric `LogLevel` values in addition to strings. The numeric form previously survived only because of a trailing `Object.assign(result, config)` raw re-copy — the same mechanism that caused the staging bug — which the reorder removes. (Side benefit: string values like `"logLevel"` set in a bsconfig *file* are now normalized too; previously file-sourced values bypassed normalization entirely.)

## Testing

- 8 new regression tests covering: legacy keys honored from a loaded project file, `outDir` precedence (in-file and provided-option), path resolution relative to the declaring bsconfig in `extends` chains, child-legacy-over-parent-`outDir` precedence, deprecated keys passing through to final options, and file-sourced `copyToStaging`
- full suite passes (4260 passing, 0 failures), lint clean
- verified end-to-end: a `--project` build with `stagingFolderPath` now emits to the configured directory instead of `./out` (found while migrating fubo's Roku app to v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
