### PR TITLE
Flag path-like codes in diagnosticFilters

### DIFF
--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -709,6 +709,57 @@ describe('DiagnosticFilterer', () => {
         });
     });
 
+    describe('getPathLikeDiagnosticFilterCodes', () => {
+        it('flags entries with `./`', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['./source/main.brs']
+            })).to.eql(['./source/main.brs']);
+        });
+
+        it('flags entries with `../`', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['../vendor/lib.bs']
+            })).to.eql(['../vendor/lib.bs']);
+        });
+
+        it('flags entries with a globstar', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['source/vendor/**/*']
+            })).to.eql(['source/vendor/**/*']);
+        });
+
+        it('flags entries ending in .bs, .brs, or .xml', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['source/main.brs', 'source/lib.bs', 'components/Widget.xml']
+            })).to.eql(['source/main.brs', 'source/lib.bs', 'components/Widget.xml']);
+        });
+
+        it('flags path-like codes nested in a `codes` array', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: [{ codes: [1, 'lint-1000', 'source/vendor/**/*'] }]
+            })).to.eql(['source/vendor/**/*']);
+        });
+
+        it('does not flag actual diagnostic codes', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: [1000, 'lint-1000', { codes: [1, 'lint-1000'] }, { files: 'source/vendor/**/*' }]
+            })).to.eql([]);
+        });
+
+        it('does not flag anything when diagnosticFiltersV0Compatibility is true', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFiltersV0Compatibility: true,
+                diagnosticFilters: ['source/vendor/**/*']
+            } as any)).to.eql([]);
+        });
+
+        it('does not duplicate repeated offenders', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['source/vendor/**/*', 'source/vendor/**/*']
+            })).to.eql(['source/vendor/**/*']);
+        });
+    });
+
 });
 
 function getDiagnostic(code: number | string, srcPath: string, destPath?: string) {

--- a/src/DiagnosticFilterer.spec.ts
+++ b/src/DiagnosticFilterer.spec.ts
@@ -758,6 +758,24 @@ describe('DiagnosticFilterer', () => {
                 diagnosticFilters: ['source/vendor/**/*', 'source/vendor/**/*']
             })).to.eql(['source/vendor/**/*']);
         });
+
+        it('flags entries with windows-style `.\\`', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['.\\source\\main.brs', '..\\vendor\\lib.bs']
+            })).to.eql(['.\\source\\main.brs', '..\\vendor\\lib.bs']);
+        });
+
+        it('flags entries that exactly match a known project file destPath', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['source/main.json']
+            }, new Set(['source/main.json']))).to.eql(['source/main.json']);
+        });
+
+        it('does not flag entries that only partially match a known project file destPath', () => {
+            expect(filterer.getPathLikeDiagnosticFilterCodes({
+                diagnosticFilters: ['lint-1000']
+            }, new Set(['source/main.json']))).to.eql([]);
+        });
     });
 
 });

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -421,15 +421,20 @@ export class DiagnosticFilterer {
     /**
      * Does this diagnostic filter "code" value look like a file path/glob instead of a diagnostic code?
      * v0-style `diagnosticFilters` entries were file globs, but v1 treats bare string/number entries as codes.
-     * This heuristic catches the common glob patterns left over from a v0-style config.
+     * This heuristic catches the common glob patterns left over from a v0-style config, as well as any value
+     * that exactly matches the destPath of a file actually in the project (if `knownDestPaths` is provided).
      */
-    public isCodeValuePathLike(value: number | string): boolean {
+    public isCodeValuePathLike(value: number | string, knownDestPaths?: Set<string>): boolean {
         if (typeof value !== 'string') {
             return false;
         }
         const lowerValue = value.toLowerCase();
+        if (knownDestPaths?.has(lowerValue.replace(/\\/g, '/'))) {
+            return true;
+        }
         return (
             value.includes('./') ||
+            value.includes('.\\') ||
             value.includes('**') ||
             lowerValue.endsWith('.bs') ||
             lowerValue.endsWith('.brs') ||
@@ -440,20 +445,24 @@ export class DiagnosticFilterer {
     /**
      * Scan the (non-v0-compat) `diagnosticFilters` config for entries that look like file paths/globs
      * rather than diagnostic codes, to help teams migrating from the v0-style config.
+     * @param config the program config, containing the `diagnosticFilters` to scan
+     * @param knownDestPaths the lower-cased, forward-slash destPaths of files actually in the project. When
+     * provided, a filter entry that exactly matches one of these paths is flagged even if it doesn't match
+     * the glob-like heuristics (e.g. a bare `source/main.json`).
      */
-    public getPathLikeDiagnosticFilterCodes(config: BsConfig): (number | string)[] {
+    public getPathLikeDiagnosticFilterCodes(config: BsConfig, knownDestPaths?: Set<string>): (number | string)[] {
         if (config.diagnosticFiltersV0Compatibility) {
             return [];
         }
         const result = new Set<number | string>();
         for (let filter of config.diagnosticFilters ?? []) {
-            if ((typeof filter === 'string' || typeof filter === 'number') && this.isCodeValuePathLike(filter)) {
+            if ((typeof filter === 'string' || typeof filter === 'number') && this.isCodeValuePathLike(filter, knownDestPaths)) {
                 result.add(filter);
                 continue;
             }
             if (filter && typeof filter === 'object' && 'codes' in filter && Array.isArray(filter.codes)) {
                 for (const code of filter.codes) {
-                    if (this.isCodeValuePathLike(code)) {
+                    if (this.isCodeValuePathLike(code, knownDestPaths)) {
                         result.add(code);
                     }
                 }

--- a/src/DiagnosticFilterer.ts
+++ b/src/DiagnosticFilterer.ts
@@ -417,4 +417,48 @@ export class DiagnosticFilterer {
         }
 
     }
+
+    /**
+     * Does this diagnostic filter "code" value look like a file path/glob instead of a diagnostic code?
+     * v0-style `diagnosticFilters` entries were file globs, but v1 treats bare string/number entries as codes.
+     * This heuristic catches the common glob patterns left over from a v0-style config.
+     */
+    public isCodeValuePathLike(value: number | string): boolean {
+        if (typeof value !== 'string') {
+            return false;
+        }
+        const lowerValue = value.toLowerCase();
+        return (
+            value.includes('./') ||
+            value.includes('**') ||
+            lowerValue.endsWith('.bs') ||
+            lowerValue.endsWith('.brs') ||
+            lowerValue.endsWith('.xml')
+        );
+    }
+
+    /**
+     * Scan the (non-v0-compat) `diagnosticFilters` config for entries that look like file paths/globs
+     * rather than diagnostic codes, to help teams migrating from the v0-style config.
+     */
+    public getPathLikeDiagnosticFilterCodes(config: BsConfig): (number | string)[] {
+        if (config.diagnosticFiltersV0Compatibility) {
+            return [];
+        }
+        const result = new Set<number | string>();
+        for (let filter of config.diagnosticFilters ?? []) {
+            if ((typeof filter === 'string' || typeof filter === 'number') && this.isCodeValuePathLike(filter)) {
+                result.add(filter);
+                continue;
+            }
+            if (filter && typeof filter === 'object' && 'codes' in filter && Array.isArray(filter.codes)) {
+                for (const code of filter.codes) {
+                    if (this.isCodeValuePathLike(code)) {
+                        result.add(code);
+                    }
+                }
+            }
+        }
+        return [...result];
+    }
 }

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -496,7 +496,10 @@ export class DiagnosticManager {
      * This is a common mistake when migrating a bsconfig.json from the v0-style filters (which were file globs)
      */
     public detectPathLikeDiagnosticFilterCodes(config: FinalizedBsConfig, context?: DiagnosticContext) {
-        const pathLikeCodes = this.diagnosticFilterer.getPathLikeDiagnosticFilterCodes(config);
+        const knownDestPaths = this.program ? new Set(
+            Object.values(this.program.files).map(file => file.destPath.toLowerCase().replace(/\\/g, '/'))
+        ) : undefined;
+        const pathLikeCodes = this.diagnosticFilterer.getPathLikeDiagnosticFilterCodes(config, knownDestPaths);
         if (pathLikeCodes.length === 0) {
             return;
         }

--- a/src/DiagnosticManager.ts
+++ b/src/DiagnosticManager.ts
@@ -13,7 +13,8 @@ import type { Logger } from './logging';
 import { LogLevel, createLogger } from './logging';
 import type { Program } from './Program';
 import type { BrsFile } from './files/BrsFile';
-import { DiagnosticCodeMap } from './DiagnosticMessages';
+import { DiagnosticCodeMap, DiagnosticMessages } from './DiagnosticMessages';
+import * as path from 'path';
 
 interface DiagnosticWithContexts {
     diagnostic: BsDiagnosticWithKey;
@@ -488,6 +489,25 @@ export class DiagnosticManager {
             this.diagnosticFilterer.options = this.options;
         }
         return this.diagnosticFilterer.isFileCompletelyFiltered(file);
+    }
+
+    /**
+     * Flag `diagnosticFilters` entries that look like file paths/globs rather than diagnostic codes.
+     * This is a common mistake when migrating a bsconfig.json from the v0-style filters (which were file globs)
+     */
+    public detectPathLikeDiagnosticFilterCodes(config: FinalizedBsConfig, context?: DiagnosticContext) {
+        const pathLikeCodes = this.diagnosticFilterer.getPathLikeDiagnosticFilterCodes(config);
+        if (pathLikeCodes.length === 0) {
+            return;
+        }
+        const location = util.createLocationFromRange(
+            util.pathToUri(config.project ?? path.join(config.cwd, 'bsconfig.json')),
+            util.createRange(0, 0, 0, 0)
+        );
+        this.register(pathLikeCodes.map(code => ({
+            ...DiagnosticMessages.diagnosticFilterLooksLikeFilePath(code.toString()),
+            location: location
+        })), context);
     }
 }
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -1165,6 +1165,11 @@ export let DiagnosticMessages = {
         legacyCode: 1154,
         severity: DiagnosticSeverity.Error,
         code: 'rsg-version-removed'
+    }),
+    diagnosticFilterLooksLikeFilePath: (value: string) => ({
+        message: `Diagnostic filter "${value}" looks like a file path or glob, not a diagnostic code. To filter diagnostics by file, use the "files" property instead: { "files": ["${value}"] }`,
+        severity: DiagnosticSeverity.Warning,
+        code: 'diagnostic-filter-looks-like-file-path'
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -411,6 +411,20 @@ describe('Program', () => {
             }]);
         });
 
+        it('flags diagnosticFilters entries that look like file paths', () => {
+            program.options.diagnosticFilters = ['source/vendor/**/*'] as any;
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.diagnosticFilterLooksLikeFilePath('source/vendor/**/*')
+            ]);
+        });
+
+        it('does not flag diagnosticFilters entries that are actual codes', () => {
+            program.options.diagnosticFilters = [1000, 'lint-1000'] as any;
+            program.validate();
+            expectDiagnostics(program, []);
+        });
+
         it('does not produce duplicate parse errors for different component scopes', () => {
             //add a file with a parse error
             program.setFile('components/lib.brs', `

--- a/src/Program.spec.ts
+++ b/src/Program.spec.ts
@@ -425,6 +425,15 @@ describe('Program', () => {
             expectDiagnostics(program, []);
         });
 
+        it('flags diagnosticFilters entries that exactly match a known project file, even without a glob-like pattern', () => {
+            program.setFile('manifest', '');
+            program.options.diagnosticFilters = ['manifest'] as any;
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.diagnosticFilterLooksLikeFilePath('manifest')
+            ]);
+        });
+
         it('does not produce duplicate parse errors for different component scopes', () => {
             //add a file with a parse error
             program.setFile('components/lib.brs', `

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -1434,6 +1434,9 @@ export class Program {
 
 
             })
+            .once('detect diagnostic filter issues', () => {
+                this.diagnostics.detectPathLikeDiagnosticFilterCodes(this.options, { tags: [ProgramValidatorDiagnosticsTag] });
+            })
             .onCancel(() => {
                 logValidateEnd('cancelled');
             })


### PR DESCRIPTION
## Summary
- Adds a new diagnostic that warns when a v1-style `diagnosticFilters` entry looks like a file path or glob (contains `./`, `../`, `**`, or ends in `.bs`/`.brs`/`.xml`) rather than a diagnostic code — a common mistake when migrating a v0-style bsconfig, where `diagnosticFilters` entries were file globs.
- Skipped when `diagnosticFiltersV0Compatibility` is enabled, since those filters are legitimately file globs.

Closes #1384

## Test plan
- [x] Added unit tests for `DiagnosticFilterer.getPathLikeDiagnosticFilterCodes`
- [x] Added an integration test in `Program.spec.ts` verifying the diagnostic is emitted/not emitted during `program.validate()`
- [x] `npm run build`, `npm run lint`, and `npm run test:nocover` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)