### PR TITLE
Fix broken benchmark harness targets

### DIFF
--- a/benchmarks/fixtures/heavy-types/components/Comp1.bs
+++ b/benchmarks/fixtures/heavy-types/components/Comp1.bs
@@ -1,0 +1,57 @@
+' Auto-generated fixture component-local file for the validate-scope benchmark target.
+' Heavily references shared.* types (ReferenceTypes resolved across file/scope boundaries).
+namespace comp0
+
+    class Local0
+        public sharedField as shared.Class0
+        public sharedIface as shared.Interface0
+        public function process(input as shared.Class0) as shared.Class1
+            return input.field1
+        end function
+    end class
+
+    class Local1
+        public sharedField as shared.Class1
+        public sharedIface as shared.Interface1
+        public function process(input as shared.Class1) as shared.Class2
+            return input.field1
+        end function
+    end class
+
+    class Local2
+        public sharedField as shared.Class2
+        public sharedIface as shared.Interface2
+        public function process(input as shared.Class2) as shared.Class3
+            return input.field1
+        end function
+    end class
+
+    class Local3
+        public sharedField as shared.Class3
+        public sharedIface as shared.Interface3
+        public function process(input as shared.Class3) as shared.Class4
+            return input.field1
+        end function
+    end class
+
+    class Local4
+        public sharedField as shared.Class4
+        public sharedIface as shared.Interface4
+        public function process(input as shared.Class4) as shared.Class5
+            return input.field1
+        end function
+    end class
+
+    class Local5
+        public sharedField as shared.Class5
+        public sharedIface as shared.Interface5
+        public function process(input as shared.Class5) as shared.Class6
+            return input.field1
+        end function
+    end class
+
+    function init()
+        instance = new Local0()
+        print instance
+    end function
+end namespace

--- a/benchmarks/fixtures/heavy-types/components/Comp1.xml
+++ b/benchmarks/fixtures/heavy-types/components/Comp1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Comp1" extends="Group">
+    <script type="text/brightscript" uri="pkg:/source/shared/lib.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Comp1.bs" />
+</component>

--- a/benchmarks/fixtures/heavy-types/components/Comp2.bs
+++ b/benchmarks/fixtures/heavy-types/components/Comp2.bs
@@ -1,0 +1,57 @@
+' Auto-generated fixture component-local file for the validate-scope benchmark target.
+' Heavily references shared.* types (ReferenceTypes resolved across file/scope boundaries).
+namespace comp1
+
+    class Local0
+        public sharedField as shared.Class5
+        public sharedIface as shared.Interface5
+        public function process(input as shared.Class5) as shared.Class6
+            return input.field1
+        end function
+    end class
+
+    class Local1
+        public sharedField as shared.Class6
+        public sharedIface as shared.Interface6
+        public function process(input as shared.Class6) as shared.Class7
+            return input.field1
+        end function
+    end class
+
+    class Local2
+        public sharedField as shared.Class7
+        public sharedIface as shared.Interface7
+        public function process(input as shared.Class7) as shared.Class8
+            return input.field1
+        end function
+    end class
+
+    class Local3
+        public sharedField as shared.Class8
+        public sharedIface as shared.Interface8
+        public function process(input as shared.Class8) as shared.Class9
+            return input.field1
+        end function
+    end class
+
+    class Local4
+        public sharedField as shared.Class9
+        public sharedIface as shared.Interface9
+        public function process(input as shared.Class9) as shared.Class10
+            return input.field1
+        end function
+    end class
+
+    class Local5
+        public sharedField as shared.Class10
+        public sharedIface as shared.Interface0
+        public function process(input as shared.Class10) as shared.Class11
+            return input.field1
+        end function
+    end class
+
+    function init()
+        instance = new Local0()
+        print instance
+    end function
+end namespace

--- a/benchmarks/fixtures/heavy-types/components/Comp2.xml
+++ b/benchmarks/fixtures/heavy-types/components/Comp2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Comp2" extends="Group">
+    <script type="text/brightscript" uri="pkg:/source/shared/lib.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Comp2.bs" />
+</component>

--- a/benchmarks/fixtures/heavy-types/components/Comp3.bs
+++ b/benchmarks/fixtures/heavy-types/components/Comp3.bs
@@ -1,0 +1,57 @@
+' Auto-generated fixture component-local file for the validate-scope benchmark target.
+' Heavily references shared.* types (ReferenceTypes resolved across file/scope boundaries).
+namespace comp2
+
+    class Local0
+        public sharedField as shared.Class10
+        public sharedIface as shared.Interface0
+        public function process(input as shared.Class10) as shared.Class11
+            return input.field1
+        end function
+    end class
+
+    class Local1
+        public sharedField as shared.Class11
+        public sharedIface as shared.Interface1
+        public function process(input as shared.Class11) as shared.Class12
+            return input.field1
+        end function
+    end class
+
+    class Local2
+        public sharedField as shared.Class12
+        public sharedIface as shared.Interface2
+        public function process(input as shared.Class12) as shared.Class13
+            return input.field1
+        end function
+    end class
+
+    class Local3
+        public sharedField as shared.Class13
+        public sharedIface as shared.Interface3
+        public function process(input as shared.Class13) as shared.Class14
+            return input.field1
+        end function
+    end class
+
+    class Local4
+        public sharedField as shared.Class14
+        public sharedIface as shared.Interface4
+        public function process(input as shared.Class14) as shared.Class15
+            return input.field1
+        end function
+    end class
+
+    class Local5
+        public sharedField as shared.Class15
+        public sharedIface as shared.Interface5
+        public function process(input as shared.Class15) as shared.Class16
+            return input.field1
+        end function
+    end class
+
+    function init()
+        instance = new Local0()
+        print instance
+    end function
+end namespace

--- a/benchmarks/fixtures/heavy-types/components/Comp3.xml
+++ b/benchmarks/fixtures/heavy-types/components/Comp3.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Comp3" extends="Group">
+    <script type="text/brightscript" uri="pkg:/source/shared/lib.bs" />
+    <script type="text/brightscript" uri="pkg:/components/Comp3.bs" />
+</component>

--- a/benchmarks/fixtures/heavy-types/manifest
+++ b/benchmarks/fixtures/heavy-types/manifest
@@ -1,0 +1,4 @@
+title=HeavyTypesBenchmarkFixture
+major_version=1
+minor_version=0
+build_version=0

--- a/benchmarks/fixtures/heavy-types/source/shared/lib.bs
+++ b/benchmarks/fixtures/heavy-types/source/shared/lib.bs
@@ -1,0 +1,316 @@
+' Auto-generated fixture: heavy cross-type-reference BrighterScript file
+' Used by the validate-scope benchmark target to stress-test ReferenceType resolution
+' across multiple component scopes.
+namespace shared
+
+    interface Interface0
+        fieldA as Class0
+        fieldB as Class1
+        function methodA(value as Class0) as Class1
+    end interface
+
+    interface Interface1
+        fieldA as Class2
+        fieldB as Class3
+        function methodA(value as Class2) as Class3
+    end interface
+
+    interface Interface2
+        fieldA as Class4
+        fieldB as Class5
+        function methodA(value as Class4) as Class5
+    end interface
+
+    interface Interface3
+        fieldA as Class6
+        fieldB as Class7
+        function methodA(value as Class6) as Class7
+    end interface
+
+    interface Interface4
+        fieldA as Class8
+        fieldB as Class9
+        function methodA(value as Class8) as Class9
+    end interface
+
+    interface Interface5
+        fieldA as Class10
+        fieldB as Class11
+        function methodA(value as Class10) as Class11
+    end interface
+
+    interface Interface6
+        fieldA as Class12
+        fieldB as Class13
+        function methodA(value as Class12) as Class13
+    end interface
+
+    interface Interface7
+        fieldA as Class14
+        fieldB as Class15
+        function methodA(value as Class14) as Class15
+    end interface
+
+    interface Interface8
+        fieldA as Class16
+        fieldB as Class17
+        function methodA(value as Class16) as Class17
+    end interface
+
+    interface Interface9
+        fieldA as Class18
+        fieldB as Class19
+        function methodA(value as Class18) as Class19
+    end interface
+
+    class Class0
+        public field1 as Class1
+        public field2 as Class2
+        public field3 as Class3
+        public ifaceField as Interface0
+        public function transform(input as Class1) as Class2
+            return m.field2
+        end function
+    end class
+
+    class Class1
+        public field1 as Class2
+        public field2 as Class3
+        public field3 as Class4
+        public ifaceField as Interface1
+        public function transform(input as Class2) as Class3
+            return m.field2
+        end function
+    end class
+
+    class Class2
+        public field1 as Class3
+        public field2 as Class4
+        public field3 as Class5
+        public ifaceField as Interface2
+        public function transform(input as Class3) as Class4
+            return m.field2
+        end function
+    end class
+
+    class Class3
+        public field1 as Class4
+        public field2 as Class5
+        public field3 as Class6
+        public ifaceField as Interface3
+        public function transform(input as Class4) as Class5
+            return m.field2
+        end function
+    end class
+
+    class Class4
+        public field1 as Class5
+        public field2 as Class6
+        public field3 as Class7
+        public ifaceField as Interface4
+        public function transform(input as Class5) as Class6
+            return m.field2
+        end function
+    end class
+
+    class Class5
+        public field1 as Class6
+        public field2 as Class7
+        public field3 as Class8
+        public ifaceField as Interface5
+        public function transform(input as Class6) as Class7
+            return m.field2
+        end function
+    end class
+
+    class Class6
+        public field1 as Class7
+        public field2 as Class8
+        public field3 as Class9
+        public ifaceField as Interface6
+        public function transform(input as Class7) as Class8
+            return m.field2
+        end function
+    end class
+
+    class Class7
+        public field1 as Class8
+        public field2 as Class9
+        public field3 as Class10
+        public ifaceField as Interface7
+        public function transform(input as Class8) as Class9
+            return m.field2
+        end function
+    end class
+
+    class Class8
+        public field1 as Class9
+        public field2 as Class10
+        public field3 as Class11
+        public ifaceField as Interface8
+        public function transform(input as Class9) as Class10
+            return m.field2
+        end function
+    end class
+
+    class Class9
+        public field1 as Class10
+        public field2 as Class11
+        public field3 as Class12
+        public ifaceField as Interface9
+        public function transform(input as Class10) as Class11
+            return m.field2
+        end function
+    end class
+
+    class Class10
+        public field1 as Class11
+        public field2 as Class12
+        public field3 as Class13
+        public ifaceField as Interface0
+        public function transform(input as Class11) as Class12
+            return m.field2
+        end function
+    end class
+
+    class Class11
+        public field1 as Class12
+        public field2 as Class13
+        public field3 as Class14
+        public ifaceField as Interface1
+        public function transform(input as Class12) as Class13
+            return m.field2
+        end function
+    end class
+
+    class Class12
+        public field1 as Class13
+        public field2 as Class14
+        public field3 as Class15
+        public ifaceField as Interface2
+        public function transform(input as Class13) as Class14
+            return m.field2
+        end function
+    end class
+
+    class Class13
+        public field1 as Class14
+        public field2 as Class15
+        public field3 as Class16
+        public ifaceField as Interface3
+        public function transform(input as Class14) as Class15
+            return m.field2
+        end function
+    end class
+
+    class Class14
+        public field1 as Class15
+        public field2 as Class16
+        public field3 as Class17
+        public ifaceField as Interface4
+        public function transform(input as Class15) as Class16
+            return m.field2
+        end function
+    end class
+
+    class Class15
+        public field1 as Class16
+        public field2 as Class17
+        public field3 as Class18
+        public ifaceField as Interface5
+        public function transform(input as Class16) as Class17
+            return m.field2
+        end function
+    end class
+
+    class Class16
+        public field1 as Class17
+        public field2 as Class18
+        public field3 as Class19
+        public ifaceField as Interface6
+        public function transform(input as Class17) as Class18
+            return m.field2
+        end function
+    end class
+
+    class Class17
+        public field1 as Class18
+        public field2 as Class19
+        public field3 as Class20
+        public ifaceField as Interface7
+        public function transform(input as Class18) as Class19
+            return m.field2
+        end function
+    end class
+
+    class Class18
+        public field1 as Class19
+        public field2 as Class20
+        public field3 as Class21
+        public ifaceField as Interface8
+        public function transform(input as Class19) as Class20
+            return m.field2
+        end function
+    end class
+
+    class Class19
+        public field1 as Class20
+        public field2 as Class21
+        public field3 as Class22
+        public ifaceField as Interface9
+        public function transform(input as Class20) as Class21
+            return m.field2
+        end function
+    end class
+
+    class Class20
+        public field1 as Class21
+        public field2 as Class22
+        public field3 as Class23
+        public ifaceField as Interface0
+        public function transform(input as Class21) as Class22
+            return m.field2
+        end function
+    end class
+
+    class Class21
+        public field1 as Class22
+        public field2 as Class23
+        public field3 as Class24
+        public ifaceField as Interface1
+        public function transform(input as Class22) as Class23
+            return m.field2
+        end function
+    end class
+
+    class Class22
+        public field1 as Class23
+        public field2 as Class24
+        public field3 as Class0
+        public ifaceField as Interface2
+        public function transform(input as Class23) as Class24
+            return m.field2
+        end function
+    end class
+
+    class Class23
+        public field1 as Class24
+        public field2 as Class0
+        public field3 as Class1
+        public ifaceField as Interface3
+        public function transform(input as Class24) as Class0
+            return m.field2
+        end function
+    end class
+
+    class Class24
+        public field1 as Class0
+        public field2 as Class1
+        public field3 as Class2
+        public ifaceField as Interface4
+        public function transform(input as Class0) as Class1
+            return m.field2
+        end function
+    end class
+
+end namespace

--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -66,6 +66,10 @@ class Runner {
             }
             //store the file system path for the project
             this.options.project = projectDir;
+        } else {
+            //a local path was provided - resolve it to absolute so it's not silently
+            //misinterpreted relative to whatever cwd `target-runner.ts` happens to run with
+            this.options.project = path.resolve(this.options.project);
         }
     }
 
@@ -241,4 +245,16 @@ function clean() {
         }
     }
     fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageJson, null, 4));
+
+    //regenerate package-lock.json to match the now-cleaned package.json. A hand-edited removal
+    //isn't safe here: npm's dedupe can hoist brighterscript's own transitive deps to the top level
+    //of node_modules, so there's no reliable way to tell "only needed by brighterscriptN" apart with
+    //a regex. Only bother if the lockfile actually still references a brighterscriptN dependency.
+    const packageLockPath = `${cwd}/package-lock.json`;
+    if (fs.existsSync(packageLockPath)) {
+        const packageLockText = fs.readFileSync(packageLockPath).toString();
+        if (/brighterscript\d+/.exec(packageLockText)) {
+            execSync('npm install --package-lock-only');
+        }
+    }
 }

--- a/benchmarks/targets/run.js
+++ b/benchmarks/targets/run.js
@@ -1,8 +1,9 @@
-module.exports = async (suite, name, brighterscript, projectPath, options) => {
+module.exports = async (options) => {
+    const { suite, fullName, brighterscript, projectPath, suiteOptions, additionalConfig } = options;
     const { ProgramBuilder } = brighterscript;
 
     let builder;
-    suite.add(name, (deferred) => {
+    suite.add(fullName, (deferred) => {
         builder = new ProgramBuilder();
         builder.run({
             cwd: projectPath,
@@ -10,12 +11,13 @@ module.exports = async (suite, name, brighterscript, projectPath, options) => {
             copyToStaging: false,
             //disable diagnostic reporting (they still get collected)
             diagnosticFilters: ['**/*'],
-            logLevel: 'error'
+            logLevel: 'error',
+            ...additionalConfig
         }).finally(() => {
             deferred.resolve();
         });
     }, {
-        ...options,
+        ...suiteOptions,
         'defer': true
     });
 };

--- a/benchmarks/targets/transpile.ts
+++ b/benchmarks/targets/transpile.ts
@@ -21,7 +21,8 @@ module.exports = async (options: TargetOptions) => {
         throw new Error('No files found in program');
     }
 
-    const files = Object.values(builder.program!.files) as Array<BrsFile>;
+    //only transpile files that actually support it (BrsFile/XmlFile) - other file types (e.g. AssetFile) don't implement `transpile()`
+    const files = (Object.values(builder.program!.files) as Array<BrsFile>).filter(x => typeof (x as any).transpile === 'function');
 
     //force transpile for every file
     for (const file of files) {

--- a/benchmarks/targets/validate-first.ts
+++ b/benchmarks/targets/validate-first.ts
@@ -1,0 +1,79 @@
+import type { BsConfig } from '../../src';
+import type { TargetOptions } from '../target-runner';
+import * as fsExtra from 'fs-extra';
+
+/**
+ * Benchmarks the cost of the very first `validate()` call on a freshly-loaded program
+ * (i.e. `Program.isFirstValidation === true`), as opposed to the `validate` target, which
+ * benchmarks re-validating an already-warmed-up program. A lot of validate-time work (building
+ * initial scope symbol tables, cross-scope resolution caches, etc.) only happens once per
+ * program, so this models the "cold start" cost of an editor/CLI opening a project for the
+ * first time - which can be significantly more expensive than any subsequent re-validate.
+ *
+ * Each benchmark sample needs its own never-before-validated `Program`, so a small queue of
+ * freshly-loaded (parsed, but not yet validated) builders is kept pre-built and replenished in
+ * the background; the timed portion of each sample is just the `validate()` call itself.
+ */
+module.exports = async (options: TargetOptions) => {
+    const { suite, fullName, brighterscript, projectPath, suiteOptions } = options;
+    const { ProgramBuilder } = brighterscript;
+
+    //cache file contents in memory so repeatedly loading/parsing fresh programs isn't dominated by disk I/O
+    const fileContentsCache = new Map();
+    const fileResolver = (filePath) => {
+        if (!fileContentsCache.has(filePath)) {
+            let result = fsExtra.readFile(filePath).then((value) => {
+                return value.toString();
+            });
+            fileContentsCache.set(filePath, result);
+            return result;
+        } else {
+            return fileContentsCache.get(filePath);
+        }
+    };
+
+    async function createUnvalidatedBuilder() {
+        const builder = new ProgramBuilder();
+        builder.addFileResolver(fileResolver);
+        await builder.load({
+            cwd: projectPath,
+            createPackage: false,
+            copyToStaging: false,
+            noEmit: true,
+            //disable diagnostic reporting (they still get collected)
+            diagnosticFilters: ['**/*'],
+            logLevel: 'error',
+            ...options.additionalConfig
+        } as BsConfig & Record<string, any>);
+        if (Object.keys(builder.program!.files).length === 0) {
+            throw new Error('No files found in program');
+        }
+        return builder;
+    }
+
+    const QUEUE_SIZE = 15;
+    const queue: Array<ReturnType<typeof createUnvalidatedBuilder>> = [];
+
+    //keep the queue topped up in the background so a sample is rarely (ideally never) stuck
+    //waiting on a full load+parse cycle inside the timed portion of the benchmark
+    function replenishQueue() {
+        while (queue.length < QUEUE_SIZE) {
+            queue.push(createUnvalidatedBuilder());
+        }
+    }
+    replenishQueue();
+    //wait for the initial queue to be fully loaded before starting the benchmark
+    await Promise.all(queue);
+
+    suite.add(fullName, (deferred) => {
+        const builderPromise = queue.shift() ?? createUnvalidatedBuilder();
+        replenishQueue();
+
+        builderPromise.then((builder) => {
+            return Promise.resolve(builder.program!.validate());
+        }).finally(() => deferred.resolve());
+    }, {
+        ...suiteOptions,
+        'defer': true
+    });
+};

--- a/benchmarks/targets/validate-scope.ts
+++ b/benchmarks/targets/validate-scope.ts
@@ -1,0 +1,48 @@
+import type { BsConfig } from '../../src';
+import type { TargetOptions } from '../target-runner';
+
+/**
+ * Benchmarks re-validating a single scope, simulating the common editor/language-server scenario
+ * where a developer edits one file and only that file's scope(s) need to be re-validated - as
+ * opposed to the `validate` target, which invalidates and re-validates every scope in the
+ * project (closer to a full/clean rebuild). This should be a much cheaper, more "steady state"
+ * operation, and is a better proxy for editor responsiveness while typing.
+ */
+module.exports = async (options: TargetOptions) => {
+    const { suite, name, version, fullName, brighterscript, projectPath, suiteOptions } = options;
+    const { ProgramBuilder } = brighterscript;
+
+    const builder = new ProgramBuilder();
+    //run the first run so we can focus the test on re-validating a single scope
+    await builder.run({
+        cwd: projectPath,
+        createPackage: false,
+        copyToStaging: false,
+        noEmit: true,
+        //disable diagnostic reporting (they still get collected)
+        diagnosticFilters: ['**/*'],
+        logLevel: 'error',
+        ...options.additionalConfig
+    } as BsConfig & Record<string, any>);
+    if (Object.keys(builder.program!.files).length === 0) {
+        throw new Error('No files found in program');
+    }
+
+    const scopes = Object.values(builder.program!['scopes']);
+    //pick a single non-global scope to repeatedly invalidate/re-validate, simulating edits
+    //to the file(s) in just that one scope/component
+    const targetScope = scopes.find((s: any) => s.name?.toLowerCase() !== 'global');
+    if (!targetScope) {
+        throw new Error('Could not find a non-global scope to benchmark single-scope re-validation against');
+    }
+
+    suite.add(fullName, (deferred) => {
+        (targetScope as any).invalidate();
+        Promise.resolve(
+            builder.program!.validate()
+        ).finally(() => deferred.resolve());
+    }, {
+        ...suiteOptions,
+        'defer': true
+    });
+};

--- a/benchmarks/targets/validate-scope.ts
+++ b/benchmarks/targets/validate-scope.ts
@@ -3,17 +3,25 @@ import type { TargetOptions } from '../target-runner';
 import * as path from 'path';
 
 /**
- * Benchmarks re-validating just the scopes affected by a single changed file, simulating the
- * common editor/language-server scenario where a developer edits one file - as opposed to the
+ * Benchmarks re-validating just the scopes/files affected by a single changed type, simulating
+ * the common editor/language-server scenario where a developer edits one file - as opposed to the
  * `validate` target, which invalidates and re-validates every scope in the project (closer to a
  * full/clean rebuild). This should be a much cheaper, more "steady state" operation, and is a
  * better proxy for editor responsiveness while typing.
  *
+ * Critically, this doesn't just call `scope.invalidate()` directly - that bypasses the real
+ * changed-symbol pipeline entirely (Program.validate() only walks `getFilesRequiringChangedSymbol`
+ * and un-validates AST segments for files whose *content* actually changed), so it would end up
+ * benchmarking a much cheaper no-op scope refresh instead of a real edit. Instead, each sample
+ * calls `program.setFile()` with a genuinely different version of a shared type (toggling one
+ * field's type back and forth between two real classes), so the normal changed-symbol/segment
+ * invalidation logic actually has real work to do.
+ *
  * Unlike the other targets, this one does NOT use the (arbitrary, real-world) `--project`; it
- * uses a purpose-built fixture at `benchmarks/fixtures/heavy-types` instead. The changed file
+ * uses a purpose-built fixture at `benchmarks/fixtures/heavy-types` instead. The changed type
  * needs to actually be interesting to re-validate:
- *   - it's shared by *multiple* component scopes (editing a shared lib/type file is the expensive
- *     case - it forces every scope that includes it to re-validate, not just one), and
+ *   - it's used by *multiple* files/scopes (editing a widely-used shared type is the expensive
+ *     case - it forces every segment/scope that references it to re-validate, not just one), and
  *   - it (and the files that reference it) are heavy with cross-file type references
  *     (ReferenceType), since that's what stresses symbol table lookups and cross-scope
  *     type-compatibility checks the most.
@@ -27,7 +35,7 @@ module.exports = async (options: TargetOptions) => {
     const fixtureProjectPath = path.join(__dirname, '..', 'fixtures', 'heavy-types');
 
     const builder = new ProgramBuilder();
-    //run the first run so we can focus the test on re-validating the affected scopes
+    //run the first run so we can focus the test on re-validating after a real change
     await builder.run({
         cwd: fixtureProjectPath,
         createPackage: false,
@@ -53,10 +61,27 @@ module.exports = async (options: TargetOptions) => {
         );
     }
 
+    const sharedLibFile = builder.program!.getFile(sharedLibSrcPath) as { fileContents: string };
+    const originalContents = sharedLibFile.fileContents;
+
+    //`shared.Class0.field1` is directly referenced by several other classes/interfaces in this
+    //file, plus at least one component's local class - toggling its type between two other real
+    //classes (both valid, so we're not just generating diagnostics-only churn) forces a genuine
+    //changed-symbol event every single sample, rather than a no-op re-parse of identical content
+    const marker = '        public field1 as Class1\n';
+    if (!originalContents.includes(marker)) {
+        throw new Error(
+            'Could not find the expected `Class0.field1 as Class1` field to toggle in benchmarks/fixtures/heavy-types/source/shared/lib.bs. ' +
+            'The fixture file may have changed - update this target to match.'
+        );
+    }
+    const toggledContents = originalContents.replace(marker, '        public field1 as Class6\n');
+    const contentVariants = [originalContents, toggledContents];
+    let iteration = 0;
+
     suite.add(fullName, (deferred) => {
-        for (const scope of affectedScopes) {
-            scope.invalidate();
-        }
+        builder.program!.setFile(sharedLibSrcPath, contentVariants[iteration % 2]);
+        iteration++;
         Promise.resolve(
             builder.program!.validate()
         ).finally(() => deferred.resolve());

--- a/benchmarks/targets/validate-scope.ts
+++ b/benchmarks/targets/validate-scope.ts
@@ -1,21 +1,35 @@
 import type { BsConfig } from '../../src';
 import type { TargetOptions } from '../target-runner';
+import * as path from 'path';
 
 /**
- * Benchmarks re-validating a single scope, simulating the common editor/language-server scenario
- * where a developer edits one file and only that file's scope(s) need to be re-validated - as
- * opposed to the `validate` target, which invalidates and re-validates every scope in the
- * project (closer to a full/clean rebuild). This should be a much cheaper, more "steady state"
- * operation, and is a better proxy for editor responsiveness while typing.
+ * Benchmarks re-validating just the scopes affected by a single changed file, simulating the
+ * common editor/language-server scenario where a developer edits one file - as opposed to the
+ * `validate` target, which invalidates and re-validates every scope in the project (closer to a
+ * full/clean rebuild). This should be a much cheaper, more "steady state" operation, and is a
+ * better proxy for editor responsiveness while typing.
+ *
+ * Unlike the other targets, this one does NOT use the (arbitrary, real-world) `--project`; it
+ * uses a purpose-built fixture at `benchmarks/fixtures/heavy-types` instead. The changed file
+ * needs to actually be interesting to re-validate:
+ *   - it's shared by *multiple* component scopes (editing a shared lib/type file is the expensive
+ *     case - it forces every scope that includes it to re-validate, not just one), and
+ *   - it (and the files that reference it) are heavy with cross-file type references
+ *     (ReferenceType), since that's what stresses symbol table lookups and cross-scope
+ *     type-compatibility checks the most.
+ * A real-world downloaded sample project can't guarantee either property, so this target ships
+ * its own small fixture instead.
  */
 module.exports = async (options: TargetOptions) => {
-    const { suite, name, version, fullName, brighterscript, projectPath, suiteOptions } = options;
+    const { suite, fullName, brighterscript, suiteOptions } = options;
     const { ProgramBuilder } = brighterscript;
 
+    const fixtureProjectPath = path.join(__dirname, '..', 'fixtures', 'heavy-types');
+
     const builder = new ProgramBuilder();
-    //run the first run so we can focus the test on re-validating a single scope
+    //run the first run so we can focus the test on re-validating the affected scopes
     await builder.run({
-        cwd: projectPath,
+        cwd: fixtureProjectPath,
         createPackage: false,
         copyToStaging: false,
         noEmit: true,
@@ -28,16 +42,21 @@ module.exports = async (options: TargetOptions) => {
         throw new Error('No files found in program');
     }
 
-    const scopes = Object.values(builder.program!['scopes']);
-    //pick a single non-global scope to repeatedly invalidate/re-validate, simulating edits
-    //to the file(s) in just that one scope/component
-    const targetScope = scopes.find((s: any) => s.name?.toLowerCase() !== 'global');
-    if (!targetScope) {
-        throw new Error('Could not find a non-global scope to benchmark single-scope re-validation against');
+    //the shared lib file is imported by every component in the fixture, so it should belong to
+    //multiple scopes - that's the scenario this benchmark is meant to exercise
+    const sharedLibSrcPath = path.join(fixtureProjectPath, 'source', 'shared', 'lib.bs');
+    const affectedScopes = builder.program!.getScopesForFile(sharedLibSrcPath);
+    if (affectedScopes.length < 2) {
+        throw new Error(
+            `Expected the shared lib fixture file to belong to multiple scopes, but it only belongs to ${affectedScopes.length}. ` +
+            'Check that benchmarks/fixtures/heavy-types still has multiple components importing source/shared/lib.bs.'
+        );
     }
 
     suite.add(fullName, (deferred) => {
-        (targetScope as any).invalidate();
+        for (const scope of affectedScopes) {
+            scope.invalidate();
+        }
         Promise.resolve(
             builder.program!.validate()
         ).finally(() => deferred.resolve());

--- a/benchmarks/targets/validate.ts
+++ b/benchmarks/targets/validate.ts
@@ -1,9 +1,23 @@
 import type { BsConfig } from '../../src';
 import type { TargetOptions } from '../target-runner';
 
+/**
+ * Benchmarks a full project re-validate, simulating something like a clean rebuild (as opposed
+ * to the `validate-scope` target, which benchmarks a much cheaper single-changed-file/scope
+ * re-validate).
+ *
+ * This must actually change every file's content via `program.setFile()` rather than just calling
+ * `scope.invalidate()` directly. Program.validate() only walks
+ * `getFilesRequiringChangedSymbol()`/`unValidateAllSegments()` and re-runs `Scope.validate()` for
+ * files/scopes whose content actually changed (tracked via `file.isValidated` and diffed provided
+ * symbols) - manually invalidating a scope object doesn't mark any file dirty, so on the 2nd+
+ * iteration `Scope.shouldValidate()` bails out immediately and `Scope.validate()` never even gets
+ * called, silently turning this into a no-op benchmark. Re-`setFile()`-ing every file (even with
+ * its own unchanged content) forces a real full re-parse and re-validate every sample.
+ */
 module.exports = async (options: TargetOptions) => {
-    const { suite, name, version, fullName, brighterscript, projectPath, suiteOptions } = options;
-    const { ProgramBuilder } = brighterscript;
+    const { suite, fullName, brighterscript, projectPath, suiteOptions } = options;
+    const { ProgramBuilder, isBrsFile, isXmlFile } = brighterscript;
 
     const builder = new ProgramBuilder();
     //run the first run so we we can focus the test on validate
@@ -21,11 +35,21 @@ module.exports = async (options: TargetOptions) => {
         throw new Error('No files found in program');
     }
 
+    //only brs/bs/xml files have re-settable source text (e.g. AssetFile - manifest, images - does not).
+    //capture the actual content strings up front (not file object references!) - setFile() disposes
+    //and replaces file objects each time it's called, which clears `fileContents` on the old object
+    //for memory, so re-reading `.fileContents` from a stale reference on the 2nd+ sample would crash
+    const fileContentsBySrcPath = new Map<string, string>(
+        Object.values(builder.program!.files)
+            .filter((x: any) => isBrsFile(x) || isXmlFile(x))
+            .map((x: any) => [x.srcPath, x.fileContents])
+    );
+
     suite.add(fullName, (deferred) => {
-        const scopes = Object.values(builder.program!['scopes']);
-        //mark all scopes as invalid so they'll re-validate
-        for (let scope of scopes) {
-            scope.invalidate();
+        for (const [srcPath, contents] of fileContentsBySrcPath) {
+            //re-supply each file's own current content - the point isn't to change what the code
+            //does, it's to force a genuine full re-parse/re-validate of everything, every sample
+            builder.program!.setFile(srcPath, contents);
         }
         Promise.resolve(
             builder.program!.validate()


### PR DESCRIPTION
## Summary
The `benchmarks/` harness had several latent bugs that broke it on any real-world run:

- **`benchmarks/index.ts`**: a local (non-URL) `--project` path wasn't resolved to absolute, so it was silently misinterpreted relative to whatever cwd `target-runner.ts` happened to run with — surfacing as a confusing `"No files found in program"` error with no clue as to the real cause.
- **`benchmarks/targets/run.js`**: the only plain-JS target, still using the old positional-args calling convention (`(suite, name, brighterscript, projectPath, options)`), while `target-runner.ts` now invokes every target with a single options object. Every other (TS) target had already been migrated. This crashed with `TypeError: Cannot destructure property 'ProgramBuilder' of 'brighterscript' as it is undefined`.
- **`benchmarks/targets/transpile.ts`**: assumed every registered program file is a `BrsFile`/`XmlFile` with a `.transpile()` method, but v1 added `AssetFile` (manifests, images, etc.) which has no such method — crashed on any real project with non-code assets.
- **`clean()`**: only reverted the temporary `brighterscriptN` dependencies from `package.json`, leaving `package-lock.json` to drift on every run (each run left lockfile churn that had to be manually `git checkout`'d away). Hand-editing the lockfile isn't safe here since npm's dedupe can hoist a temp dependency's own transitive deps to the top level of `node_modules` — so instead, only regenerate the lockfile via `npm install --package-lock-only`, and only when it still references a `brighterscriptN` dependency.

## The `validate` target wasn't actually validating anything
This is the more important fix. `Scope.invalidate()` alone doesn't mark any file dirty, and `Program.validate()`'s incremental logic only does real work for scopes where `filesToBeValidatedInScopeContext` is non-empty (built from files with `!file.isValidated`, which only changes via a genuine re-parse through `program.setFile()`). Calling `scope.invalidate()` directly bypasses this entirely: `Scope.shouldValidate()` returns `false` immediately and `Scope.validate()` never gets called at all — verified by monkey-patching `Scope.prototype.validate` and observing **0 calls** on the 2nd+ benchmark iteration.

This affected the pre-existing `validate` target (which only ever called `scope.invalidate()`), meaning its reported ~5,000 ops/sec was measuring pure sequencer/bookkeeping overhead, not real validation. Fixed by re-`setFile()`-ing every `.brs`/`.bs`/`.xml` file with its own (unchanged) content each sample, forcing a genuine full re-parse and re-validate. This drops it to a real ~4 ops/sec — now correctly in the same ballpark as `validate-first`, since both do a genuine full pass. (Also had to capture file content strings up front rather than re-reading `file.fileContents` from stale file-object references each iteration, since `setFile()` disposes/replaces file objects, clearing `fileContents` on the old object to save memory.)

## New validation benchmarks
Added two targets complementing the (now-fixed) `validate`:

- **`validate-first`**: the cost of the very first `validate()` call on a freshly-loaded, never-validated program (cold start). Each sample needs a fresh `Program`, so a small queue of pre-loaded (parsed but unvalidated) builders is kept topped up in the background, and only the `validate()` call itself is timed.
- **`validate-scope`**: the cost of re-validating after a single shared type actually changes — the common editor/language-server scenario. Uses a purpose-built fixture at `benchmarks/fixtures/heavy-types` (all BrighterScript `.bs`: a shared namespace of 25 classes + 10 interfaces cross-referencing each other, imported by 3 separate components that reference those types heavily) so the changed type is guaranteed to span multiple scopes and be dense with cross-file `ReferenceType`s. Each sample toggles `Class0.field1`'s type between two real classes via `program.setFile()`, forcing genuine cross-file/cross-scope changed-symbol propagation rather than a no-op scope refresh. Real rate: ~39 ops/sec — appropriately ~10x cheaper than a full `validate`, since it only touches one shared file and its dependents.

## Test plan
- [x] Ran `run`, `validate`, `validate-first`, `validate-scope`, and `transpile` targets end-to-end (with `--profile`) against the default `chtaylo2/Roku-GooglePhotos` sample project, a local path, and `jellyfin/jellyfin-roku`
- [x] Verified via monkey-patching that `Scope.validate()`/`CrossScopeValidator.addDiagnosticsForScopes()` are genuinely invoked (with non-zero scope counts) on every sample for all three validate targets, not just the initial cold build
- [x] Confirmed `validate-scope`'s fixture's shared lib file resolves to multiple scopes (it throws if not)
- [x] Confirmed `git status` shows no `package-lock.json`/`package.json` drift after a run completes
- [x] `npx tsc --noEmit`, `npm run lint` (doesn't cover `benchmarks/**`, confirmed pre-existing lint state unaffected), and `check-eol` over `benchmarks/**` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)