### PR TITLE
Reduce allocations in hot SymbolTable/ReferenceType lookup paths

### DIFF
--- a/src/SymbolTable.ts
+++ b/src/SymbolTable.ts
@@ -223,9 +223,9 @@ export class SymbolTable implements SymbolTypeGetter {
             // look in our map first
             let currentResults = currentTable.symbolMap.get(key);
             if (currentResults) {
+                const lookupFilter = this.getSymbolLookupFilter(currentTable, maxStatementIndex, memberOfAncestor);
                 // eslint-disable-next-line no-bitwise
-                currentResults = currentResults.filter(symbol => symbol.flags & bitFlags)
-                    .filter(this.getSymbolLookupFilter(currentTable, maxStatementIndex, memberOfAncestor));
+                currentResults = currentResults.filter(symbol => (symbol.flags & bitFlags) && lookupFilter(symbol));
             }
 
             let precedingAssignmentIndex = -1;
@@ -550,27 +550,36 @@ export class SymbolTable implements SymbolTypeGetter {
      * Get list of all symbols declared in this SymbolTable (includes parent SymbolTable).
      */
     public getAllSymbols(bitFlags: SymbolTypeFlag): BscSymbol[] {
-        let symbols: BscSymbol[] = [].concat(...this.symbolMap.values());
-        //look through any sibling maps next
-        for (let sibling of this.siblings) {
-            symbols = symbols.concat(sibling.getAllSymbols(bitFlags));
-        }
-
-        if (this.parent && !this.hasCircularReferenceWithAncestor()) {
-            symbols = symbols.concat(this.parent.getAllSymbols(bitFlags));
-        }
+        //gather every symbol from this table, its siblings, and its ancestors first, unfiltered.
+        //Filtering (and deduping) is deferred to a single pass at the end - since filter/dedup both
+        //distribute over concatenation, doing it once here produces the same result as doing it at
+        //every level of the recursion, without the redundant repeated passes over the same symbols
+        const symbols = this.collectAllSymbolsUnfiltered();
         // eslint-disable-next-line no-bitwise
-        symbols = symbols.filter(symbol => symbol.flags & bitFlags);
+        const filteredSymbols = symbols.filter(symbol => symbol.flags & bitFlags);
 
         //remove duplicate symbols
         const symbolsMap = new Map<string, BscSymbol>();
-        for (const symbol of symbols) {
+        for (const symbol of filteredSymbols) {
             const lowerSymbolName = symbol.name.toLowerCase();
             if (!symbolsMap.has(lowerSymbolName)) {
                 symbolsMap.set(lowerSymbolName, symbol);
             }
         }
         return [...symbolsMap.values()];
+    }
+
+    private collectAllSymbolsUnfiltered(): BscSymbol[] {
+        let symbols: BscSymbol[] = [].concat(...this.symbolMap.values());
+        //look through any sibling maps next
+        for (let sibling of this.siblings) {
+            symbols = symbols.concat(sibling.collectAllSymbolsUnfiltered());
+        }
+
+        if (this.parent && !this.hasCircularReferenceWithAncestor()) {
+            symbols = symbols.concat(this.parent.collectAllSymbolsUnfiltered());
+        }
+        return symbols;
     }
 
     private resetTypeCache() {

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -267,7 +267,7 @@ export class ReferenceType extends BscType {
                 this.referenceChain.add(resolvedType);
                 resolvedType = (resolvedType as any)?.getTarget?.();
             }
-            this.tableProvider().setCachedType(this.memberKey, { type: resolvedType }, { flags: this.flags });
+            symbolTable.setCachedType(this.memberKey, { type: resolvedType }, { flags: this.flags });
         }
 
         if (resolvedType && !isAnyReferenceType(resolvedType)) {


### PR DESCRIPTION
## Summary
Now that the validation benchmarks actually validate (#1754), used them to get trustworthy CPU-profiling data on the steady-state validate path. `SymbolTable.getSymbol`/`getAllSymbols` and `ReferenceType.resolve` dominate — a materially different (and more accurate) picture than the earlier profiling, which attributed most of the cost to `CrossScopeValidator`/`TypedFunctionType.isEqual`. That data turned out to be an artifact of the broken benchmarks bundling a single expensive cold-start `validate()` into the same CPU profile as thousands of near-no-op repeat iterations; it doesn't reproduce now that those iterations do real work.

Three small, localized, behavior-preserving changes to reduce allocation pressure on these hot paths:

- **`SymbolTable.getSymbol`**: combines a `.filter().filter()` chain into a single filter pass, avoiding one intermediate array allocation per lookup on this extremely hot function.
- **`SymbolTable.getAllSymbols`**: this recurses through sibling/parent tables, and previously re-ran the bitFlags filter + dedup pass at *every level* of that recursion. Since filter and dedup both distribute over concatenation, deferring both to a single pass over the fully-collected symbol list (via a new private `collectAllSymbolsUnfiltered` helper) produces an identical result without the redundant repeated passes.
- **`ReferenceType.resolve`**: reuses the already-fetched `symbolTable` local instead of calling `this.tableProvider()` a second time.

I also looked at adding an instance-level resolved-type cache on `ReferenceType` (reusing the existing `SymbolTable.cacheVerifier` token for invalidation), since `resolve()` is the single largest hot spot (~18% of samples on the `validate-scope` benchmark). Decided against including it here — the token resets on every `Scope.linkSymbolTable()` call, so it would only help across multiple property accesses on the *same* `ReferenceType` instance within a single validate pass, and I'm not confident enough in how often that actually happens in practice without more dedicated profiling/testing. Flagging as a possible follow-up rather than bundling it into this small, low-risk PR.

## Test plan
- [x] `npm run test:nocover` — 4260 passing, no regressions
- [x] `npx tsc --noEmit` and `npx eslint` on both changed files
- [x] Before/after comparison via `git stash` using the `validate-scope` benchmark target (`benchmarks/fixtures/heavy-types`, deliberately dense with cross-file `ReferenceType`s): ~35.7 → ~38.1 ops/sec (+~7%), same machine, same code otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)