### PR TITLE
Guard unset getLookupTable in BuiltInInterfaceAdder interface loop

### DIFF
--- a/src/types/BuiltInInterfaceAdder.spec.ts
+++ b/src/types/BuiltInInterfaceAdder.spec.ts
@@ -12,6 +12,7 @@ import { ClassType } from './ClassType';
 import { ArrayType } from './ArrayType';
 import { expect } from 'chai';
 import { EnumMemberType, EnumType } from './EnumType';
+import { AssociativeArrayType } from './AssociativeArrayType';
 
 describe('BuiltInInterfaceAdder', () => {
 
@@ -133,5 +134,16 @@ describe('BuiltInInterfaceAdder', () => {
         expect(enumTrim).to.be.undefined;
         const memberTrim = myEnumMember.getMemberType('trim', { flags: SymbolTypeFlag.runtime });
         expectTypeToBe(memberTrim, TypedFunctionType);
+    });
+
+    it('does not throw when getLookupTable is not set', () => {
+        const originalGetLookupTable = BuiltInInterfaceAdder.getLookupTable;
+        BuiltInInterfaceAdder.getLookupTable = undefined;
+        try {
+            const myType = new AssociativeArrayType();
+            expect(() => BuiltInInterfaceAdder.addBuiltInInterfacesToType(myType)).to.not.throw();
+        } finally {
+            BuiltInInterfaceAdder.getLookupTable = originalGetLookupTable;
+        }
     });
 });

--- a/src/types/BuiltInInterfaceAdder.ts
+++ b/src/types/BuiltInInterfaceAdder.ts
@@ -73,7 +73,7 @@ export class BuiltInInterfaceAdder {
             const lowerIfaceName = iface.name.toLowerCase();
             const ifaceData = (interfaces[lowerIfaceName] ?? events[lowerIfaceName]) as BRSInterfaceData;
 
-            if (builtInComponent.interfaces) {
+            if (builtInComponent.interfaces && this.getLookupTable) {
                 // this type has interfaces - add them directly as members
                 const ifaceType = this.getLookupTable()?.getSymbolType(iface.name, { flags: SymbolTypeFlag.typetime });
                 if (ifaceType) {


### PR DESCRIPTION
## Summary
- `BuiltInInterfaceAdder.addBuiltInInterfacesToType` calls `this.getLookupTable()` unconditionally when adding a built-in component's interfaces as members. `getLookupTable` is a static hook normally installed by a full `Program`/`Scope`, so it's `undefined` for callers that lex/parse a single file in isolation (e.g. plugins that only need an AST, no Program). This crashes with `TypeError: this.getLookupTable is not a function`.
- A few lines further down the same method already guards this exact case with `if (!this.getLookupTable) { ... }` — this just applies the same guard to the `interfacesToLoop` branch.
- Reported against `brighterscript-jsdocs-plugin`, but the crash originates here: markwpearce/brighterscript-jsdocs-plugin#17

## Repro
```brightscript
class Foo
  colliders as roAssociativeArray = {}
end class
```
Calling `.getType()` on the field's `AALiteralExpression` without a `Program`-backed `getLookupTable` throws.

## Test plan
- Added a regression test in `BuiltInInterfaceAdder.spec.ts` that unsets `getLookupTable` and asserts `addBuiltInInterfacesToType` on an `AssociativeArrayType` no longer throws.
- Ran full suite: `npm run test:nocover` — 4261 passing.
- `npm run build` and `npm run lint` pass.

Fixes markwpearce/brighterscript-jsdocs-plugin#17