### PR TITLE
Never report diagnostics for .d.bs typedef files

### DIFF
--- a/src/CrossScopeValidator.ts
+++ b/src/CrossScopeValidator.ts
@@ -263,6 +263,11 @@ export class CrossScopeValidator {
     getRequiredMap(scope: Scope) {
         const map = new Map<SymbolLookupKeys, UnresolvedSymbol>();
         scope.enumerateBrsFiles((file) => {
+            //typedef files (.d.bs) are ambient declarations only - never validated for diagnostics,
+            //so don't flag their own unresolved type references as missing symbols
+            if (file.isTypedef) {
+                return;
+            }
             for (const symbol of file.requiredSymbols) {
                 const symbolKeysArray = this.symbolMapKeys(symbol);
                 for (const symbolKeys of symbolKeysArray) {

--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4013,6 +4013,19 @@ describe('ScopeValidator', () => {
             program.validate();
             expectZeroDiagnostics(program);
         });
+
+        it('does not report cannot-find-name for unresolvable types referenced in .d.bs files', () => {
+            //simulates a .d.bs typedef whose namespace-qualified types don't actually resolve
+            //(e.g. produced by a buggy third-party rewrite tool), which should never produce diagnostics
+            program.setFile('source/util.d.bs', `
+                namespace SomeNamespace
+                    function getSomething(a as SomeNamespace.ifDraw2d) as SomeNamespace.roAssociativeArray
+                    end function
+                end namespace
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
     });
 
     describe('assignmentTypeMismatch', () => {

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -153,7 +153,7 @@ export class ScopeValidator {
 
         //do many per-file checks for every file in this (and parent) scopes
         this.event.scope.enumerateBrsFiles((file) => {
-            if (!isBrsFile(file)) {
+            if (!isBrsFile(file) || file.isTypedef) {
                 return;
             }
 
@@ -167,6 +167,11 @@ export class ScopeValidator {
 
         this.event.scope.enumerateOwnFiles((file) => {
             if (isBrsFile(file)) {
+
+                //typedef files (.d.bs) are ambient declarations only - never validated for diagnostics
+                if (file.isTypedef) {
+                    return;
+                }
 
                 if (this.event.program.diagnostics.canSkipScopeValidationForFile(file)) {
                     return;
@@ -276,9 +281,6 @@ export class ScopeValidator {
                         });
                     },
                     FunctionExpression: (func) => {
-                        if (file.isTypedef) {
-                            return;
-                        }
                         this.addValidationKindMetric('FunctionExpression', () => {
                             this.validateFunctionExpressionForReturn(func);
                         });


### PR DESCRIPTION
## Summary
- `.d.bs` files are ambient type declarations only — they're never executed, so their own content should never surface diagnostics (similar to how TypeScript's `skipLibCheck` treats `.d.ts` files).
- Skips scope-level per-file validation (`ScopeValidator`) entirely for typedef files, so cross-namespace type resolution issues (e.g. `cannot-find-name`) inside a `.d.bs` no longer break a consuming project's build.
- Also excludes typedef files from `CrossScopeValidator`'s required-symbol collection, so their own unresolved type references aren't flagged as missing symbols. Symbols *provided* by `.d.bs` files (needed by consumers) are unaffected.

Fixes #1757

## Test plan
- [x] Added a test reproducing the ropm-style mis-qualified `.d.bs` scenario from the issue (namespace-qualified ambient types that don't actually resolve) and asserting zero diagnostics
- [x] `npm run test:nocover` — full suite passes (4262 passing)
- [x] `npm run lint` passes