### PR TITLE
Fix .d.bs typedef emission for namespaced classes/enums and type aliases

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -5174,6 +5174,54 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('uses namespace-qualified type names for function params/returns referencing a same-namespace class', () => {
+            testTypedef(`
+                namespace Shapes
+                    class Circle
+                    end class
+                    sub defineCircle(newCircle as Circle)
+                    end sub
+                    function getCircle() as Circle
+                    end function
+                end namespace
+            `, trim`
+                namespace Shapes
+                    class Circle
+                        sub new()
+                        end sub
+                    end class
+                    sub defineCircle(newCircle as Shapes.Circle)
+                    end sub
+                    function getCircle() as Shapes.Circle
+                    end function
+                end namespace
+            `);
+        });
+
+        it('uses namespace-qualified type names for function params/returns referencing a fully-qualified class', () => {
+            testTypedef(`
+                namespace Shapes
+                    class Circle
+                    end class
+                    sub defineCircle(newCircle as Shapes.Circle)
+                    end sub
+                    function getCircle() as Shapes.Circle
+                    end function
+                end namespace
+            `, trim`
+                namespace Shapes
+                    class Circle
+                        sub new()
+                        end sub
+                    end class
+                    sub defineCircle(newCircle as Shapes.Circle)
+                    end sub
+                    function getCircle() as Shapes.Circle
+                    end function
+                end namespace
+            `);
+        });
+
         it('strips function body', () => {
             testTypedef(`
                 sub main(param1 as string)

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -5222,6 +5222,52 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('includes type alias statements', () => {
+            testTypedef(`
+                type fooFunc = function(a as string, b as integer) as boolean
+                function doFunc(f as fooFunc) as boolean
+                end function
+            `, trim`
+                type fooFunc = function (a as string, b as integer) as boolean
+                function doFunc(f as fooFunc) as boolean
+                end function
+            `);
+        });
+
+        it('includes namespaced type alias statements', () => {
+            testTypedef(`
+                namespace Shapes
+                    type fooFunc = function() as integer
+                    function doFunc(f as fooFunc) as integer
+                    end function
+                end namespace
+            `, trim`
+                namespace Shapes
+                    type fooFunc = function () as integer
+                    function doFunc(f as fooFunc) as integer
+                    end function
+                end namespace
+            `);
+        });
+
+        it('uses namespace-qualified type names for classes referenced by a type alias', () => {
+            testTypedef(`
+                namespace Shapes
+                    class Circle
+                    end class
+                    type circleMaker = function() as Circle
+                end namespace
+            `, trim`
+                namespace Shapes
+                    class Circle
+                        sub new()
+                        end sub
+                    end class
+                    type circleMaker = function () as Shapes.Circle
+                end namespace
+            `);
+        });
+
         it('strips function body', () => {
             testTypedef(`
                 sub main(param1 as string)

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -3081,6 +3081,12 @@ export class TypedFunctionTypeExpression extends Expression {
         return [this.getType({ flags: SymbolTypeFlag.typetime }).toTypeString()];
     }
 
+    public getTypedef(state: BrsTranspileState): TranspileResult {
+        //preserve the full signature (param names/types, return type) in typedefs,
+        //rather than the generic runtime type name used by `transpile()`
+        return [this.getType({ flags: SymbolTypeFlag.typetime }).toString()];
+    }
+
     public walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             walkArray(this.params, visitor, options, this);

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -10,7 +10,7 @@ import { ParseMode } from './Parser';
 import type { WalkOptions, WalkVisitor } from '../astUtils/visitors';
 import { WalkMode } from '../astUtils/visitors';
 import { walk, InternalWalkMode, walkArray } from '../astUtils/visitors';
-import { isAAIndexedMemberExpression, isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallableType, isCallExpression, isCallfuncExpression, isDottedGetExpression, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isInvalidType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNativeType, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isTypeStatementType, isUnaryExpression, isVariableExpression, isVoidType } from '../astUtils/reflection';
+import { isAAIndexedMemberExpression, isAALiteralExpression, isAAMemberExpression, isArrayLiteralExpression, isArrayType, isCallableType, isCallExpression, isCallfuncExpression, isClassType, isDottedGetExpression, isEnumType, isEscapedCharCodeLiteralExpression, isFunctionExpression, isFunctionStatement, isIntegerType, isInterfaceMethodStatement, isInvalidType, isLiteralBoolean, isLiteralExpression, isLiteralNumber, isLiteralString, isLongIntegerType, isMethodStatement, isNamespaceStatement, isNativeType, isNewExpression, isPrimitiveType, isReferenceType, isStringType, isTemplateStringExpression, isTypecastExpression, isTypeStatementType, isUnaryExpression, isVariableExpression, isVoidType } from '../astUtils/reflection';
 import type { GetTypeOptions, TranspileResult, TypedefProvider } from '../interfaces';
 import { TypeChainEntry } from '../interfaces';
 import { VoidType } from '../types/VoidType';
@@ -2733,8 +2733,18 @@ export class TypeExpression extends Expression implements TypedefProvider {
     }
 
     getTypedef(state: TranspileState): TranspileResult {
+        // classes and enums always know their own fully-namespace-qualified name, regardless
+        // of how they were referenced in source (bare same-namespace shorthand, fully-qualified,
+        // etc.) - use that instead of the raw written text, which would otherwise be flattened
+        // to the type's compiled runtime symbol name (e.g. `Namespace_Type`) for class references
+        const exprType = this.getType({ flags: SymbolTypeFlag.typetime });
+        if (isClassType(exprType) || isEnumType(exprType)) {
+            return [exprType.toString()];
+        }
         // TypeDefs should pass through any valid type names
-        return this.expression.transpile(state as BrsTranspileState);
+        return this.expression.getTypedef
+            ? this.expression.getTypedef(state as BrsTranspileState)
+            : this.expression.transpile(state as BrsTranspileState);
     }
 
     getName(parseMode = ParseMode.BrighterScript): string {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -4610,7 +4610,7 @@ export class ConditionalCompileConstStatement extends Statement {
 }
 
 
-export class TypeStatement extends Statement {
+export class TypeStatement extends Statement implements TypedefProvider {
     constructor(options: {
         type?: Token;
         name: Token;
@@ -4648,6 +4648,27 @@ export class TypeStatement extends Statement {
     transpile(state: BrsTranspileState) {
         //type statements have no runtime representation, so they're stripped entirely
         return [];
+    }
+
+    getTypedef(state: BrsTranspileState): TranspileResult {
+        const result: TranspileResult = [];
+        for (let comment of util.getLeadingComments(this) ?? []) {
+            result.push(
+                comment.text,
+                state.newline,
+                state.indent()
+            );
+        }
+        result.push(
+            this.tokens.type ? state.tokenToSourceNode(this.tokens.type) : 'type',
+            ' ',
+            state.tokenToSourceNode(this.tokens.name),
+            ' ',
+            this.tokens.equals ? state.tokenToSourceNode(this.tokens.equals) : '=',
+            ' ',
+            ...this.value.getTypedef(state)
+        );
+        return result;
     }
 
     walk(visitor: WalkVisitor, options: WalkOptions) {


### PR DESCRIPTION
## Summary
- `TypeExpression.getTypedef()` previously re-transpiled the referenced expression directly. For a class reference used in a callee-like position (e.g. a bare same-namespace class name in a function param/return type annotation), that transpile path flattens the name to its compiled runtime symbol name (`Namespace_Type`) - not a real, resolvable type from a consumer's perspective. This happened regardless of whether the source annotation was written bare or fully-namespace-qualified.
- Classes and enums already know their own fully-qualified name via `getName()`/`toString()`, so `TypeExpression.getTypedef()` now uses that directly for `ClassType`/`EnumType`, instead of re-transpiling the written expression.
- **Also fixes #1761**: `TypeStatement` (`type X = ...`) didn't implement `getTypedef()`, so type alias declarations were silently dropped from `emitDefinitions` output entirely, while any function signature referencing the alias kept the now-dangling reference - guaranteed `cannot-find-name` for any consumer. Added `getTypedef()` to `TypeStatement`.
- Also gave `TypedFunctionTypeExpression` its own `getTypedef()`, so function type signatures (params/return type) are preserved in typedefs instead of collapsing to the generic runtime type name (`Function`) used by `transpile()`. This also picks up namespace-qualified class/enum names for any such types referenced in the signature.

Fixes #1758
Fixes #1761

## Test plan
- [x] Added tests in `BrsFile.spec.ts` covering same-namespace-shorthand and fully-qualified class type annotations, top-level and namespaced `type` alias declarations, and class references inside a type alias's function signature
- [x] `npm run test:nocover` — full suite passes
- [x] `npm run lint` passes