### PR TITLE
Cap LSP worker thread pool to fix memory scaling with project count

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -26,6 +26,7 @@ import { standardizePath } from 'roku-deploy';
 import undent from 'undent';
 import { ProjectManager } from './lsp/ProjectManager';
 import type { WorkspaceConfig } from './lsp/ProjectManager';
+import { workerPool } from './lsp/worker/WorkerThreadProject';
 
 const sinon = createSandbox();
 
@@ -489,6 +490,53 @@ describe('LanguageServer', () => {
         });
     });
 
+    describe('syncMaxProjectWorkers', () => {
+        function makeConfig(workspaceFolder: string, maxWorkers?: number): WorkspaceConfig {
+            return {
+                languageServer: {
+                    enableThreading: false,
+                    enableProjectDiscovery: true,
+                    logLevel: 'info',
+                    ...(maxWorkers !== undefined ? { maxProjectWorkers: maxWorkers } : {})
+                },
+                workspaceFolder: workspaceFolder,
+                excludePatterns: []
+            };
+        }
+
+        it('defaults to LanguageServer.maxProjectWorkersDefault when no workspaces are configured', () => {
+            server['workspaceConfigsCache'] = new Map();
+            server['syncMaxProjectWorkers']();
+            expect(workerPool.maxWorkers).to.eql(LanguageServer.maxProjectWorkersDefault);
+        });
+
+        it('reads the limit from a single workspace config', () => {
+            server['workspaceConfigsCache'] = new Map([
+                [workspacePath, makeConfig(workspacePath, 4)]
+            ]);
+            server['syncMaxProjectWorkers']();
+            expect(workerPool.maxWorkers).to.eql(4);
+        });
+
+        it('uses the smallest limit from multiple workspace folders', () => {
+            const folder2 = s`${tempDir}/project2`;
+            server['workspaceConfigsCache'] = new Map([
+                [workspacePath, makeConfig(workspacePath, 10)],
+                [folder2, makeConfig(folder2, 2)]
+            ]);
+            server['syncMaxProjectWorkers']();
+            expect(workerPool.maxWorkers).to.eql(2);
+        });
+
+        it('defaults to 1 when the configured value is less than 1', () => {
+            server['workspaceConfigsCache'] = new Map([
+                [workspacePath, makeConfig(workspacePath, 0)]
+            ]);
+            server['syncMaxProjectWorkers']();
+            expect(workerPool.maxWorkers).to.eql(1);
+        });
+    });
+
     describe('sendDiagnostics', () => {
         it('dedupes diagnostics found at same location from multiple projects', async () => {
             fsExtra.outputFileSync(s`${rootDir}/common/lib.brs`, `
@@ -761,7 +809,8 @@ describe('LanguageServer', () => {
                         projectDiscoveryMaxDepth: 15,
                         projectDiscoveryExclude: undefined,
                         logLevel: 'info',
-                        projectActivationConcurrencyLimit: undefined
+                        projectActivationConcurrencyLimit: undefined,
+                        maxProjectWorkers: undefined
                     }
                 }
             ]);

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -574,6 +574,27 @@ describe('LanguageServer', () => {
         });
     });
 
+    describe('critical-failure', () => {
+        it('notifies the client when a project reports a critical failure', async () => {
+            server['connection'] = connection as any;
+            const deferred = new Deferred<any>();
+            const stub = sinon.stub(server['connection'], 'sendNotification').callsFake((...args: any[]) => {
+                deferred.resolve(args);
+                return Promise.resolve();
+            });
+
+            server['projectManager']['emit']('critical-failure', {
+                project: server['projectManager'].projects[0],
+                message: 'worker thread crashed unexpectedly'
+            });
+
+            const args = await deferred.promise;
+            expect(args[0]).to.eql('critical-failure');
+            expect(args[1]).to.include('worker thread crashed unexpectedly');
+            stub.restore();
+        });
+    });
+
     describe('project-activate', () => {
         it('should sync all open document changes to all projects', async () => {
 

--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -490,31 +490,31 @@ describe('LanguageServer', () => {
         });
     });
 
-    describe('syncMaxProjectWorkers', () => {
-        function makeConfig(workspaceFolder: string, maxWorkers?: number): WorkspaceConfig {
+    describe('syncMaxWorkerThreads', () => {
+        function makeConfig(workspaceFolder: string, maxWorkerThreads?: number): WorkspaceConfig {
             return {
                 languageServer: {
                     enableThreading: false,
                     enableProjectDiscovery: true,
                     logLevel: 'info',
-                    ...(maxWorkers !== undefined ? { maxProjectWorkers: maxWorkers } : {})
+                    ...(maxWorkerThreads !== undefined ? { maxWorkerThreads: maxWorkerThreads } : {})
                 },
                 workspaceFolder: workspaceFolder,
                 excludePatterns: []
             };
         }
 
-        it('defaults to LanguageServer.maxProjectWorkersDefault when no workspaces are configured', () => {
+        it('defaults to LanguageServer.maxWorkerThreadsDefault when no workspaces are configured', () => {
             server['workspaceConfigsCache'] = new Map();
-            server['syncMaxProjectWorkers']();
-            expect(workerPool.maxWorkers).to.eql(LanguageServer.maxProjectWorkersDefault);
+            server['syncMaxWorkerThreads']();
+            expect(workerPool.maxWorkers).to.eql(LanguageServer.maxWorkerThreadsDefault);
         });
 
         it('reads the limit from a single workspace config', () => {
             server['workspaceConfigsCache'] = new Map([
                 [workspacePath, makeConfig(workspacePath, 4)]
             ]);
-            server['syncMaxProjectWorkers']();
+            server['syncMaxWorkerThreads']();
             expect(workerPool.maxWorkers).to.eql(4);
         });
 
@@ -524,7 +524,7 @@ describe('LanguageServer', () => {
                 [workspacePath, makeConfig(workspacePath, 10)],
                 [folder2, makeConfig(folder2, 2)]
             ]);
-            server['syncMaxProjectWorkers']();
+            server['syncMaxWorkerThreads']();
             expect(workerPool.maxWorkers).to.eql(2);
         });
 
@@ -532,7 +532,7 @@ describe('LanguageServer', () => {
             server['workspaceConfigsCache'] = new Map([
                 [workspacePath, makeConfig(workspacePath, 0)]
             ]);
-            server['syncMaxProjectWorkers']();
+            server['syncMaxWorkerThreads']();
             expect(workerPool.maxWorkers).to.eql(1);
         });
     });
@@ -831,7 +831,7 @@ describe('LanguageServer', () => {
                         projectDiscoveryExclude: undefined,
                         logLevel: 'info',
                         projectActivationConcurrencyLimit: undefined,
-                        maxProjectWorkers: undefined
+                        maxWorkerThreads: undefined
                     }
                 }
             ]);

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -80,9 +80,10 @@ export class LanguageServer {
 
     /**
      * The default maximum number of worker threads to use for running LSP projects. Can be overridden by
-     * per-workspace settings. Multiple projects will share a single worker thread once this limit is reached.
+     * per-workspace settings. Once this limit is reached, additional projects are spread evenly across the
+     * existing worker threads instead of each getting a dedicated one.
      */
-    public static maxProjectWorkersDefault = Math.max(1, os.cpus().length);
+    public static maxWorkerThreadsDefault = Math.max(1, os.cpus().length);
 
     /**
      * The language server protocol connection, used to send and receive all requests and responses
@@ -295,7 +296,7 @@ export class LanguageServer {
         await this.syncLogLevel();
 
         this.syncProjectActivationConcurrencyLimit();
-        this.syncMaxProjectWorkers();
+        this.syncMaxWorkerThreads();
 
         try {
             if (this.hasConfigurationCapability) {
@@ -419,27 +420,27 @@ export class LanguageServer {
     }
 
     /**
-     * Get the max project workers setting from all workspaces and set the worker pool's cap to the lowest value found.
+     * Get the max worker threads setting from all workspaces and set the worker pool's cap to the lowest value found.
      * This ensures that if the user has multiple workspaces open with different limits,
      * we respect the most restrictive limit to avoid overwhelming the user's machine.
      */
-    private syncMaxProjectWorkers() {
+    private syncMaxWorkerThreads() {
         const limits = [...this.workspaceConfigsCache]
-            .map(x => x?.[1]?.languageServer?.maxProjectWorkers)
+            .map(x => x?.[1]?.languageServer?.maxWorkerThreads)
             .filter(x => typeof x === 'number');
 
         //if we don't have any limits defined, use our default value
         if (limits.length === 0) {
-            limits.push(LanguageServer.maxProjectWorkersDefault);
+            limits.push(LanguageServer.maxWorkerThreadsDefault);
         }
 
-        let maxProjectWorkers = Math.min(...limits);
+        let maxWorkerThreads = Math.min(...limits);
         //we must always support at least 1 worker, otherwise no threaded projects could ever activate
-        if (!(maxProjectWorkers >= 1)) {
-            this.logger.log(`maxProjectWorkers was set to ${maxProjectWorkers}, which is not a valid value. Defaulting to 1.`);
-            maxProjectWorkers = 1;
+        if (!(maxWorkerThreads >= 1)) {
+            this.logger.log(`maxWorkerThreads was set to ${maxWorkerThreads}, which is not a valid value. Defaulting to 1.`);
+            maxWorkerThreads = 1;
         }
-        workerPool.maxWorkers = maxProjectWorkers;
+        workerPool.maxWorkers = maxWorkerThreads;
     }
 
     @AddStackToErrorMessage
@@ -597,7 +598,7 @@ export class LanguageServer {
                         projectDiscoveryExclude: brightscriptConfig?.languageServer?.projectDiscoveryExclude,
                         logLevel: brightscriptConfig?.languageServer?.logLevel,
                         projectActivationConcurrencyLimit: brightscriptConfig?.languageServer?.projectActivationConcurrencyLimit,
-                        maxProjectWorkers: brightscriptConfig?.languageServer?.maxProjectWorkers
+                        maxWorkerThreads: brightscriptConfig?.languageServer?.maxWorkerThreads
                     }
                 };
             })
@@ -640,7 +641,7 @@ export class LanguageServer {
             this.workspaceConfigsCache = configs;
 
             this.syncProjectActivationConcurrencyLimit();
-            this.syncMaxProjectWorkers();
+            this.syncMaxWorkerThreads();
 
             //if configuration changed, rebuild the path filterer
             await this.rebuildPathFilterer();
@@ -1068,7 +1069,7 @@ export interface BrightScriptClientConfiguration {
         logLevel: LogLevel | string;
         projectDiscoveryMaxDepth?: number;
         projectActivationConcurrencyLimit?: number;
-        maxProjectWorkers?: number;
+        maxWorkerThreads?: number;
     };
 }
 

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -137,6 +137,13 @@ export class LanguageServer {
             this.sendDiagnostics(event).catch(logAndIgnoreError);
         });
 
+        //if a project's worker thread crashes unexpectedly, notify the client so the user isn't left staring at a frozen project with no explanation
+        this.projectManager.on('critical-failure', (event) => {
+            const message = `[${util.getProjectLogName(event.project)}] ${event.message}`;
+            this.logger.error(message);
+            this.sendCriticalFailure(message);
+        });
+
         // Send all open document changes whenever a project is activated. This is necessary because at project startup, the project loads files from disk
         // and may not have the latest unsaved file changes. Any existing projects that already use these files will just ignore the changes
         // because the file contents haven't changed.

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -137,7 +137,7 @@ export class LanguageServer {
             this.sendDiagnostics(event).catch(logAndIgnoreError);
         });
 
-        //if a project's worker thread crashes unexpectedly, notify the client so the user isn't left staring at a frozen project with no explanation
+        //notify the client if a project's worker thread crashes unexpectedly
         this.projectManager.on('critical-failure', (event) => {
             const message = `[${util.getProjectLogName(event.project)}] ${event.message}`;
             this.logger.error(message);

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as os from 'os';
 import type {
     CompletionItem,
     Connection,
@@ -76,6 +77,12 @@ export class LanguageServer {
      * The default number of projects that are permitted to activate concurrently.
      */
     private static projectActivationConcurrencyLimitDefault = 3;
+
+    /**
+     * The default maximum number of worker threads to use for running LSP projects. Can be overridden by
+     * per-workspace settings. Multiple projects will share a single worker thread once this limit is reached.
+     */
+    public static maxProjectWorkersDefault = Math.max(1, os.cpus().length);
 
     /**
      * The language server protocol connection, used to send and receive all requests and responses
@@ -281,6 +288,7 @@ export class LanguageServer {
         await this.syncLogLevel();
 
         this.syncProjectActivationConcurrencyLimit();
+        this.syncMaxProjectWorkers();
 
         try {
             if (this.hasConfigurationCapability) {
@@ -403,6 +411,29 @@ export class LanguageServer {
         this.projectManager.projectActivationConcurrencyLimit = concurrencyLimit;
     }
 
+    /**
+     * Get the max project workers setting from all workspaces and set the worker pool's cap to the lowest value found.
+     * This ensures that if the user has multiple workspaces open with different limits,
+     * we respect the most restrictive limit to avoid overwhelming the user's machine.
+     */
+    private syncMaxProjectWorkers() {
+        const limits = [...this.workspaceConfigsCache]
+            .map(x => x?.[1]?.languageServer?.maxProjectWorkers)
+            .filter(x => typeof x === 'number');
+
+        //if we don't have any limits defined, use our default value
+        if (limits.length === 0) {
+            limits.push(LanguageServer.maxProjectWorkersDefault);
+        }
+
+        let maxProjectWorkers = Math.min(...limits);
+        //we must always support at least 1 worker, otherwise no threaded projects could ever activate
+        if (!(maxProjectWorkers >= 1)) {
+            this.logger.log(`maxProjectWorkers was set to ${maxProjectWorkers}, which is not a valid value. Defaulting to 1.`);
+            maxProjectWorkers = 1;
+        }
+        workerPool.maxWorkers = maxProjectWorkers;
+    }
 
     @AddStackToErrorMessage
     private async onTextDocumentDidChangeContent(event: TextDocumentChangeEvent<TextDocument>) {
@@ -558,7 +589,8 @@ export class LanguageServer {
                         projectDiscoveryMaxDepth: brightscriptConfig?.languageServer?.projectDiscoveryMaxDepth ?? 15,
                         projectDiscoveryExclude: brightscriptConfig?.languageServer?.projectDiscoveryExclude,
                         logLevel: brightscriptConfig?.languageServer?.logLevel,
-                        projectActivationConcurrencyLimit: brightscriptConfig?.languageServer?.projectActivationConcurrencyLimit
+                        projectActivationConcurrencyLimit: brightscriptConfig?.languageServer?.projectActivationConcurrencyLimit,
+                        maxProjectWorkers: brightscriptConfig?.languageServer?.maxProjectWorkers
                     }
                 };
             })
@@ -601,6 +633,7 @@ export class LanguageServer {
             this.workspaceConfigsCache = configs;
 
             this.syncProjectActivationConcurrencyLimit();
+            this.syncMaxProjectWorkers();
 
             //if configuration changed, rebuild the path filterer
             await this.rebuildPathFilterer();
@@ -1028,6 +1061,7 @@ export interface BrightScriptClientConfiguration {
         logLevel: LogLevel | string;
         projectDiscoveryMaxDepth?: number;
         projectActivationConcurrencyLimit?: number;
+        maxProjectWorkers?: number;
     };
 }
 

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -6,8 +6,8 @@ import util, { standardizePath as s } from '../util';
 import type { SinonStub } from 'sinon';
 import { createSandbox } from 'sinon';
 import { Project } from './Project';
-import { WorkerThreadProject, workerPool } from './worker/WorkerThreadProject';
-import { getWakeWorkerThreadPromise } from './worker/WorkerThreadProject.spec';
+import { WorkerThreadProject } from './worker/WorkerThreadProject';
+import { getWakeWorkerThreadPromise, preloadAndWaitUntilReady } from './worker/WorkerThreadProject.spec';
 import type { LspDiagnostic } from './LspProject';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { FileChangeType } from 'vscode-languageserver-protocol';
@@ -43,12 +43,13 @@ describe('ProjectManager', () => {
         });
     });
 
-    afterEach(() => {
+    afterEach(async function keepWorkerPoolWarm() {
+        this.timeout(15_000);
         fsExtra.emptyDirSync(tempDir);
         sinon.restore();
         manager.dispose();
-        //keep a spare worker warm for the next test that needs real threading (see WorkerThreadProject.spec.ts's wakeWorkerThread())
-        workerPool.preload(1);
+        //keep a spare worker warm for the next test that needs real threading (see WorkerThreadProject.spec.ts's preloadAndWaitUntilReady())
+        await preloadAndWaitUntilReady(1);
     });
     let diagnosticsListeners: Array<(diagnostics: LspDiagnostic[]) => void> = [];
     let diagnosticsResponses: Array<LspDiagnostic[]> = [];

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -44,13 +44,12 @@ describe('ProjectManager', () => {
     });
 
     afterEach(async function keepWorkerPoolWarm() {
-        //a fresh worker's cold boot (real OS thread + ts-node/register bootstrap) can take up to the same order of
-        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget
+        //defensive fallback in case the pool ends up empty; give it a cold-boot-sized budget
         this.timeout(60_000);
         fsExtra.emptyDirSync(tempDir);
         sinon.restore();
         manager.dispose();
-        //keep a spare worker warm for the next test that needs real threading (see WorkerThreadProject.spec.ts's preloadAndWaitUntilReady())
+        //keep a spare worker warm for the next real-threading test (see WorkerThreadProject.spec.ts)
         await preloadAndWaitUntilReady(1);
     });
     let diagnosticsListeners: Array<(diagnostics: LspDiagnostic[]) => void> = [];

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -1222,7 +1222,8 @@ describe('ProjectManager', () => {
             await getWakeWorkerThreadPromise();
         });
 
-        it('spawns a worker thread when threading is enabled', async () => {
+        it('spawns a worker thread when threading is enabled', async function () {
+            this.timeout(15_000);
             await manager.syncProjects([{
                 ...workspaceSettings,
                 languageServer: {

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -44,7 +44,9 @@ describe('ProjectManager', () => {
     });
 
     afterEach(async function keepWorkerPoolWarm() {
-        this.timeout(15_000);
+        //a fresh worker's cold boot (real OS thread + ts-node/register bootstrap) can take up to the same order of
+        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget
+        this.timeout(60_000);
         fsExtra.emptyDirSync(tempDir);
         sinon.restore();
         manager.dispose();

--- a/src/lsp/ProjectManager.spec.ts
+++ b/src/lsp/ProjectManager.spec.ts
@@ -6,7 +6,7 @@ import util, { standardizePath as s } from '../util';
 import type { SinonStub } from 'sinon';
 import { createSandbox } from 'sinon';
 import { Project } from './Project';
-import { WorkerThreadProject } from './worker/WorkerThreadProject';
+import { WorkerThreadProject, workerPool } from './worker/WorkerThreadProject';
 import { getWakeWorkerThreadPromise } from './worker/WorkerThreadProject.spec';
 import type { LspDiagnostic } from './LspProject';
 import { DiagnosticMessages } from '../DiagnosticMessages';
@@ -47,6 +47,8 @@ describe('ProjectManager', () => {
         fsExtra.emptyDirSync(tempDir);
         sinon.restore();
         manager.dispose();
+        //keep a spare worker warm for the next test that needs real threading (see WorkerThreadProject.spec.ts's wakeWorkerThread())
+        workerPool.preload(1);
     });
     let diagnosticsListeners: Array<(diagnostics: LspDiagnostic[]) => void> = [];
     let diagnosticsResponses: Array<LspDiagnostic[]> = [];

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -1135,7 +1135,7 @@ export interface WorkspaceConfig {
          * The maximum number of worker threads to use for running LSP projects. Once this limit is reached,
          * additional projects are multiplexed onto existing worker threads rather than spawning new ones.
          */
-        maxProjectWorkers?: number;
+        maxWorkerThreads?: number;
     };
 }
 

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -1131,6 +1131,11 @@ export interface WorkspaceConfig {
          * The maximum number of projects that can be activated concurrently
          */
         projectActivationConcurrencyLimit?: number;
+        /**
+         * The maximum number of worker threads to use for running LSP projects. Once this limit is reached,
+         * additional projects are multiplexed onto existing worker threads rather than spawning new ones.
+         */
+        maxProjectWorkers?: number;
     };
 }
 

--- a/src/lsp/worker/MessageHandler.spec.ts
+++ b/src/lsp/worker/MessageHandler.spec.ts
@@ -118,4 +118,18 @@ describe('MessageHandler', () => {
 
         localServer.dispose();
     });
+
+    it('rejects sendRequest() calls made after dispose()', async () => {
+        let client = new MessageHandler<LspProject>({ port: channel.port2 });
+        client.dispose();
+
+        let error: Error;
+        try {
+            await client.sendRequest('activate');
+        } catch (e) {
+            error = e as any;
+        }
+        expect(error).to.exist;
+        expect(error.message).to.include('disposed');
+    });
 });

--- a/src/lsp/worker/MessageHandler.spec.ts
+++ b/src/lsp/worker/MessageHandler.spec.ts
@@ -62,4 +62,60 @@ describe('MessageHandler', () => {
         }
         expect(error?.message).to.eql('Request 0 has been rejected because MessageHandler is now disposed');
     });
+
+    it('is safe to call dispose() twice, even with pending requests', async () => {
+        let localServer = new MessageHandler({
+            port: channel.port1,
+            onRequest: (request) => {
+                //never respond, so the request stays pending
+            }
+        });
+        let localClient = new MessageHandler<LspProject>({ port: channel.port2 });
+
+        const pendingRequest = localClient.sendRequest('activate');
+
+        //first dispose should reject the pending request
+        localClient.dispose();
+        let error: Error;
+        try {
+            await pendingRequest;
+        } catch (e) {
+            error = e as any;
+        }
+        expect(error).to.exist;
+
+        //second dispose should be a no-op, not throw
+        expect(() => localClient.dispose()).to.not.throw();
+
+        localServer.dispose();
+    });
+
+    it('reject is only sent once when dispose is called multiple times', async () => {
+        let localServer = new MessageHandler({
+            port: channel.port1,
+            onRequest: (request) => {
+                //never respond, so the request stays pending
+            }
+        });
+        let localClient = new MessageHandler<LspProject>({ port: channel.port2 });
+
+        const pendingRequest = localClient.sendRequest('activate');
+
+        //first dispose should reject the pending request
+        localClient.dispose();
+        let error: Error;
+        try {
+            await pendingRequest;
+        } catch (e) {
+            error = e as any;
+        }
+        expect(error?.message).to.eql('Request 0 has been rejected because MessageHandler is now disposed');
+
+        //second dispose should not cause any additional errors
+        localClient.dispose();
+        localClient.dispose();
+        //no errors thrown = test passes
+
+        localServer.dispose();
+    });
 });

--- a/src/lsp/worker/MessageHandler.ts
+++ b/src/lsp/worker/MessageHandler.ts
@@ -54,6 +54,8 @@ export class MessageHandler<T, TRequestName = MethodNames<T>> {
 
     private emitter = new EventEmitter();
 
+    private isDisposed = false;
+
     private activeRequests = new Map<number, {
         id: number;
         deferred: Deferred<any>;
@@ -162,11 +164,16 @@ export class MessageHandler<T, TRequestName = MethodNames<T>> {
     }
 
     public dispose() {
+        if (this.isDisposed) {
+            return;
+        }
+        this.isDisposed = true;
         util.applyDispose(this.disposables);
         //reject all active requests
         for (const request of this.activeRequests.values()) {
             request.deferred.reject(new Error(`Request ${request.id} has been rejected because MessageHandler is now disposed`));
         }
+        this.activeRequests.clear();
     }
 }
 

--- a/src/lsp/worker/MessageHandler.ts
+++ b/src/lsp/worker/MessageHandler.ts
@@ -96,6 +96,9 @@ export class MessageHandler<T, TRequestName = MethodNames<T>> {
      * @param options.id an id for this request
      */
     public async sendRequest<R>(name: TRequestName, options?: { data: any[]; id?: number }) {
+        if (this.isDisposed) {
+            throw new Error(`Cannot send request '${name}' because MessageHandler is disposed`);
+        }
         const request: WorkerMessage = {
             type: 'request',
             name: name as any,

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -162,6 +162,24 @@ describe('WorkerPool', () => {
             expect(() => emitExit(worker as any)).to.not.throw();
             expect(pool['workers']).to.be.lengthOf(0);
         });
+
+        it('leaves no orphaned bookkeeping when a sibling releases a project after the shared worker crashed', () => {
+            pool.maxWorkers = 1;
+            const { worker } = pool.assignProject();
+            pool.assignProject();
+            expect(pool['workers']).to.be.lengthOf(1);
+
+            //the worker crashes while two projects are still attached to it
+            emitExit(worker as any);
+            expect(pool['workers']).to.be.lengthOf(0);
+
+            //each sibling project disposing afterward calls releaseProject with the now-dead worker - neither should
+            //throw, resurrect the entry, or re-terminate the worker
+            expect(() => pool.releaseProject(worker)).to.not.throw();
+            expect(() => pool.releaseProject(worker)).to.not.throw();
+            expect(pool['workers']).to.be.lengthOf(0);
+            expect((worker.terminate as sinon.SinonStub).called).to.be.false;
+        });
     });
 
     describe('dispose', () => {

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -158,8 +158,7 @@ describe('WorkerPool', () => {
             pool.releaseProject(worker);
             expect(pool['workers']).to.be.lengthOf(0);
 
-            //the worker's real 'exit' event fires after terminate() resolves; simulate that now.
-            //this should be a safe no-op since releaseProject already removed the entry.
+            //simulate the real 'exit' event firing after terminate() - should be a safe no-op, entry's already gone
             expect(() => emitExit(worker as any)).to.not.throw();
             expect(pool['workers']).to.be.lengthOf(0);
         });

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -5,7 +5,16 @@ import * as sinon from 'sinon';
 
 describe('WorkerPool', () => {
     let pool: WorkerPool;
-    let workers: Array<Worker & { postMessage: sinon.SinonStub; terminate: sinon.SinonStub }> = [];
+    let workers: Array<Worker & { postMessage: sinon.SinonStub; terminate: sinon.SinonStub; once: sinon.SinonStub }> = [];
+
+    /**
+     * Simulate a worker unexpectedly exiting by invoking the `'exit'` handler that `WorkerPool` registered on it
+     * via `worker.once('exit', ...)`
+     */
+    function emitExit(worker: { once: sinon.SinonStub }) {
+        const call = worker.once.getCalls().find(c => c.args[0] === 'exit');
+        call?.args[1]?.();
+    }
 
     beforeEach(() => {
         workers = [];
@@ -13,7 +22,8 @@ describe('WorkerPool', () => {
         pool = new WorkerPool(() => {
             const worker = {
                 postMessage: sinon.stub(),
-                terminate: sinon.stub().resolves()
+                terminate: sinon.stub().resolves(),
+                once: sinon.stub()
             } as any;
             workers.push(worker);
             return worker;
@@ -27,17 +37,19 @@ describe('WorkerPool', () => {
     });
 
     describe('preload', () => {
-        it('ensures enough workers have been created', () => {
+        it('respects maxWorkers even if a larger count is requested', () => {
             expect(workers.length).to.eql(0);
 
             pool.preload(5);
-            expect(workers.length).to.eql(5);
+            //maxWorkers is 2, so preload should never exceed that cap
+            expect(workers.length).to.eql(2);
 
             pool.preload(7);
-            expect(workers.length).to.eql(7);
+            expect(workers.length).to.eql(2);
         });
 
         it('does not create extra workers if enough already exist', () => {
+            pool.maxWorkers = 3;
             pool.preload(3);
             expect(workers.length).to.eql(3);
 
@@ -77,6 +89,23 @@ describe('WorkerPool', () => {
             expect(transferList).to.include(message.port);
             expect(port).to.exist;
         });
+
+        it('reuses an idle preloaded worker instead of creating a new one', () => {
+            pool.preload(2);
+            expect(workers.length).to.eql(2);
+
+            const { worker } = pool.assignProject();
+            //no new worker should have been created; the idle preloaded worker should have been reused
+            expect(workers.length).to.eql(2);
+            expect(workers).to.include(worker);
+        });
+
+        it('does not throw when maxWorkers is 0 and there are no workers yet', () => {
+            pool.maxWorkers = 0;
+            const { worker } = pool.assignProject();
+            expect(worker).to.exist;
+            expect(workers.length).to.eql(1);
+        });
     });
 
     describe('releaseProject', () => {
@@ -105,6 +134,34 @@ describe('WorkerPool', () => {
         it('does not crash when releasing an unknown worker', () => {
             const unknownWorker = {} as Worker;
             pool.releaseProject(unknownWorker);
+        });
+    });
+
+    describe('worker crash handling', () => {
+        it('removes a crashed worker from the pool so it is not selected again', () => {
+            const { worker } = pool.assignProject();
+            expect(pool['workers']).to.be.lengthOf(1);
+
+            //simulate the worker crashing/exiting unexpectedly
+            emitExit(worker as any);
+
+            expect(pool['workers']).to.be.lengthOf(0);
+
+            //a subsequent assignment should create a brand new worker instead of reusing the dead one
+            const { worker: newWorker } = pool.assignProject();
+            expect(newWorker).to.not.equal(worker);
+            expect(pool['workers']).to.be.lengthOf(1);
+        });
+
+        it('does not double-splice or re-terminate when releaseProject already removed the entry', () => {
+            const { worker } = pool.assignProject();
+            pool.releaseProject(worker);
+            expect(pool['workers']).to.be.lengthOf(0);
+
+            //the worker's real 'exit' event fires after terminate() resolves; simulate that now.
+            //this should be a safe no-op since releaseProject already removed the entry.
+            expect(() => emitExit(worker as any)).to.not.throw();
+            expect(pool['workers']).to.be.lengthOf(0);
         });
     });
 

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -1,23 +1,33 @@
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import { WorkerPool } from './WorkerPool';
 import type { Worker } from 'worker_threads';
+import * as sinon from 'sinon';
 
 describe('WorkerPool', () => {
     let pool: WorkerPool;
-    let workers: Worker[] = [] as any;
+    let workers: Array<Worker & { postMessage: sinon.SinonStub; terminate: sinon.SinonStub }> = [];
 
     beforeEach(() => {
         workers = [];
-        //our factory will create empty objects. This prevents us from having to actually run threads.
+        //our factory creates fake workers so we don't have to spin up real threads for these tests
         pool = new WorkerPool(() => {
-            const worker = {} as Worker;
+            const worker = {
+                postMessage: sinon.stub(),
+                terminate: sinon.stub().resolves()
+            } as any;
             workers.push(worker);
             return worker;
         });
+        //keep tests deterministic regardless of how many CPUs the test machine has
+        pool.maxWorkers = 2;
+    });
+
+    afterEach(() => {
+        sinon.restore();
     });
 
     describe('preload', () => {
-        it('ensures enough free workers have been created', () => {
+        it('ensures enough workers have been created', () => {
             expect(workers.length).to.eql(0);
 
             pool.preload(5);
@@ -26,40 +36,92 @@ describe('WorkerPool', () => {
             pool.preload(7);
             expect(workers.length).to.eql(7);
         });
-    });
 
-    describe('releaseWorker', () => {
-        it('releases a worker back to the pool', () => {
-            const worker = pool.getWorker();
-            expect(pool['freeWorkers']).lengthOf(0);
+        it('does not create extra workers if enough already exist', () => {
+            pool.preload(3);
+            expect(workers.length).to.eql(3);
 
-            pool.releaseWorker(worker);
-            expect(pool['freeWorkers']).lengthOf(1);
-
-            //doesn't crash if we do the same thing again
-            pool.releaseWorker(worker);
-            expect(pool['freeWorkers']).lengthOf(1);
+            pool.preload(2);
+            expect(workers.length).to.eql(3);
         });
     });
 
-    describe('getWorker', () => {
-        it('creates a new worker when none exist', () => {
-            expect(pool['allWorkers']).to.be.empty;
-            expect(pool['freeWorkers']).to.be.empty;
-            const worker = pool.getWorker();
-            expect(worker).to.eql(workers[0]);
-            expect(pool['allWorkers']).to.be.lengthOf(1);
-            //should be same instance
-            expect(pool['allWorkers'][0]).equals(workers[0]);
+    describe('assignProject', () => {
+        it('creates a new worker when below maxWorkers', () => {
+            const { worker } = pool.assignProject();
+            expect(worker).to.equal(workers[0]);
+            expect(workers).to.be.lengthOf(1);
+        });
+
+        it('creates additional workers up to maxWorkers', () => {
+            pool.assignProject();
+            pool.assignProject();
+            expect(workers).to.be.lengthOf(2);
+        });
+
+        it('reuses the least-loaded worker once maxWorkers is reached', () => {
+            const first = pool.assignProject();
+            const second = pool.assignProject();
+            //maxWorkers is 2, so a third project must be attached to one of the existing workers
+            const third = pool.assignProject();
+            expect(workers).to.be.lengthOf(2);
+            expect([first.worker, second.worker]).to.include(third.worker);
+        });
+
+        it('sends an attachProject message with a transferable port', () => {
+            const { worker, port } = pool.assignProject();
+            const stub = worker.postMessage as sinon.SinonStub;
+            expect(stub.calledOnce).to.be.true;
+            const [message, transferList] = stub.firstCall.args;
+            expect(message.type).to.eql('attachProject');
+            expect(transferList).to.include(message.port);
+            expect(port).to.exist;
+        });
+    });
+
+    describe('releaseProject', () => {
+        it('terminates and removes a worker once its last project is released', () => {
+            const { worker } = pool.assignProject();
+            pool.releaseProject(worker);
+            expect((worker.terminate as sinon.SinonStub).called).to.be.true;
+            expect(pool['workers']).to.be.lengthOf(0);
+        });
+
+        it('keeps a worker alive while it still has other attached projects', () => {
+            pool.maxWorkers = 1;
+            const { worker: workerA } = pool.assignProject();
+            const { worker: workerB } = pool.assignProject();
+            expect(workerA).to.equal(workerB);
+
+            pool.releaseProject(workerA);
+            expect((workerA.terminate as sinon.SinonStub).called).to.be.false;
+            expect(pool['workers']).to.be.lengthOf(1);
+
+            pool.releaseProject(workerA);
+            expect((workerA.terminate as sinon.SinonStub).called).to.be.true;
+            expect(pool['workers']).to.be.lengthOf(0);
+        });
+
+        it('does not crash when releasing an unknown worker', () => {
+            const unknownWorker = {} as Worker;
+            pool.releaseProject(unknownWorker);
         });
     });
 
     describe('dispose', () => {
-        it('does not crash when worker.terminate() fails', () => {
-            const worker = pool.getWorker();
-            worker['terminate'] = () => {
-                throw new Error('Test crash');
-            };
+        it('terminates all workers', () => {
+            pool.assignProject();
+            pool.assignProject();
+            pool.dispose();
+            for (const worker of workers) {
+                expect((worker.terminate as sinon.SinonStub).called).to.be.true;
+            }
+            expect(pool['workers']).to.be.lengthOf(0);
+        });
+
+        it('does not crash when worker.terminate() throws', () => {
+            const { worker } = pool.assignProject();
+            (worker.terminate as sinon.SinonStub).throws(new Error('Test crash'));
             //should not throw error
             pool.dispose();
         });

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -1,5 +1,15 @@
-import type { Worker } from 'worker_threads';
+import { MessageChannel } from 'worker_threads';
+import type { Worker, MessagePort } from 'worker_threads';
 import { createLogger } from '../../logging';
+import * as os from 'os';
+
+interface WorkerEntry {
+    worker: Worker;
+    /**
+     * How many projects currently have a MessagePort attached to this worker
+     */
+    projectCount: number;
+}
 
 export class WorkerPool {
     constructor(
@@ -11,59 +21,94 @@ export class WorkerPool {
     public logger = createLogger();
 
     /**
-     * List of workers that are free to be used by a new task
+     * The maximum number of worker threads (i.e. separate V8 isolates) this pool will create.
+     * Once this limit is reached, additional projects are multiplexed onto existing workers
+     * (each project still gets its own dedicated MessagePort) instead of spawning new threads.
      */
-    private freeWorkers: Worker[] = [];
-    /**
-     * List of all workers that we've ever created
-     */
-    private allWorkers: Worker[] = [];
+    public maxWorkers = Math.max(1, os.cpus().length);
 
     /**
-     * Ensure that there are ${count} workers available in the pool
-     * @param count the number of total free workers that should exist when this function exits
+     * Every worker thread currently in the pool, along with how many projects are attached to it
+     */
+    private workers: WorkerEntry[] = [];
+
+    /**
+     * Create a new worker and add it to the pool
+     */
+    private createWorker(): WorkerEntry {
+        const entry: WorkerEntry = {
+            worker: this.factory(),
+            projectCount: 0
+        };
+        this.workers.push(entry);
+        return entry;
+    }
+
+    /**
+     * Find the worker entry with the fewest attached projects
+     */
+    private getLeastLoadedEntry(): WorkerEntry {
+        return this.workers.reduce(
+            (least, current) => current.projectCount < least.projectCount ? current : least,
+            this.workers[0]
+        );
+    }
+
+    /**
+     * Ensure that there are at least `count` workers created in the pool
+     * @param count the minimum number of workers that should exist when this function exits
      */
     public preload(count: number) {
-        while (this.freeWorkers.length < count) {
-            this.freeWorkers.push(
-                this.createWorker()
-            );
+        while (this.workers.length < count) {
+            this.createWorker();
         }
     }
 
     /**
-     * Create a new worker
+     * Assign a new project to a worker thread. If the pool hasn't yet reached `maxWorkers`, a new worker
+     * is created for this project. Otherwise, the project is attached to the least-loaded existing worker
+     * via its own dedicated `MessagePort`, so multiple projects can share a single worker thread/isolate.
+     * @returns the worker thread hosting this project, and the MessagePort dedicated to it
      */
-    private createWorker() {
-        const worker = this.factory();
-        this.allWorkers.push(worker);
-        return worker;
-    }
-
-    /**
-     * Get a worker from the pool, or create a new one if none are available
-     * @returns a worker
-     */
-    public getWorker() {
-        //we have no free workers. spin up a new one
-        if (this.freeWorkers.length === 0) {
+    public assignProject(): { worker: Worker; port: MessagePort } {
+        let entry: WorkerEntry;
+        if (this.workers.length < this.maxWorkers) {
             this.logger.log('Creating new worker thread');
-            return this.createWorker();
+            entry = this.createWorker();
         } else {
-            //return an existing free worker
             this.logger.log('Reusing existing worker thread');
-            return this.freeWorkers.pop();
+            entry = this.getLeastLoadedEntry();
         }
+        entry.projectCount++;
+
+        const { port1, port2 } = new MessageChannel();
+        entry.worker.postMessage({ type: 'attachProject', port: port2 }, [port2]);
+        return { worker: entry.worker, port: port1 };
     }
 
     /**
-     * Give the worker back to the pool so it can be used by someone else
-     * @param worker the worker
+     * Release a project from its worker. If that worker has no more attached projects, it is
+     * terminated and removed from the pool so its memory can be reclaimed.
+     * @param worker the worker the project was assigned to (from `assignProject()`)
      */
-    public releaseWorker(worker: Worker) {
-        //add this worker back to the free workers list (if it's not already in there)
-        if (!this.freeWorkers.includes(worker)) {
-            this.freeWorkers.push(worker);
+    public releaseProject(worker: Worker) {
+        const index = this.workers.findIndex(x => x.worker === worker);
+        if (index === -1) {
+            return;
+        }
+        const entry = this.workers[index];
+        entry.projectCount--;
+        if (entry.projectCount <= 0) {
+            this.workers.splice(index, 1);
+            this.terminateWorker(worker);
+        }
+    }
+
+    private terminateWorker(worker: Worker) {
+        try {
+            Promise.resolve(worker.terminate()).catch(e => console.error(e));
+        } catch (e) {
+            console.error(e);
         }
     }
 
@@ -71,14 +116,9 @@ export class WorkerPool {
      * Shut down all active worker pools
      */
     public dispose() {
-        for (const worker of this.allWorkers) {
-            try {
-                Promise.resolve(worker.terminate()).catch(e => console.error(e));
-            } catch (e) {
-                console.error(e);
-            }
+        for (const entry of this.workers) {
+            this.terminateWorker(entry.worker);
         }
-        this.allWorkers = [];
-        this.freeWorkers = [];
+        this.workers = [];
     }
 }

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -41,7 +41,22 @@ export class WorkerPool {
             projectCount: 0
         };
         this.workers.push(entry);
+        //if this worker unexpectedly exits, stop tracking it so it can't be selected for future assignments
+        //(and so it doesn't permanently consume one of our `maxWorkers` slots)
+        entry.worker.once('exit', () => this.removeWorker(entry.worker));
         return entry;
+    }
+
+    /**
+     * Stop tracking a worker in this pool. Does NOT terminate the worker (it's assumed to already be gone,
+     * e.g. because it exited/crashed). Safe to call even if the worker is already untracked (e.g. because
+     * `releaseProject()` already removed it as part of an intentional shutdown).
+     */
+    private removeWorker(worker: Worker) {
+        const index = this.workers.findIndex(x => x.worker === worker);
+        if (index > -1) {
+            this.workers.splice(index, 1);
+        }
     }
 
     /**
@@ -59,25 +74,33 @@ export class WorkerPool {
      * @param count the minimum number of workers that should exist when this function exits
      */
     public preload(count: number) {
-        while (this.workers.length < count) {
+        while (this.workers.length < Math.min(count, this.maxWorkers)) {
             this.createWorker();
         }
     }
 
     /**
-     * Assign a new project to a worker thread. If the pool hasn't yet reached `maxWorkers`, a new worker
-     * is created for this project. Otherwise, the project is attached to the least-loaded existing worker
-     * via its own dedicated `MessagePort`, so multiple projects can share a single worker thread/isolate.
+     * Assign a new project to a worker thread. Prefers reusing an existing idle (zero-project) worker
+     * (e.g. one created via `preload()`). If none is available and the pool hasn't yet reached `maxWorkers`,
+     * a new worker is created for this project. Otherwise, the project is attached to the least-loaded
+     * existing worker via its own dedicated `MessagePort`, so multiple projects can share a single worker
+     * thread/isolate.
      * @returns the worker thread hosting this project, and the MessagePort dedicated to it
      */
     public assignProject(): { worker: Worker; port: MessagePort } {
-        let entry: WorkerEntry;
-        if (this.workers.length < this.maxWorkers) {
-            this.logger.log('Creating new worker thread');
-            entry = this.createWorker();
+        let entry = this.workers.find(x => x.projectCount === 0);
+        if (!entry) {
+            //`this.workers.length === 0` is included so a nonsensical `maxWorkers` (0, negative, NaN) can never
+            //leave the pool permanently stuck with zero workers
+            if (this.workers.length === 0 || this.workers.length < this.maxWorkers) {
+                this.logger.log('Creating new worker thread');
+                entry = this.createWorker();
+            } else {
+                this.logger.log('Reusing existing worker thread');
+                entry = this.getLeastLoadedEntry();
+            }
         } else {
-            this.logger.log('Reusing existing worker thread');
-            entry = this.getLeastLoadedEntry();
+            this.logger.log('Reusing preloaded/idle worker thread');
         }
         entry.projectCount++;
 

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -49,7 +49,7 @@ export class WorkerPool {
      */
     private getLeastLoadedEntry(): WorkerEntry {
         return this.workers.reduce(
-            (least, current) => current.projectCount < least.projectCount ? current : least,
+            (least, current) => (current.projectCount < least.projectCount ? current : least),
             this.workers[0]
         );
     }

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -41,8 +41,7 @@ export class WorkerPool {
             projectCount: 0
         };
         this.workers.push(entry);
-        //if this worker unexpectedly exits, stop tracking it so it can't be selected for future assignments
-        //(and so it doesn't permanently consume one of our `maxWorkers` slots)
+        //stop tracking a worker once it unexpectedly exits, so it can't be reused and doesn't consume a maxWorkers slot forever
         entry.worker.once('exit', () => this.removeWorker(entry.worker));
         return entry;
     }
@@ -90,8 +89,7 @@ export class WorkerPool {
     public assignProject(): { worker: Worker; port: MessagePort } {
         let entry = this.workers.find(x => x.projectCount === 0);
         if (!entry) {
-            //`this.workers.length === 0` is included so a nonsensical `maxWorkers` (0, negative, NaN) can never
-            //leave the pool permanently stuck with zero workers
+            //the `=== 0` check guards against a nonsensical maxWorkers (0, negative, NaN) stranding the pool at zero workers
             if (this.workers.length === 0 || this.workers.length < this.maxWorkers) {
                 this.logger.log('Creating new worker thread');
                 entry = this.createWorker();

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -5,6 +5,29 @@ import { DiagnosticMessages } from '../../DiagnosticMessages';
 import { expect } from '../../chai-config.spec';
 import util from '../../util';
 
+/**
+ * Ensure at least `count` workers exist in the shared `workerPool`, and wait until any newly-created ones have
+ * actually finished booting (loaded ts-node/register and registered their message listener - see `run.ts`'s
+ * `{ type: 'ready' }` postMessage) before resolving. `WorkerPool.preload()` itself returns as soon as the
+ * underlying `Worker` object is constructed, which is NOT the same as the worker being able to do anything yet:
+ * spinning up a real OS thread + ts-node bootstrap can take anywhere from milliseconds locally to 15+ seconds on
+ * slower CI hardware. Without this wait, a "preloaded" worker handed to the next test via `assignProject()`'s
+ * idle-worker-reuse can still be mid-boot, and that test's own timeout can expire before the worker ever responds.
+ */
+export async function preloadAndWaitUntilReady(count: number) {
+    const before = workerPool['workers'].length;
+    workerPool.preload(count);
+    const newEntries = workerPool['workers'].slice(before);
+    await Promise.all(newEntries.map(entry => new Promise<void>((resolve) => {
+        entry.worker.on('message', function onMessage(message: { type: string }) {
+            if (message?.type === 'ready') {
+                entry.worker.off('message', onMessage);
+                resolve();
+            }
+        });
+    })));
+}
+
 export async function wakeWorkerThread() {
     console.log('waking up a worker thread');
     const project = new WorkerThreadProject();
@@ -17,7 +40,7 @@ export async function wakeWorkerThread() {
         project.dispose();
         //keep a spare worker warm and ready so subsequent real-worker-thread tests in this run don't each pay
         //the cost of a cold worker-thread + ts-node/register bootstrap (which can take 15+ seconds on slower CI hardware)
-        workerPool.preload(1);
+        await preloadAndWaitUntilReady(1);
     }
 }
 
@@ -46,11 +69,12 @@ describe('WorkerThreadProject', () => {
         fsExtra.emptyDirSync(tempDir);
     });
 
-    afterEach(() => {
+    afterEach(async function keepWorkerPoolWarm() {
+        this.timeout(15_000);
         fsExtra.emptyDirSync(tempDir);
         project?.dispose();
-        //keep a spare worker warm for the next test (see wakeWorkerThread() for why)
-        workerPool.preload(1);
+        //keep a spare worker warm for the next test (see preloadAndWaitUntilReady() for why)
+        await preloadAndWaitUntilReady(1);
     });
 
     describe('activate', () => {

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -52,6 +52,17 @@ export function getWakeWorkerThreadPromise() {
     return wakeWorkerThreadPromise1;
 }
 
+//Kick off the worker warmup as early as possible - at module-load time, before ANY test in the whole suite runs -
+//instead of waiting until this describe block's `before` hook is reached. Mocha `require()`s every matching spec
+//file up front before running anything, so this fires essentially at time zero of the whole process. By the time
+//execution actually reaches `workerThreadWarmup` below (potentially thousands of unrelated tests later), the real
+//OS thread + ts-node/register bootstrap this depends on has usually already finished in the background, overlapping
+//with everything that ran before it instead of adding its own cold-boot cost on top. The `before` hook still awaits
+//the same (memoized) promise for correctness and to surface any real error as a normal test failure.
+void getWakeWorkerThreadPromise().catch(() => {
+    //intentionally ignored here - the `before` hook's own `await` surfaces the real error
+});
+
 after(() => {
     workerPool.dispose();
 });

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -6,13 +6,8 @@ import { expect } from '../../chai-config.spec';
 import util from '../../util';
 
 /**
- * Ensure at least `count` workers exist in the shared `workerPool`, and wait until any newly-created ones have
- * actually finished booting (loaded ts-node/register and registered their message listener - see `run.ts`'s
- * `{ type: 'ready' }` postMessage) before resolving. `WorkerPool.preload()` itself returns as soon as the
- * underlying `Worker` object is constructed, which is NOT the same as the worker being able to do anything yet:
- * spinning up a real OS thread + ts-node bootstrap can take anywhere from milliseconds locally to 15+ seconds on
- * slower CI hardware. Without this wait, a "preloaded" worker handed to the next test via `assignProject()`'s
- * idle-worker-reuse can still be mid-boot, and that test's own timeout can expire before the worker ever responds.
+ * Ensure at least `count` workers exist in `workerPool`, waiting for any newly-created ones to signal readiness
+ * (see `run.ts`'s `{ type: 'ready' }` message) - `WorkerPool.preload()` alone returns before the worker can do anything.
  */
 export async function preloadAndWaitUntilReady(count: number) {
     const before = workerPool['workers'].length;
@@ -38,8 +33,7 @@ export async function wakeWorkerThread() {
         } as any);
     } finally {
         project.dispose();
-        //keep a spare worker warm and ready so subsequent real-worker-thread tests in this run don't each pay
-        //the cost of a cold worker-thread + ts-node/register bootstrap (which can take 15+ seconds on slower CI hardware)
+        //keep a spare worker warm so subsequent real-worker-thread tests skip the cold-boot cost
         await preloadAndWaitUntilReady(1);
     }
 }
@@ -52,13 +46,8 @@ export function getWakeWorkerThreadPromise() {
     return wakeWorkerThreadPromise1;
 }
 
-//Kick off the worker warmup as early as possible - at module-load time, before ANY test in the whole suite runs -
-//instead of waiting until this describe block's `before` hook is reached. Mocha `require()`s every matching spec
-//file up front before running anything, so this fires essentially at time zero of the whole process. By the time
-//execution actually reaches `workerThreadWarmup` below (potentially thousands of unrelated tests later), the real
-//OS thread + ts-node/register bootstrap this depends on has usually already finished in the background, overlapping
-//with everything that ran before it instead of adding its own cold-boot cost on top. The `before` hook still awaits
-//the same (memoized) promise for correctness and to surface any real error as a normal test failure.
+//kick off the worker warmup at module-load time (mocha requires all spec files before running any test), so its
+//cold-boot cost overlaps with everything that runs before workerThreadWarmup's `before` hook awaits it below
 void getWakeWorkerThreadPromise().catch(() => {
     //intentionally ignored here - the `before` hook's own `await` surfaces the real error
 });
@@ -70,13 +59,7 @@ after(() => {
 describe('WorkerThreadProject', () => {
     let project: WorkerThreadProject;
 
-    //A persistent project that's never disposed until this whole describe block finishes. Its sole purpose is to
-    //hold a permanent tenant slot on the shared worker, so `WorkerPool`'s "terminate the worker once its last
-    //tenant releases" policy never actually fires between individual tests in this file: each test's own
-    //project(s) come and go freely, but this one keeps the underlying worker itself alive throughout, avoiding a
-    //real ~1-2s reboot (or 15+ seconds on slower CI hardware) between every single real-worker-thread test. Forcing
-    //`maxWorkers = 1` ensures every project activated in this file lands on that same one worker instead of
-    //spreading across several.
+    //holds a permanent tenant slot on the shared worker so it never hits zero tenants (and gets terminated) between tests
     let keepAliveProject: WorkerThreadProject;
 
     before(async function workerThreadWarmup() {
@@ -92,8 +75,7 @@ describe('WorkerThreadProject', () => {
     });
 
     after(() => {
-        //dispose cleanly here (rather than relying solely on the module-level workerPool.dispose() below) so this
-        //doesn't log a spurious "worker thread crashed unexpectedly" critical-failure when the pool tears down
+        //dispose explicitly to avoid a spurious "worker crashed" log when workerPool.dispose() tears it down instead
         keepAliveProject?.dispose();
     });
 
@@ -104,10 +86,7 @@ describe('WorkerThreadProject', () => {
     });
 
     afterEach(async function keepWorkerPoolWarm() {
-        //a fresh worker's cold boot (real OS thread + ts-node/register bootstrap) can take up to the same order of
-        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget.
-        //`keepAliveProject` above should make this a no-op in the common case; this is a defensive fallback in
-        //case something disposes it or the pool ends up empty unexpectedly.
+        //defensive fallback in case keepAliveProject didn't prevent the pool from emptying; give it a cold-boot-sized budget
         this.timeout(60_000);
         fsExtra.emptyDirSync(tempDir);
         project?.dispose();

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -156,5 +156,105 @@ describe('WorkerThreadProject', () => {
                 projectB.dispose();
             }
         });
+
+        it('leaves the surviving co-tenant project functional after the other one is disposed', async () => {
+            workerPool.maxWorkers = 1;
+
+            fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
+                sub main()
+                    print "project A"
+                end sub
+            `);
+            const rootDirB = `${tempDir}/projectB`;
+            fsExtra.outputFileSync(`${rootDirB}/source/main.brs`, `
+                sub main()
+                    print varNotThere
+                end sub
+            `);
+
+            const projectB = new WorkerThreadProject();
+            try {
+                await project.activate({
+                    projectKey: undefined,
+                    projectDir: rootDir,
+                    workspaceFolder: rootDir,
+                    bsconfigPath: undefined,
+                    projectNumber: 1
+                });
+                await projectB.activate({
+                    projectKey: undefined,
+                    projectDir: rootDirB,
+                    workspaceFolder: rootDirB,
+                    bsconfigPath: undefined,
+                    projectNumber: 2
+                });
+
+                //both projects should be sharing the same (single) worker thread
+                expect(workerPool['workers']).to.be.lengthOf(1);
+
+                //dispose project A only. project B (and the shared worker) should keep working.
+                project.dispose();
+
+                await projectB.validate();
+                const diagnosticsB = await projectB.getDiagnostics();
+                expect(diagnosticsB).to.be.lengthOf(1);
+                await expectDiagnosticsAsync(diagnosticsB, [
+                    DiagnosticMessages.cannotFindName('varNotThere').message
+                ]);
+            } finally {
+                projectB.dispose();
+            }
+        });
+
+        it('leaves the surviving co-tenant project functional even if the other one is disposed twice', async () => {
+            workerPool.maxWorkers = 1;
+
+            fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
+                sub main()
+                    print "project A"
+                end sub
+            `);
+            const rootDirB = `${tempDir}/projectB`;
+            fsExtra.outputFileSync(`${rootDirB}/source/main.brs`, `
+                sub main()
+                    print varNotThere
+                end sub
+            `);
+
+            const projectB = new WorkerThreadProject();
+            try {
+                await project.activate({
+                    projectKey: undefined,
+                    projectDir: rootDir,
+                    workspaceFolder: rootDir,
+                    bsconfigPath: undefined,
+                    projectNumber: 1
+                });
+                await projectB.activate({
+                    projectKey: undefined,
+                    projectDir: rootDirB,
+                    workspaceFolder: rootDirB,
+                    bsconfigPath: undefined,
+                    projectNumber: 2
+                });
+
+                //both projects should be sharing the same (single) worker thread
+                expect(workerPool['workers']).to.be.lengthOf(1);
+
+                //simulate the double-dispose pattern used by this file's beforeEach/afterEach hooks
+                project.dispose();
+                project.dispose();
+
+                //project B (and the shared worker) should still be alive and functional
+                await projectB.validate();
+                const diagnosticsB = await projectB.getDiagnostics();
+                expect(diagnosticsB).to.be.lengthOf(1);
+                await expectDiagnosticsAsync(diagnosticsB, [
+                    DiagnosticMessages.cannotFindName('varNotThere').message
+                ]);
+            } finally {
+                projectB.dispose();
+            }
+        });
     });
 });

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -69,9 +69,32 @@ after(() => {
 
 describe('WorkerThreadProject', () => {
     let project: WorkerThreadProject;
+
+    //A persistent project that's never disposed until this whole describe block finishes. Its sole purpose is to
+    //hold a permanent tenant slot on the shared worker, so `WorkerPool`'s "terminate the worker once its last
+    //tenant releases" policy never actually fires between individual tests in this file: each test's own
+    //project(s) come and go freely, but this one keeps the underlying worker itself alive throughout, avoiding a
+    //real ~1-2s reboot (or 15+ seconds on slower CI hardware) between every single real-worker-thread test. Forcing
+    //`maxWorkers = 1` ensures every project activated in this file lands on that same one worker instead of
+    //spreading across several.
+    let keepAliveProject: WorkerThreadProject;
+
     before(async function workerThreadWarmup() {
         this.timeout(60_000);
         await getWakeWorkerThreadPromise();
+
+        workerPool.maxWorkers = 1;
+        keepAliveProject = new WorkerThreadProject();
+        await keepAliveProject.activate({
+            projectPath: rootDir,
+            projectNumber: 0
+        } as any);
+    });
+
+    after(() => {
+        //dispose cleanly here (rather than relying solely on the module-level workerPool.dispose() below) so this
+        //doesn't log a spurious "worker thread crashed unexpectedly" critical-failure when the pool tears down
+        keepAliveProject?.dispose();
     });
 
     beforeEach(() => {
@@ -82,11 +105,12 @@ describe('WorkerThreadProject', () => {
 
     afterEach(async function keepWorkerPoolWarm() {
         //a fresh worker's cold boot (real OS thread + ts-node/register bootstrap) can take up to the same order of
-        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget
+        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget.
+        //`keepAliveProject` above should make this a no-op in the common case; this is a defensive fallback in
+        //case something disposes it or the pool ends up empty unexpectedly.
         this.timeout(60_000);
         fsExtra.emptyDirSync(tempDir);
         project?.dispose();
-        //keep a spare worker warm for the next test (see preloadAndWaitUntilReady() for why)
         await preloadAndWaitUntilReady(1);
     });
 

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -2,7 +2,7 @@ import { tempDir, rootDir, expectDiagnosticsAsync } from '../../testHelpers.spec
 import * as fsExtra from 'fs-extra';
 import { WorkerThreadProject, workerPool } from './WorkerThreadProject';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
-import { expect } from 'chai';
+import { expect } from '../../chai-config.spec';
 import util from '../../util';
 
 export async function wakeWorkerThread() {
@@ -49,7 +49,8 @@ describe('WorkerThreadProject', () => {
     });
 
     describe('activate', () => {
-        it('shows diagnostics after running', async () => {
+        it('shows diagnostics after running', async function () {
+            this.timeout(15_000);
             fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
                 sub main()
                     print varNotThere
@@ -108,7 +109,8 @@ describe('WorkerThreadProject', () => {
             workerPool.maxWorkers = originalMaxWorkers;
         });
 
-        it('allows multiple projects to share a single worker thread when capped', async () => {
+        it('allows multiple projects to share a single worker thread when capped', async function () {
+            this.timeout(15_000);
             workerPool.maxWorkers = 1;
 
             fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
@@ -157,7 +159,8 @@ describe('WorkerThreadProject', () => {
             }
         });
 
-        it('leaves the surviving co-tenant project functional after the other one is disposed', async () => {
+        it('leaves the surviving co-tenant project functional after the other one is disposed', async function () {
+            this.timeout(15_000);
             workerPool.maxWorkers = 1;
 
             fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
@@ -206,7 +209,8 @@ describe('WorkerThreadProject', () => {
             }
         });
 
-        it('leaves the surviving co-tenant project functional even if the other one is disposed twice', async () => {
+        it('leaves the surviving co-tenant project functional even if the other one is disposed twice', async function () {
+            this.timeout(15_000);
             workerPool.maxWorkers = 1;
 
             fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -46,12 +46,6 @@ export function getWakeWorkerThreadPromise() {
     return wakeWorkerThreadPromise1;
 }
 
-//kick off the worker warmup at module-load time (mocha requires all spec files before running any test), so its
-//cold-boot cost overlaps with everything that runs before workerThreadWarmup's `before` hook awaits it below
-void getWakeWorkerThreadPromise().catch(() => {
-    //intentionally ignored here - the `before` hook's own `await` surfaces the real error
-});
-
 after(() => {
     workerPool.dispose();
 });

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -3,6 +3,7 @@ import * as fsExtra from 'fs-extra';
 import { WorkerThreadProject, workerPool } from './WorkerThreadProject';
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import { expect } from 'chai';
+import util from '../../util';
 
 export async function wakeWorkerThread() {
     console.log('waking up a worker thread');
@@ -68,6 +69,92 @@ describe('WorkerThreadProject', () => {
             await expectDiagnosticsAsync(diagnostics, [
                 DiagnosticMessages.cannotFindName('varNotThere').message
             ]);
+        });
+    });
+
+    describe('handleWorkerExit', () => {
+        it('emits critical-failure when the worker exits unexpectedly', async () => {
+            const failures: Array<{ message: string }> = [];
+            project.on('critical-failure', (data) => failures.push(data));
+
+            project['handleWorkerExit'](1);
+            //emit() fires on next tick
+            await util.sleep(0);
+
+            expect(failures).to.be.lengthOf(1);
+            expect(failures[0].message).to.include('crashed unexpectedly');
+        });
+
+        it('does not emit critical-failure once the project has been disposed', async () => {
+            const failures: Array<{ message: string }> = [];
+            project.on('critical-failure', (data) => failures.push(data));
+
+            project['isDisposed'] = true;
+            project['handleWorkerExit'](1);
+            await util.sleep(0);
+
+            expect(failures).to.be.lengthOf(0);
+        });
+    });
+
+    describe('worker sharing', () => {
+        let originalMaxWorkers: number;
+
+        beforeEach(() => {
+            originalMaxWorkers = workerPool.maxWorkers;
+        });
+
+        afterEach(() => {
+            workerPool.maxWorkers = originalMaxWorkers;
+        });
+
+        it('allows multiple projects to share a single worker thread when capped', async () => {
+            workerPool.maxWorkers = 1;
+
+            fsExtra.outputFileSync(`${rootDir}/source/main.brs`, `
+                sub main()
+                    print "project A"
+                end sub
+            `);
+            const rootDirB = `${tempDir}/projectB`;
+            fsExtra.outputFileSync(`${rootDirB}/source/main.brs`, `
+                sub main()
+                    print varNotThere
+                end sub
+            `);
+
+            const projectB = new WorkerThreadProject();
+            try {
+                await project.activate({
+                    projectKey: undefined,
+                    projectDir: rootDir,
+                    workspaceFolder: rootDir,
+                    bsconfigPath: undefined,
+                    projectNumber: 1
+                });
+                await projectB.activate({
+                    projectKey: undefined,
+                    projectDir: rootDirB,
+                    workspaceFolder: rootDirB,
+                    bsconfigPath: undefined,
+                    projectNumber: 2
+                });
+
+                //both projects should be sharing the same (single) worker thread
+                expect(workerPool['workers']).to.be.lengthOf(1);
+
+                await project.validate();
+                await projectB.validate();
+
+                expect(await project.getDiagnostics()).to.be.lengthOf(0);
+                const diagnosticsB = await projectB.getDiagnostics();
+                expect(diagnosticsB).to.be.lengthOf(1);
+                await expectDiagnosticsAsync(diagnosticsB, [
+                    DiagnosticMessages.cannotFindName('varNotThere').message
+                ]);
+            } finally {
+                projectB.dispose();
+            }
         });
     });
 });

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -70,7 +70,9 @@ describe('WorkerThreadProject', () => {
     });
 
     afterEach(async function keepWorkerPoolWarm() {
-        this.timeout(15_000);
+        //a fresh worker's cold boot (real OS thread + ts-node/register bootstrap) can take up to the same order of
+        //magnitude as workerThreadWarmup's own 60s allowance on slower CI hardware - give this the same budget
+        this.timeout(60_000);
         fsExtra.emptyDirSync(tempDir);
         project?.dispose();
         //keep a spare worker warm for the next test (see preloadAndWaitUntilReady() for why)

--- a/src/lsp/worker/WorkerThreadProject.spec.ts
+++ b/src/lsp/worker/WorkerThreadProject.spec.ts
@@ -15,6 +15,9 @@ export async function wakeWorkerThread() {
         } as any);
     } finally {
         project.dispose();
+        //keep a spare worker warm and ready so subsequent real-worker-thread tests in this run don't each pay
+        //the cost of a cold worker-thread + ts-node/register bootstrap (which can take 15+ seconds on slower CI hardware)
+        workerPool.preload(1);
     }
 }
 
@@ -46,6 +49,8 @@ describe('WorkerThreadProject', () => {
     afterEach(() => {
         fsExtra.emptyDirSync(tempDir);
         project?.dispose();
+        //keep a spare worker warm for the next test (see wakeWorkerThread() for why)
+        workerPool.preload(1);
     });
 
     describe('activate', () => {

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -1,5 +1,6 @@
 import * as EventEmitter from 'eventemitter3';
 import { Worker } from 'worker_threads';
+import type { MessagePort } from 'worker_threads';
 import type { WorkerMessage } from './MessageHandler';
 import { MessageHandler } from './MessageHandler';
 import util from '../../util';
@@ -65,11 +66,14 @@ export class WorkerThreadProject implements LspProject {
         this.workspaceFolder = options.workspaceFolder ? util.standardizePath(options.workspaceFolder) : options.workspaceFolder;
         this.projectNumber = options.projectNumber;
 
-        // start a new worker thread or get an unused existing thread
-        this.worker = workerPool.getWorker();
+        // get a dedicated MessagePort on a (possibly shared) worker thread
+        const assignment = workerPool.assignProject();
+        this.worker = assignment.worker;
+        this.port = assignment.port;
+        this.worker.on('exit', this.handleWorkerExit);
         this.messageHandler = new MessageHandler<LspProject>({
             name: 'MainThread',
-            port: this.worker,
+            port: this.port,
             onRequest: this.processRequest.bind(this),
             onUpdate: this.processUpdate.bind(this)
         });
@@ -149,9 +153,34 @@ export class WorkerThreadProject implements LspProject {
     manifestSrcPath?: string;
 
     /**
-     * The worker thread where the actual project will execute
+     * The worker thread where the actual project will execute. May be shared with other projects.
      */
     private worker: Worker;
+
+    /**
+     * This project's dedicated MessagePort on `worker`, used for all request/response/update traffic
+     */
+    private port: MessagePort;
+
+    /**
+     * True once `dispose()` has run. Used to distinguish an intentional worker shutdown from an unexpected crash.
+     */
+    private isDisposed = false;
+
+    /**
+     * Called if this project's worker thread exits. If we didn't cause that ourselves via `dispose()`,
+     * treat it as a critical failure so the user finds out instead of every request just hanging forever.
+     */
+    private handleWorkerExit = (code: number) => {
+        if (this.isDisposed) {
+            return;
+        }
+        this.logger.error(`Worker thread for project #${this.projectNumber} exited unexpectedly with code ${code}`);
+        //emit() is async (it schedules on next tick); this handler can't be async since it's an EventEmitter callback, so void it per project convention
+        void this.emit('critical-failure', {
+            message: `The BrighterScript language server's worker thread crashed unexpectedly (exit code ${code}). This project (and any others sharing its worker thread) will stop responding until the language server is reloaded.`
+        });
+    };
 
     /**
      * Path to the project. For directory-only projects, this is the path to the dir. For bsconfig.json projects, this is the path to the config.
@@ -325,14 +354,18 @@ export class WorkerThreadProject implements LspProject {
     public disposables: LspProject['disposables'] = [];
 
     public dispose() {
+        this.isDisposed = true;
+        this.worker?.off('exit', this.handleWorkerExit);
+
         for (let disposable of this.disposables ?? []) {
             disposable?.dispose?.();
         }
         this.disposables = [];
 
-        //move the worker back to the pool so it can be used again
+        //close our dedicated port and release our slot on the worker (which terminates the worker if it's now empty)
+        this.port?.close();
         if (this.worker) {
-            workerPool.releaseWorker(this.worker);
+            workerPool.releaseProject(this.worker);
         }
         this.emitter?.removeAllListeners();
     }

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -180,6 +180,9 @@ export class WorkerThreadProject implements LspProject {
         void this.emit('critical-failure', {
             message: `The BrighterScript language server's worker thread crashed unexpectedly (exit code ${code}). This project (and any others sharing its worker thread) will stop responding until the language server is reloaded.`
         });
+        //the worker is gone, so any in-flight requests will never get a response. Dispose the message handler
+        //so it rejects those pending requests instead of leaving callers hanging forever.
+        this.messageHandler?.dispose();
     };
 
     /**
@@ -354,6 +357,9 @@ export class WorkerThreadProject implements LspProject {
     public disposables: LspProject['disposables'] = [];
 
     public dispose() {
+        if (this.isDisposed) {
+            return;
+        }
         this.isDisposed = true;
         this.worker?.off('exit', this.handleWorkerExit);
 

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -178,7 +178,7 @@ export class WorkerThreadProject implements LspProject {
         this.logger.error(`Worker thread for project #${this.projectNumber} exited unexpectedly with code ${code}`);
         //emit() is async; this handler can't be, so void it
         void this.emit('critical-failure', {
-            message: `The BrighterScript language server's worker thread crashed unexpectedly (exit code ${code}). This project (and any others sharing its worker thread) will stop responding until the language server is reloaded.`
+            message: `The BrighterScript language server's worker thread crashed unexpectedly (exit code ${code}). This project (and any others sharing its worker thread) will stop responding until the language server is reloaded - there is currently no automatic recovery for a crashed worker thread.`
         });
         //reject any in-flight requests instead of leaving callers hanging forever on a worker that's gone
         this.messageHandler?.dispose();

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -176,12 +176,11 @@ export class WorkerThreadProject implements LspProject {
             return;
         }
         this.logger.error(`Worker thread for project #${this.projectNumber} exited unexpectedly with code ${code}`);
-        //emit() is async (it schedules on next tick); this handler can't be async since it's an EventEmitter callback, so void it per project convention
+        //emit() is async; this handler can't be, so void it
         void this.emit('critical-failure', {
             message: `The BrighterScript language server's worker thread crashed unexpectedly (exit code ${code}). This project (and any others sharing its worker thread) will stop responding until the language server is reloaded.`
         });
-        //the worker is gone, so any in-flight requests will never get a response. Dispose the message handler
-        //so it rejects those pending requests instead of leaving callers hanging forever.
+        //reject any in-flight requests instead of leaving callers hanging forever on a worker that's gone
         this.messageHandler?.dispose();
     };
 

--- a/src/lsp/worker/WorkerThreadProjectRunner.ts
+++ b/src/lsp/worker/WorkerThreadProjectRunner.ts
@@ -45,9 +45,7 @@ export class WorkerThreadProjectRunner {
 
         this.requestInterceptors.activate = this.onActivate.bind(this);
 
-        //when this project's dedicated port is closed (either because the main thread called `.dispose()`
-        //on this project, or the whole channel was otherwise torn down), clean up this project's Program/Project
-        //instance even though the worker thread itself (and any other projects sharing it) keeps running.
+        //dispose this project's Program when its dedicated port closes, even though the shared worker keeps running
         parentPort.on('close', () => {
             this.project?.dispose();
             this.messageHandler?.dispose();

--- a/src/lsp/worker/WorkerThreadProjectRunner.ts
+++ b/src/lsp/worker/WorkerThreadProjectRunner.ts
@@ -44,6 +44,14 @@ export class WorkerThreadProjectRunner {
         });
 
         this.requestInterceptors.activate = this.onActivate.bind(this);
+
+        //when this project's dedicated port is closed (either because the main thread called `.dispose()`
+        //on this project, or the whole channel was otherwise torn down), clean up this project's Program/Project
+        //instance even though the worker thread itself (and any other projects sharing it) keeps running.
+        parentPort.on('close', () => {
+            this.project?.dispose();
+            this.messageHandler?.dispose();
+        });
     }
 
     /**

--- a/src/lsp/worker/run.ts
+++ b/src/lsp/worker/run.ts
@@ -1,12 +1,23 @@
 /**
  * This script is the entry point for worker threads that run LSP Projects.
- * It sets up the WorkerThreadProjectRunner to handle messages from the main thread.
+ *
+ * A worker thread can host multiple projects at once (see `WorkerPool.assignProject()`): each project
+ * gets its own dedicated `MessagePort`, delivered to this worker as an `attachProject` message on
+ * `parentPort`. For every such message, we spin up a new `WorkerThreadProjectRunner` bound to that
+ * project's port, so each project's request/response traffic stays fully independent even though they
+ * share this worker's JS realm (and its module-level caches).
  */
 import { parentPort } from 'worker_threads';
+import type { MessagePort } from 'worker_threads';
 import { WorkerThreadProjectRunner } from './WorkerThreadProjectRunner';
 
-const runner = new WorkerThreadProjectRunner();
 if (!parentPort) {
     throw new Error('This script must be run as a worker thread');
 }
-runner.run(parentPort);
+
+parentPort.on('message', (message: { type: string; port: MessagePort }) => {
+    if (message?.type === 'attachProject') {
+        const runner = new WorkerThreadProjectRunner();
+        runner.run(message.port);
+    }
+});

--- a/src/lsp/worker/run.ts
+++ b/src/lsp/worker/run.ts
@@ -27,9 +27,5 @@ parentPort.on('message', (message: { type: string; port: MessagePort }) => {
     }
 });
 
-//let the main thread know this worker has finished booting (loaded ts-node/register and registered its message
-//listener) and is actually ready to receive `attachProject` messages. Spinning up a brand new worker thread involves
-//real OS thread creation plus a `ts-node/register` bootstrap, which can take anywhere from milliseconds to tens of
-//seconds depending on the machine - this signal lets callers (see WorkerPool) distinguish "the Worker object exists"
-//from "the worker can actually do anything yet".
+//tell the main thread this worker has booted and is actually ready to receive `attachProject` messages (see WorkerPool)
 parentPort.postMessage({ type: 'ready' });

--- a/src/lsp/worker/run.ts
+++ b/src/lsp/worker/run.ts
@@ -26,3 +26,10 @@ parentPort.on('message', (message: { type: string; port: MessagePort }) => {
         }
     }
 });
+
+//let the main thread know this worker has finished booting (loaded ts-node/register and registered its message
+//listener) and is actually ready to receive `attachProject` messages. Spinning up a brand new worker thread involves
+//real OS thread creation plus a `ts-node/register` bootstrap, which can take anywhere from milliseconds to tens of
+//seconds depending on the machine - this signal lets callers (see WorkerPool) distinguish "the Worker object exists"
+//from "the worker can actually do anything yet".
+parentPort.postMessage({ type: 'ready' });

--- a/src/lsp/worker/run.ts
+++ b/src/lsp/worker/run.ts
@@ -17,7 +17,12 @@ if (!parentPort) {
 
 parentPort.on('message', (message: { type: string; port: MessagePort }) => {
     if (message?.type === 'attachProject') {
-        const runner = new WorkerThreadProjectRunner();
-        runner.run(message.port);
+        try {
+            const runner = new WorkerThreadProjectRunner();
+            runner.run(message.port);
+        } catch (e) {
+            //don't let one project's setup failure crash this worker thread and take down every other project sharing it
+            console.error('Failed to attach project to worker thread', e);
+        }
     }
 });


### PR DESCRIPTION
## Problem

Opening a multi-root VSCode workspace with many BrighterScript projects (e.g. ~15+, as in `brighterscript-game-engine`'s 17 `bsconfig.json` files) can crash the language server with an out-of-memory error.

Root cause: `LanguageServer.enableThreadingDefault` defaults to `true`, and `ProjectManager` spawns one dedicated OS worker thread (a full separate V8 isolate) per project via `WorkerPool.getWorker()`, which had no cap — it always created a new worker if none were free, and a worker was only returned to the pool when its project was disposed (which doesn't happen for open, in-use projects during a normal session). Each isolate independently loads the whole `brighterscript` module graph (`roku-types` static data, `globalCallables`, type caches, etc.), so total memory scaled roughly linearly with project count, multiplying fixed interpreter/type-system overhead by N.

## Fix

Replaces `WorkerPool`'s exclusive one-worker-per-project model with a capped, load-aware assignment model:

- `WorkerPool` now has a configurable `maxWorkers` (default `os.cpus().length`). Each project still gets its own `Project`/`Program` instance and its own dedicated `MessagePort` (via `MessageChannel`), but once the cap is reached, additional projects' ports are attached to an existing worker instead of spawning a new one.
- Co-located projects share that worker's JS realm, recovering cross-project sharing of the big fixed-cost singletons that per-project threading had made impossible to share.
- A worker is terminated and dropped from the pool as soon as its last attached project releases it, so memory is reclaimed promptly rather than kept warm indefinitely.
- New `languageServer.maxProjectWorkers` setting, mirroring the existing `projectActivationConcurrencyLimit` pattern, so this is tunable per-workspace.
- An unexpected worker exit now surfaces a `critical-failure` notification (previously: requests on that worker would hang forever with no signal to the user).
- Worker lifecycle edge cases handled: idempotent dispose (a project can be disposed more than once without side effects on sibling projects sharing its worker), a crashed worker is evicted from the pool's bookkeeping (so it can't silently swallow a future project's bootstrap), `preload()`/`assignProject()` agree on the cap, and `assignProject()` defends against a misconfigured `maxWorkers <= 0`.

## Testing

- New/updated unit tests in `WorkerPool.spec.ts`, `WorkerThreadProject.spec.ts` (including real-worker-thread integration tests proving multiple projects can share one worker while remaining functionally independent, and that a co-tenant surviving a sibling's dispose/double-dispose keeps working), `MessageHandler.spec.ts`, and `LanguageServer.spec.ts`.
- Full suite: 3001 passing, 0 failing. `npm run lint` and `npm run build` clean.
- Not automated: real-world confirmation against `brighterscript-game-engine`'s multi-project workspace in VSCode (recommended as a manual follow-up check).

## Notes for reviewers

- This targets `master` (not `v1`) because the affected code (`src/lsp/worker/*`) is currently identical between the two branches — landing here first means it flows to `v1` on the next `master` merge, rather than requiring a manual backport.
- Scoped out of this PR: the separate `Program.ts` cache-leak fixes identified during investigation (`fileClusters`, `getFilePathCache`, `symbolDependencies`, `util.ts` path caches never pruned) — smaller, unrelated issue, tracked separately.
- Also scoped out: automatic reload of sibling projects when a shared worker crashes — no existing mechanism reloads a project on `critical-failure` today; this PR keeps that event's existing one-way-notification behavior rather than introducing new reload semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)