### PR TITLE
Add warning for function names that exceed the truncation limit

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -833,6 +833,16 @@ export let DiagnosticMessages = {
         message: `rsg_version=${rsgVersion} was removed in firmware ${removedAt}; use rsg_version=${replacement}`,
         code: 1154,
         severity: DiagnosticSeverity.Error
+    }),
+    /**
+     * @param name the full name of the function, including namespace
+     * @param length the actual length of `name`
+     * @param maxLength the maximum length a function name may be before it gets truncated by the device at runtime
+     */
+    functionNameTooLong: (name: string, length: number, maxLength: number) => ({
+        message: `Function name '${name}' is ${length} characters long, which exceeds the maximum of ${maxLength}. It will be truncated when converted with ToStr()`,
+        code: 1155,
+        severity: DiagnosticSeverity.Warning
     })
 };
 

--- a/src/bscPlugin/validation/BrsFileValidator.spec.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.spec.ts
@@ -321,6 +321,47 @@ describe('BrsFileValidator', () => {
         }]);
     });
 
+    describe('function name length', () => {
+        it('allows a function name at exactly the max length', () => {
+            const name = 'a'.repeat(89);
+            program.setFile('source/main.brs', `
+                sub ${name}()
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('flags a function name that exceeds the max length', () => {
+            const name = 'a'.repeat(90);
+            program.setFile('source/main.brs', `
+                sub ${name}()
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.functionNameTooLong(name, 90, 89),
+                range: util.createRange(1, 20, 1, 20 + name.length)
+            }]);
+        });
+
+        it('flags a namespaced function whose flattened name exceeds the max length', () => {
+            const shortName = 'b'.repeat(85);
+            program.setFile('source/main.bs', `
+                namespace alpha
+                    sub ${shortName}()
+                    end sub
+                end namespace
+            `);
+            program.validate();
+            const flattenedName = `alpha_${shortName}`;
+            expectDiagnostics(program, [{
+                ...DiagnosticMessages.functionNameTooLong(flattenedName, flattenedName.length, 89),
+                range: util.createRange(2, 24, 2, 24 + shortName.length)
+            }]);
+        });
+    });
+
     describe('function return values', () => {
 
         it('catches sub with return value', () => {

--- a/src/bscPlugin/validation/BrsFileValidator.ts
+++ b/src/bscPlugin/validation/BrsFileValidator.ts
@@ -7,7 +7,7 @@ import { TokenKind, UnreferencableBuiltins } from '../../lexer/TokenKind';
 import type { AstNode, Expression, Statement } from '../../parser/AstNode';
 import { CallExpression, type FunctionExpression, type LiteralExpression } from '../../parser/Expression';
 import { ParseMode } from '../../parser/Parser';
-import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
+import type { ContinueStatement, EnumMemberStatement, EnumStatement, ForEachStatement, ForStatement, FunctionStatement, ImportStatement, LibraryStatement, WhileStatement } from '../../parser/Statement';
 import { DynamicType } from '../../types/DynamicType';
 import { InterfaceType } from '../../types/InterfaceType';
 import util from '../../util';
@@ -123,10 +123,13 @@ export class BrsFileValidator {
                 }
 
                 const namespace = node.findAncestor(isNamespaceStatement);
+                //the function's actual runtime name (namespaced functions get flattened into a single global name, e.g. `namespace_functionName`)
+                let runtimeName = node.name?.text;
                 //this function is declared inside a namespace
                 if (namespace) {
                     //add the transpiled name for namespaced functions to the root symbol table
                     const transpiledNamespaceFunctionName = node.getName(ParseMode.BrightScript);
+                    runtimeName = transpiledNamespaceFunctionName;
                     const funcType = node.func.getFunctionType();
                     funcType.setName(transpiledNamespaceFunctionName);
 
@@ -138,6 +141,8 @@ export class BrsFileValidator {
                         );
                     }
                 }
+
+                this.validateFunctionNameLength(node, runtimeName);
             },
             FunctionExpression: (node) => {
                 if (!node.symbolTable.hasSymbol('m')) {
@@ -244,6 +249,22 @@ export class BrsFileValidator {
             ...DiagnosticMessages.keywordMustBeDeclaredAtNamespaceLevel(keyword),
             range: rangeFactory?.() ?? statement.range
         });
+    }
+
+    /**
+     * The maximum function name length, in characters, before the Roku device truncates it
+     * when converting it to a string (e.g. via `ToStr()` or when printed in a stack trace).
+     * Verified on real devices running Roku OS 15.x. See https://github.com/rokucommunity/brighterscript/issues/1003.
+     */
+    private static MaxFunctionNameLength = 89;
+
+    private validateFunctionNameLength(node: FunctionStatement, name: string) {
+        if (name && name.length > BrsFileValidator.MaxFunctionNameLength) {
+            this.event.file.addDiagnostic({
+                ...DiagnosticMessages.functionNameTooLong(name, name.length, BrsFileValidator.MaxFunctionNameLength),
+                range: node.name.range
+            });
+        }
     }
 
     private validateFunctionParameterCount(func: FunctionExpression) {


### PR DESCRIPTION
fixes #1003

verified against real devices _(Roku OS 15.x)_. confirmed the 89-character cut-off, including namespaced functions, which get flattened into a single name at compile time.

<img width="770" height="452" alt="editor-diagnostics" src="https://github.com/user-attachments/assets/a7e3f221-49cd-4b78-96a2-2bcc875a707a" />
<img width="1164" height="232" alt="problems-panel" src="https://github.com/user-attachments/assets/9f5176ba-da80-479f-8971-07e12f33f583" />
