### PR TITLE
Report and correct mismatched XML element pairs (v1)

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -1176,6 +1176,11 @@ export let DiagnosticMessages = {
         message: `Diagnostic filter "${value}" looks like a file path or glob, not a diagnostic code. To filter diagnostics by file, use the "files" property instead: { "files": ["${value}"] }`,
         severity: DiagnosticSeverity.Warning,
         code: 'diagnostic-filter-looks-like-file-path'
+    }),
+    xmlTagMismatch: (openingTag: string, closingTag: string) => ({
+        message: `Mismatched closing tag: expected '</${openingTag}>' but found '</${closingTag}>'`,
+        severity: DiagnosticSeverity.Error,
+        code: 'xml-tag-mismatch'
     })
 };
 export const defaultMaximumTruncationLength = 160;

--- a/src/bscPlugin/validation/XmlFileValidator.ts
+++ b/src/bscPlugin/validation/XmlFileValidator.ts
@@ -1,7 +1,7 @@
 import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { XmlFile } from '../../files/XmlFile';
 import type { ValidateFileEvent } from '../../interfaces';
-import type { SGAst } from '../../parser/SGTypes';
+import type { SGAst, SGElement } from '../../parser/SGTypes';
 import util from '../../util';
 
 export class XmlFileValidator {
@@ -14,8 +14,30 @@ export class XmlFileValidator {
         util.validateTooDeepFile(this.event.file);
         if (this.event.file.parser.ast.rootElement) {
             this.validateComponent(this.event.file.parser.ast);
+            this.validateTagClosings(this.event.file.parser.ast.rootElement);
         } else {
             //skip empty XML
+        }
+    }
+
+    /**
+     * Walk the element tree and report any element whose closing tag name doesn't match its
+     * opening tag name (i.e. `<Group></LayoutGroup>`), which is a compile error on device.
+     * This runs at validation time (rather than parse time) so it also catches AST injected
+     * or mutated by plugins.
+     */
+    private validateTagClosings(element: SGElement) {
+        const endTagName = element.tokens.endTagName;
+        //only validate when a closing tag is actually present. Self-closing tags and
+        //programmatically-built elements omit it, and must remain valid.
+        if (endTagName && endTagName.text !== element.tokens.startTagName?.text) {
+            this.event.program.diagnostics.register({
+                ...DiagnosticMessages.xmlTagMismatch(element.tokens.startTagName?.text, endTagName.text),
+                location: endTagName.location
+            });
+        }
+        for (const child of element.elements) {
+            this.validateTagClosings(child);
         }
     }
 

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -14,6 +14,8 @@ import { LogLevel } from '../logging';
 import { isXmlFile } from '../astUtils/reflection';
 import { tempDir, rootDir, outDir } from '../testHelpers.spec';
 import type { BrsFile } from './BrsFile';
+import { SGNode } from '../parser/SGTypes';
+import { TranspileState } from '../parser/TranspileState';
 
 describe('XmlFile', () => {
 
@@ -508,6 +510,213 @@ describe('XmlFile', () => {
             expectDiagnostics(program, [
                 DiagnosticMessages.xmlComponentMissingExtendsAttribute()
             ]);
+        });
+    });
+
+    describe('mismatched tags', () => {
+        it('emits a diagnostic for a mismatched node tag', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                            <Label text="hello" />
+                        </LayoutGroup>
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('Group', 'LayoutGroup').message
+            ]);
+        });
+
+        it('emits a diagnostic for a mismatched <component> tag', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                </komponent>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('component', 'komponent').message
+            ]);
+        });
+
+        it('emits a diagnostic for a mismatched <interface> tag', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <interface>
+                        <field id="foo" type="string" />
+                    </interfase>
+                </component>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('interface', 'interfase').message
+            ]);
+        });
+
+        it('emits a diagnostic for a mismatched <children> tag', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup" />
+                    </kids>
+                </component>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('children', 'kids').message
+            ]);
+        });
+
+        it('emits a diagnostic for each mismatch when several are nested', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="outer">
+                            <Rectangle id="inner">
+                                <Label text="hello" />
+                            </Rectangel>
+                        </LayoutGroup>
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('Group', 'LayoutGroup').message,
+                DiagnosticMessages.xmlTagMismatch('Rectangle', 'Rectangel').message
+            ]);
+        });
+
+        it('treats a closing tag differing only by case as a mismatch', () => {
+            //XML is case-sensitive, and the Roku compiler rejects `<Group></group>`
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                        </group>
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectDiagnosticsIncludes(program, [
+                DiagnosticMessages.xmlTagMismatch('Group', 'group').message
+            ]);
+        });
+
+        it('points the diagnostic location at the closing tag', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                        </LayoutGroup>
+                    </children>
+                </component>
+            `);
+            program.validate();
+            const diagnostic = program.getDiagnostics().find(
+                x => x.message === DiagnosticMessages.xmlTagMismatch('Group', 'LayoutGroup').message
+            );
+            //the squiggle must land on `LayoutGroup` (line 4), not on the opening tag
+            expect(diagnostic?.location?.range).to.eql(Range.create(4, 10, 4, 21));
+            expect(diagnostic?.location?.uri).to.eql(util.pathToUri(file.srcPath));
+        });
+
+        it('does not emit a mismatch diagnostic for well-formed matching tags', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                            <Label text="hello" />
+                        </Group>
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('does not emit a mismatch diagnostic for self-closing tags', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup" />
+                    </children>
+                </component>
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('does not emit a mismatch diagnostic for a script tag with a cdata body', () => {
+            program.setFile('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <script type="text/brightscript"><![CDATA[
+                        sub init()
+                        end sub
+                    ]]></script>
+                </component>
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('does not emit a mismatch diagnostic for AST built programmatically without end tokens', () => {
+            //plugins build SGElements with no endTagName; that must remain valid
+            const element = new SGNode({
+                startTagName: { text: 'Group' },
+                elements: [
+                    new SGNode({ startTagName: { text: 'Label' } })
+                ]
+            });
+            expect(element.tokens.endTagName).to.be.undefined;
+            //the closing tag falls back to the opening tag name when endTagName is absent
+            expect(
+                element.transpile(new TranspileState('pkg:/components/Comp.xml', {})).toString()
+            ).to.equal(trim`
+                <Group>
+                    <Label>
+                    </Label>
+                </Group>
+            ` + '\n');
+        });
+
+        it('transpiles the opening tag name when the closing tag mismatches', () => {
+            //the device rejects mismatched tags, so emit valid xml rather than
+            //faithfully reproducing the broken closing tag
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                            <Label text="hello" />
+                        </LayoutGroup>
+                    </children>
+                </component>
+            `);
+            //force the AST-based transpile path (otherwise the raw file contents are emitted verbatim)
+            file.needsTranspiled = true;
+            program.validate();
+            expect(trimMap(file.transpile().code)).to.equal(trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="Comp" extends="Group">
+                    <children>
+                        <Group id="myGroup">
+                            <Label text="hello" />
+                        </Group>
+                    </children>
+                </component>
+            `);
         });
     });
 

--- a/src/parser/SGTypes.ts
+++ b/src/parser/SGTypes.ts
@@ -324,7 +324,15 @@ export class SGElement {
             chunks.push(
                 state.indentText,
                 state.transpileToken(this.tokens.endTagOpen, '</'),
-                state.transpileToken(this.tokens.endTagName ?? this.tokens.startTagName),
+                //always emit the opening tag's name. A mismatched closing tag (i.e.
+                //`<Group></LayoutGroup>`) is a hard compile error on device, so emit valid
+                //xml rather than faithfully reproducing the broken closing tag. The mismatch
+                //itself is reported by XmlFileValidator.
+                state.transpileToken(
+                    this.tokens.endTagName
+                        ? createSGToken(this.tokens.startTagName.text, this.tokens.endTagName.location)
+                        : this.tokens.startTagName
+                ),
                 state.transpileToken(this.tokens.endTagClose, '>'),
                 state.newline
             );


### PR DESCRIPTION
Mismatched XML tags like `<Group></LayoutGroup>` are a hard compile error on device (`XML syntax error found ---> Start-end tags mismatch`), but brighterscript accepted them silently. Worse, since v1 stores the closing tag name, transpile reproduced the broken tag verbatim — so `bsc` emitted a file the device rejects.

This is the v1 counterpart to #1746, reimplemented against v1's `SGElement` model rather than porting v0's code.

## What changed

- Added the `xml-tag-mismatch` diagnostic (error severity, matching the device)
- `XmlFileValidator` walks the element tree via the existing `elements` array and reports any element whose `tokens.endTagName` differs from its `tokens.startTagName`. Validating here rather than at parse time means plugin-injected AST is covered too.
- `SGElement.transpileBody` now always emits the opening tag's name for the closing tag, so output is valid XML. The mismatch is still surfaced as a diagnostic. The `endTagName` token is retained on the AST for location info.

Elements built programmatically (no `endTagName`) are unaffected — the check skips them and transpile keeps its existing `?? startTagName` fallback.

## Verified

Tests were written first against unmodified v1 to confirm the bug, then the fix applied. `npm run test:nocover` — 4317 passing.

Coverage: mismatches on `component`/`interface`/`children`/generic nodes, multiple nested mismatches in one file, case-only differences (XML is case-sensitive), diagnostic location on the closing tag, transpile output correctness, and no-false-positive cases (self-closing tags, `script` with a cdata body, programmatically-built elements).
