### PR TITLE
Keep synthesized Tokens on the lexer's hidden class

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -105,8 +105,8 @@ export class Lexer {
 
         this.tokens.push({
             kind: TokenKind.Eof,
-            isReserved: false,
             text: '',
+            isReserved: false,
             range: this.options.trackLocations
                 ? util.createRange(this.lineBegin, this.columnBegin, this.lineEnd, this.columnEnd + 1)
                 : undefined,
@@ -1056,6 +1056,9 @@ export class Lexer {
      */
     private addToken(kind: TokenKind) {
         let text = this.source.slice(this.start, this.current);
+        //this is the canonical Token field order. Every other place that synthesizes a
+        //Token should use this same order (and set every field) so all tokens share a
+        //single V8 hidden class instead of forcing megamorphic property access downstream
         let token: Token = {
             kind: kind,
             text: text,

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -859,9 +859,9 @@ export class Parser {
                     range: this.peek().range
                 });
                 functionType = {
-                    isReserved: true,
                     kind: TokenKind.Function,
                     text: 'function',
+                    isReserved: true,
                     //zero-length location means derived
                     range: {
                         start: this.peek().range.start,
@@ -1092,7 +1092,7 @@ export class Parser {
         } else {
             const nameExpression = new VariableExpression(name);
             result = new AssignmentStatement(
-                { kind: TokenKind.Equal, text: '=', range: operator.range },
+                { kind: TokenKind.Equal, text: '=', isReserved: false, range: operator.range, leadingWhitespace: '' },
                 name,
                 new BinaryExpression(nameExpression, operator, value)
             );
@@ -2287,7 +2287,7 @@ export class Parser {
                     left.additionalIndexes,
                     operator.kind === TokenKind.Equal
                         ? operator
-                        : { kind: TokenKind.Equal, text: '=', range: operator.range }
+                        : { kind: TokenKind.Equal, text: '=', isReserved: false, range: operator.range, leadingWhitespace: '' }
                 );
             } else if (isDottedGetExpression(left)) {
                 return new DottedSetStatement(
@@ -2299,7 +2299,7 @@ export class Parser {
                     left.dot,
                     operator.kind === TokenKind.Equal
                         ? operator
-                        : { kind: TokenKind.Equal, text: '=', range: operator.range }
+                        : { kind: TokenKind.Equal, text: '=', isReserved: false, range: operator.range, leadingWhitespace: '' }
                 );
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1198,11 +1198,13 @@ export class Util {
      */
     public cloneToken<T extends Token>(token: T) {
         if (token) {
+            //keep this field order identical to `Lexer.addToken` so cloned tokens
+            //share the same V8 hidden class as lexer-produced tokens
             const result = {
                 kind: token.kind,
-                range: this.cloneRange(token.range),
                 text: token.text,
                 isReserved: token.isReserved,
+                range: this.cloneRange(token.range),
                 leadingWhitespace: token.leadingWhitespace
             } as T;
             //handle those tokens that have charCode


### PR DESCRIPTION
Token object literals outside the lexer used differing field orders, and some omitted `isReserved`/`leadingWhitespace` entirely. Each distinct field ordering gets its own V8 hidden class, so token property access downstream (`token.text`, `token.range`, …) can go polymorphic even though nearly all tokens come from the lexer. Normalizing the shapes puts every token on one hidden class.

Extracted from #1712 — just the hidden-class normalization, none of the string-interning/allocation changes.

## What changed

All non-test token construction sites now use `Lexer.addToken`'s field order (`kind, text, isReserved, range, leadingWhitespace`):

- `Lexer.scan` EOF token — reordered
- `Parser.ts` recovered `function` token — reordered
- `Parser.ts` three compound-assignment `Equal` tokens — were missing `isReserved` and `leadingWhitespace`
- `util.cloneToken` — had `range` before `text`/`isReserved`, so every cloned token diverged from every lexer token. Not in #1712; found while sweeping.

`astUtils/creators.ts` (`createToken`/`createIdentifier`) and the three `Statement.ts` super-call tokens already matched. Added a comment on `addToken` documenting the canonical order.

## Measured

Benchmarked against a synthetic corpus (~1M tokens, deliberately dense in compound assignments and class inheritance to over-represent the touched paths), each build in its own process to avoid cross-contaminating V8's inline caches.

**The mechanism works.** Grouping tokens by their own-property ordering — a direct proxy for hidden-class identity:

| | distinct token shapes |
|---|---|
| before | 2 (`kind,text,isReserved,range,leadingWhitespace` ×47320 + `kind,text,range` ×4320) |
| after | 1 (all 51640) |

**The throughput win is not measurable.** Median wall-clock over 12–14 interleaved rounds: lex −0.04%, parse +1.09% in one run and −1.61% in another. The sign flips between runs, so the honest read is no detectable effect at this scale.

**Retained memory is a wash, very slightly negative.** Holding all tokens live: lex 242.01 → 241.99 MB (identical, as expected — field *order* doesn't change object size). Parse 425.20 → 426.15 MB, **+0.22%** — real, and expected: the three synthesized `Equal` tokens genuinely gain two slots that were previously absent. My corpus is unusually compound-assignment-heavy, so that's an upper bound.

So: this is a consistency/correctness cleanup that removes a latent polymorphism, for a rounding-error memory cost and no measured speedup. Reasonable to land on those terms, but it is not the perf win #1712 hoped for, and shouldn't be sold as one. Behavior is unchanged — identical token and statement counts from both builds.

## Verified

`npm run test:nocover` (3038 passing) and `npm run lint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)