### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3823,9 +3823,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -9787,7 +9787,7 @@
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.1.5",
+        "fast-uri": "^3.1.6",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2"
       }
@@ -11587,9 +11587,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true
     },
     "fastq": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "brace-expansion": "^2.1.4",
     "js-yaml": "^4.3.1",
     "@babel/core": "^7.29.7",
-    "fast-uri": "^3.1.5"
+    "fast-uri": "^3.1.6"
   },
   "dependencies": {
     "@rokucommunity/bslib": "^0.1.1",


### PR DESCRIPTION
Four new advisories landed against `fast-uri` <3.1.6 (one high, `GHSA-jqff-g426-hqxp` et al), failing the audit gate on master. The existing `^3.1.5` override no longer covers them.

- Bump the `fast-uri` override to `^3.1.6` (resolves to 3.1.7)

`fast-uri` is dev-only here (via `ajv`), so there's no prod/public-API exposure.

Verified: `npx audit-ci --config ./audit-ci.jsonc` passes (0 high, 4 moderate remaining, below the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)