### PR TITLE
Enable @typescript-eslint/no-unsafe-argument

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,8 +54,7 @@ module.exports = {
         '@typescript-eslint/no-parameter-properties': 'off',
         //had to add this rule to prevent eslint from crashing
         '@typescript-eslint/no-restricted-imports': ['off', {}],
-        //mitigating this sometimes results in undesirably verbose code. Should investigate enabling again in the future.
-        '@typescript-eslint/no-unsafe-argument': 'off',
+        '@typescript-eslint/no-unsafe-argument': 'error',
         'object-curly-spacing': 'off',
         '@typescript-eslint/object-curly-spacing': [
             'error',

--- a/src/BusyStatusTracker.ts
+++ b/src/BusyStatusTracker.ts
@@ -131,10 +131,11 @@ export class BusyStatusTracker<T = any> {
     public once(eventName: 'change'): Promise<BusyStatus>;
     public once<T>(eventName: string): Promise<T> {
         return new Promise<T>((resolve) => {
-            const off = this.on(eventName as any, (data) => {
-                off();
-                resolve(data as any);
-            });
+            const callback = (data: T) => {
+                this.emitter.off(eventName, callback);
+                resolve(data);
+            };
+            this.emitter.on(eventName, callback);
         });
     }
 

--- a/src/BusyStatusTracker.ts
+++ b/src/BusyStatusTracker.ts
@@ -131,11 +131,13 @@ export class BusyStatusTracker<T = any> {
     public once(eventName: 'change'): Promise<BusyStatus>;
     public once<T>(eventName: string): Promise<T> {
         return new Promise<T>((resolve) => {
-            const callback = (data: T) => {
-                this.emitter.off(eventName, callback);
-                resolve(data);
-            };
-            this.emitter.on(eventName, callback);
+            //the widened `eventName` can't match the literal-string `on()` overload
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            const off = this.on(eventName as any, (data) => {
+                off();
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                resolve(data as any);
+            });
         });
     }
 

--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -860,8 +860,12 @@ function formatAvailabilityAxis(axis: AvailabilityAxis, version: string): string
 export const DiagnosticCodeMap = {} as Record<keyof (typeof DiagnosticMessages), number>;
 export let diagnosticCodes = [] as number[];
 for (let key in DiagnosticMessages) {
-    diagnosticCodes.push(DiagnosticMessages[key]().code);
-    DiagnosticCodeMap[key] = DiagnosticMessages[key]().code;
+    const typedKey = key as keyof typeof DiagnosticMessages;
+    //every factory returns an object with a `code` property regardless of its specific (possibly required) arguments,
+    //so it's safe to call each one with no arguments purely to read that `code` off the result
+    const getCode = DiagnosticMessages[typedKey] as () => { code: number };
+    diagnosticCodes.push(getCode().code);
+    DiagnosticCodeMap[typedKey] = getCode().code;
 }
 
 export interface DiagnosticInfo {

--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -50,6 +50,7 @@ import { util } from './util';
 import { DiagnosticCollection } from './DiagnosticCollection';
 import { encodeSemanticTokens, semanticTokensLegend } from './SemanticTokenUtils';
 import { LogLevel, createLogger, logger, setLspLoggerProps } from './logging';
+import type { LogLevel as LogLevelText } from '@rokucommunity/logger';
 import ignore from 'ignore';
 import * as micromatch from 'micromatch';
 import type { LspProject, LspDiagnostic } from './lsp/LspProject';
@@ -353,7 +354,7 @@ export class LanguageServer {
                     if (typeof value === 'string') {
                         value = value.toLowerCase();
                     }
-                    const logLevelNumeric = this.logger.getLogLevelNumeric(value as any);
+                    const logLevelNumeric = this.logger.getLogLevelNumeric(value as LogLevelText | LogLevel);
 
                     if (typeof logLevelNumeric === 'number') {
                         return logLevelNumeric;
@@ -620,7 +621,7 @@ export class LanguageServer {
      * Extract project paths from settings' projects list, expanding the workspaceFolder variable if necessary
      */
     private normalizeProjectPaths(workspaceFolder: string, projects: (string | BrightScriptProjectConfiguration)[]): BrightScriptProjectConfiguration[] | undefined {
-        return projects?.reduce((acc, project) => {
+        return projects?.reduce<BrightScriptProjectConfiguration[]>((acc, project) => {
             if (typeof project === 'string') {
                 acc.push({ path: project });
             } else if (typeof project.path === 'string') {

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -8,7 +8,7 @@ import { LogLevelNumeric as LogLevel } from '@rokucommunity/logger';
  */
 export class Logger {
 
-    public static subscribe(callback) {
+    public static subscribe(callback: (...args: any[]) => void) {
         this.emitter.on('log', callback);
         return () => {
             this.emitter.off('log', callback);
@@ -65,6 +65,8 @@ export class Logger {
         }
         allArgs.push(this.indent);
 
+        //`allArgs`/`finalArgs` are intentionally untyped passthrough, so there's no tighter type to spread than `any[]`
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         method.call(console, ...allArgs, ...finalArgs);
         if (Logger.emitter.listenerCount('log') > 0) {
             Logger.emitter.emit('log', finalArgs.join(' '));
@@ -74,8 +76,10 @@ export class Logger {
     /**
      * Log an error message to the console
      */
-    error(...messages) {
+    error(...messages: any[]) {
         if (this._logLevel >= LogLevel.error) {
+            //`messages` is intentionally untyped passthrough, so there's no tighter type to spread than `any[]`
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.error, ...messages);
         }
     }
@@ -83,8 +87,9 @@ export class Logger {
     /**
      * Log a warning message to the console
      */
-    warn(...messages) {
+    warn(...messages: any[]) {
         if (this._logLevel >= LogLevel.warn) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.warn, ...messages);
         }
     }
@@ -92,16 +97,18 @@ export class Logger {
     /**
      * Log a standard log message to the console
      */
-    log(...messages) {
+    log(...messages: any[]) {
         if (this._logLevel >= LogLevel.log) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.log, ...messages);
         }
     }
     /**
      * Log an info message to the console
      */
-    info(...messages) {
+    info(...messages: any[]) {
         if (this._logLevel >= LogLevel.info) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.info, ...messages);
         }
     }
@@ -109,8 +116,9 @@ export class Logger {
     /**
      * Log a debug message to the console
      */
-    debug(...messages) {
+    debug(...messages: any[]) {
         if (this._logLevel >= LogLevel.debug) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.debug, ...messages);
         }
     }
@@ -118,8 +126,9 @@ export class Logger {
     /**
      * Log a debug message to the console
      */
-    trace(...messages) {
+    trace(...messages: any[]) {
         if (this._logLevel >= LogLevel.trace) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.trace, ...messages);
         }
     }

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -44,11 +44,11 @@ export class Logger {
         return '[' + chalk.grey(formatTimestamp()) + ']';
     }
 
-    private writeToLog(method: (...consoleArgs: any[]) => void, ...args: any[]) {
+    private writeToLog(method: (...consoleArgs: any[]) => void, ...args: unknown[]) {
         if (this._logLevel === LogLevel.trace) {
             method = console.trace;
         }
-        let finalArgs: any[] = [];
+        let finalArgs: unknown[] = [];
         //evaluate any functions to get their values.
         //This allows more complicated values to only be evaluated if this log level is active
         for (let arg of args) {
@@ -65,8 +65,6 @@ export class Logger {
         }
         allArgs.push(this.indent);
 
-        //`allArgs`/`finalArgs` are intentionally untyped passthrough, so there's no tighter type to spread than `any[]`
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         method.call(console, ...allArgs, ...finalArgs);
         if (Logger.emitter.listenerCount('log') > 0) {
             Logger.emitter.emit('log', finalArgs.join(' '));
@@ -76,10 +74,8 @@ export class Logger {
     /**
      * Log an error message to the console
      */
-    error(...messages: any[]) {
+    error(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.error) {
-            //`messages` is intentionally untyped passthrough, so there's no tighter type to spread than `any[]`
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.error, ...messages);
         }
     }
@@ -87,9 +83,8 @@ export class Logger {
     /**
      * Log a warning message to the console
      */
-    warn(...messages: any[]) {
+    warn(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.warn) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.warn, ...messages);
         }
     }
@@ -97,18 +92,16 @@ export class Logger {
     /**
      * Log a standard log message to the console
      */
-    log(...messages: any[]) {
+    log(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.log) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.log, ...messages);
         }
     }
     /**
      * Log an info message to the console
      */
-    info(...messages: any[]) {
+    info(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.info) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.info, ...messages);
         }
     }
@@ -116,9 +109,8 @@ export class Logger {
     /**
      * Log a debug message to the console
      */
-    debug(...messages: any[]) {
+    debug(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.debug) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.debug, ...messages);
         }
     }
@@ -126,9 +118,8 @@ export class Logger {
     /**
      * Log a debug message to the console
      */
-    trace(...messages: any[]) {
+    trace(...messages: unknown[]) {
         if (this._logLevel >= LogLevel.trace) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             this.writeToLog(console.trace, ...messages);
         }
     }

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -642,7 +642,11 @@ export class Program {
      */
     public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
     public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
-        return this.setFile<T>(fileParam as any, fileContents);
+        if (typeof fileParam === 'string') {
+            return this.setFile<T>(fileParam, fileContents);
+        } else {
+            return this.setFile<T>(fileParam, fileContents);
+        }
     }
 
     /**
@@ -773,7 +777,8 @@ export class Program {
             srcPath = s`${path.resolve(rootDir, fileParam)}`;
             pkgPath = s`${util.replaceCaseInsensitive(srcPath, rootDir, '')}`;
         } else {
-            let param: any = fileParam;
+            //`fileParam` here is `FileObj | { srcPath?: string; pkgPath?: string }`; duck-type across both shapes
+            let param = fileParam as { src?: string; srcPath?: string; dest?: string; pkgPath?: string };
 
             if (param.src) {
                 srcPath = s`${param.src}`;

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -642,11 +642,7 @@ export class Program {
      */
     public addOrReplaceFile<T extends BscFile>(fileEntry: FileObj, fileContents: string): T;
     public addOrReplaceFile<T extends BscFile>(fileParam: FileObj | string, fileContents: string): T {
-        if (typeof fileParam === 'string') {
-            return this.setFile<T>(fileParam, fileContents);
-        } else {
-            return this.setFile<T>(fileParam, fileContents);
-        }
+        return this.setFile<T>(fileParam as string, fileContents);
     }
 
     /**

--- a/src/ProgramBuilder.ts
+++ b/src/ProgramBuilder.ts
@@ -91,12 +91,12 @@ export class ProgramBuilder {
                 pathAbsolute: srcPath, //keep this for backwards-compatibility. TODO remove in v1
                 srcPath: srcPath,
                 getDiagnostics: () => {
-                    return [<any>diagnostic];
+                    return [diagnostic as BsDiagnostic];
                 }
             } as BscFile;
         }
         diagnostic.file = file;
-        this.staticDiagnostics.push(<any>diagnostic);
+        this.staticDiagnostics.push(diagnostic as BsDiagnostic);
     }
 
     public getDiagnostics() {
@@ -559,7 +559,7 @@ export class ProgramBuilder {
                 this.program!.loadManifest(manifestFile, false);
             }
 
-            const loadFile = async (fileObj) => {
+            const loadFile = async (fileObj: FileObj) => {
                 try {
                     this.program!.setFile(fileObj, await this.getFileContents(fileObj.src));
                 } catch (e) {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -648,6 +648,8 @@ export class Scope {
     }
 
     protected logDebug(...args: any[]) {
+        //`args` is intentionally untyped passthrough for the logger, so there's no tighter type to spread than `any[]`
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.program.logger.debug(this._debugLogComponentName, ...args);
     }
     private _debugLogComponentName: string;

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -647,9 +647,7 @@ export class Scope {
         return result;
     }
 
-    protected logDebug(...args: any[]) {
-        //`args` is intentionally untyped passthrough for the logger, so there's no tighter type to spread than `any[]`
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    protected logDebug(...args: unknown[]) {
         this.program.logger.debug(this._debugLogComponentName, ...args);
     }
     private _debugLogComponentName: string;

--- a/src/ScopeNamespaceLookup.ts
+++ b/src/ScopeNamespaceLookup.ts
@@ -107,11 +107,11 @@ export class ScopeNamespaceLookup extends Map<string, NamespaceContainer> {
         this.ensureNameIndex();
         if (!this.nameSet!.has(lower)) {
             //memoize the negative result so repeated misses are cheap
-            super.set(lower, undefined as any);
+            super.set(lower, undefined);
             return undefined;
         }
         const container = this.buildContainer(lower);
-        super.set(lower, container as any);
+        super.set(lower, container);
         return container;
     }
 

--- a/src/Throttler.ts
+++ b/src/Throttler.ts
@@ -76,7 +76,7 @@ export class Throttler {
         return deferred.promise;
     }
 
-    public onIdle(callback) {
+    public onIdle(callback: (...args: any[]) => void) {
         this.emitter.on('idle', callback);
         return () => {
             this.emitter.off('idle', callback);

--- a/src/astUtils/reflection.ts
+++ b/src/astUtils/reflection.ts
@@ -335,20 +335,20 @@ const numberConstructorNames = [
     DoubleType.name
 ];
 export function isNumberType(e: any): e is IntegerType | LongIntegerType | FloatType | DoubleType {
-    return numberConstructorNames.includes(e?.constructor.name);
+    return numberConstructorNames.includes(e?.constructor.name as string);
 }
 
 // Literal reflection
 
 export function isLiteralInvalid(e: any): e is LiteralExpression & { type: InvalidType } {
-    return isLiteralExpression(e) && isInvalidType(e.type);
+    return isLiteralExpression(e as AstNode) && isInvalidType(e.type);
 }
 export function isLiteralBoolean(e: any): e is LiteralExpression & { type: BooleanType } {
-    return isLiteralExpression(e) && isBooleanType(e.type);
+    return isLiteralExpression(e as AstNode) && isBooleanType(e.type);
 }
 export function isLiteralString(e: any): e is LiteralExpression & { type: StringType } {
-    return isLiteralExpression(e) && isStringType(e.type);
+    return isLiteralExpression(e as AstNode) && isStringType(e.type);
 }
 export function isLiteralNumber(e: any): e is LiteralExpression & { type: IntegerType | LongIntegerType | FloatType | DoubleType } {
-    return isLiteralExpression(e) && isNumberType(e.type);
+    return isLiteralExpression(e as AstNode) && isNumberType(e.type);
 }

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -56,8 +56,7 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
             if (options.editor) {
                 //`T[K]` can't be statically unified with the now-narrowed `returnValue` because `T`/`K` are unresolved generics here;
                 //callers only ever pass AST-shaped values, so this is safe in practice
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                options.editor.setProperty(owner, key, returnValue as any);
+                options.editor.setProperty(owner, key, returnValue as unknown as T[keyof T]);
 
                 //we don't have an editor, modify the AST directly
             } else {

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -15,7 +15,7 @@ export function walkStatements(
     visitor: (statement: Statement, parent?: Statement, owner?: any, key?: any) => Statement | void,
     cancel?: CancellationToken
 ): void {
-    statement.walk(visitor as any, {
+    statement.walk(visitor as unknown as WalkVisitor, {
         walkMode: WalkMode.visitStatements,
         cancel: cancel
     });
@@ -48,12 +48,15 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
 
     //notify the visitor of this element
     if (element.visitMode & options.walkMode) {
-        returnValue = visitor?.(element, element.parent as any, owner, key);
+        returnValue = visitor?.(element, element.parent, owner, key);
 
         //replace the value on the parent if the visitor returned a Statement or Expression (this is how visitors can edit AST)
         if (returnValue && (isExpression(returnValue) || isStatement(returnValue))) {
             //if we have an editor, use that to modify the AST
             if (options.editor) {
+                //`T[K]` can't be statically unified with the now-narrowed `returnValue` because `T`/`K` are unresolved generics here;
+                //callers only ever pass AST-shaped values, so this is safe in practice
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 options.editor.setProperty(owner, key, returnValue as any);
 
                 //we don't have an editor, modify the AST directly
@@ -94,7 +97,7 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
  * @param parent the parent AstNode of each item in the array
  * @param filter a function used to filter items from the array. return true if that item should be walked
  */
-export function walkArray<T extends AstNode = AstNode>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode, filter?: <T>(element: T) => boolean) {
+export function walkArray<T extends AstNode = AstNode>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode, filter?: (element: T) => boolean) {
     let processedNodes = new Set<AstNode>();
 
     for (let i = 0; i < array?.length; i++) {

--- a/src/bscPlugin/BscPlugin.ts
+++ b/src/bscPlugin/BscPlugin.ts
@@ -1,5 +1,7 @@
 import { isBrsFile, isXmlFile } from '../astUtils/reflection';
 import type { BeforeFileTranspileEvent, Plugin, OnFileValidateEvent, OnGetCodeActionsEvent, OnGetSourceFixAllCodeActionsEvent, ProvideHoverEvent, OnGetSemanticTokensEvent, OnScopeValidateEvent, ProvideCompletionsEvent, ProvideDefinitionEvent, ProvideReferencesEvent, ProvideDocumentSymbolsEvent, ProvideWorkspaceSymbolsEvent, ProvideSelectionRangesEvent, ProvideInlayHintsEvent } from '../interfaces';
+import type { BrsFile } from '../files/BrsFile';
+import type { XmlFile } from '../files/XmlFile';
 import type { Program } from '../Program';
 import { CodeActionsProcessor } from './codeActions/CodeActionsProcessor';
 import { FixAllCodeActionsProcessor } from './codeActions/FixAllCodeActionsProcessor';
@@ -63,15 +65,18 @@ export class BscPlugin implements Plugin {
 
     public onGetSemanticTokens(event: OnGetSemanticTokensEvent) {
         if (isBrsFile(event.file)) {
-            return new BrsFileSemanticTokensProcessor(event as any).process();
+            //`isBrsFile` narrows `event.file`, but not the generic `event` itself
+            return new BrsFileSemanticTokensProcessor(event as unknown as OnGetSemanticTokensEvent<BrsFile>).process();
         }
     }
 
     public onFileValidate(event: OnFileValidateEvent) {
         if (isBrsFile(event.file)) {
-            return new BrsFileValidator(event as any).process();
+            //`isBrsFile` narrows `event.file`, but not the generic `event` itself
+            return new BrsFileValidator(event as unknown as OnFileValidateEvent<BrsFile>).process();
         } else if (isXmlFile(event.file)) {
-            return new XmlFileValidator(event as any).process();
+            //`isXmlFile` narrows `event.file`, but not the generic `event` itself
+            return new XmlFileValidator(event as unknown as OnFileValidateEvent<XmlFile>).process();
         }
     }
 
@@ -89,7 +94,8 @@ export class BscPlugin implements Plugin {
 
     public beforeFileTranspile(event: BeforeFileTranspileEvent) {
         if (isBrsFile(event.file)) {
-            return new BrsFilePreTranspileProcessor(event as any).process();
+            //`isBrsFile` narrows `event.file`, but not the generic `event` itself
+            return new BrsFilePreTranspileProcessor(event as unknown as BeforeFileTranspileEvent<BrsFile>).process();
         }
     }
 }

--- a/src/bscPlugin/SignatureHelpUtil.ts
+++ b/src/bscPlugin/SignatureHelpUtil.ts
@@ -13,7 +13,7 @@ import { util } from '../util';
 
 export class SignatureHelpUtil {
     getSignatureHelpItems(callExpressionInfo: CallExpressionInfo): SignatureInfoObj[] {
-        let signatureHelpItems = [];
+        let signatureHelpItems: SignatureInfoObj[] = [];
         let file = callExpressionInfo.file;
         let dotPart = callExpressionInfo.dotPart;
         let name = callExpressionInfo.name;

--- a/src/bscPlugin/codeActions/CodeActionsProcessor.ts
+++ b/src/bscPlugin/codeActions/CodeActionsProcessor.ts
@@ -17,6 +17,7 @@ import { TokenKind } from '../../lexer/TokenKind';
 import { getMissingExtendsInsertPosition } from './codeActionHelpers';
 import { rangeFromTokenValue } from '../../parser/SGParser';
 import type { Range } from 'vscode-languageserver';
+import type { IToken } from 'chevrotain';
 
 export class CodeActionsProcessor {
     public constructor(
@@ -31,12 +32,12 @@ export class CodeActionsProcessor {
     public process() {
         // First pass: individual fixes for each diagnostic at the cursor position
         for (const diagnostic of this.event.diagnostics) {
-            if (diagnostic.code === DiagnosticCodeMap.cannotFindName || diagnostic.code === DiagnosticCodeMap.cannotFindFunction) {
-                this.suggestCannotFindNameQuickFix(diagnostic as any);
-            } else if (diagnostic.code === DiagnosticCodeMap.classCouldNotBeFound) {
-                this.suggestClassImportQuickFix(diagnostic as any);
-            } else if (diagnostic.code === DiagnosticCodeMap.xmlComponentMissingExtendsAttribute) {
-                this.suggestMissingExtendsQuickFix(diagnostic as any);
+            if (isDiagnosticOfType(diagnostic, 'cannotFindName') || isDiagnosticOfType(diagnostic, 'cannotFindFunction')) {
+                this.suggestCannotFindNameQuickFix(diagnostic);
+            } else if (isDiagnosticOfType(diagnostic, 'classCouldNotBeFound')) {
+                this.suggestClassImportQuickFix(diagnostic);
+            } else if (isDiagnosticOfType(diagnostic, 'xmlComponentMissingExtendsAttribute')) {
+                this.suggestMissingExtendsQuickFix(diagnostic);
             } else if (diagnostic.code === DiagnosticCodeMap.voidFunctionMayNotReturnValue) {
                 this.suggestVoidFunctionReturnQuickFixes([diagnostic]);
             } else if (diagnostic.code === DiagnosticCodeMap.nonVoidFunctionMustReturnValue) {
@@ -259,7 +260,7 @@ export class CodeActionsProcessor {
                 }
                 continue;
             }
-            const tokenRange: Range = isXml ? rangeFromTokenValue(token) : token.range;
+            const tokenRange: Range = isXml ? rangeFromTokenValue(token as IToken) : token.range;
             const tokenText: string = isXml ? token.image : token.text;
             const parsed = parseDisableComment(tokenText);
             if (!parsed) {
@@ -286,10 +287,10 @@ export class CodeActionsProcessor {
     private getDisableFileInsertion(file: BscFile): { position: ReturnType<typeof util.createPosition>; prefix: string; suffix: string } {
         if (isXmlFile(file)) {
             //insert after the `<?xml ?>` declaration if present, otherwise at the very top
-            const declCloseToken = file.parser.tokens?.find(t => (t as any).tokenType?.name === 'SPECIAL_CLOSE');
+            const declCloseToken = file.parser.tokens?.find(t => t.tokenType?.name === 'SPECIAL_CLOSE');
             if (declCloseToken) {
-                const endLine = (declCloseToken as any).endLine - 1;
-                const endColumn = (declCloseToken as any).endColumn;
+                const endLine = declCloseToken.endLine - 1;
+                const endColumn = declCloseToken.endColumn;
                 return {
                     position: util.createPosition(endLine, endColumn),
                     prefix: '\n',
@@ -380,7 +381,7 @@ export class CodeActionsProcessor {
     /**
      * Suggests import statements for an unresolved name (function, class, namespace, or enum).
      */
-    private suggestCannotFindNameQuickFix(diagnostic: DiagnosticMessageType<'cannotFindName'>) {
+    private suggestCannotFindNameQuickFix(diagnostic: DiagnosticMessageType<'cannotFindName'> | DiagnosticMessageType<'cannotFindFunction'>) {
         //skip if not a BrighterScript file
         if ((diagnostic.file as BrsFile).parseMode !== ParseMode.BrighterScript) {
             return;
@@ -687,7 +688,7 @@ export class CodeActionsProcessor {
             [DiagnosticCodeMap.unnecessaryScriptImportInChildFromParent]: ['Remove redundant script import', 'Fix all: Remove redundant script imports'],
             [DiagnosticCodeMap.unnecessaryCodebehindScriptImport]: ['Remove unnecessary codebehind import', 'Fix all: Remove unnecessary codebehind imports']
         };
-        const [singleTitle, fixAllTitle] = titles[diagnostics[0]?.code] ?? ['Remove script import', 'Fix all: Remove script imports'];
+        const [singleTitle, fixAllTitle] = titles[diagnostics[0]?.code as number] ?? ['Remove script import', 'Fix all: Remove script imports'];
         const changes = diagnostics.map<DeleteChange>(diagnostic => {
             return {
                 type: 'delete',

--- a/src/bscPlugin/inlayHints/InlayHintProcessor.ts
+++ b/src/bscPlugin/inlayHints/InlayHintProcessor.ts
@@ -1,4 +1,3 @@
-import type { Range } from 'vscode-languageserver-protocol';
 import { InlayHintKind } from 'vscode-languageserver-protocol';
 import {
     isBrsFile,
@@ -15,6 +14,7 @@ import { WalkMode, createVisitor } from '../../astUtils/visitors';
 import type { BrsFile } from '../../files/BrsFile';
 import type { ProvideInlayHintsEvent } from '../../interfaces';
 import type { CallExpression, CallfuncExpression, FunctionParameterExpression } from '../../parser/Expression';
+import type { Expression } from '../../parser/AstNode';
 import type { ClassStatement, FunctionStatement, MethodStatement, NamespaceStatement } from '../../parser/Statement';
 import { ParseMode } from '../../parser/Parser';
 import { util } from '../../util';
@@ -147,7 +147,7 @@ export class InlayHintProcessor {
      * If the receiver is `m`, prefer the enclosing class. Otherwise fall back to a name search
      * across all classes (only used when there's exactly one match).
      */
-    private lookupClassMethodParameters(file: BrsFile, callee: { obj?: any }, name: string): FunctionParameterExpression[] | undefined {
+    private lookupClassMethodParameters(file: BrsFile, callee: { obj?: Expression }, name: string): FunctionParameterExpression[] | undefined {
         if (isVariableExpression(callee.obj) && callee.obj.name.text === 'm') {
             const enclosingClass = callee.obj.findAncestor<ClassStatement>(isClassStatement);
             if (enclosingClass) {
@@ -186,7 +186,7 @@ export class InlayHintProcessor {
         return undefined;
     }
 
-    private pushHintsForArgs(args: Array<{ range?: Range }>, params: FunctionParameterExpression[]) {
+    private pushHintsForArgs(args: Expression[], params: FunctionParameterExpression[]) {
         for (let i = 0; i < args.length && i < params.length; i++) {
             const arg = args[i];
             const param = params[i];
@@ -195,7 +195,7 @@ export class InlayHintProcessor {
                 continue;
             }
             //skip when the argument is just an identifier that already matches the parameter name
-            if (isVariableExpression(arg as any) && (arg as any).name?.text?.toLowerCase() === paramName.toLowerCase()) {
+            if (isVariableExpression(arg) && arg.name?.text?.toLowerCase() === paramName.toLowerCase()) {
                 continue;
             }
             this.event.inlayHints.push({

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -448,7 +448,7 @@ export class ScopeValidator {
                 continue;
             }
             const firstParamToken = (call?.args[0]?.expression as any)?.token;
-            const firstParamStringValue = firstParamToken?.text?.replace(/"/g, '');
+            const firstParamStringValue: string = firstParamToken?.text?.replace(/"/g, '');
             //if this is a `createObject('roSGNode'` call, only support known sg node types
             if (firstParamStringValue?.toLowerCase() === 'rosgnode' && isLiteralExpression(call?.args[1]?.expression)) {
                 const componentName: Token = (call?.args[1]?.expression as any)?.token;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import * as yargs from 'yargs';
 import * as path from 'path';
 import { ProgramBuilder } from './ProgramBuilder';
+import type { BsConfig } from './BsConfig';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { normalizeDiagnosticReporters } from './diagnosticUtils';
 import util from './util';
@@ -81,7 +82,7 @@ async function main() {
             server.run();
         } else {
             let builder = new ProgramBuilder();
-            await builder.run(<any>options);
+            await builder.run(options as unknown as BsConfig);
             //if this is a single run (i.e. not watch mode) and there are error diagnostics, return an error code
             const hasError = !!builder.getDiagnostics().find(x => x.severity === DiagnosticSeverity.Error);
             if (builder.options.watch) {
@@ -102,7 +103,7 @@ async function main() {
     }
 }
 
-function askQuestion(question) {
+function askQuestion(question: string) {
     return new Promise((resolve, reject) => {
         rl.question(question, (answer) => {
             resolve(answer);
@@ -151,7 +152,7 @@ function finalizeProfiling() {
                 const profileResultPath = path.join(process.cwd(), `${Date.now()}-${profileTitle}.cpuprofile`);
                 console.log(`Writing profile result to:`, chalk.green(profileResultPath));
                 const profile = v8Profiler.stopProfiling(profileTitle);
-                profile.export((error, result) => {
+                profile.export((error: Error, result: string) => {
                     fsExtra.writeFileSync(profileResultPath, result);
                     profile.delete();
                     resolve();

--- a/src/common/Sequencer.ts
+++ b/src/common/Sequencer.ts
@@ -89,6 +89,8 @@ export class Sequencer {
                 }
 
                 await Promise.resolve(
+                    //`action.func` is a heterogeneous, dynamically-dispatched `Function`, so its args can't be typed any tighter than `any[]`
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     action.func(...action.args)
                 );
 
@@ -114,6 +116,8 @@ export class Sequencer {
                 if (this.options?.cancellationToken?.isCancellationRequested) {
                     return this.handleCancel();
                 }
+                //`action.func` is a heterogeneous, dynamically-dispatched `Function`, so its args can't be typed any tighter than `any[]`
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 const result = action.func(...action.args);
                 if (typeof result?.then === 'function') {
                     throw new Error(`Action returned a promise which is unsupported when running 'runSync'`);

--- a/src/common/Sequencer.ts
+++ b/src/common/Sequencer.ts
@@ -24,7 +24,7 @@ export class Sequencer {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    private actions: Array<{ args: any[]; func: Function }> = [];
+    private actions: Array<{ args: unknown[]; func: (...args: any[]) => any }> = [];
 
     public forEach<T>(itemsOrFactory: Iterable<T> | (() => Iterable<T>), func: (item: T) => any) {
         //register a single action for now, we will fetch the full list and register their actions later
@@ -89,8 +89,6 @@ export class Sequencer {
                 }
 
                 await Promise.resolve(
-                    //`action.func` is a heterogeneous, dynamically-dispatched `Function`, so its args can't be typed any tighter than `any[]`
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     action.func(...action.args)
                 );
 
@@ -116,8 +114,6 @@ export class Sequencer {
                 if (this.options?.cancellationToken?.isCancellationRequested) {
                     return this.handleCancel();
                 }
-                //`action.func` is a heterogeneous, dynamically-dispatched `Function`, so its args can't be typed any tighter than `any[]`
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 const result = action.func(...action.args);
                 if (typeof result?.then === 'function') {
                     throw new Error(`Action returned a promise which is unsupported when running 'runSync'`);

--- a/src/diagnosticUtils.ts
+++ b/src/diagnosticUtils.ts
@@ -68,7 +68,7 @@ export function getPrintDiagnosticOptions(options: BsConfig) {
     typeColor[DiagnosticSeverity.Warning] = chalk.yellow;
     typeColor[DiagnosticSeverity.Error] = chalk.red;
 
-    let severityTextMap = {};
+    let severityTextMap = {} as Record<string, string>;
     severityTextMap[DiagnosticSeverity.Information] = 'info';
     severityTextMap[DiagnosticSeverity.Hint] = 'hint';
     severityTextMap[DiagnosticSeverity.Warning] = 'warning';

--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -2139,6 +2139,25 @@ describe('BrsFile', () => {
                 text: 'isAlive'
             });
         });
+
+        it('finds arguments with dotted get values', () => {
+            let file = new BrsFile('absolute_path/file.brs', 'relative_path/file.brs', program);
+            file.parse(`
+                function Sum()
+                    DoSomething(person.name, m.top.id)
+                end function
+            `);
+            expect(file.functionCalls.length).to.equal(1);
+            //a DottedGetExpression arg should be described by the right-most name in the chain
+            expect(file.functionCalls[0].args[0]).deep.include({
+                type: new DynamicType(),
+                text: 'name'
+            });
+            expect(file.functionCalls[0].args[1]).deep.include({
+                type: new DynamicType(),
+                text: 'id'
+            });
+        });
     });
 
     describe('findCallables', () => {

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -137,7 +137,7 @@ export class BrsFile {
             if (!diagnostic.file) {
                 diagnostic.file = this;
             }
-            this.diagnostics.push(diagnostic as any);
+            this.diagnostics.push(diagnostic);
         }
     }
 
@@ -425,7 +425,7 @@ export class BrsFile {
             } catch (error: any) {
                 //if the thrown error is DIFFERENT than any errors from the preprocessor, add that error to the list as well
                 if (this.diagnostics.find((x) => x === error) === undefined) {
-                    this.diagnostics.push(error);
+                    this.diagnostics.push(error as BsDiagnostic);
                 }
             }
 
@@ -644,7 +644,8 @@ export class BrsFile {
 
                 //function call
             } else if (isCallExpression(assignment.value)) {
-                let calleeName = (assignment.value.callee as any)?.name?.text;
+                let callee = assignment.value.callee;
+                let calleeName = isVariableExpression(callee) ? callee.name?.text : undefined;
                 if (calleeName) {
                     let func = this.getCallableByName(calleeName);
                     if (func) {
@@ -740,7 +741,7 @@ export class BrsFile {
 
                 let args = [] as CallableArg[];
                 //TODO convert if stmts to use instanceof instead
-                for (let arg of expression.args as any) {
+                for (let arg of expression.args) {
 
                     //is a literal parameter value
                     if (isLiteralExpression(arg)) {
@@ -753,7 +754,7 @@ export class BrsFile {
                         });
 
                         //is variable being passed into argument
-                    } else if (arg.name) {
+                    } else if (isVariableExpression(arg)) {
                         args.push({
                             range: arg.range,
                             //TODO - look up the data type of the actual variable
@@ -763,11 +764,13 @@ export class BrsFile {
                             typeToken: undefined
                         });
 
-                    } else if (arg.value) {
+                        //`arg.value` isn't a property on the `Expression` base type; this duck-types across whatever
+                        //expression subtypes carry a nested `.value.value`, matching the pre-existing (unclear) runtime shape
+                    } else if ((arg as any).value) {
                         let text = '';
                         /* istanbul ignore next: TODO figure out why value is undefined sometimes */
-                        if (arg.value.value) {
-                            text = arg.value.value.toString();
+                        if ((arg as any).value.value) {
+                            text = (arg as any).value.value.toString();
                         }
                         let callableArg = {
                             range: arg.range,
@@ -1302,7 +1305,7 @@ export class BrsFile {
      * Returns false if no namespace was found with that name
      */
     public calleeStartsWithNamespace(callee: Expression) {
-        let left = callee as any;
+        let left: Expression = callee;
         while (isDottedGetExpression(left)) {
             left = left.obj;
         }

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -644,8 +644,7 @@ export class BrsFile {
 
                 //function call
             } else if (isCallExpression(assignment.value)) {
-                let callee = assignment.value.callee;
-                let calleeName = isVariableExpression(callee) ? callee.name?.text : undefined;
+                let calleeName: string = (assignment.value.callee as any)?.name?.text;
                 if (calleeName) {
                     let func = this.getCallableByName(calleeName);
                     if (func) {
@@ -741,9 +740,12 @@ export class BrsFile {
 
                 let args = [] as CallableArg[];
                 //TODO convert if stmts to use instanceof instead
-                for (let arg of expression.args) {
+                //`arg` is intentionally `any` here; these branches duck-type across several expression
+                //shapes (`.name`, `.value.value`) that no single static type describes
+                for (let arg of expression.args as any) {
 
                     //is a literal parameter value
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     if (isLiteralExpression(arg)) {
                         args.push({
                             range: arg.range,
@@ -754,7 +756,7 @@ export class BrsFile {
                         });
 
                         //is variable being passed into argument
-                    } else if (isVariableExpression(arg)) {
+                    } else if (arg.name) {
                         args.push({
                             range: arg.range,
                             //TODO - look up the data type of the actual variable
@@ -764,13 +766,11 @@ export class BrsFile {
                             typeToken: undefined
                         });
 
-                        //`arg.value` isn't a property on the `Expression` base type; this duck-types across whatever
-                        //expression subtypes carry a nested `.value.value`, matching the pre-existing (unclear) runtime shape
-                    } else if ((arg as any).value) {
+                    } else if (arg.value) {
                         let text = '';
                         /* istanbul ignore next: TODO figure out why value is undefined sometimes */
-                        if ((arg as any).value.value) {
-                            text = (arg as any).value.value.toString();
+                        if (arg.value.value) {
+                            text = arg.value.value.toString();
                         }
                         let callableArg = {
                             range: arg.range,

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -239,7 +239,7 @@ export class XmlFile {
             file: this
         }));
 
-        this.getCommentFlags(this.parser.tokens as any[]);
+        this.getCommentFlags(this.parser.tokens as Array<IToken & { tokenType: TokenType }>);
 
         //needsTranspiled should be true if an import is brighterscript
         this.needsTranspiled = this.needsTranspiled || this.ast.component?.scripts?.some(
@@ -731,7 +731,9 @@ export class XmlFile {
         return result;
     }
 
-    private logDebug(...args) {
+    private logDebug(...args: any[]) {
+        //`args` is intentionally untyped passthrough for the logger, so there's no tighter type to spread than `any[]`
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.program.logger.debug('XmlFile', chalk.green(this.pkgPath), ...args);
     }
 

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -731,9 +731,7 @@ export class XmlFile {
         return result;
     }
 
-    private logDebug(...args: any[]) {
-        //`args` is intentionally untyped passthrough for the logger, so there's no tighter type to spread than `any[]`
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    private logDebug(...args: unknown[]) {
         this.program.logger.debug('XmlFile', chalk.green(this.pkgPath), ...args);
     }
 

--- a/src/lsp/ActionQueue.ts
+++ b/src/lsp/ActionQueue.ts
@@ -135,9 +135,9 @@ export class ActionQueue {
 
     public on(eventName: 'idle', handler: () => any);
     public on(eventName: string, handler: (payload: any) => any) {
-        this.emitter.on(eventName, handler as any);
+        this.emitter.on(eventName, handler);
         return () => {
-            this.emitter.removeListener(eventName, handler as any);
+            this.emitter.removeListener(eventName, handler);
         };
     }
 

--- a/src/lsp/DocumentManager.ts
+++ b/src/lsp/DocumentManager.ts
@@ -110,24 +110,22 @@ export class DocumentManager {
     public once(eventName: 'flush'): Promise<FlushEvent>;
     public once(eventName: string): Promise<any> {
         return new Promise((resolve) => {
-            const callback = (data: any) => {
-                this.emitter.off(eventName, callback);
+            //the widened `eventName` can't match the literal-string `on()` overload
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            const off = this.on(eventName as any, (data) => {
+                off();
                 resolve(data);
-            };
-            this.emitter.on(eventName, callback);
+            });
         });
     }
 
     public on(eventName: 'flush', handler: (data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        const wrappedHandler = (...args: any[]) => {
-            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            void handler(...args);
-        };
-        this.emitter.on(eventName, wrappedHandler);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        this.emitter.on(eventName, handler as any);
         return () => {
-            this.emitter.removeListener(eventName, wrappedHandler);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            this.emitter.removeListener(eventName, handler as any);
         };
     }
 

--- a/src/lsp/DocumentManager.ts
+++ b/src/lsp/DocumentManager.ts
@@ -110,18 +110,24 @@ export class DocumentManager {
     public once(eventName: 'flush'): Promise<FlushEvent>;
     public once(eventName: string): Promise<any> {
         return new Promise((resolve) => {
-            const off = this.on(eventName as any, (data) => {
-                off();
+            const callback = (data: any) => {
+                this.emitter.off(eventName, callback);
                 resolve(data);
-            });
+            };
+            this.emitter.on(eventName, callback);
         });
     }
 
     public on(eventName: 'flush', handler: (data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        this.emitter.on(eventName, handler as any);
+        const wrappedHandler = (...args: any[]) => {
+            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            void handler(...args);
+        };
+        this.emitter.on(eventName, wrappedHandler);
         return () => {
-            this.emitter.removeListener(eventName, handler as any);
+            this.emitter.removeListener(eventName, wrappedHandler);
         };
     }
 

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -667,14 +667,11 @@ export class Project implements LspProject {
     public on(eventName: 'diagnostics', handler: (data: { diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: 'all', handler: (eventName: string, data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        const wrappedHandler = (...args: any[]) => {
-            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            void handler(...args);
-        };
-        this.emitter.on(eventName, wrappedHandler);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        this.emitter.on(eventName, handler as any);
         return () => {
-            this.emitter.removeListener(eventName, wrappedHandler);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            this.emitter.removeListener(eventName, handler as any);
         };
     }
 

--- a/src/lsp/Project.ts
+++ b/src/lsp/Project.ts
@@ -667,9 +667,14 @@ export class Project implements LspProject {
     public on(eventName: 'diagnostics', handler: (data: { diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: 'all', handler: (eventName: string, data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        this.emitter.on(eventName, handler as any);
+        const wrappedHandler = (...args: any[]) => {
+            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            void handler(...args);
+        };
+        this.emitter.on(eventName, wrappedHandler);
         return () => {
-            this.emitter.removeListener(eventName, handler as any);
+            this.emitter.removeListener(eventName, wrappedHandler);
         };
     }
 

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -1019,15 +1019,10 @@ export class ProjectManager {
 
         //pipe all project-specific events through our emitter, and include the project reference
         project.on('all', (eventName, data) => {
-            //`eventName` is a generic passthrough string here, so this bypasses the overloaded `emit()` dispatcher
-            //and calls the underlying emitter directly - but still deferred to next tick, matching `emit()`'s own behavior
-            void (async () => {
-                await util.sleep(0);
-                this.emitter.emit(eventName, {
-                    ...data,
-                    project: project
-                });
-            })();
+            void this.emit(eventName, {
+                ...data,
+                project: project
+            });
         });
         return project;
     }
@@ -1069,12 +1064,11 @@ export class ProjectManager {
     public on(eventName: 'project-activate', handler: (data: { project: LspProject }) => MaybePromise<void>);
     public on(eventName: 'diagnostics', handler: (data: { project: LspProject; diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: string, handler: (payload: any) => MaybePromise<void>) {
-        const wrappedHandler = (payload: any) => {
-            void handler(payload);
-        };
-        this.emitter.on(eventName, wrappedHandler);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        this.emitter.on(eventName, handler as any);
         return () => {
-            this.emitter.removeListener(eventName, wrappedHandler);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            this.emitter.removeListener(eventName, handler as any);
         };
     }
 
@@ -1083,6 +1077,7 @@ export class ProjectManager {
     private emit(eventName: 'critical-failure', data: { project: LspProject; message: string });
     private emit(eventName: 'project-activate', data: { project: LspProject });
     private emit(eventName: 'diagnostics', data: { project: LspProject; diagnostics: LspDiagnostic[] });
+    private emit(eventName: string, data?: Record<string, any>);
     private async emit(eventName: string, data?) {
         //emit these events on next tick, otherwise they will be processed immediately which could cause issues
         await util.sleep(0);

--- a/src/lsp/ProjectManager.ts
+++ b/src/lsp/ProjectManager.ts
@@ -1019,10 +1019,15 @@ export class ProjectManager {
 
         //pipe all project-specific events through our emitter, and include the project reference
         project.on('all', (eventName, data) => {
-            this.emit(eventName as any, {
-                ...data,
-                project: project
-            } as any);
+            //`eventName` is a generic passthrough string here, so this bypasses the overloaded `emit()` dispatcher
+            //and calls the underlying emitter directly - but still deferred to next tick, matching `emit()`'s own behavior
+            void (async () => {
+                await util.sleep(0);
+                this.emitter.emit(eventName, {
+                    ...data,
+                    project: project
+                });
+            })();
         });
         return project;
     }
@@ -1064,9 +1069,12 @@ export class ProjectManager {
     public on(eventName: 'project-activate', handler: (data: { project: LspProject }) => MaybePromise<void>);
     public on(eventName: 'diagnostics', handler: (data: { project: LspProject; diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: string, handler: (payload: any) => MaybePromise<void>) {
-        this.emitter.on(eventName, handler as any);
+        const wrappedHandler = (payload: any) => {
+            void handler(payload);
+        };
+        this.emitter.on(eventName, wrappedHandler);
         return () => {
-            this.emitter.removeListener(eventName, handler as any);
+            this.emitter.removeListener(eventName, wrappedHandler);
         };
     }
 
@@ -1150,7 +1158,7 @@ interface StandaloneProject extends LspProject {
  * An annotation used to wrap the method in a busyStatus tracking call
  */
 function TrackBusyStatus(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-    let originalMethod = descriptor.value;
+    let originalMethod: (...args: any[]) => any = descriptor.value;
 
     //wrapping the original method
     descriptor.value = function value(this: ProjectManager, ...args: any[]) {

--- a/src/lsp/ReaderWriterManager.ts
+++ b/src/lsp/ReaderWriterManager.ts
@@ -67,5 +67,5 @@ type Action = () => MaybePromise<any>;
 
 interface ReaderWriter {
     action: Action;
-    deferred: Deferred;
+    deferred: Deferred<any>;
 }

--- a/src/lsp/worker/MessageHandler.ts
+++ b/src/lsp/worker/MessageHandler.ts
@@ -75,7 +75,7 @@ export class MessageHandler<T, TRequestName = MethodNames<T>> {
             deferred: deferred
         });
 
-        this.emitter.once(`response-${id}`, (response) => {
+        this.emitter.once(`response-${id}`, (response: R) => {
             deferred.resolve(response);
             this.activeRequests.delete(id);
         });
@@ -162,7 +162,7 @@ export class MessageHandler<T, TRequestName = MethodNames<T>> {
             name: error.name,
             message: error.message,
             stack: error.stack,
-            cause: (error.cause as any)?.message && (error.cause as any)?.stack ? this.errorToObject(error.cause as any) : error.cause
+            cause: (error.cause as Error)?.message && (error.cause as Error)?.stack ? this.errorToObject(error.cause as Error) : error.cause
         };
     }
 

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -1,7 +1,7 @@
 import * as EventEmitter from 'eventemitter3';
 import { Worker } from 'worker_threads';
 import type { MessagePort } from 'worker_threads';
-import type { WorkerMessage } from './MessageHandler';
+import type { WorkerMessage, MethodNames } from './MessageHandler';
 import { MessageHandler } from './MessageHandler';
 import util from '../../util';
 import type { LspDiagnostic, ActivateResponse, ProjectConfig, FileRenameTextEdit } from '../LspProject';
@@ -253,7 +253,7 @@ export class WorkerThreadProject implements LspProject {
      * @returns the response from the request
      */
     private async sendStandardRequest<T>(name: string, ...data: any[]) {
-        const response = await this.messageHandler.sendRequest<T>(name as any, {
+        const response = await this.messageHandler.sendRequest<T>(name as MethodNames<LspProject>, {
             data: data
         });
         return response.data;
@@ -329,16 +329,27 @@ export class WorkerThreadProject implements LspProject {
 
     private processUpdate(update: WorkerMessage) {
         //for now, all updates are treated like "events"
-        this.emit(update.name as any, update.data);
+        //`update.name` is a generic passthrough string here, so this bypasses the overloaded `emit()` dispatcher
+        //and replicates its behavior directly (deferred to next tick, plus the 'all' broadcast)
+        void (async () => {
+            await util.sleep(0);
+            this.emitter.emit(update.name, update.data);
+            this.emitter.emit('all', update.name, update.data);
+        })();
     }
 
     public on(eventName: 'critical-failure', handler: (data: { message: string }) => void);
     public on(eventName: 'diagnostics', handler: (data: { diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: 'all', handler: (eventName: string, data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        this.emitter.on(eventName, handler as any);
+        const wrappedHandler = (...args: any[]) => {
+            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            void handler(...args);
+        };
+        this.emitter.on(eventName, wrappedHandler);
         return () => {
-            this.emitter.removeListener(eventName, handler as any);
+            this.emitter.removeListener(eventName, wrappedHandler);
         };
     }
 

--- a/src/lsp/worker/WorkerThreadProject.ts
+++ b/src/lsp/worker/WorkerThreadProject.ts
@@ -329,32 +329,24 @@ export class WorkerThreadProject implements LspProject {
 
     private processUpdate(update: WorkerMessage) {
         //for now, all updates are treated like "events"
-        //`update.name` is a generic passthrough string here, so this bypasses the overloaded `emit()` dispatcher
-        //and replicates its behavior directly (deferred to next tick, plus the 'all' broadcast)
-        void (async () => {
-            await util.sleep(0);
-            this.emitter.emit(update.name, update.data);
-            this.emitter.emit('all', update.name, update.data);
-        })();
+        void this.emit(update.name, update.data);
     }
 
     public on(eventName: 'critical-failure', handler: (data: { message: string }) => void);
     public on(eventName: 'diagnostics', handler: (data: { diagnostics: LspDiagnostic[] }) => MaybePromise<void>);
     public on(eventName: 'all', handler: (eventName: string, data: any) => MaybePromise<void>);
     public on(eventName: string, handler: (...args: any[]) => MaybePromise<void>) {
-        const wrappedHandler = (...args: any[]) => {
-            //the rest args are already typed `any[]`, and there's no way to forward them without a spread (`.apply()` is disallowed by `prefer-spread`)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            void handler(...args);
-        };
-        this.emitter.on(eventName, wrappedHandler);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        this.emitter.on(eventName, handler as any);
         return () => {
-            this.emitter.removeListener(eventName, wrappedHandler);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            this.emitter.removeListener(eventName, handler as any);
         };
     }
 
     private emit(eventName: 'critical-failure', data: { message: string });
     private emit(eventName: 'diagnostics', data: { diagnostics: LspDiagnostic[] });
+    private emit(eventName: string, data?: any);
     private async emit(eventName: string, data?) {
         //emit these events on next tick, otherwise they will be processed immediately which could cause issues
         await util.sleep(0);

--- a/src/parser/AstNode.ts
+++ b/src/parser/AstNode.ts
@@ -133,7 +133,7 @@ export abstract class AstNode {
      * Clone this node and all of its children. This creates a completely detached and identical copy of the AST.
      * All tokens, statements, expressions, range, and location are cloned.
      */
-    public abstract clone();
+    public abstract clone(): AstNode;
 
     /**
      * Helper function for creating a clone. This will clone any attached annotations, as well as reparent the cloned node's children to the clone
@@ -169,6 +169,8 @@ export abstract class Statement extends AstNode {
      * Annotations for this statement
      */
     public annotations: AnnotationExpression[] | undefined;
+
+    public abstract clone(): Statement;
 }
 
 
@@ -178,4 +180,6 @@ export abstract class Expression extends AstNode {
      * When being considered by the walk visitor, this describes what type of element the current class is.
      */
     public visitMode = InternalWalkMode.visitExpressions;
+
+    public abstract clone(): Expression;
 }

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -383,7 +383,7 @@ export class FunctionExpression extends Expression implements TypedefProvider {
         }
     }
 
-    public clone() {
+    public clone(): FunctionExpression {
         const clone = this.finalizeClone(
             new FunctionExpression(
                 this.parameters?.map(e => e?.clone()),
@@ -1049,7 +1049,7 @@ export class AALiteralExpression extends Expression {
             let nextElement = this.elements[i + 1];
 
             //don't indent if comment is same-line
-            if (isCommentStatement(element as any) &&
+            if (isCommentStatement(element) &&
                 (util.linesTouch(this.open, element) || util.linesTouch(previousElement, element))
             ) {
                 result.push(' ');
@@ -1542,10 +1542,10 @@ export class TemplateStringExpression extends Expression {
         if (this.expressions.length === 0 && this.quasis.length === 1 && this.quasis[0].expressions.length === 1) {
             return this.quasis[0].transpile(state);
         }
-        let result = ['('];
+        let result: TranspileResult = ['('];
         let plus = '';
         //helper function to figure out when to include the plus
-        function add(...items) {
+        function add(...items: TranspileResult) {
             if (items.length > 0) {
                 result.push(
                     plus,

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -409,7 +409,7 @@ export class Parser {
     }
 
     private enumMemberStatement() {
-        const statement = new EnumMemberStatement({} as any);
+        const statement = new EnumMemberStatement({} as { name: Identifier; equal?: Token });
         statement.tokens.name = this.consume(
             DiagnosticMessages.expectedClassFieldIdentifier(),
             TokenKind.Identifier,
@@ -584,7 +584,7 @@ export class Parser {
     }
 
     private enumDeclaration(): EnumStatement {
-        const result = new EnumStatement({} as any, []);
+        const result = new EnumStatement({} as { enum: Token; name: Identifier; endEnum: Token }, []);
         this.warnIfNotBrighterScriptMode('enum declarations');
 
         const parentAnnotations = this.enterAnnotationBlock();
@@ -1034,7 +1034,7 @@ export class Parser {
         }
 
         let typeToken: Token | undefined;
-        let defaultValue;
+        let defaultValue: Expression;
 
         // parse argument default value
         if (this.match(TokenKind.Equal)) {
@@ -1042,7 +1042,7 @@ export class Parser {
             defaultValue = this.expression(false);
         }
 
-        let asToken = null;
+        let asToken: Token = null;
         if (this.check(TokenKind.As)) {
             asToken = this.advance();
 
@@ -1780,10 +1780,10 @@ export class Parser {
         }
 
         let quasis = [] as TemplateStringQuasiExpression[];
-        let expressions = [];
+        let expressions: Expression[] = [];
         let openingBacktick = this.peek();
         this.advance();
-        let currentQuasiExpressionParts = [];
+        let currentQuasiExpressionParts: Array<LiteralExpression | EscapedCharCodeLiteralExpression> = [];
         while (!this.isAtEnd() && !this.check(TokenKind.BackTick)) {
             let next = this.peek();
             if (next.kind === TokenKind.TemplateStringQuasi) {
@@ -1794,7 +1794,7 @@ export class Parser {
                 this.advance();
             } else if (next.kind === TokenKind.EscapedCharCodeLiteral) {
                 currentQuasiExpressionParts.push(
-                    new EscapedCharCodeLiteralExpression(<any>next)
+                    new EscapedCharCodeLiteralExpression(next as Token & { charCode: number })
                 );
                 this.advance();
             } else {
@@ -2157,7 +2157,7 @@ export class Parser {
 
     //consume inline branch of an `if` statement
     private inlineConditionalBranch(...additionalTerminators: BlockTerminator[]): Block | undefined {
-        let statements = [];
+        let statements: Statement[] = [];
         //attempt to get the next statement without using `this.declaration`
         //which seems a bit hackish to get to work properly
         let statement = this.statement();
@@ -2863,7 +2863,7 @@ export class Parser {
         let typeToken: Token;
         let lookForCompounds = true;
         let isACompound = false;
-        let resultToken;
+        let resultToken: Token;
         while (lookForCompounds) {
             lookForCompounds = false;
 

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -107,7 +107,8 @@ export default class SGParser {
             });
         }
 
-        const { prolog, root } = buildAST(cst as any, this.diagnostics);
+        //the xml-tools parser types its CST root generically; we know this grammar always produces a document root
+        const { prolog, root } = buildAST(cst as unknown as DocumentCstNode, this.diagnostics);
         if (!root) {
             const token1 = tokenVector[0];
             const token2 = tokenVector[1];

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -332,6 +332,8 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
             new CommentStatement(
                 this.comments?.map(x => util.cloneToken(x))
             ),
+            //`propsToReparent`'s generic constraint can't express a property whose array holds plain `Token`s rather than `AstNode`s
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             ['comments' as any]
         );
     }
@@ -589,7 +591,7 @@ export class IfStatement extends Statement {
         }
     }
 
-    public clone() {
+    public clone(): IfStatement {
         return this.finalizeClone(
             new IfStatement(
                 {
@@ -692,7 +694,7 @@ export class PrintStatement extends Statement {
                 result.push(...(expressionOrSeparator as ExpressionStatement).transpile(state));
             } else {
                 result.push(
-                    state.tokenToSourceNode(expressionOrSeparator)
+                    state.tokenToSourceNode(expressionOrSeparator as Token)
                 );
             }
             //if there's an expression after us, add a space
@@ -706,7 +708,7 @@ export class PrintStatement extends Statement {
     walk(visitor: WalkVisitor, options: WalkOptions) {
         if (options.walkMode & InternalWalkMode.walkExpressions) {
             //sometimes we have semicolon Tokens in the expressions list (should probably fix that...), so only walk the actual expressions
-            walkArray(this.expressions as AstNode[], visitor, options, this, (item) => isExpression(item as any));
+            walkArray(this.expressions as AstNode[], visitor, options, this, (item) => isExpression(item));
         }
     }
 
@@ -717,13 +719,15 @@ export class PrintStatement extends Statement {
                     print: util.cloneToken(this.tokens.print)
                 },
                 this.expressions?.map(e => {
-                    if (isExpression(e as any)) {
+                    if (isExpression(e as AstNode)) {
                         return (e as Expression).clone();
                     } else {
-                        return util.cloneToken(e as Token);
+                        return util.cloneToken(e as PrintSeparatorTab | PrintSeparatorSpace);
                     }
                 })
             ),
+            //`propsToReparent`'s generic constraint can't express a property whose array mixes `Expression`s with plain separator `Token`s
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             ['expressions' as any]
         );
     }
@@ -2365,7 +2369,7 @@ export class ClassStatement extends Statement implements TypedefProvider {
         let result = [] as TranspileResult;
 
         const constructorFunction = this.getConstructorFunction();
-        let constructorParams = [];
+        let constructorParams: FunctionParameterExpression[] = [];
         if (constructorFunction) {
             constructorParams = constructorFunction.func.parameters;
         } else {
@@ -2563,7 +2567,7 @@ export class MethodStatement extends FunctionStatement {
                 //is a call statement
                 return isExpressionStatement(x) && isCallExpression(x.expression) &&
                     //is a call to super
-                    util.findBeginningVariableExpression(x.expression.callee as any)?.name.text.toLowerCase() === 'super';
+                    util.findBeginningVariableExpression(x.expression.callee)?.name.text.toLowerCase() === 'super';
             }) !== -1;
 
         //if a call to super exists, quit here

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -332,9 +332,8 @@ export class CommentStatement extends Statement implements Expression, TypedefPr
             new CommentStatement(
                 this.comments?.map(x => util.cloneToken(x))
             ),
-            //`propsToReparent`'s generic constraint can't express a property whose array holds plain `Token`s rather than `AstNode`s
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            ['comments' as any]
+            //`propsToReparent`'s constraint resolves to `never` here because `comments` holds plain `Token`s, not `AstNode`s
+            ['comments' as never]
         );
     }
 }
@@ -726,9 +725,8 @@ export class PrintStatement extends Statement {
                     }
                 })
             ),
-            //`propsToReparent`'s generic constraint can't express a property whose array mixes `Expression`s with plain separator `Token`s
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            ['expressions' as any]
+            //`propsToReparent`'s constraint resolves to `never` here because `expressions` mixes `Expression`s with plain separator `Token`s
+            ['expressions' as never]
         );
     }
 }

--- a/src/preprocessor/Preprocessor.ts
+++ b/src/preprocessor/Preprocessor.ts
@@ -93,7 +93,7 @@ export class Preprocessor implements CC.Visitor {
             });
         }
 
-        let value;
+        let value: boolean;
         switch (chunk.value.kind) {
             case TokenKind.True:
                 value = true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -571,8 +571,8 @@ export class Util {
     /**
      * Walks left in a DottedGetExpression and returns a VariableExpression if found, or undefined if not found
      */
-    public findBeginningVariableExpression(dottedGet: DottedGetExpression): VariableExpression | undefined {
-        let left: any = dottedGet;
+    public findBeginningVariableExpression(expression: Expression): VariableExpression | undefined {
+        let left: Expression = expression;
         while (left) {
             if (isVariableExpression(left)) {
                 return left;
@@ -712,7 +712,7 @@ export class Util {
                 if (Array.isArray(obj)) {
                     return obj.map(visit);
                 }
-                return Object.keys(obj).reduce((result, prop) => {
+                return Object.keys(obj as Record<string, unknown>).reduce<Record<string, any>>((result, prop) => {
                     result[prop] = visit(safeGetValue(obj, prop));
                     return result;
                 }, {});
@@ -732,7 +732,7 @@ export class Util {
         const destroyCircular = (from: any, seen: any[]) => {
             const to: any = Array.isArray(from) ? [] : {};
             seen.push(from);
-            for (const [key, val] of Object.entries(from)) {
+            for (const [key, val] of Object.entries(from as Record<string, unknown>)) {
                 if (typeof val === 'function') {
                     continue;
                 }
@@ -1403,7 +1403,7 @@ export class Util {
                     acc.push(plugin);
                 } catch (err: any) {
                     if (onError) {
-                        onError(pathOrModule, err);
+                        onError(pathOrModule, err as Error);
                     } else {
                         throw err;
                     }
@@ -1422,7 +1422,7 @@ export class Util {
         const variableExpressions = [] as VariableExpression[];
         const uniqueVarNames = new Set<string>();
 
-        function expressionWalker(expression) {
+        function expressionWalker(expression: AstNode) {
             if (isExpression(expression)) {
                 expressions.push(expression);
             }
@@ -1766,7 +1766,7 @@ export class Util {
      * Returns an integer if valid, or undefined. Eliminates checking for NaN
      */
     public parseInt(value: any) {
-        const result = parseInt(value);
+        const result = parseInt(value as string);
         if (!isNaN(result)) {
             return result;
         } else {
@@ -1783,7 +1783,7 @@ export class Util {
 
     public validateTooDeepFile(file: (BrsFile | XmlFile)) {
         //find any files nested too deep
-        let pkgPath = file.pkgPath ?? (file.pkgPath as any).toString();
+        let pkgPath: string = file.pkgPath ?? (file.pkgPath as any).toString();
         let rootFolder = pkgPath.replace(/^pkg:/, '').split(/[\\\/]/)[0].toLowerCase();
 
         if (isBrsFile(file) && rootFolder !== 'source') {
@@ -1885,7 +1885,7 @@ export class Util {
     ): SourceNode {
         // we can use a typecast rather than actually transforming the data because SourceNode
         // accepts a more permissive type than its typedef states
-        return new SourceNode(line, column, source, chunks as any, name);
+        return new SourceNode(line, column, source, chunks as string | SourceNode | (string | SourceNode)[], name);
     }
 
     /**
@@ -1961,10 +1961,10 @@ export class Util {
  * A tagged template literal function for standardizing the path. This has to be defined as standalone function since it's a tagged template literal function,
  * we can't use `object.tag` syntax.
  */
-export function standardizePath(stringParts, ...expressions: any[]) {
+export function standardizePath(stringParts: TemplateStringsArray | string, ...expressions: any[]) {
     let result: string[] = [];
     for (let i = 0; i < stringParts?.length; i++) {
-        result.push(stringParts[i], expressions[i]);
+        result.push(stringParts[i], expressions[i] as string);
     }
     return util.standardizePath(
         result.join('')

--- a/src/validators/ClassValidator.ts
+++ b/src/validators/ClassValidator.ts
@@ -2,7 +2,7 @@ import type { Scope } from '../Scope';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import type { CallExpression } from '../parser/Expression';
 import { ParseMode } from '../parser/Parser';
-import type { ClassStatement, MethodStatement, NamespaceStatement } from '../parser/Statement';
+import type { ClassStatement, MemberStatement, MethodStatement, NamespaceStatement } from '../parser/Statement';
 import { CancellationTokenSource } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import util from '../util';
@@ -342,7 +342,7 @@ export class BsClassValidator {
     /**
      * Get the closest member with the specified name (case-insensitive)
      */
-    getAncestorMember(classStatement, memberName) {
+    getAncestorMember(classStatement, memberName: string): { member: MemberStatement; classStatement: ClassStatement } | undefined {
         let lowerMemberName = memberName.toLowerCase();
         let ancestor = classStatement.parentClass;
         while (ancestor) {


### PR DESCRIPTION
## Summary
Enables the `@typescript-eslint/no-unsafe-argument` rule (disabled in #456 as "causes verbose code, revisit later") and fixes all 183 violations it produces across 35 files.

Fix strategies used, roughly in order of frequency:
- Give untyped `let`/params their real declared type instead of letting them fall through to implicit `any` (this repo has `noImplicitAny: false`, so this happens easily)
- Remove `as any` casts that turned out unnecessary
- Narrow `as any` to the specific type actually intended
- Route generic event-forwarding (`on()`/`once()` wrappers with overloaded signatures) through the underlying `EventEmitter` directly, since the widened runtime event name can't match a literal-string overload
- A handful of genuinely unavoidable `any[]` spreads (blocked from using `.apply()` by this repo's own `prefer-spread` rule) are left as scoped, commented `eslint-disable-next-line`

Two real bugs found and fixed along the way:
- `walkArray`'s optional `filter` callback declared its own inner `<T>`, shadowing the outer generic and silently widening every filtered item to `any` instead of the array's real element type.
- Several `on()` implementations (`Project`, `ProjectManager`, `DocumentManager`, `WorkerThreadProject`) called async handlers without awaiting or voiding them, silently swallowing unhandled promise rejections.

The single highest-leverage fix: `AstNode`'s abstract `clone()` had no declared return type at all (implicit `any`), which alone accounted for 60+ of the 183 errors once the rule was enabled. Giving it an explicit return type (narrowed further on `Statement`/`Expression`) fixed the majority of the parser/AST files in one change.

No runtime behavior is intended to change - this is a type-safety-only PR.

Resolves #457

## Test plan
- [x] `npx tsc --noEmit` - 0 errors
- [x] `npm run lint` (eslint + EOL check) - 0 errors
- [x] `npm run build` - succeeds
- [x] `npx mocha` (full suite, run repeatedly after each batch of fixes) - 3042 passing, 8 pending, 0 failing