### PR TITLE
Avoid emitting a duplicate sourceMappingURL comment

### DIFF
--- a/src/files/BrsFile.spec.ts
+++ b/src/files/BrsFile.spec.ts
@@ -3529,6 +3529,34 @@ describe('BrsFile', () => {
             `);
         });
 
+        it('replaces existing trailing sourceMappingURL comment instead of appending a second one', () => {
+            program.options.sourceMap = true;
+            //file already has a sourceMappingURL comment at the bottom (e.g. ingested from a previous build)
+            const file = program.setFile('source/main.bs', undent`
+                sub main()
+                end sub
+                '//# sourceMappingURL=./some-old-path.brs.map
+            `);
+            file.needsTranspiled = false;
+            const code = file.transpile().code;
+            //should only contain a single sourceMappingURL comment (the new one)
+            expect(code.match(/sourceMappingURL=/g)?.length).to.eql(1);
+            expect(code.endsWith(`'//# sourceMappingURL=./main.brs.map`)).to.be.true;
+        });
+
+        it('replaces existing trailing sourceMappingURL comment when AST-transpiling', () => {
+            program.options.sourceMap = true;
+            const file = program.setFile('source/main.bs', undent`
+                sub main()
+                end sub
+                '//# sourceMappingURL=./some-old-path.brs.map
+            `);
+            file.needsTranspiled = true;
+            const code = file.transpile().code;
+            expect(code.match(/sourceMappingURL=/g)?.length).to.eql(1);
+            expect(code.endsWith(`'//# sourceMappingURL=./main.brs.map`)).to.be.true;
+        });
+
         it('includes sourcemap.name property', () => {
             program.options.sourceMap = true;
             const file = program.setFile('source/main.bs', `

--- a/src/files/BrsFile.ts
+++ b/src/files/BrsFile.ts
@@ -1486,6 +1486,7 @@ export class BrsFile {
         state.editor.undoAll();
 
         if (this.program.options.sourceMap) {
+            util.stripTrailingSourceMappingURLComment(transpileResult);
             const stagingFileName = path.basename(state.srcPath).replace(/\.bs$/, '.brs');
             return new SourceNode(null, null, stagingFileName, [
                 transpileResult,

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -1256,6 +1256,40 @@ describe('XmlFile', () => {
             expect(code.endsWith(`<!--//# sourceMappingURL=./SimpleScene.xml.map -->`)).to.be.true;
         });
 
+        it('replaces existing trailing sourceMappingURL comment instead of appending a second one', () => {
+            program.options.sourceMap = true;
+            let file = program.setFile('components/SimpleScene.xml',
+                trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="SimpleScene" extends="Scene">
+                </component>
+                <!--//# sourceMappingURL=./some-old-path.xml.map -->
+            `);
+            //prevent the default auto-imports to ensure no transpilation from AST
+            (file as any).getMissingImportsForTranspile = () => [];
+            const code = file.transpile().code;
+            expect(code.match(/sourceMappingURL=/g)?.length).to.eql(1);
+            expect(code.endsWith(`<!--//# sourceMappingURL=./SimpleScene.xml.map -->`)).to.be.true;
+        });
+
+        it('replaces existing trailing sourceMappingURL comment when AST-transpiling', () => {
+            program.options.sourceMap = true;
+            //a script tag pointing at a .bs file forces the AST transpile path, which rebuilds output
+            //from the component tree and therefore drops a comment sitting outside the root element
+            let file = program.setFile('components/SimpleScene.xml',
+                trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="SimpleScene" extends="Scene">
+                    <script type="text/brightscript" uri="SimpleScene.bs"/>
+                </component>
+                <!--//# sourceMappingURL=./some-old-path.xml.map -->
+            `);
+            expect(file.needsTranspiled).to.be.true;
+            const code = file.transpile().code;
+            expect(code.match(/sourceMappingURL=/g)?.length).to.eql(1);
+            expect(code.endsWith(`<!--//# sourceMappingURL=./SimpleScene.xml.map -->`)).to.be.true;
+        });
+
         it('AST-based source mapping includes sourcemap reference', () => {
             program.options.sourceMap = true;
             let file = program.setFile('components/SimpleScene.xml',

--- a/src/files/XmlFile.ts
+++ b/src/files/XmlFile.ts
@@ -793,6 +793,7 @@ export class XmlFile {
 
         //add the source map comment if configured to emit sourcemaps
         if (this.program.options.sourceMap) {
+            util.stripTrailingSourceMappingURLComment(transpileResult);
             return new SourceNode(null, null, state.srcPath, [
                 transpileResult,
                 //add the sourcemap reference comment

--- a/src/util.ts
+++ b/src/util.ts
@@ -1889,6 +1889,29 @@ export class Util {
     }
 
     /**
+     * Strip a trailing `sourceMappingURL` comment (and the newline preceding it) from the end of a
+     * transpile result, so that appending a freshly-generated one doesn't produce a duplicate. A file
+     * can already carry a comment from a previous build, which is either preserved verbatim (for
+     * files that don't need transpiling) or re-emitted as a comment by the AST transpile.
+     *
+     * Handles both BrightScript-style (`'//# sourceMappingURL=...`) and XML-style
+     * (`<!--//# sourceMappingURL=... -->`) comments. Leaves the node untouched when no trailing
+     * sourceMappingURL comment is present.
+     */
+    public stripTrailingSourceMappingURLComment(node: SourceNode): SourceNode {
+        //`\S+` cannot backtrack across whitespace, so this stays linear-time on adversarial input
+        const pattern = /(?:\r?\n)?[ \t]*(?:'\/\/# sourceMappingURL=\S+|<!--[ \t]*\/\/# sourceMappingURL=\S+[ \t]*-->)\s*$/;
+        if (pattern.test(node.toString())) {
+            //`replaceRight` operates on the right-most leaf string, which is where a trailing comment
+            //lands in both the verbatim and AST-transpiled cases. The `source-map` typings declare the
+            //pattern as a string, but it is handed straight to `String.prototype.replace`, which
+            //accepts a RegExp
+            node.replaceRight(pattern as unknown as string, '');
+        }
+        return node;
+    }
+
+    /**
      * Parse the `sourceMappingURL` comment from file contents and resolve it to a RawSourceMap.
      * Handles inline base64 data URIs, absolute paths, relative paths (resolved against srcPath's
      * directory), and falls back to a co-located `<srcPath>.map` file.


### PR DESCRIPTION
The prebuild sourcemap-chaining work taught the compiler to parse an incoming `sourceMappingURL` comment from a source file. That means a file rebuilt from a previous build's output carries its stale comment through transpile and then gets a second one appended, so the emitted file ends up with two.

What changed:
- `util.stripTrailingSourceMappingURLComment(node)` strips a trailing comment (BrightScript `'//#` and XML `<!--//# ... -->` forms) off a transpile result
- `BrsFile.transpile` / `XmlFile.transpile` call it before appending the generated comment

One note for review: `SourceNode.replaceRight` only mutates the right-most leaf string, while the regex test runs against the full `toString()`. Those can disagree in principle; they align on every path exercised here, and the helper carries a comment saying so.

Verified with `npm run test:nocover` (3046 passing) and `npm run lint`.
