### PR TITLE
Recognize regex literals after `${` and `,`

### DIFF
--- a/src/lexer/Lexer.spec.ts
+++ b/src/lexer/Lexer.spec.ts
@@ -1471,6 +1471,74 @@ describe('lexer', () => {
             ]);
         });
 
+        it('recognizes a regex at the start of a template string expression', () => {
+            expect(
+                Lexer.scan('thing = `${/hello/g}`').tokens.map(x => x.kind)
+            ).to.eql([
+                TokenKind.Identifier,
+                TokenKind.Equal,
+                TokenKind.BackTick,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.RegexLiteral,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.BackTick,
+                TokenKind.Eof
+            ]);
+        });
+
+        it('does not end a template string expression at a curly brace inside a regex', () => {
+            expect(
+                Lexer.scan('thing = `${/[}]/g}`').tokens.map(x => x.kind)
+            ).to.eql([
+                TokenKind.Identifier,
+                TokenKind.Equal,
+                TokenKind.BackTick,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.RegexLiteral,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.BackTick,
+                TokenKind.Eof
+            ]);
+        });
+
+        it('recognizes a regex after a comma', () => {
+            expect(
+                Lexer.scan('thing = [1, /hello/g]').tokens.map(x => x.kind)
+            ).to.eql([
+                TokenKind.Identifier,
+                TokenKind.Equal,
+                TokenKind.LeftSquareBracket,
+                TokenKind.IntegerLiteral,
+                TokenKind.Comma,
+                TokenKind.RegexLiteral,
+                TokenKind.RightSquareBracket,
+                TokenKind.Eof
+            ]);
+        });
+
+        it('still treats a forwardslash after an identifier as division', () => {
+            expect(
+                Lexer.scan('thing = `${a/b}`').tokens.map(x => x.kind)
+            ).to.eql([
+                TokenKind.Identifier,
+                TokenKind.Equal,
+                TokenKind.BackTick,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.TemplateStringExpressionBegin,
+                TokenKind.Identifier,
+                TokenKind.Forwardslash,
+                TokenKind.Identifier,
+                TokenKind.TemplateStringExpressionEnd,
+                TokenKind.TemplateStringQuasi,
+                TokenKind.BackTick,
+                TokenKind.Eof
+            ]);
+        });
+
         it('only captures alphanumeric flags', () => {
             expect(
                 Lexer.scan('speak(/a/)').tokens.map(x => x.kind)

--- a/src/lexer/TokenKind.ts
+++ b/src/lexer/TokenKind.ts
@@ -700,9 +700,11 @@ export const PreceedingRegexTypes = new Set([
     TokenKind.To,
     TokenKind.Newline,
     TokenKind.Throw,
-    TokenKind.Throw,
     TokenKind.Colon,
-    TokenKind.Semicolon
+    TokenKind.Semicolon,
+    TokenKind.Comma,
+    //a regex may open a template string expression (i.e. `${/hello/g}`)
+    TokenKind.TemplateStringExpressionBegin
 ]);
 
 /**


### PR DESCRIPTION
A regex literal at the start of a template string expression was lexed as division instead:

```brighterscript
thing = `${/hello/g}`
```

That comes out as `Forwardslash Identifier Forwardslash Identifier` rather than a single `RegexLiteral`. It gets worse when the pattern contains a curly brace, because the `}` inside the character class then looks like the end of the expression and truncates the rest of the template string:

```brighterscript
thing = `${/[}]/g}`
```

The lexer only tries to read a regex when the previous token is one that can't be followed by division — `print`, `(`, `[`, `=`, and so on, listed in `PreceedingRegexTypes`. `TemplateStringExpressionBegin` was never added to that list, so `${` fell through to the division path.

`Comma` was missing for the same reason, so regexes in array and argument literals were broken too:

```brighterscript
thing = [1, /hello/g]
```

## What changed

- Added `TemplateStringExpressionBegin` and `Comma` to `PreceedingRegexTypes`. Neither can be followed by division, so there's no case where this turns a valid divide into a regex.
- Removed a duplicate `Throw` entry in the same list.

## Verified

`npm run test:nocover` (3051 passing) and `npm run lint` both clean.

New tests cover a regex after `${`, a curly brace inside a regex character class, and a regex after a comma. There's also one asserting `` `${a/b}` `` still lexes as division — that's the one that would catch a bad entry in this list.
