### PR TITLE
Fix walk skipping children of nodes displaced by an insertion

### DIFF
--- a/src/astUtils/visitors.spec.ts
+++ b/src/astUtils/visitors.spec.ts
@@ -5,12 +5,12 @@ import { expect } from '../chai-config.spec';
 import * as sinon from 'sinon';
 import { Program } from '../Program';
 import type { BrsFile } from '../files/BrsFile';
-import type { FunctionStatement } from '../parser/Statement';
-import { PrintStatement, Block, ReturnStatement, ExpressionStatement } from '../parser/Statement';
+import type { FunctionStatement, Body as BsBody } from '../parser/Statement';
+import { PrintStatement, Block, ReturnStatement, ExpressionStatement, AssignmentStatement } from '../parser/Statement';
 import { TokenKind } from '../lexer/TokenKind';
 import { createVisitor, walkArray, WalkMode, walkStatements } from './visitors';
-import { isBlock, isLiteralExpression, isPrintStatement } from './reflection';
-import { createCall, createIntegerLiteral, createToken, createVariableExpression } from './creators';
+import { isAssignmentStatement, isBlock, isLiteralExpression, isPrintStatement } from './reflection';
+import { createCall, createIntegerLiteral, createStringLiteral, createToken, createVariableExpression } from './creators';
 import { createStackedVisitor } from './stackedVisitor';
 import { AstEditor } from './AstEditor';
 import { Parser } from '../parser/Parser';
@@ -1248,6 +1248,390 @@ describe('astUtils visitors', () => {
             });
 
             expect(walkedLiterals).to.eql(['3', '4']);
+        });
+
+        it('walks an if statement body when a statement is inserted above it', () => {
+            const editor = new AstEditor();
+            let walkedNodes: AstNode[] = [];
+            const ast = Parser.parse(`
+                sub main()
+                    if true then
+                        result = 1 + 2
+                    end if
+                end sub
+            `).ast;
+            ast.walk(createVisitor({
+                AssignmentStatement: (node) => {
+                    walkedNodes.push(node);
+                },
+                IfStatement: (node, parent, owner: Statement[], key) => {
+                    //insert a print above every if statement
+                    editor.arraySplice(owner, key, 0, new PrintStatement(
+                        { print: createToken(TokenKind.Print) },
+                        [createStringLiteral('"Hello world"')]
+                    ));
+                }
+            }), {
+                walkMode: WalkMode.visitAllRecursive,
+                editor: editor
+            });
+
+            const expectedAssignment = ast.findChild(isAssignmentStatement);
+            expect(walkedNodes).to.include(expectedAssignment);
+        });
+
+        describe('ast mutation during walk', () => {
+            /**
+             * Parse the source, walk it with the given visitor, and return the text of every
+             * print statement and assignment the walk visited (in visit order).
+             */
+            function walkAndCollect(source: string, visitor: Parameters<typeof createVisitor>[0], useEditor = false) {
+                const editor = new AstEditor();
+                const visited: string[] = [];
+                const { ast } = Parser.parse(source);
+                const collectingVisitor = createVisitor({
+                    ...visitor,
+                    PrintStatement: (node, parent, owner, key) => {
+                        visited.push(`print ${(node.expressions[0] as LiteralExpression)?.token?.text}`);
+                        return visitor.PrintStatement?.(node, parent, owner, key);
+                    },
+                    AssignmentStatement: (node, parent, owner, key) => {
+                        visited.push(`assign ${node.name.text}`);
+                        return visitor.AssignmentStatement?.(node, parent, owner, key);
+                    }
+                });
+                ast.walk(collectingVisitor, {
+                    walkMode: WalkMode.visitAllRecursive,
+                    ...(useEditor ? { editor: editor } : {})
+                });
+                return { visited: visited, ast: ast, editor: editor };
+            }
+
+            function makePrint(text: string) {
+                return new PrintStatement(
+                    { print: createToken(TokenKind.Print) },
+                    [createStringLiteral(text)]
+                );
+            }
+
+            function bodyStatements(ast: BsBody) {
+                return (ast.statements[0] as FunctionStatement).func.body.statements;
+            }
+
+            const THREE_PRINTS = `
+                sub main()
+                    print "1"
+                    print "2"
+                    print "3"
+                end sub
+            `;
+
+            it('visits every statement exactly once when nothing is mutated', () => {
+                const { visited } = walkAndCollect(THREE_PRINTS, {});
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+            });
+
+            it('does not re-visit a node that was displaced by an insertion above it', () => {
+                //insert one new print above "2". "2" moves from index 1 to index 2, but must not be visited twice.
+                let inserted = false;
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"2"' && !inserted) {
+                            inserted = true;
+                            owner.splice(key, 0, makePrint('"inserted"'));
+                        }
+                    }
+                });
+                //every original node visited once, and the inserted node visited once
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "inserted"', 'print "3"']);
+                expect(bodyStatements(ast)).to.be.lengthOf(4);
+            });
+
+            it('walks the children of a node that was displaced by an insertion above it', () => {
+                //this is the core regression: inserting above an `if` must not rob the `if` body of its walk
+                const visitedAssignments: string[] = [];
+                let inserted = false;
+                const { ast } = Parser.parse(`
+                    sub main()
+                        if true then
+                            alpha = 1
+                            beta = 2
+                        end if
+                    end sub
+                `);
+                ast.walk(createVisitor({
+                    AssignmentStatement: (node) => {
+                        visitedAssignments.push(node.name.text);
+                    },
+                    IfStatement: (node, parent, owner: Statement[], key) => {
+                        if (!inserted) {
+                            inserted = true;
+                            owner.splice(key, 0, makePrint('"before"'));
+                        }
+                    }
+                }), { walkMode: WalkMode.visitAllRecursive });
+
+                expect(visitedAssignments).to.eql(['alpha', 'beta']);
+            });
+
+            it('walks the children of a displaced node when using an AstEditor', () => {
+                const editor = new AstEditor();
+                const visitedAssignments: string[] = [];
+                let inserted = false;
+                const { ast } = Parser.parse(`
+                    sub main()
+                        if true then
+                            alpha = 1
+                            beta = 2
+                        end if
+                    end sub
+                `);
+                ast.walk(createVisitor({
+                    AssignmentStatement: (node) => {
+                        visitedAssignments.push(node.name.text);
+                    },
+                    IfStatement: (node, parent, owner: Statement[], key) => {
+                        if (!inserted) {
+                            inserted = true;
+                            editor.arraySplice(owner, key, 0, makePrint('"before"'));
+                        }
+                    }
+                }), { walkMode: WalkMode.visitAllRecursive, editor: editor });
+
+                expect(visitedAssignments).to.eql(['alpha', 'beta']);
+
+                //undoing the edit must restore the original AST
+                editor.undoAll();
+                expect(bodyStatements(ast)).to.be.lengthOf(1);
+            });
+
+            it('handles multiple statements inserted above the current node at once', () => {
+                let inserted = false;
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"1"' && !inserted) {
+                            inserted = true;
+                            owner.splice(key, 0, makePrint('"a"'), makePrint('"b"'), makePrint('"c"'));
+                        }
+                    }
+                });
+                //the three inserted nodes are visited, and no original node is visited twice
+                expect(visited).to.eql([
+                    'print "1"', 'print "a"', 'print "b"', 'print "c"', 'print "2"', 'print "3"'
+                ]);
+                expect(bodyStatements(ast)).to.be.lengthOf(6);
+            });
+
+            it('visits a node inserted below the current node', () => {
+                let inserted = false;
+                const { visited } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"1"' && !inserted) {
+                            inserted = true;
+                            owner.splice(key + 1, 0, makePrint('"below"'));
+                        }
+                    }
+                });
+                expect(visited).to.eql(['print "1"', 'print "below"', 'print "2"', 'print "3"']);
+            });
+
+            it('does not skip the following node when the current node is deleted', () => {
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"1"') {
+                            owner.splice(key, 1);
+                        }
+                    }
+                });
+                //all three are still visited even though the first one removed itself
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                expect(bodyStatements(ast)).to.be.lengthOf(2);
+            });
+
+            it('does not skip the following node when a middle node is deleted', () => {
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"2"') {
+                            owner.splice(key, 1);
+                        }
+                    }
+                });
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                expect(bodyStatements(ast)).to.be.lengthOf(2);
+            });
+
+            it('handles every node deleting itself', () => {
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        owner.splice(key, 1);
+                    }
+                });
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                expect(bodyStatements(ast)).to.be.lengthOf(0);
+            });
+
+            it('does not re-walk a node that replaced the current node', () => {
+                //a replacement node has its children walked as part of the replacement, so it must not be visited again
+                let replaced = false;
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"2"' && !replaced) {
+                            replaced = true;
+                            return makePrint('"replacement"');
+                        }
+                    }
+                });
+                //"replacement" is never visited again after taking "2"'s place
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                expect(
+                    (bodyStatements(ast)[1] as PrintStatement).expressions[0]
+                ).to.have.nested.property('token.text', '"replacement"');
+            });
+
+            it('walks the children of a replacement node exactly once', () => {
+                let replaced = false;
+                const walkedLiterals: string[] = [];
+                Parser.parse(`
+                    sub main()
+                        print 1 + 2
+                    end sub
+                `).ast.walk(createVisitor({
+                    BinaryExpression: (node) => {
+                        if (!replaced) {
+                            replaced = true;
+                            return new BinaryExpression(
+                                createIntegerLiteral('3'),
+                                createToken(TokenKind.Plus),
+                                createIntegerLiteral('4')
+                            );
+                        }
+                    },
+                    LiteralExpression: (node) => {
+                        walkedLiterals.push(node.token.text);
+                    }
+                }), { walkMode: WalkMode.visitAllRecursive });
+
+                expect(walkedLiterals).to.eql(['3', '4']);
+            });
+
+            it('handles a node being deleted and a new one inserted in its place', () => {
+                let swapped = false;
+                const { visited, ast } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if ((node.expressions[0] as LiteralExpression)?.token?.text === '"2"' && !swapped) {
+                            swapped = true;
+                            //remove "2" and put a brand new node at the same index
+                            owner.splice(key, 1, makePrint('"swapped"'));
+                        }
+                    }
+                });
+                //the swapped-in node occupies the same slot, so it counts as a replacement and is not re-visited
+                expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                expect(bodyStatements(ast)).to.be.lengthOf(3);
+            });
+
+            it('walks statements inserted into a nested block', () => {
+                let inserted = false;
+                const visitedAssignments: string[] = [];
+                const { ast } = Parser.parse(`
+                    sub main()
+                        if true then
+                            alpha = 1
+                        end if
+                    end sub
+                `);
+                ast.walk(createVisitor({
+                    AssignmentStatement: (node, parent, owner: Statement[], key) => {
+                        visitedAssignments.push(node.name.text);
+                        if (node.name.text === 'alpha' && !inserted) {
+                            inserted = true;
+                            //insert a sibling assignment above alpha, inside the if-block
+                            owner.splice(key, 0, new AssignmentStatement(
+                                createToken(TokenKind.Equal),
+                                createToken(TokenKind.Identifier, 'zulu') as any,
+                                createIntegerLiteral('9')
+                            ));
+                        }
+                    }
+                }), { walkMode: WalkMode.visitAllRecursive });
+
+                //alpha visited once, and the newly inserted zulu also visited
+                expect(visitedAssignments).to.eql(['alpha', 'zulu']);
+            });
+
+            it('stops walking when cancelled mid-array', () => {
+                const cancel = new CancellationTokenSource();
+                const visited: string[] = [];
+                Parser.parse(THREE_PRINTS).ast.walk(createVisitor({
+                    PrintStatement: (node) => {
+                        visited.push((node.expressions[0] as LiteralExpression).token.text);
+                        if (visited.length === 2) {
+                            cancel.cancel();
+                        }
+                    }
+                }), { walkMode: WalkMode.visitAllRecursive, cancel: cancel.token });
+
+                expect(visited).to.eql(['"1"', '"2"']);
+            });
+
+            it('terminates when a visitor inserts a node above on every single visit', () => {
+                //guards against an infinite restart loop: each visit inserts, but each node is only visited once
+                let insertCount = 0;
+                const { visited } = walkAndCollect(THREE_PRINTS, {
+                    PrintStatement: (node, parent, owner: Statement[], key) => {
+                        if (insertCount < 3) {
+                            insertCount++;
+                            owner.splice(key, 0, makePrint(`"gen${insertCount}"`));
+                        }
+                    }
+                });
+                //3 originals + 3 inserted, each visited exactly once
+                expect(visited).to.be.lengthOf(6);
+                expect(new Set(visited).size).to.eql(6);
+            });
+
+            describe('known gaps', () => {
+                //These document mutations that the current walker still gets wrong. They are pending rather than
+                //deleted so the behavior is recorded rather than rediscovered. Both need the `injectedNodes`
+                //option (see the PR description) to resolve properly, because the correct answer depends on
+                //what the plugin intends, which cannot be inferred from the AST alone.
+
+                it.skip('visits every node of a splice that deletes one and inserts several', () => {
+                    //`splice(key, 1, x, y)` leaves the array length unchanged-or-larger, so the walker cannot tell
+                    //"replaced by x" from "deleted, then x and y inserted". Today `x` is treated as a replacement
+                    //(walked + marked processed) and `y` is visited, so `x` is never visited on its own.
+                    let done = false;
+                    const { visited } = walkAndCollect(THREE_PRINTS, {
+                        PrintStatement: (node, parent, owner: Statement[], key) => {
+                            if ((node.expressions[0] as LiteralExpression)?.token?.text === '"2"' && !done) {
+                                done = true;
+                                owner.splice(key, 1, makePrint('"x"'), makePrint('"y"'));
+                            }
+                        }
+                    });
+                    //actual today: ['print "1"', 'print "2"', 'print "y"', 'print "3"'] -- `"x"` is missing
+                    expect(visited).to.eql([
+                        'print "1"', 'print "2"', 'print "x"', 'print "y"', 'print "3"'
+                    ]);
+                });
+
+                it.skip('visits nodes in array order when a visitor reorders the array', () => {
+                    //Moving a node backwards past the cursor means it is never revisited; moving one forwards
+                    //means it is skipped. There is no defined semantic for reordering during a walk today.
+                    let swapped = false;
+                    const { visited } = walkAndCollect(THREE_PRINTS, {
+                        PrintStatement: (node, parent, owner: Statement[], key) => {
+                            if ((node.expressions[0] as LiteralExpression)?.token?.text === '"1"' && !swapped) {
+                                swapped = true;
+                                //move "3" to the front of the array
+                                owner.splice(0, 0, owner.splice(2, 1)[0]);
+                            }
+                        }
+                    });
+                    //actual today: ['print "1"', 'print "3"', 'print "2"']
+                    expect(visited).to.eql(['print "1"', 'print "2"', 'print "3"']);
+                });
+            });
         });
     });
 

--- a/src/astUtils/visitors.ts
+++ b/src/astUtils/visitors.ts
@@ -24,68 +24,118 @@ export function walkStatements(
 export type WalkVisitor = <T = AstNode>(node: AstNode, parent?: AstNode, owner?: any, key?: any) => void | T;
 
 /**
+ * The outcome of walking a single slot, used by `walkArray` to decide what to do next.
+ */
+interface WalkSlotResult {
+    /**
+     * The node that was actually descended into (i.e. the one whose children were walked), or undefined if nothing was walked.
+     */
+    walkedNode?: AstNode;
+    /**
+     * True when the original node was swapped out for a different node *in this same slot*
+     * (either by the visitor returning a node, or by the visitor assigning the slot directly).
+     * A node that merely got pushed to a different index by an insertion is NOT a replacement.
+     */
+    wasReplaced?: boolean;
+}
+
+/**
  * A helper function for Statement and Expression `walkAll` calls.
  * @returns a new AstNode if it was changed by returning from the visitor, or undefined if not
  */
 export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode): AstNode | void {
-    let returnValue: AstNode | void;
+    return walkSlot(owner, key, visitor, options, parent).walkedNode;
+}
 
+/**
+ * The full-fidelity version of `walk`. Walks a single `owner[key]` slot and reports exactly what happened,
+ * so array walkers can tell an in-place *replacement* apart from the node simply being *displaced* by an insertion.
+ */
+function walkSlot<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode): WalkSlotResult {
     //stop processing if canceled
     if (options.cancel?.isCancellationRequested) {
-        return returnValue;
+        return {};
     }
 
     //the object we're visiting
-    let element = owner[key] as any as AstNode;
+    const element = owner[key] as any as AstNode;
     if (!element) {
-        return returnValue;
+        return {};
     }
+    const result: WalkSlotResult = {};
+    //remember the array size so we can tell an insertion/deletion apart from an in-place replacement
+    const ownerIsArray = Array.isArray(owner);
+    const originalLength = ownerIsArray ? (owner as any[]).length : 0;
 
     //link this node to its parent
     parent = parent ?? owner as unknown as AstNode;
     element.parent = parent;
 
-
     //notify the visitor of this element
     if (element.visitMode & options.walkMode) {
-        returnValue = visitor?.(element, element.parent, owner, key);
+        const visitorResult = visitor?.(element, element.parent, owner, key);
 
         //replace the value on the parent if the visitor returned a Statement or Expression (this is how visitors can edit AST)
-        if (returnValue && (isExpression(returnValue) || isStatement(returnValue))) {
+        if (visitorResult && (isExpression(visitorResult) || isStatement(visitorResult))) {
             //if we have an editor, use that to modify the AST
             if (options.editor) {
-                //`T[K]` can't be statically unified with the now-narrowed `returnValue` because `T`/`K` are unresolved generics here;
+                //`T[K]` can't be statically unified with the now-narrowed `visitorResult` because `T`/`K` are unresolved generics here;
                 //callers only ever pass AST-shaped values, so this is safe in practice
-                options.editor.setProperty(owner, key, returnValue as unknown as T[keyof T]);
+                options.editor.setProperty(owner, key, visitorResult as unknown as T[keyof T]);
 
                 //we don't have an editor, modify the AST directly
             } else {
-                (owner as any)[key] = returnValue;
+                (owner as any)[key] = visitorResult;
             }
         }
     }
 
     //stop processing if canceled
     if (options.cancel?.isCancellationRequested) {
-        return returnValue;
+        return result;
     }
 
-    //get the element again in case it was replaced by the visitor
-    element = owner[key] as any as AstNode;
-    if (!element) {
-        return returnValue;
+    //Figure out which node we should actually descend into. The visitor may have mutated the AST in one of several ways:
+    // 1. replaced this slot with a different node -> descend into the new node, and report it as a replacement
+    // 2. inserted node(s) above this one in an array -> this node merely moved; descend into the ORIGINAL node so its children still get walked
+    // 3. removed this node entirely -> there is nothing left to descend into
+    let elementToWalk = owner[key] as any as AstNode;
+
+    if (elementToWalk !== element) {
+        const displacedIndex = ownerIsArray ? (owner as any[]).indexOf(element) : -1;
+
+        if (displacedIndex > -1) {
+            //case 2: the original node is still in the array, just at a different index (something was inserted above it).
+            //Walk IT rather than whatever landed in our slot; the array walker will reach that other node on its own.
+            elementToWalk = element;
+            key = displacedIndex as any as keyof T;
+
+        } else if (ownerIsArray && (owner as any[]).length < originalLength) {
+            //case 3: the array shrank and our node is gone -> it was deleted, not replaced. Nothing to descend into.
+            //Whatever slid into this slot still needs its own visit, so do NOT claim it here.
+            return result;
+
+        } else {
+            //case 1: the original node was swapped out in place -> a genuine replacement
+            result.wasReplaced = true;
+        }
     }
 
-    //set the parent of this new expression
-    element.parent = parent;
+    if (!elementToWalk) {
+        return result;
+    }
 
-    if (!element.walk) {
+    //set the parent of this expression
+    elementToWalk.parent = parent;
+
+    if (!elementToWalk.walk) {
         throw new Error(`${owner.constructor.name}["${String(key)}"]${parent ? ` for ${parent.constructor.name}` : ''} does not contain a "walk" method`);
     }
     //walk the child expressions
-    element.walk(visitor, options);
+    elementToWalk.walk(visitor, options);
 
-    return returnValue;
+    result.walkedNode = elementToWalk;
+    return result;
 }
 
 /**
@@ -97,27 +147,37 @@ export function walk<T>(owner: T, key: keyof T, visitor: WalkVisitor, options: W
  * @param filter a function used to filter items from the array. return true if that item should be walked
  */
 export function walkArray<T extends AstNode = AstNode>(array: Array<T>, visitor: WalkVisitor, options: WalkOptions, parent?: AstNode, filter?: (element: T) => boolean) {
+    //every node we have already visited during this array walk, so a restart never double-visits
     let processedNodes = new Set<AstNode>();
 
     for (let i = 0; i < array?.length; i++) {
-        if (!filter || filter(array[i])) {
-            let item = array[i];
-            //skip already processed nodes for this array walk
-            if (processedNodes.has(item)) {
-                continue;
-            }
-            processedNodes.add(item);
+        if (options.cancel?.isCancellationRequested) {
+            return;
+        }
+        if (filter && !filter(array[i])) {
+            continue;
+        }
+        const item = array[i];
+        //skip already processed nodes for this array walk
+        if (!item || processedNodes.has(item)) {
+            continue;
+        }
 
-            //if the walk produced a new node, we will assume the original node was handled, and the new node's children were walked, so we can skip it if we enter recovery mode
-            const newNode = walk(array, i, visitor, options, parent);
-            if (newNode) {
-                processedNodes.add(newNode);
-            }
+        //mark the item as processed BEFORE walking it. The visitor sees this node exactly once, no matter
+        //how it mutates the array afterwards (moving it, replacing it, or deleting it).
+        processedNodes.add(item);
 
-            //if the current item changed, restart the entire loop (we'll skip any already-processed items)
-            if (array[i] !== item) {
-                i = -1;
-            }
+        const { walkedNode, wasReplaced } = walkSlot(array, i, visitor, options, parent);
+
+        //a node that replaced this slot had its children walked already, so don't visit it a second time
+        if (wasReplaced && walkedNode) {
+            processedNodes.add(walkedNode);
+        }
+
+        //if the array shifted under us, restart the scan. Already-processed nodes are skipped,
+        //so this only picks up nodes that were inserted or that we haven't reached yet.
+        if (array[i] !== item) {
+            i = -1;
         }
     }
 }


### PR DESCRIPTION
When a visitor inserts a statement *above* the node currently being walked, that node's children are silently never walked. Injecting a `print` above an `if` means the `if` body never gets visited.

`walk` re-reads `owner[key]` after the visitor runs and treats any change as "this node was replaced". But three different mutations all produce that same observation, and only one of them is a replacement:

| Mutation | `owner[key]` changed? | Original node |
|---|---|---|
| Replace in place | yes | gone from array |
| **Insert above** | yes | **still in array, moved down** |
| Delete | yes | gone, array shrank |

Insert-above was being misread as replacement, so `walk` descended into the newly-inserted node and `walkArray` marked the original processed — skipping it forever.

## What changed

- Split the three cases apart in a new internal `walkSlot`, using array membership (`indexOf`) plus length change to tell them apart. Public `walk()` keeps its exact signature.
- `walkArray` marks a node processed *before* walking it, so one visit per node regardless of how the visitor mutates the array afterwards.
- `walkArray` now checks the cancellation token in its loop; previously a cancelled walk kept spinning the array, only bailing inside each `walk` call.

## Verified

`npm test` — 3088 passing, 0 failing. Reverting just `visitors.ts` while keeping the new tests fails 4 of them, so they do pin the bug rather than describe the implementation.

## Not fixed — needs a design decision

Two mutation shapes are still wrong, added as `it.skip` with the actual-vs-expected recorded:

- **`splice(key, 1, x, y)`** (delete one, insert several) — `x` is never visited. Length is unchanged-or-larger, so "replaced by x" and "deleted, then x and y inserted" are indistinguishable after the fact.
- **Reordering** — a node moved backwards past the cursor is never revisited; one moved forwards is skipped. There's no defined semantic for reordering mid-walk today.

These aren't fixable by better inference, because the right answer depends on what the plugin *intends* and that isn't in the AST. Two legitimate, mutually exclusive expectations exist today:

- **fixpoint** — keep walking until nothing changes (desugaring passes want this)
- **single-pass** — visit each original node once; injected nodes are output, not input (instrumentation wants this, and it's also what makes injection terminate — a fixpoint walk whose visitor always injects never ends)

Suggested follow-up: a `WalkOptions.injectedNodes?: 'skip' | 'visit'` flag plus a `maxPasses` safety valve, implemented by snapshotting array membership before the loop instead of inferring from index math. That approach also dissolves both gaps above and removes the `i = -1` O(n²) restart. Default should stay `'visit'` for now to avoid a breaking change, with a flip to `'skip'` considered for the next major.

Worth noting `AstEditor` already records every mutation with exact indices — if the walker consumed that change log it would *know* rather than infer, but only when an editor is passed, and much of the codebase splices arrays raw.

Drafting rather than opening for review since the follow-up design is the more important half of this.
