### PR TITLE
Fix duplicate and crashing "find all references" results

### DIFF
--- a/src/LanguageServer.spec.ts
+++ b/src/LanguageServer.spec.ts
@@ -1851,6 +1851,32 @@ describe('LanguageServer', () => {
 
             expect(references).to.be.empty;
         });
+
+        it('does not return duplicate locations for a file shared by multiple component scopes', async () => {
+            //a variable declared and used entirely within a file that many components include
+            const sharedDocument = addScriptFile('sharedLib', `
+                sub useShared()
+                    sharedValue = 1
+                    print sharedValue
+                end sub
+            `)!;
+            for (let i = 0; i < 3; i++) {
+                addXmlFile(`SharedHost${i}`, `<script type="text/brightscript" uri="sharedLib.brs" />`);
+            }
+
+            const references = await server['onReferences']({
+                textDocument: {
+                    uri: sharedDocument.uri
+                },
+                position: util.createPosition(2, 22)
+            } as any);
+
+            //the assignment and the print usage, each reported exactly once even though the
+            //file is reachable through the source scope plus 3 component scopes
+            const keys = references.map(x => `${x.uri}:${x.range.start.line}:${x.range.start.character}`);
+            expect(keys).to.eql([...new Set(keys)]);
+            expect(references).to.be.lengthOf(2);
+        });
     });
 
     describe('onWillRenameFiles', () => {

--- a/src/bscPlugin/references/ReferencesProvider.spec.ts
+++ b/src/bscPlugin/references/ReferencesProvider.spec.ts
@@ -52,6 +52,237 @@ describe('ReferencesProvider', () => {
         ]);
     });
 
+    it('returns null when the file does not exist', () => {
+        expect(
+            program.getReferences('source/not-there.brs', util.createPosition(1, 1))
+        ).to.be.null;
+    });
+
+    it('returns empty results when there is no token at the given position', () => {
+        program.setFile('source/main.brs', `
+            sub main()
+                name = "John"
+            end sub
+        `);
+        //the cursor is way past the end of the line, so there's no token there
+        expect(
+            program.getReferences('source/main.brs', util.createPosition(2, 500))
+        ).to.eql([]);
+    });
+
+    it('finds references across multiple files in the same scope', () => {
+        const mainFile = program.setFile('source/main.brs', `
+            sub main()
+                alpha = 1
+                print alpha
+            end sub
+        `);
+        const utilFile = program.setFile('source/util.brs', `
+            sub helper()
+                alpha = 2
+                print alpha
+            end sub
+        `);
+        program.validate();
+        expect(
+            util.sortByRange(
+                program.getReferences('source/main.brs', util.createPosition(2, 17))
+            ).map(locationToString).sort()
+        ).to.eql([
+            s`${mainFile.srcPath}:2:16-2:21`,
+            s`${mainFile.srcPath}:3:22-3:27`,
+            s`${utilFile.srcPath}:2:16-2:21`,
+            s`${utilFile.srcPath}:3:22-3:27`
+        ].sort());
+    });
+
+    it('does not return duplicates when the file is included in multiple scopes', () => {
+        const file = program.setFile('source/lib.brs', `
+            sub sharedFunc()
+                thing = 1
+                print thing
+            end sub
+        `);
+        //include the same file in two separate component scopes, plus the source scope
+        program.setFile('components/A.xml', `
+            <component name="A" extends="Group">
+                <script uri="pkg:/source/lib.brs" />
+            </component>
+        `);
+        program.setFile('components/B.xml', `
+            <component name="B" extends="Group">
+                <script uri="pkg:/source/lib.brs" />
+            </component>
+        `);
+        program.validate();
+        expect(
+            util.sortByRange(
+                program.getReferences('source/lib.brs', util.createPosition(2, 17))
+            ).map(locationToString)
+        ).to.eql([
+            s`${file.srcPath}:2:16-2:21`,
+            s`${file.srcPath}:3:22-3:27`
+        ]);
+    });
+
+    it('finds references from files that are unique to each scope', () => {
+        //this file lives in both component scopes, and is where the request is triggered
+        const commonFile = program.setFile('source/common.brs', `
+            sub common()
+                alpha = 0
+            end sub
+        `);
+        //this file is only present in the A scope
+        const onlyAFile = program.setFile('components/onlyA.brs', `
+            sub onlyA()
+                print alpha
+            end sub
+        `);
+        //this file is only present in the B scope
+        const onlyBFile = program.setFile('components/onlyB.brs', `
+            sub onlyB()
+                print alpha
+            end sub
+        `);
+        program.setFile('components/A.xml', `
+            <component name="A" extends="Group">
+                <script uri="pkg:/source/common.brs" />
+                <script uri="pkg:/components/onlyA.brs" />
+            </component>
+        `);
+        program.setFile('components/B.xml', `
+            <component name="B" extends="Group">
+                <script uri="pkg:/source/common.brs" />
+                <script uri="pkg:/components/onlyB.brs" />
+            </component>
+        `);
+        program.validate();
+        //every scope-specific reference must be included exactly once. Deduplicating the
+        //cross-scope file walk must not discard references only reachable through one scope
+        expect(
+            util.sortByRange(
+                program.getReferences('source/common.brs', util.createPosition(2, 17))
+            ).map(locationToString).sort()
+        ).to.eql([
+            s`${commonFile.srcPath}:2:16-2:21`,
+            s`${onlyAFile.srcPath}:2:22-2:27`,
+            s`${onlyBFile.srcPath}:2:22-2:27`
+        ].sort());
+    });
+
+    it('matches references case insensitively', () => {
+        const file = program.setFile('source/main.brs', `
+            sub main()
+                Name = "John"
+                print NAME
+                print name
+            end sub
+        `);
+        expect(
+            util.sortByRange(
+                program.getReferences('source/main.brs', util.createPosition(2, 17))
+            ).map(locationToString)
+        ).to.eql([
+            s`${file.srcPath}:2:16-2:20`,
+            s`${file.srcPath}:3:22-3:26`,
+            s`${file.srcPath}:4:22-4:26`
+        ]);
+    });
+
+    it('finds references to a function parameter', () => {
+        const file = program.setFile('source/main.brs', `
+            sub main(greeting as string)
+                print greeting
+                greeting = "hi"
+            end sub
+        `);
+        expect(
+            util.sortByRange(
+                program.getReferences('source/main.brs', util.createPosition(2, 24))
+            ).map(locationToString)
+        ).to.eql([
+            s`${file.srcPath}:2:22-2:30`,
+            s`${file.srcPath}:3:16-3:24`
+        ]);
+    });
+
+    it('emits the before/provide/after plugin events in order', () => {
+        program.setFile('source/main.brs', `
+            sub main()
+                name = "John"
+                print name
+            end sub
+        `);
+        const events: string[] = [];
+        program.plugins.add({
+            name: 'test-plugin',
+            beforeProvideReferences: () => {
+                events.push('before');
+            },
+            provideReferences: () => {
+                events.push('provide');
+            },
+            afterProvideReferences: () => {
+                events.push('after');
+            }
+        });
+        program.getReferences('source/main.brs', util.createPosition(3, 25));
+        expect(events).to.eql(['before', 'provide', 'after']);
+    });
+
+    it('allows a plugin to contribute additional references', () => {
+        const file = program.setFile('source/main.brs', `
+            sub main()
+                name = "John"
+            end sub
+        `);
+        program.plugins.add({
+            name: 'test-plugin',
+            provideReferences: (event) => {
+                event.references.push(
+                    util.createLocation(util.pathToUri(file.srcPath), util.createRange(9, 9, 9, 14))
+                );
+            }
+        });
+        expect(
+            util.sortByRange(
+                program.getReferences('source/main.brs', util.createPosition(2, 17))
+            ).map(locationToString)
+        ).to.eql([
+            s`${file.srcPath}:2:16-2:20`,
+            s`${file.srcPath}:9:9-9:14`
+        ]);
+    });
+
+    it('allows a plugin to sanitize references in afterProvideReferences', () => {
+        program.setFile('source/main.brs', `
+            sub main()
+                name = "John"
+                print name
+            end sub
+        `);
+        program.plugins.add({
+            name: 'test-plugin',
+            afterProvideReferences: (event) => {
+                //drop everything
+                event.references.splice(0, event.references.length);
+            }
+        });
+        expect(
+            program.getReferences('source/main.brs', util.createPosition(3, 25))
+        ).to.eql([]);
+    });
+
+    it('returns empty results for an xml file', () => {
+        program.setFile('components/A.xml', `
+            <component name="A" extends="Group">
+            </component>
+        `);
+        expect(
+            program.getReferences('components/A.xml', util.createPosition(1, 30))
+        ).to.eql([]);
+    });
+
     function locationToString(loc: Location) {
         return `${URI.parse(loc.uri).fsPath}:${loc.range.start.line}:${loc.range.start.character}-${loc.range.end.line}:${loc.range.end.character}`;
     }

--- a/src/bscPlugin/references/ReferencesProvider.ts
+++ b/src/bscPlugin/references/ReferencesProvider.ts
@@ -27,12 +27,20 @@ export class ReferencesProvider {
 
         const callSiteToken = file.getTokenAt(this.event.position);
 
+        //there's no token at this position (i.e. the cursor is past the end of a line), so there's nothing to search for
+        if (!callSiteToken) {
+            return;
+        }
+
         const searchFor = callSiteToken.text.toLowerCase();
 
         const scopes = this.event.program.getScopesForFile(file);
 
+        //track processed files across all scopes. A file's references are the same no matter which
+        //scope it was reached through, so walking it once per scope would emit duplicate results
+        const processedFiles = new Set<BrsFile>();
+
         for (const scope of scopes) {
-            const processedFiles = new Set<BrsFile>();
             for (const file of scope.getAllFiles()) {
                 if (!isBrsFile(file) || processedFiles.has(file)) {
                     continue;


### PR DESCRIPTION
Two bugs in `ReferencesProvider`, both user-visible in the VSCode references panel today.

**Duplicate results.** `processedFiles` was declared inside the scope loop, so a file reachable through multiple scopes got re-walked once per scope. The search is a case-insensitive text match over the file AST, so every re-walk emitted identical `Location`s, and no layer between the provider and the LSP client dedupes them — a `source/` file included by 3 components showed each reference 3× in the panel. Hoisting the set walks each file once across the whole traversal.

Worth noting since it looks like it might over-dedupe: references reachable through only one scope are still found, because the set keys on *file*, not scope. A test covers exactly that case (`alpha` referenced from a file unique to scope A and another unique to scope B — both still returned).

**Crash on positions with no token.** `getTokenAt` returns undefined when the cursor is past the end of a line, so `callSiteToken.text` threw. The plugin runner swallowed the error and the user silently got no references.

Tests: 11 new cases in `ReferencesProvider.spec.ts` (both fixes, scope-specific references, case-insensitivity, params, XML, and the three `provideReferences` plugin events, which had no coverage) plus one at the `LanguageServer.onReferences` level asserting no duplicate `Location`s reach the client. Verified both fixes fail their tests when reverted. `npm run test:nocover` 3048 → 3059 passing, lint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)