### PR TITLE
Better error message for wrong-cased XML tags

### DIFF
--- a/src/DiagnosticMessages.ts
+++ b/src/DiagnosticMessages.ts
@@ -848,6 +848,11 @@ export let DiagnosticMessages = {
         message: `Mismatched closing tag: expected '</${openingTag}>' but found '</${closingTag}>'`,
         code: 1156,
         severity: DiagnosticSeverity.Error
+    }),
+    xmlTagWrongCase: (actualTag: string, expectedTag: string) => ({
+        message: `Tag '${actualTag}' must be all lower case. Use '${expectedTag}' instead`,
+        code: 1157,
+        severity: DiagnosticSeverity.Error
     })
 };
 

--- a/src/bscPlugin/validation/XmlFileValidator.ts
+++ b/src/bscPlugin/validation/XmlFileValidator.ts
@@ -2,6 +2,7 @@ import { DiagnosticMessages } from '../../DiagnosticMessages';
 import type { XmlFile } from '../../files/XmlFile';
 import type { OnFileValidateEvent } from '../../interfaces';
 import type { SGAst, SGTag } from '../../parser/SGTypes';
+import { isSGInterface } from '../../astUtils/xml';
 import util from '../../util';
 
 export class XmlFileValidator {
@@ -15,6 +16,7 @@ export class XmlFileValidator {
         if (this.event.file.parser.ast.root) {
             this.validateComponent(this.event.file.parser.ast);
             this.validateTagClosings(this.event.file.parser.ast.root);
+            this.validateTagCasing(this.event.file.parser.ast.root);
         } else {
             //skip empty XML
         }
@@ -39,6 +41,41 @@ export class XmlFileValidator {
         }
         for (const child of tag.getChildren()) {
             this.validateTagClosings(child);
+        }
+    }
+
+    /**
+     * Report any structural tag that isn't all lower case (e.g. `<Children>` instead of
+     * `<children>`). Roku requires these tags to be lower case, but the parser matches them
+     * case-insensitively so we can emit this specific diagnostic instead of a generic
+     * "unexpected tag" error.
+     *
+     * Only the structural spine is walked (the component tag, its direct children, and the
+     * members of `<interface>`). Tags inside `<children>` are node/component names (like
+     * `<Label>`) whose casing is author-defined, so they're intentionally not validated.
+     */
+    private validateTagCasing(root: SGTag) {
+        const validate = (tag: SGTag) => {
+            const tagText = tag.tag.text;
+            if (tagText !== tagText.toLowerCase()) {
+                this.event.file.diagnostics.push({
+                    ...DiagnosticMessages.xmlTagWrongCase(tagText, tagText.toLowerCase()),
+                    range: tag.tag.range,
+                    file: this.event.file
+                });
+            }
+        };
+
+        validate(root);
+        //`<children>` holds author-cased node names, so validate the tag itself but not its contents
+        for (const child of root.getChildren()) {
+            validate(child);
+            if (isSGInterface(child)) {
+                //`<field>` and `<function>` members are structural too
+                for (const member of child.getChildren()) {
+                    validate(member);
+                }
+            }
         }
     }
 

--- a/src/files/XmlFile.spec.ts
+++ b/src/files/XmlFile.spec.ts
@@ -700,6 +700,145 @@ describe('XmlFile', () => {
         ]);
     });
 
+    describe('xml tag casing', () => {
+        it('emits a casing diagnostic for <Children>', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <Children>
+                    <Label id="myLabel" />
+                </Children>
+            </component>
+        `);
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlTagWrongCase('Children', 'children')
+            ]);
+        });
+
+        it('emits a casing diagnostic for <Interface>', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <Interface>
+                    <field id="foo" type="string" />
+                </Interface>
+            </component>
+        `);
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlTagWrongCase('Interface', 'interface')
+            ]);
+        });
+
+        it('emits a casing diagnostic for <Script>', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <Script type="text/brightscript" uri="pkg:/source/main.brs" />
+            </component>
+        `);
+            program.setFile('source/main.brs', '');
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlTagWrongCase('Script', 'script')
+            ]);
+        });
+
+        it('emits a casing diagnostic for <Component>', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <Component name="Comp" extends="Group">
+            </Component>
+        `);
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlTagWrongCase('Component', 'component')
+            ]);
+        });
+
+        it('emits casing diagnostics for <Field> and <Function>', () => {
+            program.setFile('source/main.brs', `sub doThing()
+end sub`);
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <script type="text/brightscript" uri="pkg:/source/main.brs" />
+                <interface>
+                    <Field id="foo" type="string" />
+                    <Function name="doThing" />
+                </interface>
+            </component>
+        `);
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlTagWrongCase('Field', 'field'),
+                DiagnosticMessages.xmlTagWrongCase('Function', 'function')
+            ]);
+        });
+
+        it('does not emit a casing diagnostic for node tags inside <children>', () => {
+        //node names inside <children> are author-defined component names, so their
+        //casing must be left alone
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <children>
+                    <Group id="outer">
+                        <Label id="inner" text="hello" />
+                    </Group>
+                </children>
+            </component>
+        `);
+            program.validate();
+            expectZeroDiagnostics(file);
+        });
+
+        it('points the diagnostic range at the opening tag name', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <Children>
+                </Children>
+            </component>
+        `);
+            program.validate();
+            expect(file.diagnostics).to.have.lengthOf(1);
+            //the squiggle lands on `Children` (line 2)
+            expect(file.diagnostics[0].range).to.eql(
+                Range.create(2, 5, 2, 13)
+            );
+        });
+
+        it('preserves the original casing when transpiling', () => {
+        //we report the problem but must not silently rewrite the author's markup
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <Children>
+                    <Label id="myLabel" />
+                </Children>
+            </component>
+        `);
+            program.validate();
+            expect(file.transpile().code).to.include('<Children>');
+            expect(file.transpile().code).to.include('</Children>');
+        });
+
+        it('still emits the generic unexpected-tag diagnostic for unknown tags', () => {
+            const file = program.setFile<XmlFile>('components/Comp.xml', trim`
+            <?xml version="1.0" encoding="utf-8" ?>
+            <component name="Comp" extends="Group">
+                <bogus />
+            </component>
+        `);
+            program.validate();
+            expectDiagnostics(file, [
+                DiagnosticMessages.xmlUnexpectedTag('bogus')
+            ]);
+        });
+    });
+
     describe('transpile', () => {
         it('handles single quotes properly', () => {
             testTranspile(trim`
@@ -1037,6 +1176,7 @@ describe('XmlFile', () => {
             program.validate();
             expectZeroDiagnostics(file);
         });
+
 
         it('does not include additional bslib script if already there ', () => {
             testTranspile(trim`

--- a/src/parser/SGParser.ts
+++ b/src/parser/SGParser.ts
@@ -195,7 +195,9 @@ function mapElement({ children }: ElementCstNode, diagnostics: Diagnostic[]): SG
 
     const attributes = mapAttributes(children.attribute);
     const content = children.content?.[0];
-    switch (name.text) {
+    //match structural tags case-insensitively so wrong-cased tags (like `<Children>`) still
+    //produce a proper AST node. `XmlFileValidator` reports the casing problem during validation.
+    switch (name.text.toLowerCase()) {
         case 'component':
             const componentContent = mapElements(content, ['interface', 'script', 'children', 'customization'], diagnostics);
             return new SGComponent(name, attributes, componentContent, range, closingName);
@@ -269,7 +271,9 @@ function mapElements(content: ContentCstNode, allow: string[], diagnostics: Diag
         for (const entry of element) {
             const name = entry.children.Name?.[0];
             if (name?.image) {
-                if (allow.includes(name.image)) {
+                //compare case-insensitively so wrong-cased tags (like `<Children>`) are still
+                //mapped into the AST. `XmlFileValidator` reports the casing problem separately.
+                if (allow.some(x => x === name.image.toLowerCase())) {
                     tags.push(mapElement(entry, diagnostics));
                 } else {
                     //unexpected tag


### PR DESCRIPTION
Roku requires `<children>`, `<interface>`, `<script>` etc. to be lower case. Wrong-cased tags used to fall through the parser's exact-case matching and report a generic `Unexpected tag 'Children'`, which doesn't hint at the real problem. Now they report `Tag 'Children' must be all lower case. Use 'children' instead`.

Supersedes #1540, which went stale (its diagnostic code 1143 is now taken).

- New `xmlTagWrongCase` diagnostic, code 1157
- `SGParser` matches structural tags case-insensitively, so wrong-cased tags build a real AST node instead of hitting the unexpected-tag path
- `XmlFileValidator.validateTagCasing` reports the casing, alongside the existing `validateTagClosings`

Two deliberate choices:
- Validation skips the contents of `<children>` — node names in there are author-defined and legitimately mixed-case.
- Transpile still emits the tag verbatim, so this reports the problem without rewriting the author's markup (there's a test pinning that).

Fixes #1399.