### PR TITLE
Modifies default max worker thread logic to be only as much as memory allows

### DIFF
--- a/src/LanguageServer.ts
+++ b/src/LanguageServer.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as os from 'os';
 import type {
     CompletionItem,
     Connection,
@@ -63,6 +62,7 @@ import { Deferred } from './deferred';
 import { workerPool } from './lsp/worker/WorkerThreadProject';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import isEqual = require('lodash.isequal');
+import { getDefaultMaxWorkerThreads } from './lsp/worker/WorkerPool';
 
 export class LanguageServer {
     /**
@@ -84,7 +84,7 @@ export class LanguageServer {
      * per-workspace settings. Once this limit is reached, additional projects are spread evenly across the
      * existing worker threads instead of each getting a dedicated one.
      */
-    public static maxWorkerThreadsDefault = Math.max(1, os.cpus().length);
+    public static maxWorkerThreadsDefault = getDefaultMaxWorkerThreads();
 
     /**
      * The language server protocol connection, used to send and receive all requests and responses
@@ -418,6 +418,7 @@ export class LanguageServer {
             concurrencyLimit = 1;
         }
         this.projectManager.projectActivationConcurrencyLimit = concurrencyLimit;
+        this.logger.info(`projectActivationConcurrencyLimit set to ${concurrencyLimit}`);
     }
 
     /**
@@ -442,6 +443,7 @@ export class LanguageServer {
             maxWorkerThreads = 1;
         }
         workerPool.maxWorkers = maxWorkerThreads;
+        this.logger.info(`maxWorkerThreads set to ${maxWorkerThreads}`);
     }
 
     @AddStackToErrorMessage

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from '../../chai-config.spec';
-import { WorkerPool } from './WorkerPool';
+import { getDefaultMaxWorkerThreads, MEMORY_GB_PER_V8_INSTANCE, WorkerPool } from './WorkerPool';
 import type { Worker } from 'worker_threads';
 import * as sinon from 'sinon';
+import * as os from 'os';
 
 describe('WorkerPool', () => {
     let pool: WorkerPool;
@@ -34,6 +35,32 @@ describe('WorkerPool', () => {
 
     afterEach(() => {
         sinon.restore();
+    });
+
+    describe('default max workers', () => {
+        it('should be a positive number', () => {
+            expect(getDefaultMaxWorkerThreads()).to.be.greaterThan(0);
+        });
+
+        it('should allow as many threads as CPUs if not memory bound', () => {
+            const numFakeCpus = 16;
+            const bytesInGB = 1024 * 1024 * 1024;
+            sinon.stub(os, 'cpus').returns(new Array(numFakeCpus));
+            // 2 times more memory than needed
+            sinon.stub(os, 'totalmem').returns(numFakeCpus * MEMORY_GB_PER_V8_INSTANCE * 2 * bytesInGB);
+            expect(getDefaultMaxWorkerThreads()).to.be.eq(numFakeCpus);
+            sinon.restore();
+        });
+
+        it('should only allow as many threads as memory allows', () => {
+            const numFakeCpus = 16;
+            const bytesInGB = 1024 * 1024 * 1024;
+            sinon.stub(os, 'cpus').returns(new Array(numFakeCpus));
+            // 4 GB of memory - should only allow 2 threads, even though 16 cores available
+            sinon.stub(os, 'totalmem').returns(2 * MEMORY_GB_PER_V8_INSTANCE * bytesInGB);
+            expect(getDefaultMaxWorkerThreads()).to.be.eq(2);
+            sinon.restore();
+        });
     });
 
     describe('preload', () => {

--- a/src/lsp/worker/WorkerPool.spec.ts
+++ b/src/lsp/worker/WorkerPool.spec.ts
@@ -56,9 +56,21 @@ describe('WorkerPool', () => {
             const numFakeCpus = 16;
             const bytesInGB = 1024 * 1024 * 1024;
             sinon.stub(os, 'cpus').returns(new Array(numFakeCpus));
-            // 4 GB of memory - should only allow 2 threads, even though 16 cores available
-            sinon.stub(os, 'totalmem').returns(2 * MEMORY_GB_PER_V8_INSTANCE * bytesInGB);
+            // 5 GB of memory - should only allow 2 threads, even though 16 cores available
+            // That's 2 * 2GB + 1GB buffer
+            sinon.stub(os, 'totalmem').returns(5 * bytesInGB);
             expect(getDefaultMaxWorkerThreads()).to.be.eq(2);
+            sinon.restore();
+        });
+
+        it('should not use all the memory', () => {
+            const numFakeCpus = 16;
+            const bytesInGB = 1024 * 1024 * 1024;
+            sinon.stub(os, 'cpus').returns(new Array(numFakeCpus));
+            const memory = 12 * bytesInGB;
+            sinon.stub(os, 'totalmem').returns(memory);
+            const numThreads = getDefaultMaxWorkerThreads();
+            expect(numThreads * MEMORY_GB_PER_V8_INSTANCE * bytesInGB).to.be.lessThan(memory);
             sinon.restore();
         });
     });

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -13,6 +13,7 @@ interface WorkerEntry {
 
 
 export const MEMORY_GB_PER_V8_INSTANCE = 2;
+export const MEMORY_GB_BUFFER = 1;
 
 /**
  * Gets the lower bound of number of CPUS available vs 2GB chunks of memory.
@@ -20,8 +21,8 @@ export const MEMORY_GB_PER_V8_INSTANCE = 2;
  */
 export function getDefaultMaxWorkerThreads() {
     const numCpus = os.cpus().length;
-    const memoryGB = Math.floor(os.totalmem() / (1024 * 1024 * 1024));
-    return Math.max(1, Math.min(numCpus, memoryGB / MEMORY_GB_PER_V8_INSTANCE));
+    const availableMemoryGB = Math.floor(os.totalmem() / (1024 * 1024 * 1024)) - MEMORY_GB_BUFFER;
+    return Math.max(1, Math.min(numCpus, Math.floor(availableMemoryGB / MEMORY_GB_PER_V8_INSTANCE)));
 }
 
 

--- a/src/lsp/worker/WorkerPool.ts
+++ b/src/lsp/worker/WorkerPool.ts
@@ -11,6 +11,20 @@ interface WorkerEntry {
     projectCount: number;
 }
 
+
+export const MEMORY_GB_PER_V8_INSTANCE = 2;
+
+/**
+ * Gets the lower bound of number of CPUS available vs 2GB chunks of memory.
+ * This allows as many concurrent threads as possible, while still allowing a full v8 instance per thread.
+ */
+export function getDefaultMaxWorkerThreads() {
+    const numCpus = os.cpus().length;
+    const memoryGB = Math.floor(os.totalmem() / (1024 * 1024 * 1024));
+    return Math.max(1, Math.min(numCpus, memoryGB / MEMORY_GB_PER_V8_INSTANCE));
+}
+
+
 export class WorkerPool {
     constructor(
         private factory: () => Worker
@@ -25,7 +39,7 @@ export class WorkerPool {
      * Once this limit is reached, additional projects are multiplexed onto existing workers
      * (each project still gets its own dedicated MessagePort) instead of spawning new threads.
      */
-    public maxWorkers = Math.max(1, os.cpus().length);
+    public maxWorkers = getDefaultMaxWorkerThreads();
 
     /**
      * Every worker thread currently in the pool, along with how many projects are attached to it


### PR DESCRIPTION
Instead of setting the default number of max threads to be the number of CPUs, this sets the default value to be as much as the machine's memory allows, considering there is an up-to 2GB V8 instance instantiated in each thread.

Logic is:
- Max of (Number of CPUs available vs. Memory in GB/2)
- at least 1 max thread

Added tests with sinon stubs for faking os.cpus() and os.totalmem()

