### PR TITLE
Locate the super() call when injecting field initializers

### DIFF
--- a/src/files/BrsFile.Class.spec.ts
+++ b/src/files/BrsFile.Class.spec.ts
@@ -5,7 +5,7 @@ import type { BrsFile } from './BrsFile';
 import { expect } from '../chai-config.spec';
 import { DiagnosticMessages } from '../DiagnosticMessages';
 import { Range } from 'vscode-languageserver';
-import { ParseMode } from '../parser/Parser';
+import { ParseMode, Parser } from '../parser/Parser';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile, trim } from '../testHelpers.spec';
 import { standardizePath as s } from '../util';
 import * as fsExtra from 'fs-extra';
@@ -418,6 +418,295 @@ describe('BrsFile BrighterScript classes', () => {
                 end function
                 function BabyDuck()
                     instance = __BabyDuck_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers after a super call that is not the first statement', () => {
+            testTranspile(`
+                class Animal
+                end class
+                class Duck extends Animal
+                    name = "duck"
+                    sub new()
+                        print "before super"
+                        super()
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new()
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+                sub __Duck_method_new()
+                    print "before super"
+                    m.super0_new()
+                    m.name = "duck"
+                end sub
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = __Duck_method_new
+                    return instance
+                end function
+                function Duck()
+                    instance = __Duck_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers after a super call preceded by several statements', () => {
+            testTranspile(`
+                class Animal
+                end class
+                class Duck extends Animal
+                    name = "duck"
+                    age = 1
+                    sub new()
+                        print "one"
+                        print "two"
+                        super()
+                        print "three"
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new()
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+                sub __Duck_method_new()
+                    print "one"
+                    print "two"
+                    m.super0_new()
+                    m.name = "duck"
+                    m.age = 1
+                    print "three"
+                end sub
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = __Duck_method_new
+                    return instance
+                end function
+                function Duck()
+                    instance = __Duck_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers after a super call with arguments', () => {
+            testTranspile(`
+                class Animal
+                    sub new(name)
+                        print name
+                    end sub
+                end class
+                class Duck extends Animal
+                    sound = "quack"
+                    sub new(name)
+                        print "before super"
+                        super(name)
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new(name)
+                    print name
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal(name)
+                    instance = __Animal_builder()
+                    instance.new(name)
+                    return instance
+                end function
+                sub __Duck_method_new(name)
+                    print "before super"
+                    m.super0_new(name)
+                    m.sound = "quack"
+                end sub
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = __Duck_method_new
+                    return instance
+                end function
+                function Duck(name)
+                    instance = __Duck_builder()
+                    instance.new(name)
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers at the top when the class has no parent', () => {
+            testTranspile(`
+                class Animal
+                    name = "animal"
+                    sub new()
+                        print "hello"
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new()
+                    m.name = "animal"
+                    print "hello"
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers after an injected super call in a multi-level hierarchy', () => {
+            testTranspile(`
+                class Animal
+                    a = 1
+                end class
+                class Duck extends Animal
+                    b = 2
+                    sub new()
+                        print "duck"
+                        super()
+                    end sub
+                end class
+                class BabyDuck extends Duck
+                    c = 3
+                    sub new()
+                        print "baby"
+                        super()
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new()
+                    m.a = 1
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+                sub __Duck_method_new()
+                    print "duck"
+                    m.super0_new()
+                    m.b = 2
+                end sub
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = __Duck_method_new
+                    return instance
+                end function
+                function Duck()
+                    instance = __Duck_builder()
+                    instance.new()
+                    return instance
+                end function
+                sub __BabyDuck_method_new()
+                    print "baby"
+                    m.super1_new()
+                    m.c = 3
+                end sub
+                function __BabyDuck_builder()
+                    instance = __Duck_builder()
+                    instance.super1_new = instance.new
+                    instance.new = __BabyDuck_method_new
+                    return instance
+                end function
+                function BabyDuck()
+                    instance = __BabyDuck_builder()
+                    instance.new()
+                    return instance
+                end function
+            `, undefined, 'source/main.bs');
+        });
+
+        it('injects field initializers after super when a plugin inserts a statement before it', () => {
+            //this mirrors what rooibos' code-coverage instrumentation does: it walks the AST and splices
+            //a tracking statement in front of every statement, which used to push `super()` off index 0
+            //and cause field initializers to be emitted *before* the super call
+            program.plugins.add({
+                name: 'test-plugin',
+                beforeFileTranspile: (event) => {
+                    const classStatement = (event.file as BrsFile).parser.references.classStatements.find(x => x.name.text === 'Duck');
+                    const ctor = classStatement?.memberMap['new'] as MethodStatement;
+                    if (ctor) {
+                        const tracker = Parser.parse(`track("line1")`).ast.statements[0];
+                        event.editor.arrayUnshift(ctor.func.body.statements, tracker);
+                    }
+                }
+            });
+            testTranspile(`
+                class Animal
+                end class
+                class Duck extends Animal
+                    name = "duck"
+                    sub new()
+                        super()
+                    end sub
+                end class
+            `, `
+                sub __Animal_method_new()
+                end sub
+                function __Animal_builder()
+                    instance = {}
+                    instance.new = __Animal_method_new
+                    return instance
+                end function
+                function Animal()
+                    instance = __Animal_builder()
+                    instance.new()
+                    return instance
+                end function
+                sub __Duck_method_new()
+                    track("line1")
+                    m.super0_new()
+                    m.name = "duck"
+                end sub
+                function __Duck_builder()
+                    instance = __Animal_builder()
+                    instance.super0_new = instance.new
+                    instance.new = __Duck_method_new
+                    return instance
+                end function
+                function Duck()
+                    instance = __Duck_builder()
                     instance.new()
                     return instance
                 end function

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2576,17 +2576,8 @@ export class MethodStatement extends FunctionStatement {
             return;
         }
 
-        //check whether any calls to super exist
-        let containsSuperCall =
-            this.func.body.statements.findIndex((x) => {
-                //is a call statement
-                return isExpressionStatement(x) && isCallExpression(x.expression) &&
-                    //is a call to super
-                    util.findBeginningVariableExpression(x.expression.callee)?.name.text.toLowerCase() === 'super';
-            }) !== -1;
-
         //if a call to super exists, quit here
-        if (containsSuperCall) {
+        if (this.findSuperCallIndex() !== -1) {
             return;
         }
 
@@ -2623,10 +2614,28 @@ export class MethodStatement extends FunctionStatement {
     }
 
     /**
+     * Find the index of the `super()` call within this function's body, or -1 if there isn't one.
+     * The call is usually the first statement, but plugins are free to insert statements ahead of it,
+     * so we locate it rather than assuming a fixed position.
+     */
+    private findSuperCallIndex() {
+        return this.func.body.statements.findIndex((x) => {
+            //is a call statement
+            return isExpressionStatement(x) && isCallExpression(x.expression) &&
+                //is a call to super
+                util.findBeginningVariableExpression(x.expression.callee)?.name.text.toLowerCase() === 'super';
+        });
+    }
+
+    /**
      * Inject field initializers at the top of the `new` function (after any present `super()` call)
      */
     private injectFieldInitializersForConstructor(state: BrsTranspileState) {
-        let startingIndex = state.classStatement!.hasParentClass() ? 1 : 0;
+        //field initializers must run after the `super()` call. `ensureSuperConstructorCall` has already
+        //guaranteed a super call exists for derived classes, but it isn't necessarily at index 0 -- a plugin
+        //may have inserted statements before it -- so find it instead of assuming its position.
+        const superCallIndex = state.classStatement!.hasParentClass() ? this.findSuperCallIndex() : -1;
+        let startingIndex = superCallIndex + 1;
 
         let newStatements = [] as Statement[];
         //insert the field initializers in order


### PR DESCRIPTION
`injectFieldInitializersForConstructor` assumed the `super()` call sits at index 0 of the constructor body and spliced field initializers in at index 1:

```ts
let startingIndex = state.classStatement!.hasParentClass() ? 1 : 0;
```

That holds for hand-written source, but a plugin that inserts a statement ahead of `super()` pushes it to index 1 — so the field initializers land at index 1 too, and are emitted *before* the super call:

```brightscript
' plugin inserts a tracking statement, then:
track("line1")
m.someField = "initialized"   ' <-- runs before the base constructor
m.super0_new()
```

The method's own doc comment already states the intent ("after any present `super()` call"); this makes the implementation match it by locating the call instead of assuming its position. The detection predicate already existed inline in `ensureSuperConstructorCall`, so it's extracted to a shared `findSuperCallIndex` helper and reused by both — a net simplification.

Behavior is unchanged for every existing case: no parent class gives `-1 + 1 = 0`, and a super call at index 0 gives `1`.

Surfaced by rooibos' code-coverage instrumentation, which splices a tracking statement in front of every statement ([rooibos#354](https://github.com/rokucommunity/rooibos/issues/354)). Rooibos currently works around it by special-casing `super()`; with this fix that workaround can be removed, and coverage markers land adjacent to the statements they measure.

**What changed:** locate the `super()` call rather than assuming index 0; extract the shared `findSuperCallIndex` helper.

**Verified:** 6 new tests (statement before super, several statements before, super with args, no parent class, multi-level hierarchy, and a plugin-inserted statement mirroring rooibos). 5 of the 6 fail without the fix; the no-parent case correctly passes either way. Full suite 3175 passing, lint and tsc clean. Also validated end-to-end against rooibos with this build: with the fix in place its `super()` workaround becomes unnecessary and all 136 of its tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
