### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7091,10 +7091,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -13979,9 +13980,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "requires": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Clears the two open `qs` advisories (both moderate, dev-only).

`npm audit --omit=dev`: **0 vulnerabilities** across 97 prod deps — unchanged, since this dep is not reachable from `dependencies`.

## Ships to consumers

Nothing. No `package.json` change, so consumers' resolution is unaffected.

## Lockfile only (dev deps)

| Package | From | To | Advisories |
|---|---|---|---|
| qs | 6.15.3 | 6.16.0 | [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx), [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) |

## Notes for the reviewer

- Reached only via `sync-request` > `then-request` > `qs`, and `sync-request` is a devDependency. Nothing here ships.
- The audit gate was already passing before this change — `audit-ci` has a `high` floor and these are moderate. This is hygiene to keep `npm audit` quiet, not a fix for a red gate.

## Verification

`npm run preversion` (build + lint + test) passed: 3175 passing, 0 failing; audit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)