### PR TITLE
Fix binary op false positive on enum unions of the same type

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -4742,6 +4742,29 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        it('allows comparisons on a variable whose union includes both an enum type and an enum member type', () => {
+            // https://github.com/rokucommunity/brighterscript/issues/1807
+            program.setFile('source/util.bs', `
+                enum Direction
+                    north = "n"
+                    south = "s"
+                end enum
+
+                sub makeEasterly(input as string)
+                    d = input as Direction
+                    if d = Direction.north
+                        d = Direction.south
+                    end if
+                    if d = Direction.north
+                        print "still north"
+                    end if
+                end sub
+            `);
+            program.validate();
+            //should have no errors
+            expectZeroDiagnostics(program);
+        });
+
         it('validates unary operators', () => {
             program.setFile('source/util.bs', `
                 sub doStuff()

--- a/src/bscPlugin/validation/ScopeValidator.ts
+++ b/src/bscPlugin/validation/ScopeValidator.ts
@@ -1009,8 +1009,14 @@ export class ScopeValidator {
             const leftTypesToTest = isUnionType(leftTypeToTest) ? getAllTypesFromCompoundType(leftTypeToTest) : [leftTypeToTest];
             const rightTypesToTest = isUnionType(rightTypeToTest) ? getAllTypesFromCompoundType(rightTypeToTest) : [rightTypeToTest];
 
-            for (const leftInnerType of leftTypesToTest) {
-                for (const rightInnerType of rightTypesToTest) {
+            for (let leftInnerType of leftTypesToTest) {
+                if (isEnumMemberType(leftInnerType) || isEnumType(leftInnerType)) {
+                    leftInnerType = leftInnerType.underlyingType;
+                }
+                for (let rightInnerType of rightTypesToTest) {
+                    if (isEnumMemberType(rightInnerType) || isEnumType(rightInnerType)) {
+                        rightInnerType = rightInnerType.underlyingType;
+                    }
                     if (!util.binaryOperatorResultType(leftInnerType, binaryExpr.tokens.operator, rightInnerType)) {
                         this.addMultiScopeDiagnostic({
                             ...DiagnosticMessages.operatorTypeMismatch(binaryExpr.tokens.operator.text, leftType.toString(), rightType.toString()),


### PR DESCRIPTION
Fixes #1807

When a var gets assigned an enum type in one spot and a specific enum member in another (e.g. `x = val as MyEnum` then later `x = MyEnum.member`), its inferred type ends up a union of `EnumType` + `EnumMemberType`. Those two don't dedup against each other since they're different classes, even though they're logically "the same enum."

`validateBinaryExpression` unwraps enum types down to their underlying type before checking operator compatibility, but it only did that on the outer left/right type, not on each member of a union. So when the union hit the binary op check, the raw enum types got compared against primitives and always failed — hence the confusing "cannot be applied to types 'DeeplinkType' and 'DeeplinkType'" (enum member's `toString()` just prints the enum name, so both sides look identical).

Fix: unwrap enum type/enum member type to underlying type for each inner type in the union loop too, same as the non-union path already does.

Added a regression test modeled on the existing enum operator tests in `ScopeValidator.spec.ts`. Full suite passes, lint clean.