### PR TITLE
Tolerate older BrsTranspileState in continue back-transpile

### DIFF
--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -228,7 +228,9 @@ export class Block extends Statement {
         //if a `continue` inside this block was rewritten into a `goto`, emit its jump target as
         //the last line of the block. Done here (rather than in the loop statements) so the label
         //picks up the block's own indent depth.
-        const loopLabel = state.peekLoopLabel();
+        //`state` can come from an older brighterscript version (i.e. a plugin bundling a newer
+        //brighterscript than the host), so guard against the loop-label api being absent
+        const loopLabel = state.peekLoopLabel?.();
         if (loopLabel?.wasAccessed && loopLabel.blockDepth === state.blockDepth) {
             results.push(
                 state.newline,
@@ -1042,9 +1044,9 @@ export class ForStatement extends Statement {
         }
         //loop body
         state.lineage.unshift(this);
-        state.pushLoopLabel();
+        state.pushLoopLabel?.();
         result.push(...this.body.transpile(state));
-        state.popLoopLabel();
+        state.popLoopLabel?.();
         state.lineage.shift();
 
         // add new line before "end for"
@@ -1134,9 +1136,9 @@ export class ForEachStatement extends Statement {
         result.push(...this.target.transpile(state));
         //body
         state.lineage.unshift(this);
-        state.pushLoopLabel();
+        state.pushLoopLabel?.();
         result.push(...this.body.transpile(state));
-        state.popLoopLabel();
+        state.popLoopLabel?.();
         state.lineage.shift();
 
         // add new line before "end for"
@@ -1209,9 +1211,9 @@ export class WhileStatement extends Statement {
         );
         state.lineage.unshift(this);
         //body
-        state.pushLoopLabel();
+        state.pushLoopLabel?.();
         result.push(...this.body.transpile(state));
-        state.popLoopLabel();
+        state.popLoopLabel?.();
         state.lineage.shift();
 
         //trailing newline only if we have body statements
@@ -3283,8 +3285,11 @@ export class ContinueStatement extends Statement {
     transpile(state: BrsTranspileState) {
         //when targeting firmware without native `continue` support, rewrite into a jump to the
         //label at the end of the enclosing loop body
-        if (!state.firmwareCapabilities.continueStatement) {
-            const label = state.getLoopLabel();
+        //`false` means the target firmware lacks native `continue`. `undefined` means `state` came
+        //from an older brighterscript (i.e. a plugin bundling a newer brighterscript than the
+        //host) which has no back-transpile support at all, so emit `continue` as-is
+        if (state.firmwareCapabilities?.continueStatement === false) {
+            const label = state.getLoopLabel?.();
             //no enclosing loop means this is a `continue` outside a loop, which validation already
             //flags as an error. fall through to the passthrough emit rather than producing a
             //`goto undefined`

--- a/src/parser/tests/statement/Continue.spec.ts
+++ b/src/parser/tests/statement/Continue.spec.ts
@@ -7,6 +7,8 @@ import { Program } from '../../../Program';
 import { expectDiagnostics, expectZeroDiagnostics, getTestTranspile } from '../../../testHelpers.spec';
 import { rootDir } from '../../../testHelpers.spec';
 import type { BrsFile } from '../../../files/BrsFile';
+import { BrsTranspileState } from '../../BrsTranspileState';
+import { SourceNode } from 'source-map';
 const sinon = createSandbox();
 
 describe('parser continue statements', () => {
@@ -214,6 +216,28 @@ describe('parser continue statements', () => {
                 end sub
             `);
         });
+    });
+
+    it('emits `continue` as-is when the transpile state predates the loop-label api', () => {
+        //simulates a plugin bundling a newer brighterscript than the host: the AST nodes are new
+        //but the BrsTranspileState comes from the older host, so it has none of the loop-label api
+        program = new Program({ rootDir: rootDir, sourceMap: true, minFirmwareVersion: '11.0.0' });
+        const file = program.setFile<BrsFile>('source/main.bs', `
+            sub main()
+                for i = 0 to 10
+                    continue for
+                end for
+            end sub
+        `);
+        const state = new BrsTranspileState(file);
+        //strip the newer api from this instance only (the host's state would never have had it)
+        const legacyState = Object.create(state);
+        for (let name of ['firmwareCapabilities', 'pushLoopLabel', 'popLoopLabel', 'peekLoopLabel', 'getLoopLabel']) {
+            legacyState[name] = undefined;
+        }
+        expect(
+            new SourceNode(null, null, null, file.ast.transpile(legacyState) as any).toString()
+        ).to.include('continue for');
     });
 
     it('does not crash when missing loop type', () => {


### PR DESCRIPTION
When a plugin bundles a newer brighterscript than the host (e.g. rooibos with its own nested copy), the plugin's AST nodes get handed a `BrsTranspileState` constructed by the *older* host. That state has none of the five members the continue back-transpile added, so transpiling any `Block` threw `TypeError: state.peekLoopLabel is not a function`.

Those five members are now accessed defensively, falling through to emitting `continue` verbatim — which is exactly what the old host would have emitted on its own, since it has no `minFirmwareVersion` continue handling and no way for the user to have asked for back-transpiling.

What changed (all in `Statement.ts`):
- `state.peekLoopLabel?.()` in `Block.transpile`, and `pushLoopLabel?.()`/`popLoopLabel?.()` in the three loop statements
- `ContinueStatement.transpile` now keys off `state.firmwareCapabilities?.continueStatement === false` — `false` means back-transpile, `true` means native, `undefined` means an old host with no such feature
- One test transpiling against a state with those members stripped

Not addressed: the reverse mismatch (new host, plugin bundling an older bsc) means the plugin's own `ContinueStatement`/`Block` classes don't back-transpile at all. That's inherent to nested-copy AST nodes for any transpile feature, not something these guards affect.

Verified with `npx tsc --noEmit`, `npm run test:nocover` (3176 passing), and `npm run lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)