### PR TITLE
Fix Array<Interface> callfunc argument false-positive across component scopes

### DIFF
--- a/src/bscPlugin/validation/ScopeValidator.spec.ts
+++ b/src/bscPlugin/validation/ScopeValidator.spec.ts
@@ -6590,6 +6590,95 @@ describe('ScopeValidator', () => {
             ]);
         });
 
+        it('allows an array of an interface type as a callfunc arg, when the interface is imported into two different component scopes', () => {
+            program.setFile('components/types.bs', `
+                interface MyItem
+                    sku as string
+                end interface
+            `);
+
+            program.setFile('components/A.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="A" extends="Group">
+                    <script uri="A.bs"/>
+                    <interface>
+                        <function name="doThing" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/A.bs', `
+                import "pkg:/components/types.bs"
+
+                function doThing(items as MyItem[]) as void
+                    print items.Count()
+                end function
+            `);
+
+            program.setFile('components/B.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="B" extends="Group">
+                    <script uri="B.bs"/>
+                </component>
+            `);
+
+            program.setFile('components/B.bs', `
+                import "pkg:/components/types.bs"
+
+                sub callIt(aNode as roSGNodeA)
+                    item as MyItem = { sku: "abc" }
+                    aNode@.doThing([item])
+                end sub
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+        });
+
+        it('still catches a genuinely incompatible array arg to a callfunc, alongside a compatible interface array', () => {
+            program.setFile('components/types.bs', `
+                interface MyItem
+                    sku as string
+                end interface
+            `);
+
+            program.setFile('components/A.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="A" extends="Group">
+                    <script uri="A.bs"/>
+                    <interface>
+                        <function name="doThing" />
+                    </interface>
+                </component>
+            `);
+
+            program.setFile('components/A.bs', `
+                import "pkg:/components/types.bs"
+
+                function doThing(items as MyItem[]) as void
+                    print items.Count()
+                end function
+            `);
+
+            program.setFile('components/B.xml', trim`
+                <?xml version="1.0" encoding="utf-8" ?>
+                <component name="B" extends="Group">
+                    <script uri="B.bs"/>
+                </component>
+            `);
+
+            program.setFile('components/B.bs', `
+                import "pkg:/components/types.bs"
+
+                sub callIt(aNode as roSGNodeA)
+                    aNode@.doThing([1, 2, 3])
+                end sub
+            `);
+            program.validate();
+            expectDiagnostics(program, [
+                DiagnosticMessages.argumentTypeMismatch('Array<integer>', 'Array<MyItem>').message
+            ]);
+        });
+
         it('allows return value of as void functions to be dynamic', () => {
             program.setFile('components/Widget.xml', trim`
                 <?xml version="1.0" encoding="utf-8" ?>

--- a/src/types/ReferenceType.ts
+++ b/src/types/ReferenceType.ts
@@ -98,8 +98,20 @@ export class ReferenceType extends BscType {
                         if (resolvedType && !isReferenceType(resolvedType)) {
                             return resolvedType.isTypeCompatible(targetType, data);
                         } else if (isReferenceType(targetType)) {
-                            return this.fullName.toLowerCase() === targetType.fullName.toLowerCase() &&
-                                this.tableProvider === targetType.tableProvider;
+                            if (this.fullName.toLowerCase() !== targetType.fullName.toLowerCase()) {
+                                // different named references -- definitely not a match
+                                return false;
+                            }
+                            if (this.tableProvider === targetType.tableProvider) {
+                                // exact same reference source -- trivially compatible
+                                return true;
+                            }
+                            //Same name, but resolved via a different scope's symbol table -- e.g. the same
+                            //.bs `interface` imported into two different component scopes. tableProvider
+                            //identity can't tell these apart (each scope builds its own closure), and we
+                            //can't resolve `this` to compare structurally either. A same-named reference is
+                            //our best signal here, so assume compatible rather than falsely rejecting it.
+                            return true;
                         }
                         return targetType.isTypeCompatible(this, data);
                     };


### PR DESCRIPTION
## Summary
Fixes #1816. Calling a component function through `@` callfunc with an `Array<MyItem>` argument was rejected as incompatible with its own declared parameter type whenever the interface was imported into two different component scopes and the callfunc target was typed as a specific generated node type (e.g. `roSGNodeA`) rather than generic `roSGNode`.

## Root cause
`ReferenceType.isTypeCompatible` has a fallback for comparing two same-named reference types that requires their `tableProvider` closures to be reference-identical. Two independently-resolved references to the same `.bs` interface (one from the declaring component's scope, one from the calling component's own scope) never share that closure, even though both resolve to the same declaration -- causing a spurious mismatch.

This only surfaces for arrays because `ArrayType.defaultType` permanently memoizes its element type on first access, and for a callfunc target that first access happens once against a shared, global `ComponentType` built while the declaring component's scope is transiently linked. By the time a different calling scope validates its own call, that cached reference can no longer live-resolve. A scalar param re-resolves fresh each time instead of being cached, so it self-heals.

## Fix
When two same-named references can't be proven identical only because they came from different scopes, treat them as compatible -- matching the "can't resolve, assume compatible" fallback already used elsewhere in this file.

## Test plan
- Added a test reproducing the issue (two components, shared imported interface, array param, `roSGNodeA` callfunc target) -- zero diagnostics now.
- Added a negative-case test confirming a genuinely incompatible array arg (`Array<integer>` vs `Array<MyItem>`) is still flagged.
- `npx mocha`: 4561 passing (2 new), 9 pending, 0 failing.
- `npm run lint`: 0 errors. `npm run build`: succeeds.
- Manually verified against the issue's exact repro with `bsc --project bsconfig.json`.